### PR TITLE
style: migrate brainstorm-manager/taskmaster-page/lora-triage buttons to kr-btn-xs

### DIFF
--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -330,7 +330,7 @@
           </div>
           <button
             type="button"
-            class="btn btn-ghost btn-xs rounded-xl text-error"
+            class="kr-btn-xs btn-ghost text-error"
             data-testid="brainstorm-source-remove"
             @click="clearSource"
           >

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -726,7 +726,7 @@
                       <button
                         v-else
                         type="button"
-                        class="btn btn-warning btn-xs rounded-xl"
+                        class="kr-btn-xs btn-warning"
                         :disabled="item.status === 'queued'"
                         @click="store.applyWriteBack(item.beatId)"
                       >

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -337,7 +337,7 @@
           </div>
           <button
             type="button"
-            class="btn btn-ghost btn-xs rounded-xl text-base-content/50"
+            class="kr-btn-xs btn-ghost text-base-content/50"
             :disabled="triageStore.confirmedCount === 0"
             @click="clearProgress"
           >


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules — slice 101 (kind: software)

### What changed / what I produced
- Migrated the single hand-rolled `btn btn-xs ... rounded-xl` occurrence in each of:
  - `components/brainstorm/brainstorm-manager.vue` (preserving `btn-ghost` + `text-error`)
  - `components/pages/taskmaster-page.vue` (preserving `btn-warning`)
  - `pages/admin/lora-triage.vue` (preserving `btn-ghost` + `text-base-content/50`)
  to the shared `kr-btn-xs` class, via `utils/scripts/codemods/kr_btn_xs_codemod.py --apply`.
- No geometry or behavior change — only the base `btn btn-xs rounded-xl` triplet is replaced; all color modifiers and utility classes are preserved verbatim.

### How I verified
- `grep`'d `utils/scripts/*.mjs` for the three filenames and the exact pre-change class strings — no regression-guard hits.
- `vue-tsc --noEmit` clean.
- `eslint` on the three changed files: 0 issues.
- `test:layout-contract` (`verifyLayoutContract.ts`): holds at the existing 207-violation baseline, no new violations.
- `test:lint-ratchet` (`verifyLintRatchet.ts`): holds at 333 problems / -59, no rule regressed.
- `prettier --check` flags pre-existing drift on `brainstorm-manager.vue` and `taskmaster-page.vue` — confirmed via `git stash` that the same warnings exist on `main` before this change, so nothing new was introduced.

### Stakes
reversible

### Kaizen suggestion
The remaining-occurrence count from `kr_btn_xs_codemod.py` (no `--path`) is now 0 across the whole repo — this recurring sweep may want a fresh dry-run audit of a *different* shared-class family (e.g. hand-rolled `btn-sm`/`btn-md` variants) once t-104's current `btn-xs` backlog is confirmed empty, so the umbrella task doesn't idle.

### Notes for reviewer
Companion conductor bookkeeping (task status transitions) is tracked in interface-vision/t-104.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DA3FtSWfBRy39xeqSNnwgB)_