### PR TITLE
style: migrate challenge-center-page.vue reward card to kr-panel-section

### DIFF
--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -141,7 +141,7 @@
               v-for="(challenge, index) in challenges"
               :key="challenge.id"
               :to="`/play/challenges/${challenge.slug}`"
-              class="group relative flex min-h-64 flex-col overflow-hidden rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm transition duration-200 hover:-translate-y-1 hover:border-primary/50 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+              class="kr-panel-section group relative flex min-h-64 flex-col overflow-hidden transition duration-200 hover:-translate-y-1 hover:border-primary/50 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
             >
               <div
                 class="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-primary via-secondary to-accent opacity-60 transition group-hover:opacity-100"


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules — slice 102, new target family (kind: software)

### What changed / what I produced
- This task's original `btn-xs` family is now fully migrated (confirmed 0 occurrences after kind_robots#2445). This slice starts a new target family already tracked by an existing, previously-unused codemod tool, `utils/scripts/codemods/kr_panel_section_codemod.py`, which had exactly one remaining candidate in the whole repo.
- Migrates the hand-rolled `rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm` surface on the challenge reward-card link in `components/conductor/challenge-center-page.vue` to `kr-panel-section`, preserving every other utility and hover/focus modifier verbatim. No geometry or behavior change.

### How I verified
- Confirmed the target file is pure LF (no CRLF risk for this line-oriented codemod, per the LEARNING.yaml lesson from an earlier slice).
- `grep`'d `utils/scripts/*.mjs` and other `.ts`/`.mjs`/`.js` sources for the filename and exact pre-change class string — no regression-guard hits.
- `vue-tsc --noEmit` clean.
- `eslint` on the changed file: 0 issues.
- `test:layout-contract` (`verifyLayoutContract.ts`): holds at the existing 207-violation baseline, no new violations.
- `test:lint-ratchet` (`verifyLintRatchet.ts`): holds at 333 problems / -59, no rule regressed.
- `prettier --check` flags pre-existing drift on this file — confirmed via `git stash` that the same warning exists on `main` before this change.
- Re-ran `kr_panel_section_codemod.py --root .` post-change: 0 candidate occurrences remain.

### Stakes
reversible

### Kaizen suggestion
`kr_panel_codemod.py --root .` (a sibling, unrelated codemod) currently reports 0 clean candidates but 2 occurrences skipped for manual review in `components/user/chat-gallery.vue` (extra tokens: `btn-sm shrink-0`/no `btn-sm`). Worth a manual look next slice rather than widening the codemod's auto-match rules.

### Notes for reviewer
Companion conductor bookkeeping (task note/scoping) is tracked in interface-vision/t-104.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DA3FtSWfBRy39xeqSNnwgB)_