### PR TITLE
style: migrate 19 kr-btn-* class-order near-misses to canonical classes

### DIFF
--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -82,11 +82,7 @@
               New Chat
             </button>
 
-            <button
-              class="btn btn-sm btn-ghost rounded-xl"
-              type="button"
-              @click="clearBot"
-            >
+            <button class="kr-btn-ghost" type="button" @click="clearBot">
               Clear Bot
             </button>
           </div>

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -87,7 +87,7 @@
         </button>
         <button
           type="button"
-          class="btn btn-xs btn-ghost rounded-lg"
+          class="kr-btn-ghost-xs-lg"
           :disabled="anyBatching || store.autoBuilding"
           @click="
             store.batchApproveStage(group.outputKey, 'FIELDS_AND_PROMPTS')
@@ -205,7 +205,7 @@
           </span>
           <button
             type="button"
-            class="btn btn-xs btn-ghost rounded-lg"
+            class="kr-btn-ghost-xs-lg"
             @click="emit('select-item', item.id)"
           >
             <Icon name="kind-icon:pencil" class="h-3 w-3" />

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -81,7 +81,7 @@
         <button
           v-if="item.stages.PITCH.status === 'approved'"
           type="button"
-          class="btn btn-xs btn-ghost rounded-lg"
+          class="kr-btn-ghost-xs-lg"
           :disabled="isCommitting"
           @click="store.reopenStage(item.id, 'PITCH')"
         >
@@ -196,7 +196,7 @@
         <button
           v-if="item.stages.FIELDS_AND_PROMPTS.status === 'approved'"
           type="button"
-          class="btn btn-xs btn-ghost rounded-lg"
+          class="kr-btn-ghost-xs-lg"
           :disabled="isCommitting"
           @click="store.reopenStage(item.id, 'FIELDS_AND_PROMPTS')"
         >
@@ -328,7 +328,7 @@
         <button
           v-if="item.stages.GENERATE_ASSETS.status === 'approved'"
           type="button"
-          class="btn btn-xs btn-ghost rounded-lg"
+          class="kr-btn-ghost-xs-lg"
           :disabled="isCommitting"
           @click="store.reopenStage(item.id, 'GENERATE_ASSETS')"
         >

--- a/components/navigation/mana-widget.vue
+++ b/components/navigation/mana-widget.vue
@@ -56,7 +56,7 @@
           </NuxtLink>
           <NuxtLink
             to="/giving#monthly-support"
-            class="btn btn-sm btn-primary rounded-xl"
+            class="kr-btn-primary"
             @click="open = false"
           >
             Get more mana 🚀

--- a/components/newsfeed/newsfeed-filters.vue
+++ b/components/newsfeed/newsfeed-filters.vue
@@ -41,7 +41,7 @@
           />
           <button
             type="button"
-            class="btn btn-sm btn-primary rounded-xl"
+            class="kr-btn-primary"
             :disabled="!includeDraft.trim()"
             @click="submitInclude()"
           >
@@ -81,7 +81,7 @@
           />
           <button
             type="button"
-            class="btn btn-sm btn-primary rounded-xl"
+            class="kr-btn-primary"
             :disabled="!excludeDraft.trim()"
             @click="submitExclude()"
           >

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -23,7 +23,7 @@
           {{ loading ? 'Refreshing…' : 'Refresh' }}
         </button>
         <button
-          class="btn btn-sm btn-ghost"
+          class="kr-btn-ghost-plain"
           @click="pageStore.setWorkspaceCardKey('overview')"
         >
           ← Workspace

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -83,7 +83,7 @@
         <button
           v-for="phrase in quickPhrases"
           :key="phrase"
-          class="btn btn-xs btn-outline"
+          class="kr-btn-outline-xs"
           type="button"
           @click="send(phrase)"
         >

--- a/components/servers/add-server.vue
+++ b/components/servers/add-server.vue
@@ -18,7 +18,7 @@
       </div>
 
       <button
-        class="btn btn-sm btn-ghost rounded-xl"
+        class="kr-btn-ghost"
         type="button"
         title="Close"
         @click="closeForm"

--- a/components/servers/server-status.vue
+++ b/components/servers/server-status.vue
@@ -25,7 +25,7 @@
           </button>
           <button
             v-if="isA1111"
-            class="btn btn-sm btn-primary rounded-xl"
+            class="kr-btn-primary"
             type="button"
             :disabled="!activeServer"
             @click="fetchModelOptions"

--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -32,7 +32,7 @@
         <button
           v-if="modelValue.length"
           type="button"
-          class="btn btn-xs btn-ghost"
+          class="kr-btn-ghost-xs-plain"
           @click="emitValue([])"
         >
           Clear all

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -23,7 +23,7 @@
 
         <div class="flex flex-wrap items-center gap-2">
           <button
-            class="btn btn-sm btn-ghost rounded-xl"
+            class="kr-btn-ghost"
             type="button"
             @click="coloringStore.undo()"
           >
@@ -32,7 +32,7 @@
           </button>
 
           <button
-            class="btn btn-sm btn-ghost rounded-xl"
+            class="kr-btn-ghost"
             type="button"
             @click="coloringStore.resetPage()"
           >
@@ -41,7 +41,7 @@
           </button>
 
           <button
-            class="btn btn-sm btn-ghost rounded-xl"
+            class="kr-btn-ghost"
             type="button"
             title="Download the colored mural plan as a PNG image"
             :disabled="isExporting || !pageDefinition"

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -92,7 +92,7 @@
             </label>
             <button
               type="button"
-              class="btn btn-xs btn-outline"
+              class="kr-btn-outline-xs"
               @click="useLogoAsFirst"
             >
               Use logo
@@ -166,7 +166,7 @@
           <label class="font-semibold">Motion prompt</label>
           <button
             type="button"
-            class="btn btn-xs btn-ghost"
+            class="kr-btn-ghost-xs-plain"
             @click="prompt = WINK_PRESET"
           >
             ✨ Wink &amp; grin preset

--- a/utils/scripts/codemods/kr_btn_order_variant_codemod.py
+++ b/utils/scripts/codemods/kr_btn_order_variant_codemod.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Migrate hand-rolled `.kr-btn-*` order-variant near-misses to their canonical class.
+
+Every `.kr-btn-*` primitive in assets/css/tailwind.css was originally discovered and
+migrated one exact token-order at a time (interface-vision/t-104, slices 42-104+): a
+hand-rolled site whose class list is a different *word order* of an already-canonical
+set (e.g. `btn btn-sm btn-ghost rounded-xl` vs. the canonical `btn btn-ghost btn-sm
+rounded-xl`) was left unmigrated unless a slice happened to add that specific order as
+a second variant. This script closes the remaining gap in one bounded, mechanical pass:
+for every currently-defined `.kr-btn-*` class, find any `class="..."` attribute whose
+token *set* (order-independent) exactly matches that class's required tokens and has
+no `kr-*` class yet, and rewrite it to the single canonical class name.
+
+Deliberately exact-set only (no extra/near-miss tokens): every hit this script touches
+already carries precisely the tokens a `.kr-btn-*` primitive already owns, nothing more,
+so the rewrite can never silently drop or reinterpret an unrelated utility class. Sites
+with additional utilities (gap-1.5, mt-3, shrink-0, ...) are a *different* class of
+near-miss (a distinct/wider hand-rolled shape) and are intentionally left for a future
+slice to name and migrate on its own, exactly as prior slices' own comments describe.
+
+`components/ui/ui-gallery.vue` is excluded: its bare `btn`/`btn btn-primary` etc.
+occurrences are the page's own style-guide demo, out of scope by every prior slice's
+documented convention (see slice 77's comment in tailwind.css).
+
+Dry-run is the default; pass --write to apply.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+EXCLUDED_DIR_PARTS = {"node_modules", ".nuxt", "abandonware", "dist"}
+EXCLUDED_FILES = {ROOT / "components/ui/ui-gallery.vue"}
+
+KR_CSS_PATTERN = re.compile(
+    r"\.(kr-btn[\w-]*)\s*\{\s*@apply\s+([^;]+);", re.MULTILINE
+)
+
+
+def load_mappings() -> dict[frozenset[str], str]:
+    """Read assets/css/tailwind.css and build {required-token-set: class-name}.
+
+    Only exact-set matches with no ambiguity are usable: if two class names
+    somehow ever shared an identical token set, keeping either would be a
+    silent, wrong rewrite, so such a set is dropped from the mapping entirely
+    (never guessed at) and reported separately.
+    """
+    css_text = (ROOT / "assets/css/tailwind.css").read_text(encoding="utf-8")
+    by_set: dict[frozenset[str], str] = {}
+    ambiguous: set[frozenset[str]] = set()
+    for match in KR_CSS_PATTERN.finditer(css_text):
+        name = match.group(1)
+        tokens = frozenset(match.group(2).split())
+        if tokens in by_set and by_set[tokens] != name:
+            ambiguous.add(tokens)
+            continue
+        by_set[tokens] = name
+    for tokens in ambiguous:
+        by_set.pop(tokens, None)
+    return by_set
+
+
+def rewrite_classes(value: str, by_set: dict[frozenset[str], str]) -> tuple[str, bool]:
+    tokens = value.split()
+    if any(token.startswith("kr-") for token in tokens):
+        return value, False
+    if "btn" not in tokens:
+        return value, False
+    name = by_set.get(frozenset(tokens))
+    if name is None:
+        return value, False
+    return name, True
+
+
+def candidates(scopes: list[str]) -> list[Path]:
+    roots = [ROOT / scope for scope in scopes] if scopes else [ROOT]
+    paths: set[Path] = set()
+    for root in roots:
+        if root.is_file() and root.suffix == ".vue":
+            paths.add(root)
+            continue
+        if root.is_dir():
+            paths.update(root.rglob("*.vue"))
+
+    return sorted(
+        path
+        for path in paths
+        if path.is_relative_to(ROOT)
+        and path not in EXCLUDED_FILES
+        and not EXCLUDED_DIR_PARTS.intersection(path.relative_to(ROOT).parts)
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--path",
+        action="append",
+        default=[],
+        help="Limit the scan to a repo-relative .vue file or directory; repeatable.",
+    )
+    args = parser.parse_args()
+
+    by_set = load_mappings()
+    total = 0
+    changed_files = 0
+    for path in candidates(args.path):
+        # newline="" preserves the file's existing line-ending style verbatim
+        # (interface-vision/t-104 CRLF-collapse lesson: Path.read_text()/
+        # write_text() always translate newlines and have no `newline=` param
+        # before Python 3.13).
+        with path.open(encoding="utf-8", newline="") as fh:
+            original = fh.read()
+
+        count = 0
+
+        def replace(match: re.Match[str]) -> str:
+            nonlocal count
+            rewritten, changed = rewrite_classes(match.group(1), by_set)
+            if not changed:
+                return match.group(0)
+            count += 1
+            return f'class="{rewritten}"'
+
+        rewritten_text = CLASS_ATTR.sub(replace, original)
+        if not count:
+            continue
+        total += count
+        changed_files += 1
+        rel = path.relative_to(ROOT)
+        print(f"{rel}: {count} occurrence(s)")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as fh:
+                fh.write(rewritten_text)
+
+    mode = "written" if args.write else "found (dry-run, use --write to apply)"
+    print(f"\n{total} occurrence(s) across {changed_files} file(s) {mode}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules — slice 103 (kind: software)

### What changed
Every `.kr-btn-*` primitive in `assets/css/tailwind.css` was discovered and migrated one exact token-order at a time across ~100 prior slices; a hand-rolled site whose class list was a different *word order* of an already-canonical set (e.g. `btn btn-sm btn-ghost rounded-xl` vs. the canonical `btn btn-ghost btn-sm rounded-xl`) was left unmigrated unless a slice happened to add that order as a second variant.

Added `utils/scripts/codemods/kr_btn_order_variant_codemod.py`: parses the current `.kr-btn-*` definitions straight out of `tailwind.css` and rewrites any `class="..."` attribute whose token *set* (order-independent) exactly matches one of them, with no `kr-*` class yet, to the single canonical class. Exact-set only — no near-miss with extra tokens is touched, so nothing is silently reinterpreted or dropped. `components/ui/ui-gallery.vue`'s style-guide demo occurrences are excluded, per every prior slice's documented convention.

Migrated 19 occurrences across 12 files: `kr-btn-ghost` (5), `kr-btn-ghost-xs-lg` (5), `kr-btn-primary` (4), `kr-btn-ghost-xs-plain` (2), `kr-btn-outline-xs` (2), `kr-btn-ghost-plain` (1). No geometry or behavior change.

### Verification
- `vue-tsc --noEmit` clean
- `eslint` 0 issues on all changed `.vue` files
- `test:layout-contract` holds (207 baseline unchanged)
- `prettier --check` clean on all changed files (`bot-chat.vue`'s one-line reformat from the shorter class name applied via `prettier --write`; the remaining pre-existing drift on 6 other files confirmed via `git stash` — not introduced here)
- Re-running the codemod confirms 0 occurrences remain for this pass
- Grepped `utils/scripts/*.mjs`/`.js` and `tests/` for the exact literal class strings being replaced — no regression-guard hits

### Stakes
reversible

### Notes for reviewer
Companion conductor roadmap task (interface-vision/t-104) will be closed out with this PR reference once merged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9piSnXrqKVGxoWFd1jEuf

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9piSnXrqKVGxoWFd1jEuf)_