### PR TITLE
style: migrate 62 hand-rolled input/select shapes to kr-input-sm/kr-select-sm

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -912,6 +912,22 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-outline btn-xs;
   }
 
+  /* The most-repeated hand-rolled text-input shape in the app (interface-
+   * vision t-104 slice 104): a small, rounded DaisyUI input used across
+   * curation/facet/admin forms -- `input input-bordered input-sm
+   * rounded-xl`, previously hand-rolled in 9+ files (29 occurrences). */
+  .kr-input-sm {
+    @apply input input-bordered input-sm rounded-xl;
+  }
+
+  /* The `select` counterpart to .kr-input-sm (interface-vision t-104 slice
+   * 104): the same small/rounded shape on DaisyUI's select control --
+   * `select select-bordered select-sm rounded-xl`, previously hand-rolled
+   * in 13+ files (31 occurrences). */
+  .kr-select-sm {
+    @apply select select-bordered select-sm rounded-xl;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -80,7 +80,7 @@
                   :min="field.min"
                   :max="field.max"
                   :step="field.step"
-                  class="input input-bordered input-sm rounded-xl"
+                  class="kr-input-sm"
                   :placeholder="field.placeholder"
                 />
               </label>
@@ -90,7 +90,7 @@
                 <input
                   v-model="form.sampler"
                   list="artjob-sampler-presets"
-                  class="input input-bordered input-sm rounded-xl"
+                  class="kr-input-sm"
                 />
               </label>
               <label class="flex flex-col gap-1 text-xs">
@@ -98,7 +98,7 @@
                 <input
                   v-model="form.scheduler"
                   list="artjob-scheduler-presets"
-                  class="input input-bordered input-sm rounded-xl"
+                  class="kr-input-sm"
                 />
               </label>
             </div>
@@ -129,7 +129,7 @@
                     min="0.25"
                     max="30"
                     step="0.25"
-                    class="input input-bordered input-sm rounded-xl"
+                    class="kr-input-sm"
                   />
                 </label>
 
@@ -141,7 +141,7 @@
                     min="1"
                     max="60"
                     step="1"
-                    class="input input-bordered input-sm rounded-xl"
+                    class="kr-input-sm"
                   />
                 </label>
 

--- a/components/art/artjob-trainer-redo-controls.vue
+++ b/components/art/artjob-trainer-redo-controls.vue
@@ -18,7 +18,7 @@
           </span>
           <select
             v-model="mode"
-            class="select select-bordered select-sm rounded-xl"
+            class="kr-select-sm"
             :disabled="submitting"
           >
             <option value="TEXT">Prompt-only redo</option>
@@ -34,7 +34,7 @@
           </span>
           <select
             v-model="model"
-            class="select select-bordered select-sm rounded-xl"
+            class="kr-select-sm"
             :disabled="submitting"
           >
             <option value="SDXL">SDXL img2img</option>

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -259,7 +259,7 @@
       <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <label class="form-control gap-1">
           <span class="text-xs font-semibold text-base-content/60">Target</span>
-          <select v-model="selectedField" class="select select-bordered select-sm rounded-xl" :disabled="submitting">
+          <select v-model="selectedField" class="kr-select-sm" :disabled="submitting">
             <option v-for="slot in slots" :key="slot.field" :value="slot.field">
               {{ slot.label }}
             </option>
@@ -268,7 +268,7 @@
 
         <label class="form-control gap-1">
           <span class="text-xs font-semibold text-base-content/60">Method</span>
-          <select v-model="generationMode" class="select select-bordered select-sm rounded-xl" :disabled="submitting">
+          <select v-model="generationMode" class="kr-select-sm" :disabled="submitting">
             <option value="recreate">New prompt · recreate</option>
             <option value="img2img" :disabled="!currentSrc">Current image · img2img</option>
           </select>
@@ -276,7 +276,7 @@
 
         <label class="form-control gap-1">
           <span class="text-xs font-semibold text-base-content/60">Engine</span>
-          <select v-model="generationEngine" class="select select-bordered select-sm rounded-xl" :disabled="submitting">
+          <select v-model="generationEngine" class="kr-select-sm" :disabled="submitting">
             <template v-if="generationMode === 'recreate'">
               <option value="krea2">Krea 2 · default</option>
               <option value="comfy">SDXL · prompt only</option>
@@ -290,7 +290,7 @@
 
         <label class="form-control gap-1">
           <span class="text-xs font-semibold text-base-content/60">Preset</span>
-          <select v-model="presetKey" class="select select-bordered select-sm rounded-xl" :disabled="submitting">
+          <select v-model="presetKey" class="kr-select-sm" :disabled="submitting">
             <option v-for="preset in availablePresets" :key="preset.key" :value="preset.key">
               {{ preset.label }}
             </option>
@@ -320,7 +320,7 @@
           <span class="text-xs font-semibold text-base-content/60">SDXL checkpoint</span>
           <select
             v-model.number="checkpointResourceId"
-            class="select select-bordered select-sm rounded-xl"
+            class="kr-select-sm"
             :disabled="submitting || loadingResources"
           >
             <option :value="0">Use current quality default</option>
@@ -422,7 +422,7 @@
       <div class="grid gap-3 sm:grid-cols-2">
         <label class="form-control gap-1">
           <span class="text-xs font-semibold text-base-content/60">Target</span>
-          <select v-model="selectedField" class="select select-bordered select-sm rounded-xl" :disabled="submitting">
+          <select v-model="selectedField" class="kr-select-sm" :disabled="submitting">
             <option v-for="slot in slots" :key="slot.field" :value="slot.field">
               {{ slot.label }}
             </option>

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -706,7 +706,7 @@
           <span class="sr-only">Art engine</span>
           <select
             v-model="artEngine"
-            class="select select-bordered select-sm rounded-xl"
+            class="kr-select-sm"
             :disabled="isGeneratingArt"
             data-testid="brainstorm-art-engine"
             aria-label="Art engine"

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -95,7 +95,7 @@
                 type="text"
                 maxlength="255"
                 placeholder="Who are you?"
-                class="input input-bordered input-sm rounded-xl"
+                class="kr-input-sm"
               />
             </label>
             <label class="form-control w-full max-w-sm">
@@ -107,7 +107,7 @@
                 type="text"
                 maxlength="255"
                 placeholder="e.g. quiet epic, folk tale, heist"
-                class="input input-bordered input-sm rounded-xl"
+                class="kr-input-sm"
               />
             </label>
             <button

--- a/components/curation/coloring-book-curation.vue
+++ b/components/curation/coloring-book-curation.vue
@@ -5,7 +5,7 @@
         <span class="text-xs font-bold text-base-content/55">Book</span>
         <select
           :value="store.selectedBookSlug"
-          class="select select-bordered select-sm rounded-xl"
+          class="kr-select-sm"
           @change="store.selectBook(eventValue($event))"
         >
           <option
@@ -26,7 +26,7 @@
         <input
           v-model="search"
           type="search"
-          class="input input-bordered input-sm rounded-xl"
+          class="kr-input-sm"
           placeholder="title, prompt, notes..."
         />
       </label>

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -8,7 +8,7 @@
         <input
           v-model="search"
           type="search"
-          class="input input-bordered input-sm rounded-xl"
+          class="kr-input-sm"
           placeholder="name, species, lore..."
         />
       </label>
@@ -220,10 +220,7 @@
             <div class="flex flex-wrap gap-3">
               <label class="form-control min-w-52 flex-1 gap-1">
                 <span class="text-xs font-black">Render preset</span>
-                <select
-                  v-model="draft.presetId"
-                  class="select select-bordered select-sm rounded-xl"
-                >
+                <select v-model="draft.presetId" class="kr-select-sm">
                   <option
                     v-for="preset in presets"
                     :key="preset.id"
@@ -241,10 +238,7 @@
 
               <label class="form-control min-w-52 flex-1 gap-1">
                 <span class="text-xs font-black">Starting point</span>
-                <select
-                  v-model="draft.sourceMode"
-                  class="select select-bordered select-sm rounded-xl"
-                >
+                <select v-model="draft.sourceMode" class="kr-select-sm">
                   <option value="fresh">Fresh composition</option>
                   <option value="existing">Existing candidate art</option>
                 </select>
@@ -259,10 +253,7 @@
               class="form-control mt-3 gap-1"
             >
               <span class="text-xs font-black">SDXL checkpoint</span>
-              <select
-                v-model="draft.checkpoint"
-                class="select select-bordered select-sm rounded-xl"
-              >
+              <select v-model="draft.checkpoint" class="kr-select-sm">
                 <option value="">Choose checkpoint</option>
                 <option
                   v-for="checkpoint in checkpoints"
@@ -279,10 +270,7 @@
               class="form-control mt-3 gap-1"
             >
               <span class="text-xs font-black">Source ArtImage</span>
-              <select
-                v-model.number="draft.sourceImageId"
-                class="select select-bordered select-sm rounded-xl"
-              >
+              <select v-model.number="draft.sourceImageId" class="kr-select-sm">
                 <option :value="0">Choose candidate</option>
                 <option
                   v-if="fish.curation.selectedDesignImageId"

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -63,17 +63,14 @@
           <input
             v-model="search"
             type="search"
-            class="input input-bordered input-sm rounded-xl"
+            class="kr-input-sm"
             placeholder="Hanzi, pinyin, meaning, source…"
           />
         </label>
 
         <label class="form-control gap-1">
           <span class="text-xs font-black text-base-content/55">Category</span>
-          <select
-            v-model="categoryFilter"
-            class="select select-bordered select-sm rounded-xl"
-          >
+          <select v-model="categoryFilter" class="kr-select-sm">
             <option value="all">All categories</option>
             <option
               v-for="category in payload?.categories || []"
@@ -87,10 +84,7 @@
 
         <label class="form-control gap-1">
           <span class="text-xs font-black text-base-content/55">HSK</span>
-          <select
-            v-model="hskFilter"
-            class="select select-bordered select-sm rounded-xl"
-          >
+          <select v-model="hskFilter" class="kr-select-sm">
             <option value="all">All levels</option>
             <option value="1">HSK 1</option>
             <option value="2">HSK 2</option>
@@ -99,10 +93,7 @@
 
         <label class="form-control gap-1">
           <span class="text-xs font-black text-base-content/55">Sort</span>
-          <select
-            v-model="sortKey"
-            class="select select-bordered select-sm rounded-xl"
-          >
+          <select v-model="sortKey" class="kr-select-sm">
             <option value="hsk">HSK / frequency</option>
             <option value="hanzi">Hanzi</option>
             <option value="pinyin">Pinyin</option>
@@ -353,7 +344,7 @@
             <span class="text-xs font-black">Traditional form</span>
             <input
               v-model="draft.traditional"
-              class="input input-bordered input-sm rounded-xl"
+              class="kr-input-sm"
               placeholder="Leave blank if none"
             />
           </label>
@@ -369,10 +360,7 @@
                 >changed</span
               >
             </span>
-            <input
-              v-model="draft.pinyin"
-              class="input input-bordered input-sm rounded-xl"
-            />
+            <input v-model="draft.pinyin" class="kr-input-sm" />
             <span class="text-[11px] text-base-content/45"
               >Use tone marks, not tone numbers.</span
             >
@@ -389,10 +377,7 @@
                 >changed</span
               >
             </span>
-            <input
-              v-model="draft.meaning"
-              class="input input-bordered input-sm rounded-xl"
-            />
+            <input v-model="draft.meaning" class="kr-input-sm" />
           </label>
 
           <label class="form-control gap-1">
@@ -412,7 +397,7 @@
             <span class="text-xs font-black">Topical categories</span>
             <input
               v-model="draft.categoriesText"
-              class="input input-bordered input-sm rounded-xl"
+              class="kr-input-sm"
               placeholder="animals, food-drink, casino"
             />
             <span class="text-[11px] leading-5 text-base-content/45">

--- a/components/dreams/daily-dream-generator.vue
+++ b/components/dreams/daily-dream-generator.vue
@@ -32,7 +32,7 @@
           <span class="label py-1 text-xs font-bold">Characters</span>
           <select
             v-model.number="characterCount"
-            class="select select-bordered select-sm rounded-xl"
+            class="kr-select-sm"
           >
             <option :value="1">1</option>
             <option :value="2">2</option>
@@ -44,7 +44,7 @@
           <span class="label py-1 text-xs font-bold">Objects</span>
           <select
             v-model.number="rewardCount"
-            class="select select-bordered select-sm rounded-xl"
+            class="kr-select-sm"
           >
             <option :value="1">1</option>
             <option :value="2">2</option>

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -74,7 +74,7 @@
             <span class="text-xs font-bold text-base-content/60">Method</span>
             <select
               v-model="mode"
-              class="select select-bordered select-sm rounded-xl"
+              class="kr-select-sm"
               :disabled="submitting"
             >
               <option value="recreate">Redo from prompt</option>
@@ -86,7 +86,7 @@
             <span class="text-xs font-bold text-base-content/60">Engine</span>
             <select
               v-model="engine"
-              class="select select-bordered select-sm rounded-xl"
+              class="kr-select-sm"
               :disabled="submitting"
             >
               <template v-if="mode === 'recreate'">
@@ -104,7 +104,7 @@
             <span class="text-xs font-bold text-base-content/60">Strength</span>
             <select
               v-model="presetKey"
-              class="select select-bordered select-sm rounded-xl"
+              class="kr-select-sm"
               :disabled="submitting"
             >
               <option

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -25,7 +25,7 @@
       />
       <select
         v-model="taxonomyFilter"
-        class="select select-bordered select-sm rounded-xl"
+        class="kr-select-sm"
         aria-label="Filter by taxonomy"
       >
         <option :value="null">All taxonomies ({{ totalCount }})</option>

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -111,12 +111,12 @@
         <input
           v-model="newTitle"
           type="text"
-          class="input input-bordered input-sm rounded-xl"
+          class="kr-input-sm"
           placeholder="Canonical title, e.g. CowCore"
         />
         <select
           v-model="newTaxonomy"
-          class="select select-bordered select-sm rounded-xl"
+          class="kr-select-sm"
         >
           <option
             v-for="taxonomy in FACET_TAXONOMIES"

--- a/components/facets/facet-profile-editor.vue
+++ b/components/facets/facet-profile-editor.vue
@@ -7,7 +7,7 @@
         <input
           v-model="form.title"
           type="text"
-          class="input input-bordered input-sm rounded-xl"
+          class="kr-input-sm"
           placeholder="CowCore"
         />
       </label>
@@ -16,7 +16,7 @@
         <input
           v-model="form.canonicalValue"
           type="text"
-          class="input input-bordered input-sm rounded-xl"
+          class="kr-input-sm"
           placeholder="Defaults to title"
         />
       </label>
@@ -24,7 +24,7 @@
         <span class="label-text text-xs">Taxonomy</span>
         <select
           v-model="form.taxonomy"
-          class="select select-bordered select-sm rounded-xl"
+          class="kr-select-sm"
         >
           <option
             v-for="taxonomy in FACET_TAXONOMIES"
@@ -40,7 +40,7 @@
         <input
           v-model="form.aliases"
           type="text"
-          class="input input-bordered input-sm rounded-xl"
+          class="kr-input-sm"
           placeholder="Aliases separated by commas"
         />
       </label>
@@ -49,7 +49,7 @@
         <input
           v-model="form.groupKey"
           type="text"
-          class="input input-bordered input-sm rounded-xl"
+          class="kr-input-sm"
           placeholder="cosmic-species"
         />
       </label>
@@ -58,7 +58,7 @@
         <input
           v-model="form.groupLabel"
           type="text"
-          class="input input-bordered input-sm rounded-xl"
+          class="kr-input-sm"
           placeholder="Cosmic Species"
         />
       </label>
@@ -68,7 +68,7 @@
           v-model.number="form.sortOrder"
           type="number"
           step="1"
-          class="input input-bordered input-sm rounded-xl"
+          class="kr-input-sm"
         />
       </label>
       <label class="form-control">
@@ -78,7 +78,7 @@
           type="number"
           min="0"
           step="1"
-          class="input input-bordered input-sm rounded-xl"
+          class="kr-input-sm"
         />
       </label>
       <label class="form-control">
@@ -88,7 +88,7 @@
           type="number"
           min="0"
           step="0.1"
-          class="input input-bordered input-sm rounded-xl"
+          class="kr-input-sm"
         />
       </label>
       <label class="form-control sm:col-span-2 xl:col-span-3">
@@ -137,7 +137,7 @@
             <input
               v-model="form.imagePath"
               type="text"
-              class="input input-bordered input-sm rounded-xl"
+              class="kr-input-sm"
               placeholder="/images/facets/example.webp"
             />
           </label>
@@ -146,7 +146,7 @@
             <input
               v-model="form.iconPath"
               type="text"
-              class="input input-bordered input-sm rounded-xl"
+              class="kr-input-sm"
               placeholder="/images/facets/icons/example.webp"
             />
           </label>
@@ -155,7 +155,7 @@
             <input
               v-model="form.cardPath"
               type="text"
-              class="input input-bordered input-sm rounded-xl"
+              class="kr-input-sm"
               placeholder="/images/facets/cards/example.webp"
             />
           </label>
@@ -164,7 +164,7 @@
             <input
               v-model="form.heroPath"
               type="text"
-              class="input input-bordered input-sm rounded-xl"
+              class="kr-input-sm"
               placeholder="/images/facets/heroes/example.webp"
             />
           </label>

--- a/components/newsfeed/newsfeed-filters.vue
+++ b/components/newsfeed/newsfeed-filters.vue
@@ -194,7 +194,7 @@
       <label for="newsfeed-sort-mode" class="text-xs font-bold">Sort by</label>
       <select
         id="newsfeed-sort-mode"
-        class="select select-sm select-bordered rounded-xl"
+        class="kr-select-sm"
         :value="feedPreferenceStore.sortMode"
         @change="
           feedPreferenceStore.setSortMode(

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -273,14 +273,14 @@
               <div class="flex flex-wrap items-center gap-2">
                 <select
                   v-model="newTodoCategory"
-                  class="select select-bordered select-sm rounded-xl"
+                  class="kr-select-sm"
                 >
                   <option value="AGENT">🤖 Agent Task</option>
                   <option value="HONEYDO">🍯 Honey Do</option>
                 </select>
                 <select
                   v-model="newTodoPriority"
-                  class="select select-bordered select-sm rounded-xl"
+                  class="kr-select-sm"
                 >
                   <option value="HIGH">🔴 High</option>
                   <option value="NORMAL">🟡 Normal</option>
@@ -636,7 +636,7 @@
                 <div class="flex flex-wrap items-center gap-2">
                   <select
                     v-model="projectTaskCategory"
-                    class="select select-bordered select-sm rounded-xl"
+                    class="kr-select-sm"
                   >
                     <option value="AGENT">🤖 Agent Task / Comment</option>
                     <option value="HONEYDO">🍯 Honey Do</option>
@@ -644,7 +644,7 @@
                   </select>
                   <select
                     v-model="projectTaskPriority"
-                    class="select select-bordered select-sm rounded-xl"
+                    class="kr-select-sm"
                   >
                     <option value="HIGH">🔴 High</option>
                     <option value="NORMAL">🟡 Normal</option>

--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -28,7 +28,7 @@
             <input
               v-model="createForm.title"
               type="text"
-              class="input input-bordered input-sm rounded-xl"
+              class="kr-input-sm"
               placeholder="Project title"
               @input="onTitleInput"
             />

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -421,11 +421,7 @@
           />
         </label>
 
-        <select
-          v-model="sort"
-          class="select select-sm select-bordered rounded-xl"
-          aria-label="Sort order"
-        >
+        <select v-model="sort" class="kr-select-sm" aria-label="Sort order">
           <option value="date_desc">Newest first</option>
           <option value="date_asc">Oldest first</option>
           <option value="title_asc">Title A–Z</option>

--- a/pages/admin/achievement-art.vue
+++ b/pages/admin/achievement-art.vue
@@ -53,7 +53,7 @@
               <input
                 v-model="search"
                 type="search"
-                class="input input-bordered input-sm rounded-xl"
+                class="kr-input-sm"
                 placeholder="Search label, trigger, or message"
               />
             </label>

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -77,7 +77,7 @@
             <span class="text-xs font-bold text-base-content/60">Status</span>
             <select
               v-model="draftsStore.statusFilter"
-              class="select select-bordered select-sm rounded-xl"
+              class="kr-select-sm"
               @change="draftsStore.fetchDrafts()"
             >
               <option value="DRAFT">Pending review</option>
@@ -90,7 +90,7 @@
             <span class="text-xs font-bold text-base-content/60">Platform</span>
             <select
               v-model="draftsStore.platformFilter"
-              class="select select-bordered select-sm rounded-xl"
+              class="kr-select-sm"
               @change="draftsStore.fetchDrafts()"
             >
               <option value="">All</option>

--- a/utils/scripts/codemods/kr_input_select_codemod.py
+++ b/utils/scripts/codemods/kr_input_select_codemod.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled kr-input-sm / kr-select-sm form controls.
+
+Dry-run is the default. Pass --write to update matching Vue files in place.
+Only the approved small/rounded-xl DaisyUI input and select shapes are
+touched (`input input-bordered input-sm rounded-xl` and `select
+select-bordered select-sm rounded-xl`), and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings. A source that already
+carries the target primitive, or is missing any one of the base tokens, is
+left untouched. Extra tokens beyond the base set (w-full, bg-base-200, mt-1,
+...) are preserved verbatim after the primitive class, matching the
+kr-panel-section codemod's subset-match convention -- they're plain
+Tailwind utilities layered on top, not another component-root class, so
+resolution order is unaffected by folding the four base tokens into one name.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+FAMILIES = [
+    ("kr-input-sm", {"input", "input-bordered", "input-sm", "rounded-xl"}),
+    ("kr-select-sm", {"select", "select-bordered", "select-sm", "rounded-xl"}),
+]
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    for primitive, base_tokens in FAMILIES:
+        if primitive in tokens or not base_tokens.issubset(tokens):
+            continue
+        remaining = [token for token in tokens if token not in base_tokens]
+        if exact_only and remaining:
+            continue
+        return " ".join([primitive, *remaining])
+    return None
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        text = path.read_text(encoding="utf-8")
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            path.write_text(migrated, encoding="utf-8")
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-input-sm/kr-select-sm {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

Slice 104.

### What changed / what I produced
- Added two new shared form-control primitives to `assets/css/tailwind.css`'s `@layer components`, following the established `kr-btn-*`/`kr-panel-*` naming convention:
  - `.kr-input-sm` → `input input-bordered input-sm rounded-xl`
  - `.kr-select-sm` → `select select-bordered select-sm rounded-xl`
- Added `utils/scripts/codemods/kr_input_select_codemod.py` (dry-run by default, `--write` to apply, `--exact-only` to restrict to the safest literal-match pool).
- Ran it in `--exact-only` mode across the repo: migrated 62 occurrences across 19 files, no geometry/behavior change.

### How I verified
- Checked `utils/scripts/*.mjs` for every touched filename — no regression-guard hits.
- `npm run test` (vue-tsc --noEmit): clean.
- `npx eslint` on all 19 touched files: 0 new issues. 2 pre-existing errors surfaced in `entity-art-manager.vue` and `daily-dream-object-art-workbench.vue` (unrelated `vue/no-mutating-props`/`no-empty` findings) — confirmed via `git stash` to predate this change.
- `npx tsx utils/scripts/verifyLayoutContract.ts`: holds, 207-violation baseline unchanged.
- `npx prettier --check`: flagged 15 files; 12 were pre-existing drift (confirmed via `git stash`), 3 (`cthulhuquarium-curation.vue`, `mandarin-curation.vue`, `watchlist-browse.vue`) were newly triggered because the shortened class attribute let a tag collapse onto fewer lines — same pattern as slice 103's `bot-chat.vue` case. Ran `prettier --write` on those 3 only; re-checked clean afterward.
- Confirmed all touched files are pure LF (no CRLF risk).

### Stakes
reversible

### Flags for Reviewer
- Re-running the codemod without `--exact-only` reports ~50 more occurrences across 20+ additional files that carry extra utility tokens (`w-full`, `bg-base-200`, `mt-1`, ...) alongside the same four base tokens. Left for the next bounded slice per this task's established one-family-at-a-time convention — the tool already supports this without `--exact-only`.

### Kaizen suggestion
The next `t-104` slice should re-run `kr_input_select_codemod.py --root .` (without `--exact-only`) to pick up the remaining ~50 occurrences with extra utility tokens, then look for a fresh family (the layout-utility combos like `select select-bordered select-sm w-auto max-w-44 bg-base-100` are the next most-repeated pool once this family clears).

### Notes for reviewer
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yXwVyRwS4xwW9eGeuTtTg

---
_Generated by [Claude Code](https://claude.ai/code/session_016yXwVyRwS4xwW9eGeuTtTg)_