### PR TITLE
style: migrate 50 hand-rolled input/select shapes to kr-input-sm/kr-select-sm

### DIFF
--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -48,7 +48,7 @@
       <input
         v-model="search"
         type="search"
-        class="input input-bordered input-sm w-full rounded-xl bg-base-200"
+        class="kr-input-sm w-full bg-base-200"
         placeholder="Search or browse styles, themes, moods, materials, traits…"
         @focus="open = true"
         @keydown.esc="open = false"

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -233,7 +233,7 @@
                 <input
                   v-model="editForm.designer"
                   type="text"
-                  class="input input-bordered input-sm rounded-xl bg-base-100"
+                  class="kr-input-sm bg-base-100"
                   placeholder="Kind Designer"
                 />
               </label>
@@ -247,7 +247,7 @@
                 <input
                   v-model="editForm.sampler"
                   type="text"
-                  class="input input-bordered input-sm rounded-xl bg-base-100"
+                  class="kr-input-sm bg-base-100"
                 />
               </label>
 
@@ -260,7 +260,7 @@
                 <input
                   v-model="editForm.checkpoint"
                   type="text"
-                  class="input input-bordered input-sm rounded-xl bg-base-100"
+                  class="kr-input-sm bg-base-100"
                 />
               </label>
 
@@ -272,7 +272,7 @@
                   v-model.number="editForm.steps"
                   type="number"
                   min="1"
-                  class="input input-bordered input-sm rounded-xl bg-base-100"
+                  class="kr-input-sm bg-base-100"
                 />
               </label>
 
@@ -283,7 +283,7 @@
                 <input
                   v-model.number="editForm.seed"
                   type="number"
-                  class="input input-bordered input-sm rounded-xl bg-base-100"
+                  class="kr-input-sm bg-base-100"
                 />
               </label>
 
@@ -295,7 +295,7 @@
                   v-model.number="editForm.cfg"
                   type="number"
                   step="0.5"
-                  class="input input-bordered input-sm rounded-xl bg-base-100"
+                  class="kr-input-sm bg-base-100"
                 />
               </label>
 
@@ -420,7 +420,7 @@
                 <input
                   v-model="collectionSearch"
                   type="search"
-                  class="input input-bordered input-sm mb-2 w-full rounded-xl bg-base-200"
+                  class="kr-input-sm mb-2 w-full bg-base-200"
                   placeholder="Search collections..."
                 />
 

--- a/components/art/art-lora-picker.vue
+++ b/components/art/art-lora-picker.vue
@@ -156,7 +156,7 @@
         <input
           v-model="search"
           type="search"
-          class="input input-bordered input-sm w-full rounded-xl bg-base-200"
+          class="kr-input-sm w-full bg-base-200"
           placeholder="Search compatible LoRAs by name, path, or trigger word…"
         />
 

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -351,7 +351,7 @@
             >
             <select
               v-model="sourceModelType"
-              class="select select-bordered select-sm rounded-xl bg-base-100"
+              class="kr-select-sm bg-base-100"
               data-testid="brainstorm-source-type"
             >
               <option v-for="adapter in sourceAdapters" :key="adapter.modelType" :value="adapter.modelType">
@@ -368,7 +368,7 @@
             <input
               v-model="sourceQuery"
               type="search"
-              class="input input-bordered input-sm rounded-xl bg-base-100"
+              class="kr-input-sm bg-base-100"
               placeholder="Search by name…"
               data-testid="brainstorm-source-query"
               @keydown.enter.prevent="runSourceSearch"

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -42,7 +42,7 @@
       <input
         v-model="search"
         type="search"
-        class="input input-bordered input-sm w-full rounded-xl bg-base-200"
+        class="kr-input-sm w-full bg-base-200"
         placeholder="Search species, archetypes, quirks, themes..."
         @focus="showResults = true"
       />

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -193,7 +193,7 @@
               </label>
               <input
                 type="url"
-                class="input input-bordered input-sm w-full rounded-xl text-sm"
+                class="kr-input-sm w-full text-sm"
                 placeholder="https://…"
                 :value="linkedProject.liveUrl ?? ''"
                 :disabled="projectSaving"
@@ -206,7 +206,7 @@
               </label>
               <input
                 type="url"
-                class="input input-bordered input-sm w-full rounded-xl text-sm"
+                class="kr-input-sm w-full text-sm"
                 placeholder="https://github.com/…"
                 :value="linkedProject.repoUrl ?? ''"
                 :disabled="projectSaving"
@@ -219,7 +219,7 @@
                   <span class="label-text text-xs font-semibold">Status</span>
                 </label>
                 <select
-                  class="select select-bordered select-sm w-full rounded-xl text-sm"
+                  class="kr-select-sm w-full text-sm"
                   :value="linkedProject.status"
                   :disabled="projectSaving"
                   @change="onStatusSelect"
@@ -240,7 +240,7 @@
                   <span class="label-text text-xs font-semibold">Priority</span>
                 </label>
                 <select
-                  class="select select-bordered select-sm w-full rounded-xl text-sm"
+                  class="kr-select-sm w-full text-sm"
                   :value="linkedProject.priority"
                   :disabled="projectSaving"
                   @change="onPrioritySelect"
@@ -276,7 +276,7 @@
           <div class="flex flex-wrap items-center gap-2">
             <select
               v-model="projectTaskCategory"
-              class="select select-bordered select-sm min-w-40 flex-1 rounded-xl"
+              class="kr-select-sm min-w-40 flex-1"
               :disabled="projectTaskSubmitting"
             >
               <option value="AGENT">🤖 Agent / comment</option>
@@ -284,7 +284,7 @@
             </select>
             <select
               v-model="projectTaskPriority"
-              class="select select-bordered select-sm min-w-32 flex-1 rounded-xl"
+              class="kr-select-sm min-w-32 flex-1"
               :disabled="projectTaskSubmitting"
             >
               <option value="HIGH">🔴 High</option>

--- a/components/conductor/voice-lab-page.vue
+++ b/components/conductor/voice-lab-page.vue
@@ -35,7 +35,7 @@
             v-model="tryText"
             type="text"
             placeholder="Serendipity: turn butterflies on"
-            class="input input-bordered input-sm min-w-0 flex-1 rounded-xl"
+            class="kr-input-sm min-w-0 flex-1"
             :disabled="voice.sending"
           />
           <button

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -173,7 +173,7 @@
             <input
               v-model="draft.inspirationUrl"
               type="url"
-              class="input input-bordered input-sm min-w-56 flex-1 rounded-xl"
+              class="kr-input-sm min-w-56 flex-1"
               placeholder="Add inspiration image URL"
             />
             <button

--- a/components/dreams/daily-digest-browser.vue
+++ b/components/dreams/daily-digest-browser.vue
@@ -194,7 +194,7 @@
         <select
           v-if="digestDreams.length"
           v-model.number="selectedDreamId"
-          class="select select-bordered select-sm min-w-0 flex-1 rounded-xl"
+          class="kr-select-sm min-w-0 flex-1"
           aria-label="Choose a daily digest"
         >
           <option v-for="dream in digestDreams" :key="dream.id" :value="dream.id">

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -292,7 +292,7 @@
 
                 <input
                   v-model="candidate.title"
-                  class="input input-bordered input-sm mb-2 w-full rounded-xl bg-base-100 font-bold"
+                  class="kr-input-sm mb-2 w-full bg-base-100 font-bold"
                   placeholder="Idea title"
                   @input="editCandidate(candidate.id)"
                 />

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -50,7 +50,7 @@
 
       <select
         v-model="mode"
-        class="select select-bordered select-sm shrink-0 rounded-xl"
+        class="kr-select-sm shrink-0"
         aria-label="Facet gallery layout"
       >
         <option

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -46,7 +46,7 @@
       <input
         v-model="search"
         type="search"
-        class="input input-bordered input-sm w-full rounded-xl bg-base-200"
+        class="kr-input-sm w-full bg-base-200"
         placeholder="Search title, taxonomy, slug, or alias — try species, cow, cows..."
         @focus="showResults = true"
       />
@@ -129,7 +129,7 @@
         <input
           v-model="newAliases"
           type="text"
-          class="input input-bordered input-sm rounded-xl sm:col-span-2"
+          class="kr-input-sm sm:col-span-2"
           placeholder="Aliases separated by commas, e.g. cow, cows"
         />
         <button

--- a/components/gallery/kr-search-field.vue
+++ b/components/gallery/kr-search-field.vue
@@ -83,7 +83,7 @@
     -->
     <div
       v-else
-      class="input input-bordered input-sm flex w-full min-w-0 items-center gap-2 rounded-xl bg-base-200"
+      class="kr-input-sm flex w-full min-w-0 items-center gap-2 bg-base-200"
     >
       <Icon name="kind-icon:search" class="h-4 w-4 shrink-0 opacity-50" />
 

--- a/components/narrative/narrative-ingredient-multi-picker.vue
+++ b/components/narrative/narrative-ingredient-multi-picker.vue
@@ -44,7 +44,7 @@
 
     <label
       v-if="searchVisible"
-      class="input input-bordered input-sm flex w-full items-center gap-2 rounded-xl bg-base-100"
+      class="kr-input-sm flex w-full items-center gap-2 bg-base-100"
     >
       <Icon
         name="kind-icon:search"

--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -39,7 +39,7 @@
 
     <label
       v-if="searchVisible"
-      class="input input-bordered input-sm flex w-full items-center gap-2 rounded-xl bg-base-100"
+      class="kr-input-sm flex w-full items-center gap-2 bg-base-100"
     >
       <Icon
         name="kind-icon:search"

--- a/components/newsfeed/newsfeed-filters.vue
+++ b/components/newsfeed/newsfeed-filters.vue
@@ -36,7 +36,7 @@
             v-model="includeDraft"
             type="text"
             placeholder="e.g. robotics"
-            class="input input-sm input-bordered w-full rounded-xl"
+            class="kr-input-sm w-full"
             @keydown.enter.prevent="submitInclude()"
           />
           <button
@@ -76,7 +76,7 @@
             v-model="excludeDraft"
             type="text"
             placeholder="e.g. crypto"
-            class="input input-sm input-bordered w-full rounded-xl"
+            class="kr-input-sm w-full"
             @keydown.enter.prevent="submitExclude()"
           />
           <button

--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -42,7 +42,7 @@
               ref="slugInputRef"
               v-model="createForm.slug"
               type="text"
-              class="input input-bordered input-sm rounded-xl font-mono"
+              class="kr-input-sm font-mono"
               :class="{ 'input-error': slugError }"
               placeholder="project-slug"
               @input="onSlugInput"

--- a/components/pages/memory-dungeon.vue
+++ b/components/pages/memory-dungeon.vue
@@ -89,7 +89,7 @@
               <span>Difficulty</span>
               <select
                 v-model="pendingDifficulty"
-                class="select select-bordered select-sm rounded-xl bg-base-200"
+                class="kr-select-sm bg-base-200"
               >
                 <option
                   v-for="difficulty in memoryStore.difficulties"

--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -154,7 +154,7 @@
                 step="0.01"
                 required
                 placeholder="25.00"
-                class="input input-bordered input-sm rounded-xl bg-base-200"
+                class="kr-input-sm bg-base-200"
               />
             </label>
             <label class="form-control sm:col-span-2">
@@ -164,7 +164,7 @@
                 type="text"
                 required
                 placeholder="Against Malaria Foundation direct donation, receipt #..."
-                class="input input-bordered input-sm rounded-xl bg-base-200"
+                class="kr-input-sm bg-base-200"
               />
             </label>
             <label class="form-control sm:col-span-1">
@@ -173,7 +173,7 @@
                 v-model="form.reference"
                 type="text"
                 placeholder="RCPT-123"
-                class="input input-bordered input-sm rounded-xl bg-base-200"
+                class="kr-input-sm bg-base-200"
               />
             </label>
             <div class="sm:col-span-4 flex items-center gap-3">

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -42,7 +42,7 @@
       <input
         v-model="search"
         type="search"
-        class="input input-bordered input-sm w-full rounded-xl bg-base-200"
+        class="kr-input-sm w-full bg-base-200"
         placeholder="Search materials, colors, themes, styles..."
         @focus="showResults = true"
       />

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -255,7 +255,7 @@
           <input
             v-model="speciesSearch"
             type="text"
-            class="input input-bordered input-sm rounded-xl bg-base-100 focus:border-primary"
+            class="kr-input-sm bg-base-100 focus:border-primary"
             placeholder="Filter species..."
           />
 
@@ -321,7 +321,7 @@
             <input
               v-model="form.species"
               type="text"
-              class="input input-bordered input-sm flex-1 rounded-xl bg-base-100 focus:border-primary"
+              class="kr-input-sm flex-1 bg-base-100 focus:border-primary"
               placeholder="Enter species name..."
               maxlength="100"
               autofocus
@@ -373,7 +373,7 @@
           <input
             v-model="traitSearch"
             type="text"
-            class="input input-bordered input-sm rounded-xl bg-base-100 focus:border-primary"
+            class="kr-input-sm bg-base-100 focus:border-primary"
             placeholder="Filter traits..."
           />
 
@@ -442,7 +442,7 @@
             <input
               v-model="customTraitInput"
               type="text"
-              class="input input-bordered input-sm flex-1 rounded-xl bg-base-100 focus:border-primary"
+              class="kr-input-sm flex-1 bg-base-100 focus:border-primary"
               placeholder="Describe a personality trait..."
               maxlength="100"
               @keydown.enter="addCustomTrait"

--- a/components/user/account-settings.vue
+++ b/components/user/account-settings.vue
@@ -222,7 +222,7 @@
               </span>
             </span>
             <select
-              class="select select-bordered select-sm rounded-xl bg-base-200"
+              class="kr-select-sm bg-base-200"
               :value="consent.messagePolicy"
               :disabled="account.isSaving"
               @change="onMessagePolicy($event)"

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -154,7 +154,7 @@
         v-model="newLabel"
         type="text"
         placeholder="Label, e.g. Rainbow research agent"
-        class="input input-bordered input-sm w-full rounded-xl bg-base-200"
+        class="kr-input-sm w-full bg-base-200"
         required
       />
 
@@ -162,7 +162,7 @@
         <span class="label-text mb-1 text-xs font-bold">Bot identity</span>
         <select
           v-model.number="newBotId"
-          class="select select-bordered select-sm w-full rounded-xl bg-base-200"
+          class="kr-select-sm w-full bg-base-200"
           required
         >
           <option :value="0" disabled>Choose one of your Bots</option>
@@ -203,7 +203,7 @@
         <span class="label-text mb-1 text-xs font-bold">Expiry</span>
         <select
           v-model="expiryChoice"
-          class="select select-bordered select-sm w-full rounded-xl bg-base-200"
+          class="kr-select-sm w-full bg-base-200"
         >
           <option value="30">30 days</option>
           <option value="90">90 days</option>

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -23,12 +23,9 @@
           v-model="store.search"
           type="search"
           placeholder="Search name, email, id…"
-          class="input input-bordered input-sm w-48 rounded-xl bg-base-200"
+          class="kr-input-sm w-48 bg-base-200"
         />
-        <select
-          v-model="store.roleFilter"
-          class="select select-bordered select-sm rounded-xl bg-base-200"
-        >
+        <select v-model="store.roleFilter" class="kr-select-sm bg-base-200">
           <option value="ALL">All roles</option>
           <option v-for="r in ROLES" :key="r" :value="r">{{ r }}</option>
         </select>

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -306,7 +306,7 @@
           v-model="search"
           type="search"
           placeholder="Search title or author…"
-          class="input input-sm input-bordered w-full rounded-xl sm:w-56"
+          class="kr-input-sm w-full sm:w-56"
         />
 
         <button
@@ -417,7 +417,7 @@
             max="99"
             placeholder="Any"
             aria-label="Season number (TV only)"
-            class="input input-sm input-bordered w-16 rounded-xl"
+            class="kr-input-sm w-16"
           />
         </label>
 

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -104,14 +104,14 @@
             <input
               v-model="query"
               type="search"
-              class="input input-bordered input-sm min-w-52 flex-1 rounded-xl"
+              class="kr-input-sm min-w-52 flex-1"
               placeholder="Search name, trigger, or base model"
               aria-label="Search LoRAs"
             />
 
             <select
               v-model="generation"
-              class="select select-bordered select-sm w-auto max-w-56 rounded-xl"
+              class="kr-select-sm w-auto max-w-56"
               aria-label="Filter by base model"
             >
               <option value="ALL">All base models</option>


### PR DESCRIPTION
## Summary
- Ran `utils/scripts/codemods/kr_input_select_codemod.py --root . --write` (no `--exact-only`) to pick up the remaining hand-rolled input/select shapes carrying extra utility tokens (`w-full`, `bg-base-200`, `mt-1`, ...) alongside the four approved base tokens.
- Migrated 50 occurrences across 26 files to `kr-input-sm`/`kr-select-sm`. No geometry/behavior change — extra utilities are preserved verbatim after the primitive class.

Part of interface-vision/t-104's recurring kr-* consistency umbrella (slice 105).

## Validation
- `vue-tsc --noEmit` clean
- `eslint`: 0 new issues (2 pre-existing errors in `memory-dungeon.vue`, 2 pre-existing warnings in `performer-creator.vue`, confirmed via `git stash` to predate this change)
- `test:layout-contract` held (207 baseline unchanged)
- `prettier --check`: 16 files flagged, 15 pre-existing (confirmed via `git stash`), 1 newly triggered (`user-manager-directory.vue`, shortened class attribute collapsing onto fewer lines) — fixed with a targeted `prettier --write`, re-checked clean
- Regression guards for every touched file pass: `verifyBrainstormObjectEntryLinks`, `verifyBrainstormWorkbench`, `verifySerendipityRouteCutover`, `verifyNarrativeAccessibility`, `verifyStorybookPickerRestoredSelectionGuard`, `verifyStorybookPickerSearchResetGuard`, `verifyStorybookStudio`, `verifyNarrativePrimitives`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Zx2RSR7RCJLaKEZL1BPdb

---
_Generated by [Claude Code](https://claude.ai/code/session_011Zx2RSR7RCJLaKEZL1BPdb)_