### PR TITLE
style: migrate hand-rolled checkbox shapes to kr-checkbox-primary-sm

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -928,6 +928,16 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply select select-bordered select-sm rounded-xl;
   }
 
+  /* The most-repeated hand-rolled checkbox shape (interface-vision t-104
+   * slice 106): a small, primary-colored DaisyUI checkbox used across
+   * character/bot/model-builder creation forms -- `checkbox checkbox-sm
+   * checkbox-primary`, previously hand-rolled in 6 files (8 occurrences,
+   * including one class-order variant: `checkbox checkbox-primary
+   * checkbox-sm`). */
+  .kr-checkbox-primary-sm {
+    @apply checkbox checkbox-sm checkbox-primary;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -156,7 +156,7 @@
       <span class="text-xs font-black text-base-content">What are we changing?</span>
 
       <label class="flex items-start gap-2">
-        <input v-model="changeColor" type="checkbox" class="checkbox checkbox-sm checkbox-primary mt-1" />
+        <input v-model="changeColor" type="checkbox" class="kr-checkbox-primary-sm mt-1" />
         <div class="flex flex-1 flex-col gap-1">
           <span class="text-sm font-bold">Change color</span>
           <input
@@ -170,7 +170,7 @@
       </label>
 
       <label class="flex items-start gap-2">
-        <input v-model="changeStyle" type="checkbox" class="checkbox checkbox-sm checkbox-primary mt-1" />
+        <input v-model="changeStyle" type="checkbox" class="kr-checkbox-primary-sm mt-1" />
         <div class="flex flex-1 flex-col gap-1">
           <span class="text-sm font-bold">Change style</span>
           <input
@@ -184,7 +184,7 @@
       </label>
 
       <label class="flex items-start gap-2">
-        <input v-model="enhanceImage" type="checkbox" class="checkbox checkbox-sm checkbox-primary mt-1" />
+        <input v-model="enhanceImage" type="checkbox" class="kr-checkbox-primary-sm mt-1" />
         <div class="flex flex-1 flex-col gap-1">
           <span class="text-sm font-bold">Improve the overall image</span>
           <span class="text-xs text-base-content/50">Cleaner lighting, sharper detail — face and identity kept.</span>

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -278,7 +278,7 @@
                 <input
                   v-model="keepField[field.key]"
                   type="checkbox"
-                  class="checkbox checkbox-sm checkbox-primary"
+                  class="kr-checkbox-primary-sm"
                   @change="handleKeepFieldChange(field.key)"
                 />
               </label>

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -386,7 +386,7 @@
                 <input
                   v-model="characterStore.keepField[field.key]"
                   type="checkbox"
-                  class="checkbox checkbox-sm checkbox-primary"
+                  class="kr-checkbox-primary-sm"
                   @change="handleKeepFieldChange(field.key)"
                 />
               </label>

--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -82,7 +82,7 @@
       >
         <input
           type="checkbox"
-          class="checkbox checkbox-sm checkbox-primary"
+          class="kr-checkbox-primary-sm"
           :checked="store.selections[output.key]?.on"
           :disabled="store.startingRun"
           @change="store.toggleOutput(output.key)"

--- a/components/navigation/tutorial-flyer.vue
+++ b/components/navigation/tutorial-flyer.vue
@@ -254,7 +254,7 @@
             <input
               v-model="showNextTime"
               type="checkbox"
-              class="checkbox checkbox-sm checkbox-primary"
+              class="kr-checkbox-primary-sm"
             />
             <span class="font-medium text-base-content/70">
               Show this next time

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -211,7 +211,7 @@
               >
                 <input
                   type="checkbox"
-                  class="checkbox checkbox-primary checkbox-sm"
+                  class="kr-checkbox-primary-sm"
                   :checked="triageStore.isSelected(resource.id)"
                   :aria-label="`Select ${resourceLabel(resource)}`"
                   @change="handleSelection(resource.id, $event)"

--- a/utils/scripts/codemods/kr_checkbox_codemod.py
+++ b/utils/scripts/codemods/kr_checkbox_codemod.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
-"""Find or migrate hand-rolled kr-input-sm / kr-select-sm form controls.
+"""Find or migrate hand-rolled kr-checkbox-primary-sm form controls.
 
 Dry-run is the default. Pass --write to update matching Vue files in place.
-Only the approved small/rounded-xl DaisyUI input and select shapes are
-touched (`input input-bordered input-sm rounded-xl` and `select
-select-bordered select-sm rounded-xl`), and only in static `class="..."`
-attributes -- never `:class`/`v-bind:class` bindings. A source that already
-carries the target primitive, or is missing any one of the base tokens, is
-left untouched. Extra tokens beyond the base set (w-full, bg-base-200, mt-1,
-...) are preserved verbatim after the primitive class, matching the
-kr-panel-section codemod's subset-match convention -- they're plain
-Tailwind utilities layered on top, not another component-root class, so
-resolution order is unaffected by folding the four base tokens into one name.
+Only the approved small/primary-colored DaisyUI checkbox shape is touched
+(`checkbox checkbox-sm checkbox-primary`), and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings, and regardless of the
+base tokens' order in the source (`checkbox-primary checkbox-sm` counts the
+same as `checkbox-sm checkbox-primary`). A source that already carries the
+target primitive, or is missing any one of the base tokens, is left
+untouched. Extra tokens beyond the base set (mt-1, ...) are preserved
+verbatim after the primitive class, matching the kr-input-sm/kr-select-sm
+codemod's subset-match convention -- they're plain Tailwind utilities layered
+on top, not another component-root class, so resolution order is unaffected
+by folding the three base tokens into one name.
 """
 
 from __future__ import annotations
@@ -23,8 +24,7 @@ from pathlib import Path
 CLASS_ATTR = re.compile(r'class="([^"]*)"')
 
 FAMILIES = [
-    ("kr-input-sm", {"input", "input-bordered", "input-sm", "rounded-xl"}),
-    ("kr-select-sm", {"select", "select-bordered", "select-sm", "rounded-xl"}),
+    ("kr-checkbox-primary-sm", {"checkbox", "checkbox-sm", "checkbox-primary"}),
 ]
 
 
@@ -76,8 +76,7 @@ def main() -> int:
         # universal-newline translation) -- a handful of source files carry
         # CRLF, and translating those to LF on write would turn a one-line
         # class-attribute change into a whole-file rewrite (kind_robots
-        # add-bot.vue, caught while extending this codemod's sibling for
-        # interface-vision t-104 slice 106).
+        # add-bot.vue, interface-vision t-104 slice 106).
         text = path.read_text(encoding="utf-8", newline="")
         migrated, count = migrate_text(text, args.exact_only)
         if not count:
@@ -88,7 +87,7 @@ def main() -> int:
             path.write_text(migrated, encoding="utf-8", newline="")
 
     mode = "migrated" if args.write else "candidate"
-    print(f"kr-input-sm/kr-select-sm {mode} occurrences: {total}")
+    print(f"kr-checkbox-primary-sm {mode} occurrences: {total}")
     return 0
 
 


### PR DESCRIPTION
## Summary
- New `utils/scripts/codemods/kr_checkbox_codemod.py` (dry-run by default, `--write` to apply, `--exact-only` to restrict to the safest literal-match pool) migrates the most-repeated hand-rolled checkbox shape — `checkbox checkbox-sm checkbox-primary` (regardless of source token order) — to a new `.kr-checkbox-primary-sm` primitive, following the established kr-btn-*/kr-input-sm/kr-select-sm naming convention.
- Ran it in default (subset-match) mode: migrated 8 occurrences across 6 files. No geometry/behavior change.
- Also fixes a latent newline bug in both this codemod and its `kr_input_select_codemod.py` sibling: reading/writing with the default universal-newline translation silently converts a touched file's CRLF line endings to LF, turning a one-line class-attribute change into a whole-file rewrite (caught on `components/bots/add-bot.vue`, the one CRLF file in this slice — fixed by passing `newline=""` on both read and write so original line endings are preserved verbatim).

Part of interface-vision/t-104's recurring kr-* consistency umbrella (slice 106).

## Validation
- `vue-tsc --noEmit` clean
- `eslint`: 0 new issues (1 pre-existing error in `add-bot.vue`, confirmed via `git stash` to predate this change)
- `test:layout-contract` held (207 baseline unchanged)
- `prettier --check`: 5 files flagged, all pre-existing (confirmed via `git stash`)
- No touched-file regression-guard scripts (`utils/scripts/*.mjs`) apply to any of the 6 migrated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Zx2RSR7RCJLaKEZL1BPdb

---
_Generated by [Claude Code](https://claude.ai/code/session_011Zx2RSR7RCJLaKEZL1BPdb)_