### PR TITLE
style: migrate hand-rolled checkbox shapes to kr-checkbox-secondary-sm

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -938,6 +938,14 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply checkbox checkbox-sm checkbox-primary;
   }
 
+  /* The secondary-colored counterpart to .kr-checkbox-primary-sm (interface-
+   * vision t-104 slice 107): the same small checkbox shape on DaisyUI's
+   * secondary color -- `checkbox checkbox-sm checkbox-secondary`, previously
+   * hand-rolled in 4 files (5 occurrences). */
+  .kr-checkbox-secondary-sm {
+    @apply checkbox checkbox-sm checkbox-secondary;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -265,7 +265,7 @@
                 <input
                   v-model="useGenerated[field.key]"
                   type="checkbox"
-                  class="checkbox checkbox-sm checkbox-secondary"
+                  class="kr-checkbox-secondary-sm"
                   :disabled="isKept(field.key)"
                 />
               </label>

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -210,7 +210,7 @@
             <label class="flex cursor-pointer items-start gap-3">
               <input
                 type="checkbox"
-                class="checkbox checkbox-secondary checkbox-sm mt-0.5"
+                class="kr-checkbox-secondary-sm mt-0.5"
                 :checked="returnTypeSelected(option.id)"
                 :disabled="isGenerating"
                 :data-testid="`brainstorm-return-type-${option.id}`"
@@ -605,7 +605,7 @@
         >
           <input
             type="checkbox"
-            class="checkbox checkbox-sm checkbox-secondary mt-0.5"
+            class="kr-checkbox-secondary-sm mt-0.5"
             :checked="!excludedKeptIds.has(candidate.id)"
             :data-testid="`brainstorm-kept-select-${candidate.id}`"
             @change="toggleKeptSelection(candidate.id)"

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -374,7 +374,7 @@
                 <input
                   v-model="characterStore.useGenerated[field.key]"
                   type="checkbox"
-                  class="checkbox checkbox-sm checkbox-secondary"
+                  class="kr-checkbox-secondary-sm"
                   :disabled="isKept(field.key)"
                 />
               </label>

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -136,7 +136,7 @@
           <input
             v-model="preserveOriginal"
             type="checkbox"
-            class="checkbox checkbox-secondary checkbox-sm mt-0.5"
+            class="kr-checkbox-secondary-sm mt-0.5"
             :disabled="submitting"
           />
           <span>

--- a/utils/scripts/codemods/kr_checkbox_codemod.py
+++ b/utils/scripts/codemods/kr_checkbox_codemod.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
-"""Find or migrate hand-rolled kr-checkbox-primary-sm form controls.
+"""Find or migrate hand-rolled kr-checkbox-{primary,secondary}-sm form controls.
 
 Dry-run is the default. Pass --write to update matching Vue files in place.
-Only the approved small/primary-colored DaisyUI checkbox shape is touched
-(`checkbox checkbox-sm checkbox-primary`), and only in static `class="..."`
-attributes -- never `:class`/`v-bind:class` bindings, and regardless of the
-base tokens' order in the source (`checkbox-primary checkbox-sm` counts the
-same as `checkbox-sm checkbox-primary`). A source that already carries the
-target primitive, or is missing any one of the base tokens, is left
-untouched. Extra tokens beyond the base set (mt-1, ...) are preserved
-verbatim after the primitive class, matching the kr-input-sm/kr-select-sm
-codemod's subset-match convention -- they're plain Tailwind utilities layered
-on top, not another component-root class, so resolution order is unaffected
-by folding the three base tokens into one name.
+Only the approved small/colored DaisyUI checkbox shapes are touched
+(`checkbox checkbox-sm checkbox-primary` and `checkbox checkbox-sm
+checkbox-secondary`), and only in static `class="..."` attributes -- never
+`:class`/`v-bind:class` bindings, and regardless of the base tokens' order in
+the source (`checkbox-primary checkbox-sm` counts the same as `checkbox-sm
+checkbox-primary`). A source that already carries the target primitive, or is
+missing any one of the base tokens, is left untouched. Extra tokens beyond
+the base set (mt-1, mt-0.5, ...) are preserved verbatim after the primitive
+class, matching the kr-input-sm/kr-select-sm codemod's subset-match
+convention -- they're plain Tailwind utilities layered on top, not another
+component-root class, so resolution order is unaffected by folding the three
+base tokens into one name.
 """
 
 from __future__ import annotations
@@ -25,6 +26,7 @@ CLASS_ATTR = re.compile(r'class="([^"]*)"')
 
 FAMILIES = [
     ("kr-checkbox-primary-sm", {"checkbox", "checkbox-sm", "checkbox-primary"}),
+    ("kr-checkbox-secondary-sm", {"checkbox", "checkbox-sm", "checkbox-secondary"}),
 ]
 
 
@@ -77,17 +79,19 @@ def main() -> int:
         # CRLF, and translating those to LF on write would turn a one-line
         # class-attribute change into a whole-file rewrite (kind_robots
         # add-bot.vue, interface-vision t-104 slice 106).
-        text = path.read_text(encoding="utf-8", newline="")
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
         migrated, count = migrate_text(text, args.exact_only)
         if not count:
             continue
         total += count
         print(f"{path.relative_to(args.root)}: {count}")
         if args.write:
-            path.write_text(migrated, encoding="utf-8", newline="")
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
 
     mode = "migrated" if args.write else "candidate"
-    print(f"kr-checkbox-primary-sm {mode} occurrences: {total}")
+    print(f"kr-checkbox-*-sm {mode} occurrences: {total}")
     return 0
 
 

--- a/utils/scripts/codemods/kr_input_select_codemod.py
+++ b/utils/scripts/codemods/kr_input_select_codemod.py
@@ -78,14 +78,16 @@ def main() -> int:
         # class-attribute change into a whole-file rewrite (kind_robots
         # add-bot.vue, caught while extending this codemod's sibling for
         # interface-vision t-104 slice 106).
-        text = path.read_text(encoding="utf-8", newline="")
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
         migrated, count = migrate_text(text, args.exact_only)
         if not count:
             continue
         total += count
         print(f"{path.relative_to(args.root)}: {count}")
         if args.write:
-            path.write_text(migrated, encoding="utf-8", newline="")
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
 
     mode = "migrated" if args.write else "candidate"
     print(f"kr-input-sm/kr-select-sm {mode} occurrences: {total}")


### PR DESCRIPTION
## Summary
- Extends `kr_checkbox_codemod.py` with a second family — the secondary-colored counterpart to `kr-checkbox-primary-sm` (slice 106): `checkbox checkbox-sm checkbox-secondary` (any token order), previously hand-rolled in 4 files (5 occurrences). Migrated in default (subset-match) mode, no geometry/behavior change.
- Also fixes a real bug in slice 106's own newline fix: `Path.read_text()`/`write_text()`'s `newline=` keyword argument was added in Python 3.13 (this repo's local tooling runs 3.11), so the previous fix would raise `TypeError` the moment either codemod script actually ran — caught only now because slice 106 added the keyword but never re-ran the script afterward. Both scripts now open the path directly (`path.open(encoding=..., newline=...)`) instead, which supports the `newline` argument on any Python 3 version.

Part of interface-vision/t-104's recurring kr-* consistency umbrella (slice 107).

## Validation
- `vue-tsc --noEmit` clean
- `eslint`: 0 new issues (1 pre-existing error in `add-bot.vue`, 1 pre-existing error in `daily-dream-object-art-workbench.vue`, both confirmed via `git stash` to predate this change)
- `test:layout-contract` held (207 baseline unchanged)
- `prettier --check`: 5 files flagged, all pre-existing (confirmed via `git stash`)
- Regression guards for touched files pass: `verifyBrainstormObjectEntryLinks`, `verifyBrainstormWorkbench`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Zx2RSR7RCJLaKEZL1BPdb

---
_Generated by [Claude Code](https://claude.ai/code/session_011Zx2RSR7RCJLaKEZL1BPdb)_