### PR TITLE
style: migrate hand-rolled checkbox-xs shapes to kr-checkbox-primary-xs

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -946,6 +946,14 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply checkbox checkbox-sm checkbox-secondary;
   }
 
+  /* The extra-small, primary-colored counterpart to .kr-checkbox-primary-sm
+   * (interface-vision t-104 slice 108): the same primary-colored DaisyUI
+   * checkbox at the smaller `checkbox-xs` size -- `checkbox checkbox-xs
+   * checkbox-primary`, previously hand-rolled in 2 files (3 occurrences). */
+  .kr-checkbox-primary-xs {
+    @apply checkbox checkbox-xs checkbox-primary;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -129,7 +129,7 @@
       </div>
 
       <label v-if="sourceImageData" class="flex items-center gap-2">
-        <input v-model="maskEnabled" type="checkbox" class="checkbox checkbox-xs checkbox-primary" />
+        <input v-model="maskEnabled" type="checkbox" class="kr-checkbox-primary-xs" />
         <span class="text-xs text-base-content/70">
           Only restyle the hair (paint a mask instead of changing the whole photo)
         </span>
@@ -226,7 +226,7 @@
         <span>Keep it them</span>
       </div>
       <label class="flex items-start gap-2 pt-1">
-        <input v-model="protectIdentity" type="checkbox" class="checkbox checkbox-xs checkbox-primary mt-0.5" />
+        <input v-model="protectIdentity" type="checkbox" class="kr-checkbox-primary-xs mt-0.5" />
         <span class="text-xs text-base-content/70">
           Extra-protect the face &amp; identity (a little slower — guards against turning
           them into someone else)

--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -145,7 +145,7 @@
         >
           <input
             type="checkbox"
-            class="checkbox checkbox-xs checkbox-primary"
+            class="kr-checkbox-primary-xs"
             :checked="store.includeArt"
             :disabled="store.startingRun"
             @change="onIncludeArt($event)"

--- a/utils/scripts/codemods/kr_checkbox_codemod.py
+++ b/utils/scripts/codemods/kr_checkbox_codemod.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Find or migrate hand-rolled kr-checkbox-{primary,secondary}-sm form controls.
+"""Find or migrate hand-rolled kr-checkbox-{primary,secondary}-sm/xs form controls.
 
 Dry-run is the default. Pass --write to update matching Vue files in place.
 Only the approved small/colored DaisyUI checkbox shapes are touched
-(`checkbox checkbox-sm checkbox-primary` and `checkbox checkbox-sm
-checkbox-secondary`), and only in static `class="..."` attributes -- never
+(`checkbox checkbox-sm checkbox-primary`, `checkbox checkbox-sm
+checkbox-secondary`, and `checkbox checkbox-xs checkbox-primary`), and only
+in static `class="..."` attributes -- never
 `:class`/`v-bind:class` bindings, and regardless of the base tokens' order in
 the source (`checkbox-primary checkbox-sm` counts the same as `checkbox-sm
 checkbox-primary`). A source that already carries the target primitive, or is
@@ -27,6 +28,7 @@ CLASS_ATTR = re.compile(r'class="([^"]*)"')
 FAMILIES = [
     ("kr-checkbox-primary-sm", {"checkbox", "checkbox-sm", "checkbox-primary"}),
     ("kr-checkbox-secondary-sm", {"checkbox", "checkbox-sm", "checkbox-secondary"}),
+    ("kr-checkbox-primary-xs", {"checkbox", "checkbox-xs", "checkbox-primary"}),
 ]
 
 
@@ -91,7 +93,7 @@ def main() -> int:
                 f.write(migrated)
 
     mode = "migrated" if args.write else "candidate"
-    print(f"kr-checkbox-*-sm {mode} occurrences: {total}")
+    print(f"kr-checkbox-* {mode} occurrences: {total}")
     return 0
 
 


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 108: drive live front-end consistency onto shared kr-* components (kind: software)

### What changed / what I produced
- New `.kr-checkbox-primary-xs` primitive in `assets/css/tailwind.css` (`checkbox checkbox-xs checkbox-primary`) — the xs-size counterpart to the existing `kr-checkbox-primary-sm`/`kr-checkbox-secondary-sm`.
- Extended `utils/scripts/codemods/kr_checkbox_codemod.py`'s `FAMILIES` list to cover the new primitive.
- Migrated the 3 exact-match occurrences across 2 files: `components/art/stylist-restyle.vue` (2) and `components/model-builder/model-builder-recipe-selector.vue` (1). Extra utility tokens (e.g. `mt-0.5`) preserved verbatim after the primitive class, per the established subset-match convention. No geometry or behavior change.

### How I verified
- `npm run test` (vue-tsc --noEmit): clean, no errors.
- `npx eslint` on the two touched `.vue` files: 0 errors, 0 warnings.
- `npm run test:layout-contract`: holds, no new violations.
- `npm run test:lint-ratchet`: holds (333 problems, -59 vs. baseline — no rule got worse).
- Grepped `utils/scripts/*.mjs` and test/cypress dirs for the literal class string being replaced — no regression guard hardcodes it (the slice-69 lesson).
- Confirmed via `git stash`/prettier-check that `stylist-restyle.vue` and `tailwind.css` already failed `prettier --check` on `origin/main` before this change (pre-existing debt, not introduced here) — kept this PR's diff scoped to the checkbox migration only rather than reformatting either file.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
Next bounded slice: audit hand-rolled textarea shapes (129 class attrs, highly varied — scoping likely needs picking one common `min-h`/`rounded-2xl`/`bg-base-200` combo rather than a single universal primitive), or move to a different `kr-*` family entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zoCWEHLq3SV7ootrjC4w8

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoCWEHLq3SV7ootrjC4w8)_