### PR TITLE
interface-vision/t-104 slice 109: add .kr-badge-{ghost,warning,outline}-sm and migrate 54 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -954,6 +954,28 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply checkbox checkbox-xs checkbox-primary;
   }
 
+  /* First badge-family primitive (interface-vision t-104 slice 109): the
+   * small, ghost-styled DaisyUI badge -- `badge badge-ghost badge-sm` --
+   * the single most common hand-rolled badge shape in the codebase (31
+   * exact-match occurrences across 24 files). */
+  .kr-badge-ghost-sm {
+    @apply badge badge-ghost badge-sm;
+  }
+
+  /* The warning-colored counterpart to .kr-badge-ghost-sm (same slice):
+   * `badge badge-warning badge-sm`, previously hand-rolled in 12 files (13
+   * occurrences). */
+  .kr-badge-warning-sm {
+    @apply badge badge-warning badge-sm;
+  }
+
+  /* The outline counterpart to .kr-badge-ghost-sm (same slice): `badge
+   * badge-outline badge-sm`, previously hand-rolled in 10 files (12
+   * occurrences). */
+  .kr-badge-outline-sm {
+    @apply badge badge-outline badge-sm;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -16,7 +16,7 @@
           and let the Kontext engine repaint it the way the masters would have.
         </p>
       </div>
-      <span class="badge badge-ghost badge-sm">
+      <span class="kr-badge-ghost-sm">
         {{ academyStore.stylesRemixedCount }}/{{ academyStore.styles.length }}
         styles remixed
       </span>

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -118,7 +118,7 @@
         <div class="flex flex-wrap items-center gap-2">
           <h3 class="text-2xl font-black text-base-content">{{ lesson.name }}</h3>
           <span class="badge badge-primary badge-sm font-bold">{{ lesson.era }}</span>
-          <span class="badge badge-ghost badge-sm">{{ lesson.region }}</span>
+          <span class="kr-badge-ghost-sm">{{ lesson.region }}</span>
         </div>
         <p class="max-w-3xl text-sm leading-relaxed text-base-content/75">
           {{ lesson.keyIdeas }}

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -112,7 +112,7 @@
               <Icon :name="store.isEffectActive(effect.id) ? 'kind-icon:x' : 'kind-icon:eye'" class="h-3 w-3" />
               {{ store.isEffectActive(effect.id) ? 'Stop' : 'Preview' }}
             </button>
-            <span class="badge badge-ghost badge-sm">
+            <span class="kr-badge-ghost-sm">
               {{ surfaceLabel(effect.preferredSurface) }}
             </span>
             <span v-if="effect.generationSafe" class="badge badge-success badge-outline badge-sm">

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -122,10 +122,10 @@
         <span
           class="ml-auto hidden flex-wrap items-center gap-1.5 text-xs text-base-content/50 sm:flex"
         >
-          <span class="badge badge-ghost badge-sm">
+          <span class="kr-badge-ghost-sm">
             {{ visibleGroups.length }} collections
           </span>
-          <span class="badge badge-ghost badge-sm">
+          <span class="kr-badge-ghost-sm">
             {{ totalImageCount }} images
           </span>
           <span v-if="activeGroup" class="badge badge-primary badge-sm">

--- a/components/art/stylist-client-gallery.vue
+++ b/components/art/stylist-client-gallery.vue
@@ -4,7 +4,7 @@
     <header class="mb-3 flex flex-wrap items-center gap-2">
       <Icon name="kind-icon:image" class="size-4 text-primary" />
       <h3 class="font-black">{{ client.name }}’s gallery</h3>
-      <span class="badge badge-ghost badge-sm">{{ photos.length }}</span>
+      <span class="kr-badge-ghost-sm">{{ photos.length }}</span>
       <div class="flex-1" />
       <select v-model="folderFilter" class="select select-bordered select-xs">
         <option value="">All folders</option>

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -4,7 +4,7 @@
     <header class="flex items-center gap-2">
       <Icon name="kind-icon:heart" class="h-5 w-5 text-primary" />
       <h2 class="text-base font-black text-base-content">Clients</h2>
-      <span class="badge badge-ghost badge-sm">{{ superkate.sortedCustomers.length }}</span>
+      <span class="kr-badge-ghost-sm">{{ superkate.sortedCustomers.length }}</span>
     </header>
 
     <form class="flex flex-wrap items-end gap-2 rounded-xl border border-base-300 bg-base-100 p-3" @submit.prevent="save">

--- a/components/art/stylist-history.vue
+++ b/components/art/stylist-history.vue
@@ -10,7 +10,7 @@
     <header class="flex items-center gap-2">
       <Icon name="kind-icon:book" class="h-5 w-5 text-primary" />
       <h2 class="text-base font-black text-base-content">Appointments</h2>
-      <span class="badge badge-ghost badge-sm">{{ results.length }}</span>
+      <span class="kr-badge-ghost-sm">{{ results.length }}</span>
     </header>
 
     <div class="flex flex-wrap gap-2">

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -18,7 +18,7 @@
       <Icon name="kind-icon:magic" class="h-5 w-5 text-primary" />
       <h2 class="text-base font-black text-base-content">Hair Studio</h2>
       <span class="badge badge-primary badge-sm">Kontext</span>
-      <span class="badge badge-ghost badge-sm">Private</span>
+      <span class="kr-badge-ghost-sm">Private</span>
       <div class="flex-1" />
       <span
         v-if="stylist.isBusy"

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -332,18 +332,18 @@
                 Public
               </span>
 
-              <span v-else class="badge badge-ghost badge-sm"> Private </span>
+              <span v-else class="kr-badge-ghost-sm"> Private </span>
 
               <span
                 v-if="botStore.currentBot.isMature"
-                class="badge badge-warning badge-sm"
+                class="kr-badge-warning-sm"
               >
                 Mature
               </span>
 
               <span
                 v-if="botStore.currentBot.underConstruction"
-                class="badge badge-warning badge-sm"
+                class="kr-badge-warning-sm"
               >
                 Building
               </span>

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -528,7 +528,7 @@
                     </span>
                   </span>
                   <span class="flex shrink-0 flex-col items-end gap-0.5">
-                    <span class="badge badge-ghost badge-sm">
+                    <span class="kr-badge-ghost-sm">
                       {{ saved.candidateCount }} idea{{
                         saved.candidateCount === 1 ? '' : 's'
                       }}

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -11,7 +11,7 @@
         </p>
       </div>
       <span v-if="loading || saving" class="loading loading-spinner loading-xs" />
-      <span class="badge badge-ghost badge-sm">{{ selectedFacets.length }}</span>
+      <span class="kr-badge-ghost-sm">{{ selectedFacets.length }}</span>
     </div>
 
     <div v-if="selectedFacets.length" class="flex flex-wrap gap-2">

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -223,18 +223,18 @@
                 Public
               </span>
 
-              <span v-else class="badge badge-ghost badge-sm"> Private </span>
+              <span v-else class="kr-badge-ghost-sm"> Private </span>
 
               <span
                 v-if="characterStore.selectedCharacter.isMature"
-                class="badge badge-warning badge-sm"
+                class="kr-badge-warning-sm"
               >
                 Mature
               </span>
 
               <span
                 v-if="characterStore.selectedCharacter.genre"
-                class="badge badge-outline badge-sm"
+                class="kr-badge-outline-sm"
               >
                 {{ characterStore.selectedCharacter.genre }}
               </span>

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -25,7 +25,7 @@
       <div v-for="set in sets" :key="set.slug" class="flex flex-col gap-2">
         <div class="flex items-baseline gap-2">
           <h3 class="text-sm font-black text-base-content">{{ set.title }}</h3>
-          <span class="badge badge-ghost badge-sm">
+          <span class="kr-badge-ghost-sm">
             {{ set.pages.length }} pages
           </span>
           <span

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -72,9 +72,7 @@
             <div class="min-w-0">
               <div class="flex flex-wrap items-center gap-2">
                 <h2 class="text-xl font-black">{{ fish.name }}</h2>
-                <span class="badge badge-sm badge-outline">{{
-                  fish.rarity
-                }}</span>
+                <span class="kr-badge-outline-sm">{{ fish.rarity }}</span>
               </div>
               <p class="mt-1 text-xs italic text-base-content/50">
                 {{ fish.species }}

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -206,7 +206,7 @@
                 <td>
                   <span
                     v-if="row.effective.hskLevel"
-                    class="badge badge-sm badge-outline"
+                    class="kr-badge-outline-sm"
                   >
                     {{ row.effective.hskLevel }}
                   </span>
@@ -216,7 +216,7 @@
                     <span
                       v-for="category in row.effective.categories"
                       :key="category"
-                      class="badge badge-ghost badge-sm"
+                      class="kr-badge-ghost-sm"
                     >
                       {{ category }}
                     </span>
@@ -235,9 +235,7 @@
                   </span>
                 </td>
                 <td>
-                  <span
-                    v-if="row.hasOverride"
-                    class="badge badge-warning badge-sm"
+                  <span v-if="row.hasOverride" class="kr-badge-warning-sm"
                     >overridden</span
                   >
                   <span v-else class="text-xs text-base-content/35"

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -384,18 +384,18 @@
                 Public
               </span>
 
-              <span v-else class="badge badge-ghost badge-sm">Private</span>
+              <span v-else class="kr-badge-ghost-sm">Private</span>
 
               <span
                 v-if="dreamStore.selectedDream.isMature"
-                class="badge badge-warning badge-sm"
+                class="kr-badge-warning-sm"
               >
                 Mature
               </span>
 
               <span
                 v-if="dreamStore.selectedDream.dreamType"
-                class="badge badge-outline badge-sm"
+                class="kr-badge-outline-sm"
               >
                 {{ dreamTypeLabel(dreamStore.selectedDream.dreamType) }}
               </span>

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -14,7 +14,7 @@
         v-if="saving || loadingAssignments"
         class="loading loading-spinner loading-xs"
       />
-      <span class="badge badge-ghost badge-sm">{{ selectedFacets.length }}</span>
+      <span class="kr-badge-ghost-sm">{{ selectedFacets.length }}</span>
     </div>
 
     <div v-if="selectedFacets.length" class="flex flex-wrap gap-2">

--- a/components/facets/facet-profile.vue
+++ b/components/facets/facet-profile.vue
@@ -94,7 +94,7 @@
             <span
               v-for="alias in selectedFacet.aliases"
               :key="alias"
-              class="badge badge-ghost badge-sm"
+              class="kr-badge-ghost-sm"
             >
               {{ alias }}
             </span>
@@ -112,7 +112,7 @@
             </span>
             <span
               v-if="selectedFacet.artRequired"
-              class="badge badge-warning badge-sm"
+              class="kr-badge-warning-sm"
             >
               art expected
             </span>

--- a/components/gallery/kr-card-back.vue
+++ b/components/gallery/kr-card-back.vue
@@ -120,7 +120,7 @@
           <span
             v-for="badge in badges"
             :key="badge"
-            class="badge badge-outline badge-sm"
+            class="kr-badge-outline-sm"
           >
             {{ badge }}
           </span>

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -122,7 +122,7 @@
             <span v-if="card.baseModel" class="badge badge-secondary badge-sm">
               {{ card.baseModel }}
             </span>
-            <span v-if="card.isMature" class="badge badge-warning badge-sm">
+            <span v-if="card.isMature" class="kr-badge-warning-sm">
               Mature
             </span>
           </div>

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -3,8 +3,8 @@
   <div v-if="item" class="flex min-h-0 flex-1 flex-col gap-2 kr-panel-flat p-3">
     <div class="flex items-center gap-2">
       <h4 class="text-sm font-black text-base-content">{{ item.label }}</h4>
-      <span class="badge badge-sm badge-ghost">{{ item.action }}</span>
-      <span class="badge badge-sm badge-ghost">{{ item.generation }}</span>
+      <span class="kr-badge-ghost-sm">{{ item.action }}</span>
+      <span class="kr-badge-ghost-sm">{{ item.generation }}</span>
       <button
         type="button"
         class="btn btn-xs btn-ghost ml-auto gap-1 rounded-lg text-primary"

--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -154,7 +154,7 @@
               <span class="badge badge-primary badge-outline">
                 {{ channel.tabs.length }} tabs
               </span>
-              <span v-if="channel.requiredRole" class="badge badge-warning badge-sm">
+              <span v-if="channel.requiredRole" class="kr-badge-warning-sm">
                 {{ channel.requiredRole }}
               </span>
             </div>

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -143,7 +143,7 @@
 
                   <span
                     v-if="rewardStore.selectedReward.collection"
-                    class="badge badge-outline badge-sm"
+                    class="kr-badge-outline-sm"
                   >
                     {{ rewardStore.selectedReward.collection }}
                   </span>

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -11,7 +11,7 @@
         </p>
       </div>
       <span v-if="loading || saving" class="loading loading-spinner loading-xs" />
-      <span class="badge badge-ghost badge-sm">{{ selectedFacets.length }}</span>
+      <span class="kr-badge-ghost-sm">{{ selectedFacets.length }}</span>
     </div>
 
     <div v-if="selectedFacets.length" class="flex flex-wrap gap-2">

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -272,16 +272,16 @@
                 Public
               </span>
 
-              <span v-else class="badge badge-ghost badge-sm">Private</span>
+              <span v-else class="kr-badge-ghost-sm">Private</span>
 
               <span
                 v-if="rewardStore.selectedReward.isMature"
-                class="badge badge-warning badge-sm"
+                class="kr-badge-warning-sm"
               >
                 Mature
               </span>
 
-              <span class="badge badge-outline badge-sm">
+              <span class="kr-badge-outline-sm">
                 {{ rewardStore.selectedReward.rarity }}
               </span>
 

--- a/components/ruler-hooked/ruler-hooked-catch.vue
+++ b/components/ruler-hooked/ruler-hooked-catch.vue
@@ -5,7 +5,7 @@
         <div class="flex flex-wrap items-center gap-2">
           <span v-if="catchResult.newDiscovery" class="badge badge-primary badge-sm">NEW SPECIES</span>
           <span class="badge badge-sm" :class="affinityClass">{{ catchResult.affinity }}</span>
-          <span class="badge badge-outline badge-sm">{{ catchResult.rarity }}</span>
+          <span class="kr-badge-outline-sm">{{ catchResult.rarity }}</span>
         </div>
         <h3 class="mt-2 text-xl font-black">{{ catchResult.name }}</h3>
         <p class="mt-1 text-sm opacity-75">{{ catchResult.catchBehavior }}</p>

--- a/components/servers/checkpoint-card.vue
+++ b/components/servers/checkpoint-card.vue
@@ -49,7 +49,7 @@
         </span>
         <span
           v-if="checkpoint.isMature && showMatureBadge"
-          class="badge badge-warning badge-sm"
+          class="kr-badge-warning-sm"
         >
           Mature
         </span>
@@ -82,10 +82,10 @@
       </p>
 
       <div v-if="showMeta" class="flex flex-wrap justify-center gap-2">
-        <span v-if="checkpointLocalPath" class="badge badge-outline badge-sm">
+        <span v-if="checkpointLocalPath" class="kr-badge-outline-sm">
           Local
         </span>
-        <span v-if="checkpoint.artImageId" class="badge badge-ghost badge-sm">
+        <span v-if="checkpoint.artImageId" class="kr-badge-ghost-sm">
           Preview
         </span>
         <span v-if="checkpoint.userId" class="badge badge-primary badge-sm">

--- a/components/user/friends-panel.vue
+++ b/components/user/friends-panel.vue
@@ -136,7 +136,7 @@
             </button>
             <span
               v-else-if="friends.relationship(u.id) === 'outgoing'"
-              class="badge badge-ghost badge-sm"
+              class="kr-badge-ghost-sm"
               >Requested</span
             >
             <span

--- a/pages/admin/forum-moderation.vue
+++ b/pages/admin/forum-moderation.vue
@@ -58,9 +58,7 @@
           >
             <div class="flex items-start justify-between gap-2">
               <div class="flex items-center gap-2">
-                <span class="badge badge-warning badge-sm">
-                  pending review
-                </span>
+                <span class="kr-badge-warning-sm"> pending review </span>
                 <span v-if="post.channel" class="badge badge-outline">
                   {{ post.channel }}
                 </span>

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -58,7 +58,7 @@
             <span class="text-xs text-base-content/50">approved today</span>
             <span
               v-if="row.approvedToday >= row.ceiling"
-              class="badge badge-warning badge-sm"
+              class="kr-badge-warning-sm"
             >
               ceiling reached
             </span>

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -82,7 +82,7 @@
             >
               <span class="flex items-start justify-between gap-2">
                 <span class="font-bold">{{ set.label }}</span>
-                <span class="badge badge-ghost badge-sm">{{ set.cardKeys.length }}</span>
+                <span class="kr-badge-ghost-sm">{{ set.cardKeys.length }}</span>
               </span>
               <span class="mt-1 block text-xs leading-relaxed opacity-65">{{ set.description }}</span>
             </button>
@@ -117,7 +117,7 @@
             <template #toolbar>
               <div class="flex min-w-0 flex-wrap items-center gap-2">
                 <b class="truncate">{{ selectedSet?.label || 'Study set' }}</b>
-                <span class="badge badge-ghost badge-sm">{{ galleryItems.length }}</span>
+                <span class="kr-badge-ghost-sm">{{ galleryItems.length }}</span>
                 <span class="text-xs opacity-55">Tap a card to study it.</span>
               </div>
             </template>
@@ -200,13 +200,13 @@
           >
             <div class="flex flex-wrap items-center justify-between gap-2 border-b border-base-300 p-3">
               <div class="flex flex-wrap items-center gap-2 text-xs">
-                <span v-if="currentCard.hskLevel" class="badge badge-outline badge-sm">HSK {{ currentCard.hskLevel }}</span>
-                <span class="badge badge-ghost badge-sm">{{ currentPositionLabel }}</span>
-                <span class="badge badge-ghost badge-sm">{{ studySessionRatedForSet }} rated</span>
+                <span v-if="currentCard.hskLevel" class="kr-badge-outline-sm">HSK {{ currentCard.hskLevel }}</span>
+                <span class="kr-badge-ghost-sm">{{ currentPositionLabel }}</span>
+                <span class="kr-badge-ghost-sm">{{ studySessionRatedForSet }} rated</span>
                 <span v-if="studyDiagnostics?.dueCount" class="badge badge-primary badge-outline badge-sm">
                   {{ studyDiagnostics.dueCount }} due
                 </span>
-                <span v-if="studyDiagnostics?.retentionRate !== null && studyDiagnostics?.retentionRate !== undefined" class="badge badge-ghost badge-sm">
+                <span v-if="studyDiagnostics?.retentionRate !== null && studyDiagnostics?.retentionRate !== undefined" class="kr-badge-ghost-sm">
                   {{ Math.round(studyDiagnostics.retentionRate * 100) }}% retention
                 </span>
               </div>
@@ -378,9 +378,9 @@
 
               <div class="flex min-h-64 flex-col p-5">
                 <div class="flex flex-wrap gap-1">
-                  <span v-if="currentCard.hskLevel" class="badge badge-outline badge-sm">HSK {{ currentCard.hskLevel }}</span>
-                  <span v-if="currentCard.radical" class="badge badge-outline badge-sm">Radical {{ currentCard.radical }}</span>
-                  <span v-for="category in currentCard.categories.slice(0, 4)" :key="category" class="badge badge-ghost badge-sm">{{ category }}</span>
+                  <span v-if="currentCard.hskLevel" class="kr-badge-outline-sm">HSK {{ currentCard.hskLevel }}</span>
+                  <span v-if="currentCard.radical" class="kr-badge-outline-sm">Radical {{ currentCard.radical }}</span>
+                  <span v-for="category in currentCard.categories.slice(0, 4)" :key="category" class="kr-badge-ghost-sm">{{ category }}</span>
                 </div>
 
                 <div class="my-auto py-5 text-center">

--- a/utils/scripts/codemods/kr_badge_codemod.py
+++ b/utils/scripts/codemods/kr_badge_codemod.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled kr-badge-{ghost,warning,outline}-sm badges.
+
+Dry-run is the default. Pass --write to update matching Vue files in place.
+Only the approved small badge shapes are touched (`badge badge-ghost
+badge-sm`, `badge badge-warning badge-sm`, `badge badge-outline badge-sm`),
+and only in static `class="..."` attributes -- never `:class`/`v-bind:class`
+bindings, and regardless of the base tokens' order in the source
+(`badge-ghost badge-sm` counts the same as `badge-sm badge-ghost`). A source
+that already carries the target primitive, or is missing any one of the base
+tokens, is left untouched. Extra tokens beyond the base set (ml-auto,
+shrink-0, rounded-lg, ...) are preserved verbatim after the primitive class,
+matching the kr-input-sm/kr-checkbox-* codemods' subset-match convention --
+they're plain Tailwind utilities layered on top, not another component-root
+class, so resolution order is unaffected by folding the three base tokens
+into one name.
+
+FAMILIES is ordered most-specific-first on purpose: each entry's base token
+set differs only in its color modifier (ghost/warning/outline), so order
+among them doesn't matter for correctness here, but a future plain-size
+family (e.g. a colorless `kr-badge-sm`) would need to come LAST, since its
+smaller base set is a subset of every colored family's tokens above.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+FAMILIES = [
+    ("kr-badge-ghost-sm", {"badge", "badge-ghost", "badge-sm"}),
+    ("kr-badge-warning-sm", {"badge", "badge-warning", "badge-sm"}),
+    ("kr-badge-outline-sm", {"badge", "badge-outline", "badge-sm"}),
+]
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    for primitive, base_tokens in FAMILIES:
+        if primitive in tokens or not base_tokens.issubset(tokens):
+            continue
+        remaining = [token for token in tokens if token not in base_tokens]
+        if exact_only and remaining:
+            continue
+        return " ".join([primitive, *remaining])
+    return None
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim (no
+        # universal-newline translation) -- a handful of source files carry
+        # CRLF, and translating those to LF on write would turn a one-line
+        # class-attribute change into a whole-file rewrite (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-badge-* {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds three new `.kr-badge-*` primitives to `tailwind.css`'s `@layer components`, mirroring the existing `kr-checkbox-*` convention: `.kr-badge-ghost-sm`, `.kr-badge-warning-sm`, `.kr-badge-outline-sm`.
- New `utils/scripts/codemods/kr_badge_codemod.py`, mirroring `kr_checkbox_codemod.py`'s subset-match shape (order-independent base-token matching, `--exact-only` bounding, extra utility tokens preserved verbatim).
- Ran `--exact-only` this slice: 54 occurrences migrated across 31 files. `components/ui/ui-gallery.vue`'s style-guide demo table excluded per established convention — it intentionally renders raw DaisyUI classes as a living reference, not a migration target.
- No geometry or behavior change — only the DaisyUI `badge badge-{ghost,warning,outline} badge-sm` token combos are folded into one class name.

## Verification
- `vue-tsc --noEmit` clean
- `eslint` on touched files: 0 new issues (9 pre-existing errors confirmed unrelated via `git stash`)
- `test:layout-contract` holds (207 baseline unchanged)
- `test:lint-ratchet` holds (333 problems / -59 vs baseline)
- `prettier --check` clean on touched files (21 pre-existing drift files confirmed via `git stash`; 3 files where the shortened class attribute collapsed a multi-line tag were reformatted with a scoped `prettier --write`)

## Flags for Reviewer
- Codemod re-run post-write confirms 0 remaining `--exact-only` candidates except the intentionally-excluded `ui-gallery.vue`.
- Next bounded slice per the umbrella note: audit hand-rolled textarea shapes (129 class attrs, highly varied — needs picking one common `min-h`/`rounded-2xl`/`bg-base-200` combo rather than a single universal primitive), or continue the badge family (primary-sm/secondary-sm/xs variants surveyed at ~60 more subset-match occurrences).

Conductor task: interface-vision/t-104 (recurring umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUWPWn5bv6Wo5GZAGmLy2g)_