### PR TITLE
style: migrate hand-rolled badge shapes to kr-badge-{ghost,warning,outline}-sm (subset-match)

### DIFF
--- a/components/achievements/achievement-gallery.vue
+++ b/components/achievements/achievement-gallery.vue
@@ -104,7 +104,7 @@
             <Icon name="kind-icon:question" class="h-4 w-4" />
           </span>
           <h2 class="text-sm font-black text-base-content">Undiscovered</h2>
-          <span class="ml-auto badge badge-ghost badge-sm">{{
+          <span class="kr-badge-ghost-sm ml-auto">{{
             unearnedAchievements.length
           }}</span>
         </div>

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -115,7 +115,7 @@
             <span class="kr-badge-ghost-sm">
               {{ surfaceLabel(effect.preferredSurface) }}
             </span>
-            <span v-if="effect.generationSafe" class="badge badge-success badge-outline badge-sm">
+            <span v-if="effect.generationSafe" class="kr-badge-outline-sm badge-success">
               generation-safe
             </span>
           </div>

--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -269,16 +269,16 @@
             <div class="rounded-2xl border border-base-300 p-3 text-xs">
               <div class="font-semibold">Current selection</div>
               <div class="mt-2 flex flex-wrap gap-1">
-                <span class="badge badge-outline badge-sm rounded-2xl">
+                <span class="kr-badge-outline-sm rounded-2xl">
                   {{ facetIds.length }} Facets
                 </span>
-                <span class="badge badge-outline badge-sm rounded-2xl">
+                <span class="kr-badge-outline-sm rounded-2xl">
                   {{ form.steps || '—' }} steps
                 </span>
-                <span class="badge badge-outline badge-sm rounded-2xl">
+                <span class="kr-badge-outline-sm rounded-2xl">
                   CFG {{ form.cfg || '—' }}
                 </span>
-                <span class="badge badge-outline badge-sm rounded-2xl">
+                <span class="kr-badge-outline-sm rounded-2xl">
                   {{ form.sampler || 'sampler default' }}
                 </span>
                 <span
@@ -299,13 +299,13 @@
                 </span>
                 <span
                   v-if="isVideoJob"
-                  class="badge badge-accent badge-outline badge-sm rounded-2xl"
+                  class="kr-badge-outline-sm badge-accent rounded-2xl"
                 >
                   {{ form.durationSeconds }}s · {{ form.fps }}fps
                 </span>
                 <span
                   v-if="isVideoJob"
-                  class="badge badge-accent badge-outline badge-sm rounded-2xl"
+                  class="kr-badge-outline-sm badge-accent rounded-2xl"
                 >
                   {{ form.loop ? 'loop' : 'play once' }}
                 </span>

--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -79,7 +79,7 @@
       <div
         class="absolute right-2 top-2 flex max-w-[65%] flex-wrap justify-end gap-1"
       >
-        <span class="badge badge-outline badge-sm rounded-2xl">
+        <span class="kr-badge-outline-sm rounded-2xl">
           {{ job.engine }}
         </span>
         <span
@@ -108,7 +108,7 @@
           </span>
         </div>
         <div class="flex flex-wrap justify-end gap-1">
-          <span class="badge badge-outline badge-sm rounded-2xl">
+          <span class="kr-badge-outline-sm rounded-2xl">
             {{ job.engine }}
           </span>
           <span
@@ -134,10 +134,7 @@
               Destination · {{ jobPageLabel }}
             </p>
           </div>
-          <span
-            v-if="jobVariant"
-            class="badge badge-ghost badge-sm rounded-2xl"
-          >
+          <span v-if="jobVariant" class="kr-badge-ghost-sm rounded-2xl">
             {{ jobVariant }}
           </span>
         </div>
@@ -176,7 +173,7 @@
         </span>
         <span
           v-if="jobRequestId"
-          class="badge badge-ghost badge-sm max-w-full truncate rounded-2xl"
+          class="kr-badge-ghost-sm max-w-full truncate rounded-2xl"
           :title="jobRequestId"
         >
           {{ jobRequestId }}
@@ -200,7 +197,7 @@
         <span
           v-for="setting in jobSettings.slice(0, 6)"
           :key="setting"
-          class="badge badge-ghost badge-sm h-auto rounded-2xl py-1 text-[10px]"
+          class="kr-badge-ghost-sm h-auto rounded-2xl py-1 text-[10px]"
         >
           {{ setting }}
         </span>
@@ -269,7 +266,7 @@
               <span
                 v-for="setting in jobSettings"
                 :key="setting"
-                class="badge badge-outline badge-sm h-auto rounded-2xl py-1 text-[10px]"
+                class="kr-badge-outline-sm h-auto rounded-2xl py-1 text-[10px]"
               >
                 {{ setting }}
               </span>

--- a/components/art/artjob-slideshow.vue
+++ b/components/art/artjob-slideshow.vue
@@ -68,7 +68,7 @@
                 {{ isPlaying ? `${intervalSeconds}s` : 'Paused' }}
               </span>
               <span
-                class="badge badge-outline badge-sm rounded-2xl"
+                class="kr-badge-outline-sm rounded-2xl"
                 :title="`Drawing at random from the ${depth} most recent finished jobs`"
               >
                 depth {{ slideshowStore.pool.length }}/{{ depth }}
@@ -169,7 +169,7 @@
               </span>
               <span
                 v-if="currentJob?.engine"
-                class="badge badge-outline badge-sm rounded-2xl"
+                class="kr-badge-outline-sm rounded-2xl"
               >
                 {{ currentJob.engine }}
               </span>
@@ -203,7 +203,7 @@
               <span
                 v-for="setting in slideSettings"
                 :key="setting"
-                class="badge badge-ghost badge-sm h-auto rounded-2xl py-1 text-[10px]"
+                class="kr-badge-ghost-sm h-auto rounded-2xl py-1 text-[10px]"
               >
                 {{ setting }}
               </span>

--- a/components/art/artjob-trainer-redo-controls.vue
+++ b/components/art/artjob-trainer-redo-controls.vue
@@ -4,7 +4,7 @@
     <summary class="cursor-pointer list-none text-xs font-semibold marker:hidden">
       <span class="flex flex-wrap items-center justify-between gap-2">
         <span>Revise and queue a real redo</span>
-        <span class="badge badge-warning badge-outline badge-sm rounded-2xl">
+        <span class="kr-badge-warning-sm badge-outline rounded-2xl">
           priority 100
         </span>
       </span>

--- a/components/art/forum-art-generation-context.vue
+++ b/components/art/forum-art-generation-context.vue
@@ -47,7 +47,7 @@
         <div
           class="flex flex-wrap items-center gap-2 text-xs text-base-content/55"
         >
-          <span class="badge badge-outline badge-sm rounded-xl">
+          <span class="kr-badge-outline-sm rounded-xl">
             {{
               store.sourcePost.author.kind === 'AI_AGENT'
                 ? 'Declared AI agent'

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -92,7 +92,7 @@
 
         <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-base-content/45">
           <span>{{ promptDraft.length }} characters</span>
-          <span v-if="promptDirty" class="badge badge-warning badge-sm rounded-2xl">
+          <span v-if="promptDirty" class="kr-badge-warning-sm rounded-2xl">
             Unsaved changes
           </span>
         </div>

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -425,7 +425,7 @@
             <span>{{ promptDraft.length }} characters</span>
             <span
               v-if="promptDirty"
-              class="badge badge-warning badge-sm rounded-2xl"
+              class="kr-badge-warning-sm rounded-2xl"
             >
               Unsaved changes
             </span>

--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -227,7 +227,7 @@
                   </div>
                   <span
                     v-if="leaders[challenge.slug]"
-                    class="badge badge-ghost badge-sm rounded-lg font-black"
+                    class="kr-badge-ghost-sm rounded-lg font-black"
                   >
                     {{ signedScore(leaders[challenge.slug]?.netScore || 0) }}
                   </span>

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -90,7 +90,7 @@
     <template v-if="selectedPack">
       <!-- Pack header -->
       <div class="flex flex-wrap items-center gap-2">
-        <span class="badge badge-outline badge-sm rounded-xl">{{
+        <span class="kr-badge-outline-sm rounded-xl">{{
           selectedPack.price.hook
         }}</span>
         <span

--- a/components/conductor/project-gallery-strip.vue
+++ b/components/conductor/project-gallery-strip.vue
@@ -13,7 +13,7 @@
       >
         {{ title }}
       </h3>
-      <span class="badge badge-ghost badge-sm ml-auto rounded-lg">{{
+      <span class="kr-badge-ghost-sm ml-auto rounded-lg">{{
         images.length
       }}</span>
     </div>

--- a/components/conductor/sketchy-page.vue
+++ b/components/conductor/sketchy-page.vue
@@ -49,14 +49,14 @@
             <span
               v-for="dim in activeSample.scoredDimensions"
               :key="dim"
-              class="badge badge-sm badge-primary badge-outline rounded-xl"
+              class="kr-badge-outline-sm badge-primary rounded-xl"
             >
               {{ dim }}
             </span>
             <span
               v-for="dim in activeSample.sometimesDimensions"
               :key="dim"
-              class="badge badge-sm badge-ghost rounded-xl"
+              class="kr-badge-ghost-sm rounded-xl"
             >
               {{ dim }} (sometimes)
             </span>

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -332,7 +332,7 @@
             <span
               v-for="field in selectedRow.overriddenFields"
               :key="field"
-              class="badge badge-warning badge-outline badge-sm"
+              class="kr-badge-warning-sm badge-outline"
             >
               {{ field }}
             </span>

--- a/components/dreams/daily-digest-object-dialog.vue
+++ b/components/dreams/daily-digest-object-dialog.vue
@@ -14,8 +14,8 @@
           <div class="min-w-0 flex-1">
             <div class="flex flex-wrap items-center gap-2">
               <span class="badge badge-primary badge-sm rounded-lg">{{ typeLabel }}</span>
-              <span class="badge badge-ghost badge-sm rounded-lg">#{{ entity.id }}</span>
-              <span v-if="entity.slug" class="badge badge-outline badge-sm max-w-full truncate rounded-lg">
+              <span class="kr-badge-ghost-sm rounded-lg">#{{ entity.id }}</span>
+              <span v-if="entity.slug" class="kr-badge-outline-sm max-w-full truncate rounded-lg">
                 {{ entity.slug }}
               </span>
             </div>

--- a/components/facets/facet-manager.vue
+++ b/components/facets/facet-manager.vue
@@ -89,7 +89,7 @@
           class="flex items-center justify-between rounded-xl border border-base-300 bg-base-100 px-3 py-2"
         >
           <dt class="truncate text-sm">{{ taxonomyLabel(taxonomy) }}</dt>
-          <dd class="badge badge-ghost badge-sm shrink-0">
+          <dd class="kr-badge-ghost-sm shrink-0">
             {{ taxonomyCounts[taxonomy] || 0 }}
           </dd>
         </div>

--- a/components/facets/facet-profile.vue
+++ b/components/facets/facet-profile.vue
@@ -30,7 +30,7 @@
         </p>
       </div>
 
-      <span class="badge badge-outline badge-sm shrink-0">
+      <span class="kr-badge-outline-sm shrink-0">
         {{ selectedFacet.canonicalValue }}
       </span>
 

--- a/components/narrative/narrative-ingredient-multi-picker.vue
+++ b/components/narrative/narrative-ingredient-multi-picker.vue
@@ -31,7 +31,7 @@
       <span
         v-else
         :id="countId"
-        class="badge badge-ghost badge-sm rounded-xl"
+        class="kr-badge-ghost-sm rounded-xl"
         aria-live="polite"
       >
         {{ modelValue.length }} / {{ maxSelections }} selected

--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -30,7 +30,7 @@
       />
       <span
         v-else
-        class="badge badge-ghost badge-sm rounded-xl"
+        class="kr-badge-ghost-sm rounded-xl"
         aria-live="polite"
       >
         {{ items.length }} options

--- a/components/navigation/tutorial-flyer.vue
+++ b/components/navigation/tutorial-flyer.vue
@@ -55,7 +55,7 @@
 
           <span
             v-if="section.underConstruction"
-            class="badge badge-warning badge-sm gap-1 rounded-lg font-semibold"
+            class="kr-badge-warning-sm gap-1 rounded-lg font-semibold"
           >
             <Icon name="kind-icon:wrench" class="h-3 w-3" />
             Coming soon
@@ -214,7 +214,7 @@
 
                     <span
                       v-if="section.underConstruction"
-                      class="badge badge-warning badge-sm gap-1 rounded-lg font-semibold"
+                      class="kr-badge-warning-sm gap-1 rounded-lg font-semibold"
                     >
                       <Icon name="kind-icon:wrench" class="h-3 w-3" />
                       Coming soon

--- a/components/navigation/workspace-narrator.vue
+++ b/components/navigation/workspace-narrator.vue
@@ -283,7 +283,7 @@
                       Topics & Threads
                     </p>
 
-                    <span class="badge badge-outline badge-sm rounded-xl">
+                    <span class="kr-badge-outline-sm rounded-xl">
                       {{ topicButtons.length }}
                     </span>
                   </div>

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -115,7 +115,7 @@
                     class="toggle toggle-warning toggle-sm"
                   />
                   <span>Show paused projects</span>
-                  <span class="badge badge-ghost badge-sm rounded-lg">
+                  <span class="kr-badge-ghost-sm rounded-lg">
                     {{ conductorStore.pausedHumanGates.length }}
                   </span>
                 </label>
@@ -182,13 +182,13 @@
                 <div class="mt-3 flex flex-wrap gap-1.5">
                   <span
                     v-if="gate.task.stakes"
-                    class="badge badge-ghost badge-sm rounded-xl"
+                    class="kr-badge-ghost-sm rounded-xl"
                   >
                     {{ gate.task.stakes }}
                   </span>
                   <span
                     v-if="!gate.task.softGate && !isPausedGate(gate)"
-                    class="badge badge-outline badge-sm rounded-xl"
+                    class="kr-badge-outline-sm rounded-xl"
                   >
                     blocking work
                   </span>
@@ -358,7 +358,7 @@
                   </div>
                   <span
                     v-if="pitch.effort"
-                    class="badge badge-ghost badge-sm rounded-xl"
+                    class="kr-badge-ghost-sm rounded-xl"
                   >
                     {{ pitch.effort }}
                   </span>

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -405,7 +405,7 @@
             <div class="min-w-0">
               <h2 class="text-lg font-bold text-base-content">
                 Add a Character
-                <span class="badge badge-ghost badge-sm ml-2">Optional</span>
+                <span class="kr-badge-ghost-sm ml-2">Optional</span>
               </h2>
 
               <p class="mt-0.5 truncate text-sm text-base-content/60">

--- a/components/scenarios/scenario-story.vue
+++ b/components/scenarios/scenario-story.vue
@@ -55,7 +55,7 @@
       <div class="flex shrink-0 items-center gap-1.5">
         <span
           v-if="selectedScenario?.isMature"
-          class="badge badge-warning badge-sm text-smart-caption"
+          class="kr-badge-warning-sm text-smart-caption"
         >
           Mature
         </span>

--- a/components/screenfx/animation-selector.vue
+++ b/components/screenfx/animation-selector.vue
@@ -21,7 +21,7 @@
         </div>
       </div>
 
-      <span class="badge badge-outline badge-sm gap-1 border-info/40 text-info">
+      <span class="kr-badge-outline-sm gap-1 border-info/40 text-info">
         <Icon name="kind-icon:save" class="h-3 w-3" />
         local storage
       </span>
@@ -99,7 +99,7 @@
       >
         <span class="flex items-center justify-between gap-2 text-xs">
           <span class="font-black text-base-content/70">{{ control.label }}</span>
-          <span class="badge badge-ghost badge-sm font-mono">
+          <span class="kr-badge-ghost-sm font-mono">
             {{ formatValue(control.key) }}
           </span>
         </span>

--- a/components/taskmaster/taskmaster-sample-tasks.vue
+++ b/components/taskmaster/taskmaster-sample-tasks.vue
@@ -21,7 +21,7 @@
       </div>
       <span
         v-if="gateProject"
-        class="badge badge-warning badge-outline badge-sm h-auto rounded-xl py-1 text-[0.65rem]"
+        class="kr-badge-warning-sm badge-outline h-auto rounded-xl py-1 text-[0.65rem]"
       >
         {{ gateProject.gateCount }} human
         {{ gateProject.gateCount === 1 ? 'gate' : 'gates' }}

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -87,7 +87,7 @@
           <span
             v-for="scope in credential.scopes"
             :key="scope"
-            class="badge badge-ghost badge-sm font-mono text-[0.65rem]"
+            class="kr-badge-ghost-sm font-mono text-[0.65rem]"
           >
             {{ scope }}
           </span>

--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -227,7 +227,7 @@
                 <span class="flex shrink-0 items-center gap-1">
                   <span
                     v-if="resource.isMature"
-                    class="badge badge-error badge-outline badge-sm"
+                    class="kr-badge-outline-sm badge-error"
                   >
                     18+
                   </span>

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -513,20 +513,20 @@
             >
               <span
                 v-if="entry.rating"
-                class="badge badge-warning badge-sm gap-0.5 rounded-lg"
+                class="kr-badge-warning-sm gap-0.5 rounded-lg"
               >
                 <Icon name="kind-icon:star" class="size-3" />{{ entry.rating }}
               </span>
               <span
                 v-if="entry.rewatch && entry.rewatch >= 2"
-                class="badge badge-ghost badge-sm gap-0.5 rounded-lg"
+                class="kr-badge-ghost-sm gap-0.5 rounded-lg"
                 :title="`Watched ${entry.rewatch}x`"
               >
                 <Icon name="kind-icon:history" class="size-3" />{{
                   entry.rewatch
                 }}x
               </span>
-              <span class="badge badge-ghost badge-sm rounded-lg">{{
+              <span class="kr-badge-ghost-sm rounded-lg">{{
                 entry.mediaType
               }}</span>
               <span>{{ formatDate(entry) }}</span>

--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -28,9 +28,7 @@
         </h2>
       </div>
       <div class="flex shrink-0 items-center gap-2">
-        <span class="badge badge-ghost badge-sm rounded-lg">{{
-          entry.mediaType
-        }}</span>
+        <span class="kr-badge-ghost-sm rounded-lg">{{ entry.mediaType }}</span>
         <slot name="close" />
       </div>
     </div>
@@ -186,7 +184,7 @@
             name="kind-icon:star"
             class="size-3 shrink-0 text-warning"
           />
-          <span class="badge badge-ghost badge-sm rounded-lg">{{
+          <span class="kr-badge-ghost-sm rounded-lg">{{
             related.mediaType
           }}</span>
           <span>{{ related.year ?? 'Year unknown' }}</span>

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -199,7 +199,7 @@
                     >
                       #{{ submission.rank }}
                     </span>
-                    <span class="badge badge-outline badge-sm rounded-lg">
+                    <span class="kr-badge-outline-sm rounded-lg">
                       {{ submission.variantKey }}
                     </span>
                     <span

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -170,7 +170,7 @@
             <div class="min-w-0">
               <b>{{ focusKey ? 'Focused card' : selectedSet.label }}</b>
               <span v-if="!focusKey" class="ml-2 opacity-55">{{ selectedSet.description }}</span>
-              <span v-else-if="focusPosition && focusPosition.total > 1" class="ml-2 badge badge-ghost badge-sm">
+              <span v-else-if="focusPosition && focusPosition.total > 1" class="kr-badge-ghost-sm ml-2">
                 result {{ focusPosition.index + 1 }} / {{ focusPosition.total }}
               </span>
             </div>
@@ -203,7 +203,7 @@
                 <span v-if="currentCard.hskLevel" class="kr-badge-outline-sm">HSK {{ currentCard.hskLevel }}</span>
                 <span class="kr-badge-ghost-sm">{{ currentPositionLabel }}</span>
                 <span class="kr-badge-ghost-sm">{{ studySessionRatedForSet }} rated</span>
-                <span v-if="studyDiagnostics?.dueCount" class="badge badge-primary badge-outline badge-sm">
+                <span v-if="studyDiagnostics?.dueCount" class="kr-badge-outline-sm badge-primary">
                   {{ studyDiagnostics.dueCount }} due
                 </span>
                 <span v-if="studyDiagnostics?.retentionRate !== null && studyDiagnostics?.retentionRate !== undefined" class="kr-badge-ghost-sm">


### PR DESCRIPTION
Slice 110 of the interface-vision/t-104 kr-* consistency sweep (conductor).

Migrates the remaining subset-match candidates for the `badge-{ghost,warning,outline}-sm` family (55 occurrences across 32 files) using `kr_badge_codemod.py` without `--exact-only` — the exact-match pool cleared in slice 109 (kind_robots#2453), leaving only the style-guide demo in `ui-gallery.vue`, which stays hand-rolled per established convention.

No geometry or behavior change — only the base badge tokens (`badge badge-{ghost,warning,outline} badge-sm`) fold into the primitive; every extra utility class is preserved verbatim.

**Verification:**
- `vue-tsc --noEmit` clean
- `eslint` on changed files: 0 new issues (4 pre-existing errors confirmed via `git stash` on `achievement-gallery.vue`, `daily-digest-object-dialog.vue`, `workspace-narrator.vue`, `for-you-manager.vue`)
- `test:layout-contract` holds (207 baseline, unchanged)
- `test:lint-ratchet` holds (333 problems / -59, unchanged)
- `prettier --check`: scoped `--write` applied to `artjob-queue-card.vue` and `watchlist-entry-detail.vue` (shorter class name collapsed a multi-line tag); all other flagged files confirmed pre-existing drift via `git stash`
- CRLF line endings preserved verbatim in `workspace-narrator.vue` (codemod uses `newline=""`)
- No regression-guard hits for the exact class strings in `utils/scripts/*.mjs`/`.ts`/`.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jMs7H83MbHwzDhFHCMLrN

---
_Generated by [Claude Code](https://claude.ai/code/session_017jMs7H83MbHwzDhFHCMLrN)_