### PR TITLE
style: migrate hand-rolled badge shapes to kr-badge-{ghost,outline}-xs

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -990,6 +990,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply badge badge-secondary badge-sm;
   }
 
+  /* The extra-small, ghost-styled counterpart to .kr-badge-ghost-sm
+   * (interface-vision t-104 slice 112): `badge badge-ghost badge-xs`, the
+   * largest hand-rolled `badge-xs` pool surveyed (16 files, 21 occurrences). */
+  .kr-badge-ghost-xs {
+    @apply badge badge-ghost badge-xs;
+  }
+
+  /* The extra-small outline counterpart to .kr-badge-outline-sm (same
+   * slice): `badge badge-outline badge-xs`, previously hand-rolled in 16
+   * files (18 occurrences). */
+  .kr-badge-outline-xs {
+    @apply badge badge-outline badge-xs;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/art-lora-picker.vue
+++ b/components/art/art-lora-picker.vue
@@ -206,7 +206,7 @@
                   </span>
                   <span
                     v-if="entry.resource.isMature"
-                    class="badge badge-error badge-outline badge-xs shrink-0"
+                    class="kr-badge-outline-xs badge-error shrink-0"
                   >
                     18+
                   </span>

--- a/components/art/art-manager.vue
+++ b/components/art/art-manager.vue
@@ -112,7 +112,7 @@
                 Queue
                 <span
                   v-if="artJobWorkspaceTab === 'queue'"
-                  class="badge badge-success badge-outline badge-xs rounded-2xl"
+                  class="kr-badge-outline-xs badge-success rounded-2xl"
                 >
                   Live · 15s
                 </span>

--- a/components/art/collection-card.vue
+++ b/components/art/collection-card.vue
@@ -142,7 +142,7 @@
         </p>
       </div>
       <div v-if="showMeta" class="flex flex-wrap items-center gap-1">
-        <span class="badge badge-outline badge-xs">{{ imageCountLabel }}</span>
+        <span class="kr-badge-outline-xs">{{ imageCountLabel }}</span>
         <span v-if="collectionUsername" class="badge badge-primary badge-xs">
           {{ collectionUsername }}
         </span>

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -6,7 +6,7 @@
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:palette" class="size-4 text-secondary" />
           <h3 class="text-sm font-black">Artwork</h3>
-          <span class="badge badge-ghost badge-xs">{{ entityLabel }}</span>
+          <span class="kr-badge-ghost-xs">{{ entityLabel }}</span>
         </div>
         <p class="mt-1 text-xs text-base-content/50">
           Recreate with Krea, edit the current image with SDXL or Kontext, or upload a finished replacement.
@@ -100,7 +100,7 @@
           <h4 class="text-xs font-black uppercase tracking-wide text-base-content/55">
             Inspiration history
           </h4>
-          <span class="badge badge-ghost badge-xs ml-auto">{{ filteredHistory.length }}</span>
+          <span class="kr-badge-ghost-xs ml-auto">{{ filteredHistory.length }}</span>
         </div>
         <div v-if="filteredHistory.length" class="grid max-h-72 grid-cols-2 gap-2 overflow-y-auto">
           <article

--- a/components/art/image-card.vue
+++ b/components/art/image-card.vue
@@ -191,7 +191,7 @@
       >
         <button
           v-if="checkpointDisplay"
-          class="badge badge-outline badge-xs max-w-full cursor-copy gap-1 truncate hover:badge-primary transition-colors"
+          class="kr-badge-outline-xs max-w-full cursor-copy gap-1 truncate hover:badge-primary transition-colors"
           type="button"
           :title="checkpointTitle"
           @click.stop="copyCheckpoint"
@@ -199,7 +199,7 @@
           <span class="truncate">{{ checkpointDisplay }}</span>
         </button>
 
-        <span v-if="displayImage.sampler" class="badge badge-ghost badge-xs">
+        <span v-if="displayImage.sampler" class="kr-badge-ghost-xs">
           {{ displayImage.sampler }}
         </span>
 

--- a/components/art/stylist-client-gallery.vue
+++ b/components/art/stylist-client-gallery.vue
@@ -131,10 +131,10 @@
             </div>
             <div class="flex flex-col gap-1 p-2">
               <div class="flex flex-wrap gap-1">
-                <span class="badge badge-outline badge-xs">
+                <span class="kr-badge-outline-xs">
                   {{ photoById.get(Number(item.id))!.folder }}
                 </span>
-                <span class="badge badge-ghost badge-xs">
+                <span class="kr-badge-ghost-xs">
                   {{ photoById.get(Number(item.id))!.kind }}
                 </span>
               </div>

--- a/components/art/stylist-relay-status.vue
+++ b/components/art/stylist-relay-status.vue
@@ -95,13 +95,13 @@
             <span
               v-for="engine in agent.engines"
               :key="engine"
-              class="badge badge-outline badge-xs rounded-2xl"
+              class="kr-badge-outline-xs rounded-2xl"
             >
               {{ engine }}
             </span>
             <span
               v-if="!agent.engines.length"
-              class="badge badge-ghost badge-xs rounded-2xl"
+              class="kr-badge-ghost-xs rounded-2xl"
             >
               no engines declared
             </span>

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -73,7 +73,7 @@
               class="size-5 text-base-content/40"
             />
           </span>
-          <span class="badge badge-outline badge-xs shrink-0">
+          <span class="kr-badge-outline-xs shrink-0">
             {{ facet.taxonomy.replace(/_/g, ' ') }}
           </span>
           <span class="min-w-0 flex-1">

--- a/components/conductor/packmaker-pack-editor.vue
+++ b/components/conductor/packmaker-pack-editor.vue
@@ -117,7 +117,7 @@
         <summary
           class="flex cursor-pointer flex-wrap items-center gap-2 px-3 py-2"
         >
-          <span class="badge badge-xs rounded-lg badge-ghost">{{
+          <span class="kr-badge-ghost-xs rounded-lg">{{
             item.type
           }}</span>
           <span class="text-sm font-bold">{{

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -325,7 +325,7 @@
         >
           Roadmap
         </span>
-        <span class="badge badge-ghost badge-xs ml-auto">
+        <span class="kr-badge-ghost-xs ml-auto">
           {{ selectedProject.tasks.length }} tasks
         </span>
       </summary>
@@ -450,7 +450,7 @@
         >
           Milestones
         </span>
-        <span class="badge badge-ghost badge-xs ml-auto">
+        <span class="kr-badge-ghost-xs ml-auto">
           {{ selectedProject.milestones.length }}
         </span>
       </summary>

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -317,7 +317,7 @@
               <span
                 v-for="category in selectedRow.source.categories"
                 :key="category"
-                class="badge badge-ghost badge-xs"
+                class="kr-badge-ghost-xs"
               >
                 {{ category }}
               </span>

--- a/components/dreams/daily-digest-object-gallery.vue
+++ b/components/dreams/daily-digest-object-gallery.vue
@@ -81,7 +81,7 @@
               <span
                 v-for="meta in item.meta.slice(0, 1)"
                 :key="meta"
-                class="badge badge-ghost badge-xs max-w-full truncate rounded-md"
+                class="kr-badge-ghost-xs max-w-full truncate rounded-md"
               >
                 {{ meta }}
               </span>

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -78,7 +78,7 @@
               class="size-5 text-base-content/40"
             />
           </span>
-          <span class="badge badge-outline badge-xs shrink-0">{{
+          <span class="kr-badge-outline-xs shrink-0">{{
             taxonomyLabel(facet.taxonomy)
           }}</span>
           <span class="min-w-0 flex-1">

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -105,7 +105,7 @@
         >
           <Icon name="kind-icon:bolt" class="h-3.5 w-3.5" />
           Auto-build group
-          <span v-if="busyCount" class="badge badge-xs badge-ghost"
+          <span v-if="busyCount" class="kr-badge-ghost-xs"
             >{{ busyCount }} busy</span
           >
         </button>

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -37,7 +37,7 @@
           <template v-else>
             <Icon name="kind-icon:bolt" class="h-3.5 w-3.5" />
             Auto-build all
-            <span v-if="busyCount" class="badge badge-xs badge-ghost"
+            <span v-if="busyCount" class="kr-badge-ghost-xs"
               >{{ busyCount }} busy</span
             >
           </template>
@@ -75,7 +75,7 @@
           <span class="truncate text-sm font-bold text-base-content">
             {{ run?.sourceLabel }}
           </span>
-          <span class="badge badge-xs badge-ghost">{{ run?.sourceType }}</span>
+          <span class="kr-badge-ghost-xs">{{ run?.sourceType }}</span>
           <span class="text-[10px] text-base-content/35">#{{ run?.sourceId }}</span>
         </div>
         <p

--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -93,7 +93,7 @@
             <span class="truncate text-sm font-bold text-base-content">
               {{ output.label }}
             </span>
-            <span class="badge badge-xs badge-ghost">{{
+            <span class="kr-badge-ghost-xs">{{
               output.generation
             }}</span>
             <span v-if="output.size" class="text-[10px] text-base-content/40">

--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -76,7 +76,7 @@
               <span class="truncate text-sm font-bold text-base-content">
                 {{ run.sourceLabel || `#${run.sourceId}` }}
               </span>
-              <span class="badge badge-xs badge-ghost">{{
+              <span class="kr-badge-ghost-xs">{{
                 run.sourceType
               }}</span>
             </div>

--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -195,11 +195,11 @@
                 </span>
                 <span
                   v-if="tab.dashboardKey"
-                  class="badge badge-warning badge-outline badge-xs"
+                  class="kr-badge-outline-xs badge-warning"
                 >
                   {{ tab.dashboardKey }}/{{ tab.dashboardTab }}
                 </span>
-                <span v-if="tab.requiredRole" class="badge badge-error badge-outline badge-xs">
+                <span v-if="tab.requiredRole" class="kr-badge-outline-xs badge-error">
                   {{ tab.requiredRole }}
                 </span>
               </div>

--- a/components/navigation/snapshot-mode-banner.vue
+++ b/components/navigation/snapshot-mode-banner.vue
@@ -17,7 +17,7 @@
       <span
         v-for="model in snapshotActiveModels"
         :key="model"
-        class="badge badge-warning badge-outline badge-xs"
+        class="kr-badge-outline-xs badge-warning"
       >
         {{ model }}
       </span>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -443,7 +443,7 @@
                     >
                     <span
                       v-else-if="todo.priority === 'LOW'"
-                      class="badge badge-ghost badge-xs shrink-0"
+                      class="kr-badge-ghost-xs shrink-0"
                       >🟢 low</span
                     >
                     <span
@@ -849,7 +849,7 @@
                   class="text-xs font-bold uppercase tracking-wide text-base-content/60"
                   >Milestones</span
                 >
-                <span class="badge badge-ghost badge-xs ml-auto">
+                <span class="kr-badge-ghost-xs ml-auto">
                   {{ selectedProject.milestones.length }}
                 </span>
               </summary>
@@ -907,7 +907,7 @@
                   class="text-xs font-bold uppercase tracking-wide text-base-content/60"
                   >Roadmap</span
                 >
-                <span class="badge badge-ghost badge-xs ml-auto">
+                <span class="kr-badge-ghost-xs ml-auto">
                   {{ selectedProject.tasks.length }} tasks
                 </span>
               </summary>

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -158,7 +158,7 @@
                     {{ pitch.projectTarget }}
                   </span>
                   <span v-if="pitch.date">{{ pitch.date }}</span>
-                  <span v-if="pitch.effort" class="badge badge-ghost badge-xs rounded-xl">
+                  <span v-if="pitch.effort" class="kr-badge-ghost-xs rounded-xl">
                     {{ pitch.effort }} effort
                   </span>
                 </div>

--- a/components/pages/creator-earnings-page.vue
+++ b/components/pages/creator-earnings-page.vue
@@ -181,7 +181,7 @@
                         </span>
                         <span
                           v-if="interaction.isSelfAttribution"
-                          class="badge badge-ghost badge-xs"
+                          class="kr-badge-ghost-xs"
                         >
                           Self-generated
                         </span>

--- a/components/resources/resource-card.vue
+++ b/components/resources/resource-card.vue
@@ -51,7 +51,7 @@
         {{ humanDescription }}
       </p>
 
-      <span v-if="showsServerBadge" class="badge badge-outline badge-xs w-fit">
+      <span v-if="showsServerBadge" class="kr-badge-outline-xs w-fit">
         {{ resource.supportedServer }}
       </span>
     </div>

--- a/components/reviews/review-list.vue
+++ b/components/reviews/review-list.vue
@@ -65,13 +65,13 @@
 
           <span
             v-if="authorOf(review)"
-            class="badge badge-primary badge-outline badge-xs"
+            class="kr-badge-outline-xs badge-primary"
             :title="`Written in character, published by a Kind Robots account`"
           >
             {{ authorOf(review)?.kind === 'BOT' ? 'bot' : 'character' }}
           </span>
 
-          <span v-if="roleFor(review)" class="badge badge-outline badge-xs">
+          <span v-if="roleFor(review)" class="kr-badge-outline-xs">
             {{ roleFor(review) }}
           </span>
 

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -73,7 +73,7 @@
               class="size-5 text-base-content/40"
             />
           </span>
-          <span class="badge badge-outline badge-xs shrink-0">
+          <span class="kr-badge-outline-xs shrink-0">
             {{ facet.taxonomy.replace(/_/g, ' ') }}
           </span>
           <span class="min-w-0 flex-1">

--- a/components/ruler-hooked/ruler-hooked-fishopedia.vue
+++ b/components/ruler-hooked/ruler-hooked-fishopedia.vue
@@ -19,7 +19,7 @@
           <template v-if="entryFor(fish.slug)">
             <div class="flex flex-wrap items-center gap-2">
               <span class="badge badge-xs" :class="affinityClass(fish.affinity)">{{ fish.affinity }}</span>
-              <span class="badge badge-outline badge-xs">{{ fish.rarity }}</span>
+              <span class="kr-badge-outline-xs">{{ fish.rarity }}</span>
               <span class="text-xs opacity-50">×{{ entryFor(fish.slug)!.countCaught }}</span>
             </div>
             <h4 class="mt-2 font-black">{{ fish.name }}</h4>

--- a/components/stages/stage-preset.vue
+++ b/components/stages/stage-preset.vue
@@ -46,7 +46,7 @@
         <span
           v-for="role in preset.roles"
           :key="role.key"
-          class="badge badge-outline badge-xs gap-1"
+          class="kr-badge-outline-xs gap-1"
         >
           <img
             v-if="role.badgeImagePath"

--- a/components/tasks/honeydo-card.vue
+++ b/components/tasks/honeydo-card.vue
@@ -42,7 +42,7 @@
       >
       <span
         v-else-if="todo.priority === 'LOW'"
-        class="badge badge-ghost badge-xs shrink-0"
+        class="kr-badge-ghost-xs shrink-0"
         >🟢 low</span
       >
       <span

--- a/components/user/user-galleries.vue
+++ b/components/user/user-galleries.vue
@@ -138,7 +138,7 @@
                   </div>
                   <span
                     v-if="getItemVisibility(item)"
-                    class="badge badge-outline badge-xs"
+                    class="kr-badge-outline-xs"
                   >
                     {{ getItemVisibility(item) }}
                   </span>

--- a/utils/scripts/codemods/kr_badge_codemod.py
+++ b/utils/scripts/codemods/kr_badge_codemod.py
@@ -1,30 +1,32 @@
 #!/usr/bin/env python3
-"""Find or migrate hand-rolled kr-badge-{ghost,warning,outline,primary,secondary}-sm badges.
+"""Find or migrate hand-rolled kr-badge-{ghost,warning,outline,primary,secondary}-sm
+and kr-badge-{ghost,outline}-xs badges.
 
 Dry-run is the default. Pass --write to update matching Vue files in place.
-Only the approved small badge shapes are touched (`badge badge-ghost
-badge-sm`, `badge badge-warning badge-sm`, `badge badge-outline badge-sm`,
-`badge badge-primary badge-sm`, `badge badge-secondary badge-sm`), and only
-in static `class="..."` attributes -- never `:class`/`v-bind:class`
-bindings, and regardless of the base tokens' order in the source
-(`badge-ghost badge-sm` counts the same as `badge-sm badge-ghost`). A source
-that already carries the target primitive, or is missing any one of the base
-tokens, is left untouched. Extra tokens beyond the base set (ml-auto,
-shrink-0, rounded-lg, ...) are preserved verbatim after the primitive class,
-matching the kr-input-sm/kr-checkbox-* codemods' subset-match convention --
-they're plain Tailwind utilities layered on top, not another component-root
-class, so resolution order is unaffected by folding the three base tokens
-into one name. This includes a second color modifier (e.g. `badge-outline`
-alongside `badge-primary`) preserved as an "extra" token verbatim -- the
-same latent behavior the ghost/warning/outline families already had for a
-stray color token, not new to this pair.
+Only the approved badge shapes are touched (`badge badge-ghost badge-sm`,
+`badge badge-warning badge-sm`, `badge badge-outline badge-sm`, `badge
+badge-primary badge-sm`, `badge badge-secondary badge-sm`, `badge
+badge-ghost badge-xs`, `badge badge-outline badge-xs`), and only in static
+`class="..."` attributes -- never `:class`/`v-bind:class` bindings, and
+regardless of the base tokens' order in the source (`badge-ghost badge-sm`
+counts the same as `badge-sm badge-ghost`). A source that already carries
+the target primitive, or is missing any one of the base tokens, is left
+untouched. Extra tokens beyond the base set (ml-auto, shrink-0, rounded-lg,
+...) are preserved verbatim after the primitive class, matching the
+kr-input-sm/kr-checkbox-* codemods' subset-match convention -- they're plain
+Tailwind utilities layered on top, not another component-root class, so
+resolution order is unaffected by folding the three base tokens into one
+name. This includes a second color modifier (e.g. `badge-outline` alongside
+`badge-primary`) preserved as an "extra" token verbatim -- the same latent
+behavior the ghost/warning/outline families already had for a stray color
+token, not new to this pair.
 
 FAMILIES is ordered most-specific-first on purpose: each entry's base token
-set differs only in its color modifier (ghost/warning/outline/primary/
-secondary), so order among them doesn't matter for correctness here, but a
-future plain-size family (e.g. a colorless `kr-badge-sm`) would need to come
-LAST, since its smaller base set is a subset of every colored family's
-tokens above.
+set differs in its size (sm/xs) and color modifier (ghost/warning/outline/
+primary/secondary), so order among them doesn't matter for correctness here
+(no entry's base set is a subset of another's), but a future plain-size
+family (e.g. a colorless `kr-badge-sm`) would need to come LAST, since its
+smaller base set would be a subset of every colored family's tokens above.
 """
 
 from __future__ import annotations
@@ -41,6 +43,8 @@ FAMILIES = [
     ("kr-badge-outline-sm", {"badge", "badge-outline", "badge-sm"}),
     ("kr-badge-primary-sm", {"badge", "badge-primary", "badge-sm"}),
     ("kr-badge-secondary-sm", {"badge", "badge-secondary", "badge-sm"}),
+    ("kr-badge-ghost-xs", {"badge", "badge-ghost", "badge-xs"}),
+    ("kr-badge-outline-xs", {"badge", "badge-outline", "badge-xs"}),
 ]
 
 


### PR DESCRIPTION
interface-vision/t-104 slice 112: extend `kr_badge_codemod.py`'s badge family with the extra-small ghost and outline badge shapes (`kr-badge-ghost-xs`, `kr-badge-outline-xs`), the two largest hand-rolled `badge-xs` pools surveyed now that the `-sm` family has full color coverage (slice 111).

**What changed**
- Surveyed all `badge-xs` color combinations: ghost (21 occurrences/16 files) and outline (18/16) were the two largest pools, ahead of primary (11/7), error/warning (8/7 each), success (7/7), secondary (5/4), accent (3/3), info/neutral (2/2 each).
- Added the two CSS primitives to `assets/css/tailwind.css` and two `FAMILIES` entries to `kr_badge_codemod.py`.
- Subset-match run (no `--exact-only`) migrated 41 occurrences across 30 files.
- `ui-gallery.vue`'s style-guide demo excluded per established convention (its 2 matches were pre-existing ghost/warning-**sm** demo badges, confirmed via direct script invocation — no new xs matches there).

**Verification**
- No regression-guard hits (`utils/scripts/*.{mjs,ts,js}` searched for the literal `badge-ghost`/`badge-outline` class strings).
- `vue-tsc --noEmit`: clean.
- `eslint` on all 29 changed files: 5 pre-existing errors confirmed via `git stash` (`vue/no-mutating-props`, 2x `no-empty`, `no-dynamic-delete`, `no-unused-vars`), 0 new.
- `test:layout-contract`: held at 207 baseline.
- `test:lint-ratchet`: held at 333 problems/-59.
- `prettier --check`: flagged 21 files, all confirmed pre-existing via `git stash` — 0 newly-flagged.

Tracked in conductor as `interface-vision/t-104` (recurring kr-* consistency sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTKvtZ5dA8mb3Rk9xrhXNV)_