### PR TITLE
art: migration to drop the retired entity art columns (BLOCKED — do not merge yet)

### DIFF
--- a/prisma/migrations/20260906120000_drop_retired_entity_art_slots/migration.sql
+++ b/prisma/migrations/20260906120000_drop_retired_entity_art_slots/migration.sql
@@ -1,0 +1,78 @@
+-- Entity art slot collapse: drop the retired card/hero/icon columns.
+--
+-- Every object now carries ONE primary render, cropped per frame at display
+-- time, plus an inspiration gallery (EntityArtImage). The four-slots-per-object
+-- model cost four renders each for no display benefit -- the frames differ, but
+-- the picture does not need to.
+--
+-- SAFE TO RUN because the data migration already completed and was verified
+-- against production on 2026-09-06:
+--   * 1,820 card/hero/icon renders were linked into EntityArtImage, so every
+--     one of them remains reachable as an inspiration entry. No ArtImage row is
+--     touched by this migration -- only the entity columns that pointed at them.
+--   * each of those images was retagged from `entity:<type>:<id>:current:<field>`
+--     to `entity:<type>:<id>:history:<field>:<timestamp>` BEFORE its column was
+--     cleared, so none can fall to the unfiled landing zone that the container
+--     triage pass deletes, and the field it used to serve is still recorded.
+--   * all 917 objects were confirmed to hold a primary render, so none can go
+--     blank as a result of this drop.
+--   * every column below was then verified empty in production.
+--
+-- ONE EXCEPTION, deliberately accepted: Facet 16 ("Circus") holds a bare
+-- `cardPath` string with no ArtImage row behind it, so the fail-closed clearing
+-- guard refused to touch it -- there was no id to link or verify. Dropping the
+-- column discards that one path string. The image it points at is not deleted;
+-- it simply stops being referenced from the Facet row.
+--
+-- These columns carry no foreign-key constraints (plain nullable Int/Text in
+-- schema.prisma, no @relation), so no constraint has to be dropped first.
+
+ALTER TABLE `Character`
+    DROP COLUMN `cardPath`,
+    DROP COLUMN `heroPath`,
+    DROP COLUMN `iconPath`,
+    DROP COLUMN `cardArtImageId`,
+    DROP COLUMN `heroArtImageId`,
+    DROP COLUMN `iconArtImageId`;
+
+ALTER TABLE `Bot`
+    DROP COLUMN `cardPath`,
+    DROP COLUMN `heroPath`,
+    DROP COLUMN `iconPath`,
+    DROP COLUMN `cardArtImageId`,
+    DROP COLUMN `heroArtImageId`,
+    DROP COLUMN `iconArtImageId`;
+
+ALTER TABLE `Scenario`
+    DROP COLUMN `cardPath`,
+    DROP COLUMN `heroPath`,
+    DROP COLUMN `iconPath`,
+    DROP COLUMN `cardArtImageId`,
+    DROP COLUMN `heroArtImageId`,
+    DROP COLUMN `iconArtImageId`;
+
+ALTER TABLE `Reward`
+    DROP COLUMN `cardPath`,
+    DROP COLUMN `heroPath`,
+    DROP COLUMN `iconPath`,
+    DROP COLUMN `cardArtImageId`,
+    DROP COLUMN `heroArtImageId`,
+    DROP COLUMN `iconArtImageId`;
+
+ALTER TABLE `Facet`
+    DROP COLUMN `cardPath`,
+    DROP COLUMN `heroPath`,
+    DROP COLUMN `iconPath`,
+    DROP COLUMN `cardArtImageId`,
+    DROP COLUMN `heroArtImageId`,
+    DROP COLUMN `iconArtImageId`;
+
+-- Dream never carried per-slot ArtImage foreign keys, only the three paths,
+-- and the live census found all three empty across every Dream.
+ALTER TABLE `Dream`
+    DROP COLUMN `cardPath`,
+    DROP COLUMN `heroPath`,
+    DROP COLUMN `iconPath`;
+
+-- Project is intentionally NOT included. It keeps its own art flow and its own
+-- ProjectArtImage gallery, and its columns were never part of this collapse.


### PR DESCRIPTION
⚠️ **Draft — do not merge.** Auto-migrate means merging applies this, and it would break the build and the deploy together. Details below.

## The migration

Drops all **33** retired columns — `cardPath`/`heroPath`/`iconPath` plus their `*ArtImageId` keys — across Character, Bot, Scenario, Reward and Facet, plus Dream's three paths (Dream never had the foreign keys). Project is deliberately excluded: it keeps its own art flow and `ProjectArtImage` gallery and was never part of this collapse.

The columns carry no foreign-key constraints (plain nullable `Int`/`Text`, no `@relation`), so nothing has to be dropped first.

## Why it's safe on the data side

All verified against production today:

- **1,820** card/hero/icon renders linked into `EntityArtImage` — every one still reachable as an inspiration entry. This migration touches no `ArtImage` row, only the entity columns that pointed at them.
- Each was retagged from `entity:<type>:<id>:current:<field>` to `entity:<type>:<id>:history:<field>:<timestamp>` **before** its column was cleared, so none can fall to the unfiled landing zone the triage pass deletes — and the field it used to serve is still recorded in the tag.
- **917 of 917** objects confirmed to hold a primary render, so none can go blank.
- Every column listed was then verified empty.

One deliberate exception, documented in the SQL: Facet 16 ("Circus") holds a bare `cardPath` with no `ArtImage` row behind it, so the fail-closed guard refused to clear it. Dropping the column discards that one path string; the image itself is not deleted, it just stops being referenced from the Facet row.

## Why it's blocked

**130 TypeScript references across ~40 files still read these columns.** I measured this empirically rather than by grepping — dropped the columns locally, regenerated the Prisma client, ran `vue-tsc`. Raw greps suggested ~600 hits, but most are string literals in verification scripts; the real number that fails compilation is 130.

Roughly: 46 were whole-line field entries in selects and type declarations (mechanically removable — I did these in a scratch pass to get the true count, then reverted), and the remaining ~130 are property accesses in fallback chains, API patch handlers and local type definitions that need per-site judgment, plus cascading inference errors that should resolve once those land.

Note the `schema.prisma` change is **not** in this commit. Leaving the model fields in place keeps `main` compiling while the reference cleanup lands; the schema edit belongs in the same PR as the last of those fixes, so the drop and the last reference removal go green together.

## Next

The reference cleanup is a real slice of work — ~40 files, mostly mechanical but with behaviour-changing decisions in the fallback chains. Happy to take it on; it wants to land as a few reviewable PRs rather than one sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoXLrc2yHnkZtNBY4b8zSX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoXLrc2yHnkZtNBY4b8zSX)_