### PR TITLE
style: migrate hand-rolled badge shapes to kr-badge-{primary,warning}-xs

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1004,6 +1004,21 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply badge badge-outline badge-xs;
   }
 
+  /* The primary-colored counterpart to .kr-badge-primary-sm at the xs size
+   * (interface-vision t-104 slice 113): `badge badge-primary badge-xs`, the
+   * largest remaining hand-rolled `badge-xs` pool surveyed (6 files, 10
+   * occurrences). */
+  .kr-badge-primary-xs {
+    @apply badge badge-primary badge-xs;
+  }
+
+  /* The warning-colored counterpart to .kr-badge-warning-sm at the xs size
+   * (same slice): `badge badge-warning badge-xs`, tied with success/error-xs
+   * as the next-largest pool (5 files, 6 occurrences). */
+  .kr-badge-warning-xs {
+    @apply badge badge-warning badge-xs;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/collection-card.vue
+++ b/components/art/collection-card.vue
@@ -105,13 +105,11 @@
         <span v-if="collection.isPublic" class="badge badge-success badge-xs"
           >Public</span
         >
-        <span v-else class="badge badge-warning badge-xs">Private</span>
+        <span v-else class="kr-badge-warning-xs">Private</span>
         <span v-if="collection.isMature" class="badge badge-error badge-xs"
           >Mature</span
         >
-        <span v-if="activeSelected" class="badge badge-primary badge-xs"
-          >Selected</span
-        >
+        <span v-if="activeSelected" class="kr-badge-primary-xs">Selected</span>
       </div>
 
       <div
@@ -143,7 +141,7 @@
       </div>
       <div v-if="showMeta" class="flex flex-wrap items-center gap-1">
         <span class="kr-badge-outline-xs">{{ imageCountLabel }}</span>
-        <span v-if="collectionUsername" class="badge badge-primary badge-xs">
+        <span v-if="collectionUsername" class="kr-badge-primary-xs">
           {{ collectionUsername }}
         </span>
       </div>

--- a/components/art/image-card.vue
+++ b/components/art/image-card.vue
@@ -90,9 +90,7 @@
         <span v-if="displayImage.imageData" class="badge badge-success badge-xs"
           >data</span
         >
-        <span
-          v-else-if="displayImage.imagePath"
-          class="badge badge-warning badge-xs"
+        <span v-else-if="displayImage.imagePath" class="kr-badge-warning-xs"
           >path</span
         >
         <span v-else class="badge badge-error badge-xs">none</span>
@@ -105,7 +103,7 @@
         <span v-if="displayImage.isMature" class="badge badge-error badge-xs"
           >Mature</span
         >
-        <span v-if="!displayImage.isPublic" class="badge badge-warning badge-xs"
+        <span v-if="!displayImage.isPublic" class="kr-badge-warning-xs"
           >Private</span
         >
       </div>
@@ -205,7 +203,7 @@
 
         <span
           v-if="displayImage.designer && size === 'lg'"
-          class="badge badge-primary badge-xs"
+          class="kr-badge-primary-xs"
         >
           {{ displayImage.designer }}
         </span>

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -509,7 +509,7 @@
                 <p class="text-sm font-bold">{{ entry.title }}</p>
                 <span
                   v-if="entry.equipped"
-                  class="badge badge-primary badge-xs shrink-0"
+                  class="kr-badge-primary-xs shrink-0"
                 >
                   Equipped
                 </span>
@@ -747,7 +747,7 @@
             <p class="text-sm font-bold">{{ tankStore.finaleConfig.title }}</p>
             <span
               v-if="tankStore.finaleTriggered"
-              class="badge badge-primary badge-xs shrink-0"
+              class="kr-badge-primary-xs shrink-0"
             >
               Yours
             </span>

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -152,7 +152,7 @@
               Art prompt
               <span
                 v-if="fish.curation.promptOverride"
-                class="badge badge-xs badge-warning"
+                class="kr-badge-warning-xs"
                 >draft override</span
               >
             </span>

--- a/components/navigation/channel-tab-list.vue
+++ b/components/navigation/channel-tab-list.vue
@@ -74,7 +74,7 @@
                 </span>
                 <span
                   v-if="isAdminOnlyTab(channel, tab)"
-                  class="badge badge-warning badge-xs shrink-0 font-bold uppercase"
+                  class="kr-badge-warning-xs shrink-0 font-bold uppercase"
                   title="Admin-only page"
                 >
                   Admin

--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -189,7 +189,7 @@
                 <span class="font-black">{{ tab.label }}</span>
                 <span
                   v-if="tab.tabKey === channel.defaultTab"
-                  class="badge badge-primary badge-xs"
+                  class="kr-badge-primary-xs"
                 >
                   default
                 </span>

--- a/components/navigation/navigation-trimmed.vue
+++ b/components/navigation/navigation-trimmed.vue
@@ -97,7 +97,7 @@
                 </span>
                 <span
                   v-if="isAdminOnlyTab(channel, tab)"
-                  class="badge badge-warning badge-xs shrink-0 font-bold uppercase"
+                  class="kr-badge-warning-xs shrink-0 font-bold uppercase"
                   title="Admin-only page"
                 >
                   Admin

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -144,7 +144,7 @@
                 {{ app.taskDone }} of {{ app.taskTotal }} tasks done
                 <span
                   v-if="app.needsHuman > 0"
-                  class="badge badge-primary badge-xs ml-1"
+                  class="kr-badge-primary-xs ml-1"
                 >
                   {{ app.needsHuman }} need you
                 </span>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -26,7 +26,7 @@
           <span class="text-xs font-semibold text-base-content/50">
             {{ userStore.isAdmin ? 'Conductor' : 'Projects' }}
           </span>
-          <span v-if="userStore.isAdmin" class="badge badge-primary badge-xs"
+          <span v-if="userStore.isAdmin" class="kr-badge-primary-xs"
             >ADMIN</span
           >
         </span>
@@ -38,7 +38,7 @@
           >· Tasks
           <span
             v-if="todoStore.openTodos.length"
-            class="badge badge-primary badge-xs ml-1"
+            class="kr-badge-primary-xs ml-1"
             >{{ todoStore.openTodos.length }}</span
           >
         </span>
@@ -312,7 +312,7 @@
                   🤖 Agent
                   <span
                     v-if="todoStore.regularAgentTodos.length"
-                    class="badge badge-xs badge-primary"
+                    class="kr-badge-primary-xs"
                     >{{ todoStore.regularAgentTodos.length }}</span
                   >
                 </button>

--- a/utils/scripts/codemods/kr_badge_codemod.py
+++ b/utils/scripts/codemods/kr_badge_codemod.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """Find or migrate hand-rolled kr-badge-{ghost,warning,outline,primary,secondary}-sm
-and kr-badge-{ghost,outline}-xs badges.
+and kr-badge-{ghost,outline,primary,warning}-xs badges.
 
 Dry-run is the default. Pass --write to update matching Vue files in place.
 Only the approved badge shapes are touched (`badge badge-ghost badge-sm`,
 `badge badge-warning badge-sm`, `badge badge-outline badge-sm`, `badge
 badge-primary badge-sm`, `badge badge-secondary badge-sm`, `badge
-badge-ghost badge-xs`, `badge badge-outline badge-xs`), and only in static
+badge-ghost badge-xs`, `badge badge-outline badge-xs`, `badge badge-primary
+badge-xs`, `badge badge-warning badge-xs`), and only in static
 `class="..."` attributes -- never `:class`/`v-bind:class` bindings, and
 regardless of the base tokens' order in the source (`badge-ghost badge-sm`
 counts the same as `badge-sm badge-ghost`). A source that already carries
@@ -45,6 +46,8 @@ FAMILIES = [
     ("kr-badge-secondary-sm", {"badge", "badge-secondary", "badge-sm"}),
     ("kr-badge-ghost-xs", {"badge", "badge-ghost", "badge-xs"}),
     ("kr-badge-outline-xs", {"badge", "badge-outline", "badge-xs"}),
+    ("kr-badge-primary-xs", {"badge", "badge-primary", "badge-xs"}),
+    ("kr-badge-warning-xs", {"badge", "badge-warning", "badge-xs"}),
 ]
 
 


### PR DESCRIPTION
interface-vision/t-104 slice 113: extend `kr_badge_codemod.py`'s badge family with the extra-small primary and warning badge shapes (`kr-badge-primary-xs`, `kr-badge-warning-xs`), the largest remaining hand-rolled `badge-xs` pools now that ghost/outline-xs are covered (slice 112).

**What changed**
- Surveyed remaining `badge-xs` color combinations: primary (10 occurrences/6 files) was the clear largest, ahead of a three-way tie between success/warning/error (6/5 each); secondary (5/4), accent (3/3), info/neutral (2/2 each). Picked primary + warning to round out the xs family alongside ghost/outline, mirroring four of the five colors already covered at the -sm size.
- Added the two CSS primitives to `assets/css/tailwind.css` and two `FAMILIES` entries to `kr_badge_codemod.py`.
- Subset-match run (no `--exact-only`) migrated 16 occurrences across 9 files.
- `ui-gallery.vue`'s style-guide demo excluded per established convention (its 2 matches were pre-existing ghost/warning-**sm** demo badges, confirmed via direct script invocation — no new xs matches there).

**Verification**
- No regression-guard hits (`utils/scripts/*.{mjs,ts,js}` searched for the literal `badge-primary`/`badge-warning` class strings; the 6 changed files referenced by name in contract verifiers checked individually for badge class assertions — none found).
- `vue-tsc --noEmit`: clean.
- `eslint` on all 9 changed files: clean.
- `test:layout-contract`: held at 207 baseline.
- `test:lint-ratchet`: held at 333 problems/-59.
- `prettier --check`: 2 newly-flagged files (`collection-card.vue`, `image-card.vue`) fixed with scoped `--write` (class-shortening collapsed a multi-line tag); `navigation-health.vue`/`conductor-page.vue`/`tailwind.css` confirmed pre-existing drift via `git stash`.
- Re-ran the codemod post-write: 0 remaining candidates outside the excluded `ui-gallery.vue`.

Tracked in conductor as `interface-vision/t-104` (recurring kr-* consistency sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GPvHs9ZXg1J2Ts5fxakDP

---
_Generated by [Claude Code](https://claude.ai/code/session_012GPvHs9ZXg1J2Ts5fxakDP)_