### PR TITLE
style: migrate hand-rolled badge shapes to kr-badge-{success,error,secondary,accent,info,neutral}-xs

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1019,6 +1019,35 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply badge badge-warning badge-xs;
   }
 
+  /* The remaining `badge-xs` color variants (interface-vision t-104 slice
+   * 114), rounding out full xs-size coverage alongside ghost/outline/
+   * primary/warning above: `badge-success`, `badge-error`, `badge-secondary`,
+   * `badge-accent`, `badge-info`, `badge-neutral`, each `badge-xs` -- the
+   * last 24 hand-rolled occurrences across 12 files. */
+  .kr-badge-success-xs {
+    @apply badge badge-success badge-xs;
+  }
+
+  .kr-badge-error-xs {
+    @apply badge badge-error badge-xs;
+  }
+
+  .kr-badge-secondary-xs {
+    @apply badge badge-secondary badge-xs;
+  }
+
+  .kr-badge-accent-xs {
+    @apply badge badge-accent badge-xs;
+  }
+
+  .kr-badge-info-xs {
+    @apply badge badge-info badge-xs;
+  }
+
+  .kr-badge-neutral-xs {
+    @apply badge badge-neutral badge-xs;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/art-lora-picker.vue
+++ b/components/art/art-lora-picker.vue
@@ -212,7 +212,7 @@
                   </span>
                 </span>
 
-                <span class="badge badge-secondary badge-xs rounded-lg">
+                <span class="kr-badge-secondary-xs rounded-lg">
                   {{ entry.resource.supportedServer }}
                 </span>
 

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -470,7 +470,7 @@
           class="absolute left-1.5 top-1.5"
           title="Loaded from resource DB"
         >
-          <span class="badge badge-xs badge-success px-1">DB</span>
+          <span class="kr-badge-success-xs px-1">DB</span>
         </div>
       </button>
     </div>

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -197,7 +197,7 @@
         >
           <span class="truncate">
             <strong>{{ engineLabel(m.a.engine) }}</strong> vs <strong>{{ engineLabel(m.b.engine) }}</strong>
-            <span v-if="m.winner" class="badge badge-success badge-xs ml-1">{{ m.winner }} won</span>
+            <span v-if="m.winner" class="kr-badge-success-xs ml-1">{{ m.winner }} won</span>
             <span class="ml-1 opacity-60">{{ m.note }}</span>
           </span>
           <span class="flex gap-1">

--- a/components/art/collection-card.vue
+++ b/components/art/collection-card.vue
@@ -102,13 +102,11 @@
         v-if="activeSelected || (collection.isMature && !showMature)"
         class="absolute left-2 top-2 flex flex-wrap gap-1"
       >
-        <span v-if="collection.isPublic" class="badge badge-success badge-xs"
+        <span v-if="collection.isPublic" class="kr-badge-success-xs"
           >Public</span
         >
         <span v-else class="kr-badge-warning-xs">Private</span>
-        <span v-if="collection.isMature" class="badge badge-error badge-xs"
-          >Mature</span
-        >
+        <span v-if="collection.isMature" class="kr-badge-error-xs">Mature</span>
         <span v-if="activeSelected" class="kr-badge-primary-xs">Selected</span>
       </div>
 

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -164,13 +164,13 @@
         </span>
         <span
           v-if="history.length"
-          class="badge badge-info badge-xs"
+          class="kr-badge-info-xs"
         >
           {{ history.length }} inspiration{{ history.length === 1 ? '' : 's' }}
         </span>
         <span
           v-if="collectionSlides.length"
-          class="badge badge-secondary badge-xs"
+          class="kr-badge-secondary-xs"
         >
           {{ collectionSlides.length }} collection
         </span>

--- a/components/art/image-card.vue
+++ b/components/art/image-card.vue
@@ -87,20 +87,20 @@
         v-if="showDebug"
         class="absolute left-1.5 top-1.5 flex flex-wrap gap-1"
       >
-        <span v-if="displayImage.imageData" class="badge badge-success badge-xs"
+        <span v-if="displayImage.imageData" class="kr-badge-success-xs"
           >data</span
         >
         <span v-else-if="displayImage.imagePath" class="kr-badge-warning-xs"
           >path</span
         >
-        <span v-else class="badge badge-error badge-xs">none</span>
+        <span v-else class="kr-badge-error-xs">none</span>
       </div>
 
       <div
         v-if="selected && size !== 'xs'"
         class="absolute left-1.5 top-1.5 flex flex-wrap gap-1"
       >
-        <span v-if="displayImage.isMature" class="badge badge-error badge-xs"
+        <span v-if="displayImage.isMature" class="kr-badge-error-xs"
           >Mature</span
         >
         <span v-if="!displayImage.isPublic" class="kr-badge-warning-xs"
@@ -157,10 +157,7 @@
         class="rounded-xl border border-base-300 bg-base-100 p-2 text-xs"
       >
         <div class="flex flex-wrap gap-1.5">
-          <span
-            class="badge badge-info badge-xs"
-            :title="`Image #${displayImage.id}`"
-          >
+          <span class="kr-badge-info-xs" :title="`Image #${displayImage.id}`">
             Image #{{ displayImage.id }}
           </span>
           <span class="badge badge-xs" :class="imageDataBadgeClass">

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -327,8 +327,8 @@
               <span class="loading loading-spinner loading-xs" />
               {{ job.queueState === 'rendering' ? 'rendering' : 'queued' }}
             </span>
-            <span v-else-if="job.status === 'failed'" class="badge badge-error badge-xs">failed</span>
-            <span v-else class="badge badge-success badge-xs">done</span>
+            <span v-else-if="job.status === 'failed'" class="kr-badge-error-xs">failed</span>
+            <span v-else class="kr-badge-success-xs">done</span>
             <div class="flex-1" />
             <button
               v-if="job.status === 'failed'"

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -394,9 +394,7 @@
               class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
             />
             Completed
-            <span class="badge badge-success badge-xs ml-auto">{{
-              doneTaskCount
-            }}</span>
+            <span class="kr-badge-success-xs ml-auto">{{ doneTaskCount }}</span>
           </summary>
           <div class="space-y-2 px-3 pb-3">
             <div v-for="group in doneTasksByMilestone" :key="group.id">

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -146,7 +146,7 @@
           Clean
           <span
             v-if="tankStore.pendingCleanClicks > 0"
-            class="badge badge-neutral badge-xs ml-1"
+            class="kr-badge-neutral-xs ml-1"
           >
             ×{{ tankStore.pendingCleanClicks }}
           </span>

--- a/components/dreams/daily-digest-object-gallery.vue
+++ b/components/dreams/daily-digest-object-gallery.vue
@@ -54,7 +54,7 @@
                 </span>
               </div>
               <span
-                class="badge badge-neutral badge-xs absolute left-1.5 top-1.5 max-w-[calc(100%-0.75rem)] truncate rounded-md shadow"
+                class="kr-badge-neutral-xs absolute left-1.5 top-1.5 max-w-[calc(100%-0.75rem)] truncate rounded-md shadow"
               >
                 {{ item.role }}
               </span>

--- a/components/navigation/cart-button.vue
+++ b/components/navigation/cart-button.vue
@@ -10,7 +10,7 @@
   >
     <span class="indicator">
       <Icon name="kind-icon:cart" class="h-5 w-5" />
-      <span class="badge indicator-item badge-secondary badge-xs">
+      <span class="kr-badge-secondary-xs indicator-item">
         {{ compactItemCount }}
       </span>
     </span>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -326,7 +326,7 @@
                   ✨ Story
                   <span
                     v-if="todoStore.serendipityAgentTodos.length"
-                    class="badge badge-xs badge-secondary"
+                    class="kr-badge-secondary-xs"
                     >{{ todoStore.serendipityAgentTodos.length }}</span
                   >
                 </button>
@@ -340,7 +340,7 @@
                   🍯 Honey Do
                   <span
                     v-if="todoStore.honeyDoTodos.length"
-                    class="badge badge-xs badge-accent"
+                    class="kr-badge-accent-xs"
                     >{{ todoStore.honeyDoTodos.length }}</span
                   >
                 </button>
@@ -438,7 +438,7 @@
                     >
                     <span
                       v-if="todo.priority === 'HIGH'"
-                      class="badge badge-error badge-xs shrink-0"
+                      class="kr-badge-error-xs shrink-0"
                       >🔴 high</span
                     >
                     <span
@@ -448,7 +448,7 @@
                     >
                     <span
                       v-if="todoStore.isSerendipityAgentTodo(todo)"
-                      class="badge badge-secondary badge-xs shrink-0"
+                      class="kr-badge-secondary-xs shrink-0"
                       >✨ story</span
                     >
                     <div class="flex shrink-0 gap-1">

--- a/components/tasks/honeydo-card.vue
+++ b/components/tasks/honeydo-card.vue
@@ -37,7 +37,7 @@
       >
       <span
         v-if="todo.priority === 'HIGH'"
-        class="badge badge-error badge-xs shrink-0"
+        class="kr-badge-error-xs shrink-0"
         >🔴 high</span
       >
       <span
@@ -47,7 +47,7 @@
       >
       <span
         v-if="showCategoryBadge"
-        class="badge badge-accent badge-xs shrink-0"
+        class="kr-badge-accent-xs shrink-0"
         >🍯 honey do</span
       >
       <span

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -67,7 +67,7 @@
                 {{ preset.label }}
                 <span
                   v-if="preset.id === defaultPreset.id"
-                  class="badge badge-xs badge-accent"
+                  class="kr-badge-accent-xs"
                 >
                   default
                 </span>

--- a/utils/scripts/codemods/kr_badge_codemod.py
+++ b/utils/scripts/codemods/kr_badge_codemod.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
 """Find or migrate hand-rolled kr-badge-{ghost,warning,outline,primary,secondary}-sm
-and kr-badge-{ghost,outline,primary,warning}-xs badges.
+and kr-badge-{ghost,outline,primary,warning,success,error,secondary,accent,info,neutral}-xs
+badges.
 
 Dry-run is the default. Pass --write to update matching Vue files in place.
 Only the approved badge shapes are touched (`badge badge-ghost badge-sm`,
 `badge badge-warning badge-sm`, `badge badge-outline badge-sm`, `badge
 badge-primary badge-sm`, `badge badge-secondary badge-sm`, `badge
 badge-ghost badge-xs`, `badge badge-outline badge-xs`, `badge badge-primary
-badge-xs`, `badge badge-warning badge-xs`), and only in static
+badge-xs`, `badge badge-warning badge-xs`, `badge badge-success badge-xs`,
+`badge badge-error badge-xs`, `badge badge-secondary badge-xs`, `badge
+badge-accent badge-xs`, `badge badge-info badge-xs`, `badge badge-neutral
+badge-xs`), and only in static
 `class="..."` attributes -- never `:class`/`v-bind:class` bindings, and
 regardless of the base tokens' order in the source (`badge-ghost badge-sm`
 counts the same as `badge-sm badge-ghost`). A source that already carries
@@ -48,6 +52,12 @@ FAMILIES = [
     ("kr-badge-outline-xs", {"badge", "badge-outline", "badge-xs"}),
     ("kr-badge-primary-xs", {"badge", "badge-primary", "badge-xs"}),
     ("kr-badge-warning-xs", {"badge", "badge-warning", "badge-xs"}),
+    ("kr-badge-success-xs", {"badge", "badge-success", "badge-xs"}),
+    ("kr-badge-error-xs", {"badge", "badge-error", "badge-xs"}),
+    ("kr-badge-secondary-xs", {"badge", "badge-secondary", "badge-xs"}),
+    ("kr-badge-accent-xs", {"badge", "badge-accent", "badge-xs"}),
+    ("kr-badge-info-xs", {"badge", "badge-info", "badge-xs"}),
+    ("kr-badge-neutral-xs", {"badge", "badge-neutral", "badge-xs"}),
 ]
 
 


### PR DESCRIPTION
### Task
interface-vision/t-104 (recurring kr-* consistency sweep) — slice 114.

### What changed / what I produced
Adds the six remaining `badge-xs` color primitives to `assets/css/tailwind.css`, completing full xs-size badge coverage alongside the existing ghost/outline/primary/warning-xs and the five -sm variants:
- `kr-badge-success-xs`, `kr-badge-error-xs`, `kr-badge-secondary-xs`, `kr-badge-accent-xs`, `kr-badge-info-xs`, `kr-badge-neutral-xs`

Extended `kr_badge_codemod.py`'s `FAMILIES` with these six entries and migrated 24 hand-rolled `badge badge-<color> badge-xs` occurrences across 12 files (art-lora-picker, art-styler, build-bench, collection-card, entity-art-manager, image-card, stylist-restyle, project-detail, cthulhuquarium-game, daily-digest-object-gallery, cart-button, conductor-page, honeydo-card, video-generator). `components/ui/ui-gallery.vue`'s style-guide demo badges were left untouched per established convention — none of its badges matched the new families anyway (its 2 pre-existing matches are the older ghost/warning-sm demo badges).

No geometry or behavior change — pure class-name consolidation, same underlying DaisyUI classes via `@apply`.

### How I verified
- `vue-tsc --noEmit` (`npm run test`): clean.
- `eslint` on all 16 changed files: 3 pre-existing errors in `entity-art-manager.vue` confirmed via `git stash` diff against baseline `main` (vue/no-mutating-props, 2x no-empty), 0 new.
- `test:layout-contract`: held at 207 baseline, no new violations.
- `test:lint-ratchet`: held at 333 problems / -59, no rule regressed.
- `prettier --check`: 12 files flagged; 9 confirmed pre-existing drift via `git stash`, 3 newly-flagged (`collection-card.vue`, `image-card.vue`, `project-detail.vue` — class-shortening collapsed line wrapping) fixed with scoped `--write`.
- Searched `utils/scripts/*.{mjs,ts,js}` for the literal badge class strings — no regression-guard hits (one unrelated comment match only).

### Stakes
Reversible — pure CSS/class-name refactor, no behavior change.

### Flags for Reviewer
None — mechanical continuation of the established badge codemod pattern (slices 109-113).

### Kaizen suggestion
Badge family now covers every `-sm` and `-xs` color/style combo surveyed so far. Next bounded slice per t-104's own note: audit hand-rolled textarea shapes (129 class attrs, highly varied — needs picking one common `min-h`/`rounded-2xl`/`bg-base-200` combo before a mechanical codemod is safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RJyHj5T64u1jfx3ymm1py

---
_Generated by [Claude Code](https://claude.ai/code/session_017RJyHj5T64u1jfx3ymm1py)_