### PR TITLE
style: migrate hand-rolled textarea shapes to kr-textarea / kr-textarea-muted

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1048,6 +1048,27 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply badge badge-neutral badge-xs;
   }
 
+  /* The most-repeated hand-rolled textarea shape (interface-vision t-104
+   * slice 115): a full-width, bordered DaisyUI textarea on the "plain"
+   * base-100 background -- `textarea textarea-bordered w-full
+   * bg-base-100`, previously hand-rolled in 7 files (11 occurrences,
+   * always paired with a per-instance `min-h-*` utility that stays
+   * alongside the primitive since the height varies per usage). Named to
+   * mirror .kr-panel's base-100 "plain" vs .kr-panel-muted's base-200
+   * convention below. */
+  .kr-textarea {
+    @apply textarea textarea-bordered w-full bg-base-100;
+  }
+
+  /* The base-200 "muted" counterpart to .kr-textarea (interface-vision
+   * t-104 slice 115): the same full-width bordered textarea shape on the
+   * muted background -- `textarea textarea-bordered w-full bg-base-200`,
+   * previously hand-rolled in 12 files (30 occurrences), the larger of
+   * the two background pools. */
+  .kr-textarea-muted {
+    @apply textarea textarea-bordered w-full bg-base-200;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -1221,7 +1221,7 @@ onMounted(async () => {
             :value="builtPrompt"
             rows="8"
             readonly
-            class="textarea textarea-bordered w-full rounded-2xl bg-base-100 font-mono text-sm"
+            class="kr-textarea rounded-2xl font-mono text-sm"
           />
         </div>
 

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -80,7 +80,7 @@
 
               <textarea
                 v-model="botStore.botForm.description"
-                class="textarea textarea-bordered min-h-28 w-full bg-base-200"
+                class="kr-textarea-muted min-h-28"
                 placeholder="Describe what this bot does..."
                 :disabled="isKept('description')"
               />
@@ -301,7 +301,7 @@
 
               <textarea
                 v-model="botStore.botForm.personality"
-                class="textarea textarea-bordered min-h-32 w-full bg-base-200"
+                class="kr-textarea-muted min-h-32"
                 placeholder="How should this bot behave?"
                 :disabled="isKept('personality')"
               />
@@ -314,7 +314,7 @@
 
               <textarea
                 v-model="botStore.botForm.prompt"
-                class="textarea textarea-bordered min-h-44 w-full bg-base-200"
+                class="kr-textarea-muted min-h-44"
                 placeholder="Core model instructions..."
                 :disabled="isKept('prompt')"
               />
@@ -327,7 +327,7 @@
 
               <textarea
                 v-model="botStore.botForm.sampleResponse"
-                class="textarea textarea-bordered min-h-28 w-full bg-base-200"
+                class="kr-textarea-muted min-h-28"
                 placeholder="Example of how this bot answers..."
                 :disabled="isKept('sampleResponse')"
               />
@@ -348,7 +348,7 @@
 
               <textarea
                 v-model="botStore.botForm.botIntro"
-                class="textarea textarea-bordered min-h-36 w-full bg-base-200"
+                class="kr-textarea-muted min-h-36"
                 placeholder="Opening message from the bot..."
                 :disabled="isKept('botIntro')"
               />
@@ -361,7 +361,7 @@
 
               <textarea
                 v-model="botStore.botForm.userIntro"
-                class="textarea textarea-bordered min-h-36 w-full bg-base-200"
+                class="kr-textarea-muted min-h-36"
                 placeholder="Suggested first user prompt. Separate quick prompts with |"
                 :disabled="isKept('userIntro')"
               />
@@ -374,7 +374,7 @@
 
               <textarea
                 v-model="botStore.botForm.modules"
-                class="textarea textarea-bordered min-h-24 w-full bg-base-200"
+                class="kr-textarea-muted min-h-24"
                 placeholder="Optional module notes..."
               />
             </label>

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -55,7 +55,7 @@
         <textarea
           id="brainstorm-premise"
           v-model="premiseModel"
-          class="textarea textarea-bordered mt-2 min-h-28 w-full resize-y bg-base-100 text-base leading-6"
+          class="kr-textarea mt-2 min-h-28 resize-y text-base leading-6"
           maxlength="12000"
           placeholder="Invent ten terrible ice cream flavors with an actual comic premise…"
           :disabled="isGenerating"
@@ -267,7 +267,7 @@
             <textarea
               id="brainstorm-constraints"
               v-model="constraintsModel"
-              class="textarea textarea-bordered mt-1 min-h-24 w-full resize-y bg-base-100"
+              class="kr-textarea mt-1 min-h-24 resize-y"
               maxlength="8000"
               placeholder="Each under 15 words. No repeats. Make the danger obvious but cartoonish."
               :disabled="isGenerating"
@@ -280,7 +280,7 @@
             <textarea
               id="brainstorm-examples"
               v-model="examplesText"
-              class="textarea textarea-bordered mt-1 min-h-24 w-full resize-y bg-base-100"
+              class="kr-textarea mt-1 min-h-24 resize-y"
               maxlength="12000"
               placeholder="One example per line. These are context, not a mold."
               :disabled="isGenerating"

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -165,7 +165,7 @@
             <span class="label-text font-bold">Art prompt</span>
             <textarea
               v-model="characterStore.characterForm.artPrompt"
-              class="textarea textarea-bordered mt-1 min-h-28 w-full bg-base-200"
+              class="kr-textarea-muted mt-1 min-h-28"
               placeholder="Describe the portrait you want..."
               :disabled="isKept('artPrompt')"
             />
@@ -209,7 +209,7 @@
               <span class="label-text font-bold">Personality</span>
               <textarea
                 v-model="characterStore.characterForm.personality"
-                class="textarea textarea-bordered mt-1 min-h-32 w-full bg-base-200"
+                class="kr-textarea-muted mt-1 min-h-32"
                 placeholder="Temperament, habits, contradictions..."
                 :disabled="isKept('personality')"
               />
@@ -219,7 +219,7 @@
               <span class="label-text font-bold">Voice</span>
               <textarea
                 v-model="characterStore.characterForm.voice"
-                class="textarea textarea-bordered mt-1 min-h-28 w-full bg-base-200"
+                class="kr-textarea-muted mt-1 min-h-28"
                 placeholder="How this character sounds"
                 :disabled="isKept('voice')"
               />
@@ -229,7 +229,7 @@
               <span class="label-text font-bold">Sample response</span>
               <textarea
                 v-model="characterStore.characterForm.sampleResponse"
-                class="textarea textarea-bordered mt-1 min-h-28 w-full bg-base-200"
+                class="kr-textarea-muted mt-1 min-h-28"
                 placeholder="A line that sounds unmistakably like them"
                 :disabled="isKept('sampleResponse')"
               />
@@ -247,7 +247,7 @@
               <span class="label-text font-bold">Backstory</span>
               <textarea
                 v-model="characterStore.characterForm.backstory"
-                class="textarea textarea-bordered mt-1 min-h-36 w-full bg-base-200"
+                class="kr-textarea-muted mt-1 min-h-36"
                 placeholder="Where they came from and what still follows them"
                 :disabled="isKept('backstory')"
               />
@@ -268,7 +268,7 @@
               <span class="label-text font-bold">Quirks</span>
               <textarea
                 v-model="characterStore.characterForm.quirks"
-                class="textarea textarea-bordered mt-1 min-h-28 w-full bg-base-200"
+                class="kr-textarea-muted mt-1 min-h-28"
                 placeholder="Odd rules, tells, comforts, and tiny disasters"
                 :disabled="isKept('quirks')"
               />

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -307,7 +307,7 @@
 
             <textarea
               v-model="chatMessage"
-              class="textarea textarea-bordered min-h-32 w-full resize-none rounded-2xl bg-base-200"
+              class="kr-textarea-muted min-h-32 resize-none rounded-2xl"
               placeholder="Say something to the character..."
               :disabled="!characterStore.selectedCharacter || isSendingChat"
               @input="syncSelectedPromptFromText"
@@ -379,7 +379,7 @@
 
             <textarea
               v-model="adventureDirection"
-              class="textarea textarea-bordered mt-4 min-h-32 w-full resize-none rounded-2xl bg-base-200"
+              class="kr-textarea-muted mt-4 min-h-32 resize-none rounded-2xl"
               placeholder="What should happen next? Skill check, reward use, inventory item, dialogue, chaos goblin cameo..."
             />
 
@@ -426,7 +426,7 @@
 
             <textarea
               v-model="promptText"
-              class="textarea textarea-bordered min-h-56 w-full resize-none rounded-2xl bg-base-200"
+              class="kr-textarea-muted min-h-56 resize-none rounded-2xl"
               placeholder="Build or edit a reusable character prompt..."
             />
 

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -199,7 +199,7 @@
 
             <textarea
               v-model="chatMessage"
-              class="textarea textarea-bordered min-h-32 w-full resize-none rounded-2xl bg-base-200"
+              class="kr-textarea-muted min-h-32 resize-none rounded-2xl"
               placeholder="Say something to the character..."
               :disabled="!characterStore.selectedCharacter || isSendingChat"
               @input="syncSelectedPromptFromText"
@@ -271,7 +271,7 @@
 
             <textarea
               v-model="adventureDirection"
-              class="textarea textarea-bordered mt-4 min-h-32 w-full resize-none rounded-2xl bg-base-200"
+              class="kr-textarea-muted mt-4 min-h-32 resize-none rounded-2xl"
               placeholder="What should happen next? Skill check, reward use, inventory item, dialogue, chaos goblin cameo..."
             />
 
@@ -305,7 +305,7 @@
 
             <textarea
               v-model="promptText"
-              class="textarea textarea-bordered min-h-56 w-full resize-none rounded-2xl bg-base-200"
+              class="kr-textarea-muted min-h-56 resize-none rounded-2xl"
               placeholder="Build or edit a reusable character prompt..."
             />
 

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -159,7 +159,7 @@
               <textarea
                 v-model="store.setupDraft.premise"
                 rows="5"
-                class="textarea textarea-bordered w-full rounded-xl bg-base-100 text-sm leading-relaxed"
+                class="kr-textarea rounded-xl text-sm leading-relaxed"
                 placeholder="Every midnight, the town's abandoned observatory receives a letter from a star that should not exist…"
               />
               <span class="mt-1 text-[0.7rem] text-base-content/45">
@@ -333,7 +333,7 @@
               <textarea
                 v-model="store.setupDraft.notes"
                 rows="3"
-                class="textarea textarea-bordered w-full rounded-xl bg-base-100 text-sm leading-relaxed"
+                class="kr-textarea rounded-xl text-sm leading-relaxed"
                 placeholder="Keep the rivalry affectionate. Let every machine feel slightly alive. Avoid a chosen-one prophecy."
               />
             </label>

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -298,7 +298,7 @@
                 />
                 <textarea
                   v-model="candidate.pitch"
-                  class="textarea textarea-bordered min-h-28 w-full rounded-2xl bg-base-100 text-sm leading-relaxed"
+                  class="kr-textarea min-h-28 rounded-2xl text-sm leading-relaxed"
                   placeholder="Idea pitch"
                   @input="editCandidate(candidate.id)"
                 />

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -207,7 +207,7 @@
 
             <textarea
               v-model="dreamStore.dreamForm.artPrompt"
-              class="textarea textarea-bordered mt-3 min-h-32 w-full rounded-2xl bg-base-200 leading-relaxed"
+              class="kr-textarea-muted mt-3 min-h-32 rounded-2xl leading-relaxed"
               placeholder="Cinematic establishing shot of the Dream, clear composition, emotional lighting..."
             />
           </div>

--- a/components/lora/add-lora.vue
+++ b/components/lora/add-lora.vue
@@ -191,7 +191,7 @@
 
       <textarea
         v-model="form.description"
-        class="textarea textarea-bordered min-h-24 w-full bg-base-200"
+        class="kr-textarea-muted min-h-24"
         placeholder="What this LoRA does, recommended weight, notes."
       />
     </label>

--- a/components/model/add-model.vue
+++ b/components/model/add-model.vue
@@ -139,7 +139,7 @@
 
       <textarea
         v-model="form.description"
-        class="textarea textarea-bordered min-h-24 w-full bg-base-200"
+        class="kr-textarea-muted min-h-24"
         placeholder="What this checkpoint is good for, recommended sampler/steps, notes."
       />
     </label>

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -249,7 +249,7 @@
                         v-model="
                           gateMessages[gateKey(gate.project.slug, gate.task.id)]
                         "
-                        class="textarea textarea-bordered min-h-24 w-full rounded-xl bg-base-100 text-sm"
+                        class="kr-textarea min-h-24 rounded-xl text-sm"
                         placeholder="Add context, requested changes, or a note…"
                         :disabled="
                           taskIsUpdating(gate.project.slug, gate.task.id)

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -63,7 +63,7 @@
           <textarea
             v-model="rewardStore.rewardForm.description"
             placeholder="Describe what this reward is..."
-            class="textarea textarea-bordered min-h-24 w-full bg-base-100"
+            class="kr-textarea min-h-24"
           />
         </label>
 
@@ -89,7 +89,7 @@
           <textarea
             v-model="rewardStore.rewardForm.effect"
             placeholder="Describe what this reward does when played into a scene..."
-            class="textarea textarea-bordered min-h-28 w-full bg-base-100"
+            class="kr-textarea min-h-28"
           />
         </label>
       </section>
@@ -244,7 +244,7 @@
               <textarea
                 v-model="rewardStore.rewardForm.artPrompt"
                 placeholder="Describe the reward's appearance..."
-                class="textarea textarea-bordered min-h-32 w-full bg-base-200"
+                class="kr-textarea-muted min-h-32"
                 :disabled="isGeneratingArt"
               />
             </label>

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -72,7 +72,7 @@
           <textarea
             v-model="scenarioStore.scenarioForm.description"
             placeholder="Describe your scenario..."
-            class="textarea textarea-bordered min-h-32 w-full bg-base-100"
+            class="kr-textarea min-h-32"
           />
         </label>
       </section>
@@ -93,7 +93,7 @@
           <textarea
             v-model="scenarioStore.scenarioForm.inspirations"
             placeholder="Studio Ghibli, Disco Elysium, The Princess Bride, Kafka..."
-            class="textarea textarea-bordered min-h-28 w-full bg-base-200"
+            class="kr-textarea-muted min-h-28"
           />
         </label>
 
@@ -258,7 +258,7 @@
               <textarea
                 v-model="scenarioStore.scenarioForm.artPrompt"
                 placeholder="Describe your scenario's appearance..."
-                class="textarea textarea-bordered min-h-32 w-full bg-base-200"
+                class="kr-textarea-muted min-h-32"
                 :disabled="keepArtPrompt || isGeneratingArt"
               />
             </label>

--- a/components/scenarios/scenario-story.vue
+++ b/components/scenarios/scenario-story.vue
@@ -150,7 +150,7 @@
 
         <textarea
           :value="storyStore.customDirection"
-          class="textarea textarea-bordered min-h-28 w-full resize-none rounded-2xl bg-base-200 text-smart"
+          class="kr-textarea-muted min-h-28 resize-none rounded-2xl text-smart"
           placeholder="Add a tone, goal, complication, question, or narrative twist..."
           :disabled="storyStore.isBusy"
           @input="
@@ -304,7 +304,7 @@
 
         <textarea
           :value="storyStore.customDirection"
-          class="textarea textarea-bordered min-h-20 w-full resize-none rounded-2xl bg-base-200 text-smart"
+          class="kr-textarea-muted min-h-20 resize-none rounded-2xl text-smart"
           placeholder="Choose a reply above, type your own action, ask a question, or do something deeply unwise..."
           :disabled="storyStore.isBusy"
           @input="

--- a/components/servers/add-checkpoint.vue
+++ b/components/servers/add-checkpoint.vue
@@ -184,7 +184,7 @@
 
       <textarea
         v-model="form.description"
-        class="textarea textarea-bordered min-h-28 w-full bg-base-200"
+        class="kr-textarea-muted min-h-28"
         placeholder="What does this resource do, where does it live, and why should future-you care?"
       />
     </label>
@@ -196,7 +196,7 @@
 
       <textarea
         v-model="form.generation"
-        class="textarea textarea-bordered min-h-24 w-full bg-base-200"
+        class="kr-textarea-muted min-h-24"
         placeholder="Optional generation notes, trigger words, recommended sampler, CFG, etc."
       />
     </label>

--- a/components/user/user-panel.vue
+++ b/components/user/user-panel.vue
@@ -61,7 +61,7 @@
             v-if="field.type === 'textarea'"
             v-model="form[field.key]"
             :placeholder="field.placeholder"
-            class="textarea textarea-bordered min-h-28 w-full resize-none rounded-2xl bg-base-200"
+            class="kr-textarea-muted min-h-28 resize-none rounded-2xl"
           />
 
           <input

--- a/utils/scripts/codemods/kr_textarea_codemod.py
+++ b/utils/scripts/codemods/kr_textarea_codemod.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled kr-textarea / kr-textarea-muted shapes.
+
+Dry-run is the default. Pass --write to update matching Vue files in place.
+Only the approved full-width, bordered DaisyUI textarea shapes are touched
+(`textarea textarea-bordered w-full bg-base-100` and `textarea
+textarea-bordered w-full bg-base-200`), and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings. A source that already
+carries the target primitive, or is missing any one of the base tokens, is
+left untouched. Extra tokens beyond the base set (min-h-*, resize-none,
+rounded-2xl, mt-1, text-sm, ...) are preserved verbatim after the primitive
+class, matching the kr-input-sm/kr-select-sm codemod's subset-match
+convention -- they're plain Tailwind utilities layered on top (min-h-* in
+particular varies per instance, so it can never be folded into the shared
+primitive), not another component-root class, so resolution order is
+unaffected by folding the four base tokens into one name.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+FAMILIES = [
+    ("kr-textarea", {"textarea", "textarea-bordered", "w-full", "bg-base-100"}),
+    ("kr-textarea-muted", {"textarea", "textarea-bordered", "w-full", "bg-base-200"}),
+]
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    for primitive, base_tokens in FAMILIES:
+        if primitive in tokens or not base_tokens.issubset(tokens):
+            continue
+        remaining = [token for token in tokens if token not in base_tokens]
+        if exact_only and remaining:
+            continue
+        return " ".join([primitive, *remaining])
+    return None
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim (no
+        # universal-newline translation) -- a handful of source files carry
+        # CRLF, and translating those to LF on write would turn a one-line
+        # class-attribute change into a whole-file rewrite (kind_robots
+        # add-bot.vue, caught while extending this codemod's sibling for
+        # interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-textarea/kr-textarea-muted {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

interface-vision/t-104 slice 115: the next bounded slice of the recurring kr-* consistency sweep, per slice 114's own note ("audit hand-rolled textarea shapes").

Surveyed all 130 `<textarea>` tags across 61 files (all static `class="..."`, none via `:class` bindings). The largest coherent shape family — `textarea textarea-bordered w-full` plus `bg-base-100` or `bg-base-200`, with a per-instance `min-h-*` utility (and other extras like `resize-none`/`rounded-2xl`/`text-sm`) preserved verbatim alongside — covers 41 occurrences across 17 files (30 on `bg-base-200`, 11 on `bg-base-100`).

## Changes

- Added two new primitives to `assets/css/tailwind.css`, mirroring `.kr-panel`'s base-100 "plain" vs `.kr-panel-muted`'s base-200 naming convention:
  - `.kr-textarea` = `textarea textarea-bordered w-full bg-base-100`
  - `.kr-textarea-muted` = `textarea textarea-bordered w-full bg-base-200`
- Added `utils/scripts/codemods/kr_textarea_codemod.py`, following the `kr_input_select_codemod.py` subset-match pattern exactly (dry-run by default, `--write` to apply, `--exact-only` to bound to the strictest candidates).
- Ran the codemod with `--write`: migrated 41 occurrences across 17 files. `min-h-*` (and any other extra utility tokens) stay on the element next to the new primitive since height varies per instance.
- `components/ui/ui-gallery.vue`'s style-guide demo textarea (`textarea textarea-bordered w-full`, no `bg-base-*`) does not match either family and was left untouched — no manual exclusion needed.

## Verification

- `vue-tsc --noEmit`: clean.
- `eslint` on all 17 changed `.vue` files: 5 pre-existing errors confirmed via `git stash` (add-bot.vue, character-flip-card.vue, dream-maker.vue, for-you-manager.vue, add-checkpoint.vue), 0 new.
- `utils/scripts/verifyLayoutContract.ts`: holds at 207 baseline, no new violations.
- `utils/scripts/verifyLintRatchet.ts`: holds at 333 problems/-59, no rule regressed.
- `prettier --check` on all changed files: 10 pre-existing formatting issues confirmed via `git stash` (9 `.vue` files + `tailwind.css`), 0 newly flagged this slice.
- Regression-guard scripts (`utils/scripts/*.{mjs,ts,js}`): no hardcoded literal `class="..."` string containing `textarea`/`textarea-bordered` found — a class-only codemod does not perturb any of them.

## Next

Per this slice's own survey, no further textarea shapes cluster as a clean bounded family (long tail of 90 distinct exact strings across the remaining ~89 occurrences). The recurring consistency umbrella (`interface-vision/t-104`) will need a fresh candidate for its next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011APAn52hckb83v91AGcJxb

---
_Generated by [Claude Code](https://claude.ai/code/session_011APAn52hckb83v91AGcJxb)_