### PR TITLE
style: migrate hand-rolled input shapes to kr-input / kr-input-muted

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1069,6 +1069,23 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply textarea textarea-bordered w-full bg-base-200;
   }
 
+  /* The `input` counterpart to .kr-textarea (interface-vision t-104 slice
+   * 116): the same full-width, bordered DaisyUI shape on a single-line
+   * text input, "plain" base-100 background -- `input input-bordered
+   * w-full bg-base-100`, previously hand-rolled (8 occurrences). */
+  .kr-input {
+    @apply input input-bordered w-full bg-base-100;
+  }
+
+  /* The base-200 "muted" counterpart to .kr-input (interface-vision t-104
+   * slice 116): the same full-width bordered input shape on the muted
+   * background -- `input input-bordered w-full bg-base-200`, previously
+   * hand-rolled across curation/creation forms (47 occurrences, the
+   * larger of the two background pools). */
+  .kr-input-muted {
+    @apply input input-bordered w-full bg-base-200;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -879,7 +879,7 @@ onMounted(async () => {
                   :value="seed ?? ''"
                   type="number"
                   placeholder="random"
-                  class="input input-bordered w-full rounded-2xl bg-base-100"
+                  class="kr-input rounded-2xl"
                   @input="updateSeed"
                 />
                 <button

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -53,7 +53,7 @@
               <input
                 v-model="botStore.botForm.name"
                 type="text"
-                class="input input-bordered w-full bg-base-200"
+                class="kr-input-muted"
                 placeholder="Dotti"
                 :disabled="isKept('name')"
               />
@@ -67,7 +67,7 @@
               <input
                 v-model="botStore.botForm.subtitle"
                 type="text"
-                class="input input-bordered w-full bg-base-200"
+                class="kr-input-muted"
                 placeholder="Tiny robot, big opinions"
                 :disabled="isKept('subtitle')"
               />
@@ -94,7 +94,7 @@
               <input
                 v-model="botStore.botForm.tagline"
                 type="text"
-                class="input input-bordered w-full bg-base-200"
+                class="kr-input-muted"
                 placeholder="Now with 30% more charm."
                 :disabled="isKept('tagline')"
               />
@@ -125,7 +125,7 @@
               <input
                 v-model="botStore.botForm.designer"
                 type="text"
-                class="input input-bordered w-full bg-base-200"
+                class="kr-input-muted"
                 :disabled="!canEditDesigner"
               />
             </label>
@@ -138,7 +138,7 @@
               <input
                 v-model="botStore.botForm.theme"
                 type="text"
-                class="input input-bordered w-full bg-base-200"
+                class="kr-input-muted"
                 placeholder="cyber-cafe, moth-oracle, bot-lab..."
               />
             </label>
@@ -175,7 +175,7 @@
               <input
                 v-model="avatarImageModel"
                 type="text"
-                class="input input-bordered w-full bg-base-200"
+                class="kr-input-muted"
                 placeholder="/images/bot.webp"
                 :disabled="isKept('avatarImage')"
               />

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -431,7 +431,7 @@
             <input
               id="brainstorm-session-name"
               v-model="sessionNameModel"
-              class="input input-bordered mt-2 w-full bg-base-100"
+              class="kr-input mt-2"
               maxlength="255"
               :placeholder="suggestedSessionName"
               :disabled="isPersisting"

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -50,7 +50,7 @@
               <input
                 v-model="characterStore.characterForm.name"
                 type="text"
-                class="input input-bordered mt-1 w-full bg-base-200"
+                class="kr-input-muted mt-1"
                 placeholder="Moss Lantern"
                 :disabled="isKept('name')"
               />
@@ -61,7 +61,7 @@
               <input
                 v-model="characterStore.characterForm.honorific"
                 type="text"
-                class="input input-bordered mt-1 w-full bg-base-200"
+                class="kr-input-muted mt-1"
                 placeholder="the Unreasonably Prepared"
                 :disabled="isKept('honorific')"
               />
@@ -72,7 +72,7 @@
               <input
                 v-model="characterStore.characterForm.role"
                 type="text"
-                class="input input-bordered mt-1 w-full bg-base-200"
+                class="kr-input-muted mt-1"
                 placeholder="guide, rival, archivist..."
               />
             </label>
@@ -82,7 +82,7 @@
               <input
                 v-model="characterStore.characterForm.title"
                 type="text"
-                class="input input-bordered mt-1 w-full bg-base-200"
+                class="kr-input-muted mt-1"
                 placeholder="Keeper of the Last Teacup"
               />
             </label>
@@ -92,7 +92,7 @@
               <input
                 v-model="characterStore.characterForm.class"
                 type="text"
-                class="input input-bordered mt-1 w-full bg-base-200"
+                class="kr-input-muted mt-1"
                 placeholder="storm librarian"
                 :disabled="isKept('class')"
               />
@@ -103,7 +103,7 @@
               <input
                 v-model="characterStore.characterForm.species"
                 type="text"
-                class="input input-bordered mt-1 w-full bg-base-200"
+                class="kr-input-muted mt-1"
                 placeholder="human, robot, mothfolk..."
                 :disabled="isKept('species')"
               />
@@ -114,7 +114,7 @@
               <input
                 v-model="characterStore.characterForm.genre"
                 type="text"
-                class="input input-bordered mt-1 w-full bg-base-200"
+                class="kr-input-muted mt-1"
                 placeholder="cozy fantasy"
                 :disabled="isKept('genre')"
               />
@@ -125,7 +125,7 @@
               <input
                 v-model="characterStore.characterForm.gender"
                 type="text"
-                class="input input-bordered mt-1 w-full bg-base-200"
+                class="kr-input-muted mt-1"
                 placeholder="Optional"
               />
             </label>
@@ -135,7 +135,7 @@
               <input
                 v-model="characterStore.characterForm.presentation"
                 type="text"
-                class="input input-bordered mt-1 w-full bg-base-200"
+                class="kr-input-muted mt-1"
                 placeholder="How they present visually and socially"
               />
             </label>
@@ -258,7 +258,7 @@
               <input
                 v-model="characterStore.characterForm.drive"
                 type="text"
-                class="input input-bordered mt-1 w-full bg-base-200"
+                class="kr-input-muted mt-1"
                 placeholder="What they want badly enough to act"
                 :disabled="isKept('drive')"
               />
@@ -418,7 +418,7 @@
               v-model.number="characterStore.characterForm.level"
               type="number"
               min="1"
-              class="input input-bordered mt-1 w-full bg-base-200"
+              class="kr-input-muted mt-1"
             />
           </label>
 
@@ -428,7 +428,7 @@
               v-model.number="characterStore.characterForm.experience"
               type="number"
               min="0"
-              class="input input-bordered mt-1 w-full bg-base-200"
+              class="kr-input-muted mt-1"
             />
           </label>
 
@@ -437,7 +437,7 @@
             <input
               v-model="characterStore.characterForm.designer"
               type="text"
-              class="input input-bordered mt-1 w-full bg-base-200"
+              class="kr-input-muted mt-1"
             />
           </label>
 

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -145,7 +145,7 @@
               <input
                 v-model="store.setupDraft.title"
                 type="text"
-                class="input input-bordered w-full rounded-xl bg-base-100"
+                class="kr-input rounded-xl"
                 placeholder="The Clockwork Orchard"
               />
             </label>

--- a/components/lora/add-lora.vue
+++ b/components/lora/add-lora.vue
@@ -46,7 +46,7 @@
 
         <input
           v-model="form.name"
-          class="input input-bordered w-full bg-base-200"
+          class="kr-input-muted"
           type="text"
           autocomplete="off"
           placeholder="ume_classic_impressionist"
@@ -62,7 +62,7 @@
 
         <input
           v-model="form.customLabel"
-          class="input input-bordered w-full bg-base-200"
+          class="kr-input-muted"
           type="text"
           autocomplete="off"
           placeholder="Classic Impressionist"
@@ -115,7 +115,7 @@
 
       <input
         v-model="form.localPath"
-        class="input input-bordered w-full bg-base-200 font-mono text-sm"
+        class="kr-input-muted font-mono text-sm"
         type="text"
         autocomplete="off"
         placeholder="Flux/SFW/ume_classic_impressionist.safetensors"
@@ -131,7 +131,7 @@
 
         <input
           v-model="form.triggerWords"
-          class="input input-bordered w-full bg-base-200"
+          class="kr-input-muted"
           type="text"
           autocomplete="off"
           placeholder="impressionist, oil painting, loose brushwork"
@@ -146,7 +146,7 @@
 
         <input
           v-model="form.defaultTrigger"
-          class="input input-bordered w-full bg-base-200"
+          class="kr-input-muted"
           type="text"
           autocomplete="off"
           placeholder="impressionist oil painting"
@@ -162,7 +162,7 @@
 
         <input
           v-model="form.previewImageUrl"
-          class="input input-bordered w-full bg-base-200"
+          class="kr-input-muted"
           type="url"
           autocomplete="off"
           placeholder="https://image.civitai.com/..."
@@ -176,7 +176,7 @@
 
         <input
           v-model="form.civitaiUrl"
-          class="input input-bordered w-full bg-base-200"
+          class="kr-input-muted"
           type="url"
           autocomplete="off"
           placeholder="https://civitai.com/models/..."

--- a/components/model/add-model.vue
+++ b/components/model/add-model.vue
@@ -46,7 +46,7 @@
 
         <input
           v-model="form.name"
-          class="input input-bordered w-full bg-base-200"
+          class="kr-input-muted"
           type="text"
           autocomplete="off"
           placeholder="dreamshaperXL_v21TurboDPMSDE.safetensors"
@@ -62,7 +62,7 @@
 
         <input
           v-model="form.customLabel"
-          class="input input-bordered w-full bg-base-200"
+          class="kr-input-muted"
           type="text"
           autocomplete="off"
           placeholder="DreamShaper XL Turbo"
@@ -95,7 +95,7 @@
 
       <input
         v-model="form.localPath"
-        class="input input-bordered w-full bg-base-200 font-mono text-sm"
+        class="kr-input-muted font-mono text-sm"
         type="text"
         autocomplete="off"
         placeholder="SDXL/dreamshaperXL_v21TurboDPMSDE.safetensors"
@@ -110,7 +110,7 @@
 
         <input
           v-model="form.previewImageUrl"
-          class="input input-bordered w-full bg-base-200"
+          class="kr-input-muted"
           type="url"
           autocomplete="off"
           placeholder="https://image.civitai.com/..."
@@ -124,7 +124,7 @@
 
         <input
           v-model="form.civitaiUrl"
-          class="input input-bordered w-full bg-base-200"
+          class="kr-input-muted"
           type="url"
           autocomplete="off"
           placeholder="https://civitai.com/models/..."

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -37,7 +37,7 @@
             v-model="rewardStore.rewardForm.name"
             type="text"
             placeholder="The Coin of Questionable Wisdom"
-            class="input input-bordered w-full bg-base-100"
+            class="kr-input"
           />
         </label>
 
@@ -50,7 +50,7 @@
             v-model="rewardStore.rewardForm.collection"
             type="text"
             placeholder="starter, weirdlandia, relics..."
-            class="input input-bordered w-full bg-base-100"
+            class="kr-input"
           />
         </label>
 
@@ -77,7 +77,7 @@
             v-model="rewardStore.rewardForm.flavorText"
             type="text"
             placeholder="It says please. It still works."
-            class="input input-bordered w-full bg-base-100"
+            class="kr-input"
           />
         </label>
 
@@ -104,7 +104,7 @@
             v-model="rewardStore.rewardForm.icon"
             type="text"
             placeholder="kind-icon:gift"
-            class="input input-bordered w-full bg-base-100"
+            class="kr-input"
           />
         </label>
 

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -37,7 +37,7 @@
             v-model="scenarioStore.scenarioForm.title"
             type="text"
             placeholder="The Casino Under the Moon"
-            class="input input-bordered w-full bg-base-100"
+            class="kr-input"
           />
         </label>
 

--- a/components/servers/add-checkpoint.vue
+++ b/components/servers/add-checkpoint.vue
@@ -39,7 +39,7 @@
 
         <input
           v-model="form.name"
-          class="input input-bordered w-full bg-base-200"
+          class="kr-input-muted"
           type="text"
           autocomplete="off"
           placeholder="ponyFaetality_v11.safetensors"
@@ -54,7 +54,7 @@
 
         <input
           v-model="form.customLabel"
-          class="input input-bordered w-full bg-base-200"
+          class="kr-input-muted"
           type="text"
           autocomplete="off"
           placeholder="Pony Faetality"
@@ -112,7 +112,7 @@
 
       <input
         v-model="form.localPath"
-        class="input input-bordered w-full bg-base-200 font-mono text-sm"
+        class="kr-input-muted font-mono text-sm"
         type="text"
         autocomplete="off"
         placeholder="SDXL/ponyFaetality_v11.safetensors"
@@ -127,7 +127,7 @@
 
         <input
           v-model="form.civitaiUrl"
-          class="input input-bordered w-full bg-base-200"
+          class="kr-input-muted"
           type="url"
           autocomplete="off"
           placeholder="https://civitai.com/..."
@@ -141,7 +141,7 @@
 
         <input
           v-model="form.huggingUrl"
-          class="input input-bordered w-full bg-base-200"
+          class="kr-input-muted"
           type="url"
           autocomplete="off"
           placeholder="https://huggingface.co/..."
@@ -155,7 +155,7 @@
 
         <input
           v-model="form.customUrl"
-          class="input input-bordered w-full bg-base-200"
+          class="kr-input-muted"
           type="url"
           autocomplete="off"
           placeholder="https://..."
@@ -170,7 +170,7 @@
 
       <input
         v-model="form.MediaPath"
-        class="input input-bordered w-full bg-base-200"
+        class="kr-input-muted"
         type="text"
         autocomplete="off"
         placeholder="/images/checkpoints/preview.webp"

--- a/components/user/account-settings.vue
+++ b/components/user/account-settings.vue
@@ -89,7 +89,7 @@
               v-model="pw.current"
               type="password"
               autocomplete="current-password"
-              class="input input-bordered w-full rounded-xl bg-base-200"
+              class="kr-input-muted rounded-xl"
             />
           </label>
           <label class="flex flex-col gap-1">
@@ -100,7 +100,7 @@
               v-model="pw.next"
               type="password"
               autocomplete="new-password"
-              class="input input-bordered w-full rounded-xl bg-base-200"
+              class="kr-input-muted rounded-xl"
             />
           </label>
           <label class="flex flex-col gap-1">
@@ -111,7 +111,7 @@
               v-model="pw.confirm"
               type="password"
               autocomplete="new-password"
-              class="input input-bordered w-full rounded-xl bg-base-200"
+              class="kr-input-muted rounded-xl"
             />
           </label>
           <div class="flex items-center gap-3 sm:col-span-2">

--- a/components/user/friends-panel.vue
+++ b/components/user/friends-panel.vue
@@ -100,7 +100,7 @@
         v-model="search"
         type="search"
         placeholder="Search the directory…"
-        class="input input-bordered mb-3 w-full rounded-xl bg-base-200"
+        class="kr-input-muted mb-3 rounded-xl"
         @input="onSearch"
       />
       <p v-if="isSearching" class="text-sm text-base-content/50">Searching…</p>

--- a/components/user/password-reset.vue
+++ b/components/user/password-reset.vue
@@ -31,7 +31,7 @@
           v-model="email"
           type="email"
           autocomplete="email"
-          class="input input-bordered w-full rounded-xl bg-base-200"
+          class="kr-input-muted rounded-xl"
         />
       </label>
       <button
@@ -59,7 +59,7 @@
           v-model="next"
           type="password"
           autocomplete="new-password"
-          class="input input-bordered w-full rounded-xl bg-base-200"
+          class="kr-input-muted rounded-xl"
         />
       </label>
       <label class="flex flex-col gap-1">
@@ -70,7 +70,7 @@
           v-model="confirm"
           type="password"
           autocomplete="new-password"
-          class="input input-bordered w-full rounded-xl bg-base-200"
+          class="kr-input-muted rounded-xl"
         />
       </label>
       <button

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -229,7 +229,7 @@
           v-model="newPassword"
           type="password"
           placeholder="New password (min 8)"
-          class="input input-bordered w-full rounded-xl bg-base-200"
+          class="kr-input-muted rounded-xl"
         />
         <p v-if="pwError" class="mt-2 text-sm text-error">{{ pwError }}</p>
         <div class="modal-action">

--- a/components/user/user-panel.vue
+++ b/components/user/user-panel.vue
@@ -69,7 +69,7 @@
             v-model="form[field.key]"
             :type="field.type"
             :placeholder="field.placeholder"
-            class="input input-bordered w-full rounded-2xl bg-base-200"
+            class="kr-input-muted rounded-2xl"
           />
         </label>
       </div>

--- a/utils/scripts/codemods/kr_input_codemod.py
+++ b/utils/scripts/codemods/kr_input_codemod.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled kr-input / kr-input-muted shapes.
+
+Dry-run is the default. Pass --write to update matching Vue files in place.
+Only the approved full-width, bordered DaisyUI text-input shapes are touched
+(`input input-bordered w-full bg-base-100` and `input input-bordered w-full
+bg-base-200`), and only in static `class="..."` attributes -- never
+`:class`/`v-bind:class` bindings. A source that already carries the target
+primitive, or is missing any one of the base tokens, is left untouched.
+Extra tokens beyond the base set (mt-1, rounded-xl, font-mono, ...) are
+preserved verbatim after the primitive class, matching the kr-textarea/
+kr-textarea-muted codemod's subset-match convention -- they're plain
+Tailwind utilities layered on top, not another component-root class, so
+resolution order is unaffected by folding the four base tokens into one
+name.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+FAMILIES = [
+    ("kr-input", {"input", "input-bordered", "w-full", "bg-base-100"}),
+    ("kr-input-muted", {"input", "input-bordered", "w-full", "bg-base-200"}),
+]
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    for primitive, base_tokens in FAMILIES:
+        if primitive in tokens or not base_tokens.issubset(tokens):
+            continue
+        remaining = [token for token in tokens if token not in base_tokens]
+        if exact_only and remaining:
+            continue
+        return " ".join([primitive, *remaining])
+    return None
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim (no
+        # universal-newline translation) -- a handful of source files carry
+        # CRLF, and translating those to LF on write would turn a one-line
+        # class-attribute change into a whole-file rewrite (kind_robots
+        # add-bot.vue, caught while extending this codemod's sibling for
+        # interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-input/kr-input-muted {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: kr-* front-end consistency sweep, slice 116 (kind: software)

### What changed / what I produced
- Added `.kr-input` (`input input-bordered w-full bg-base-100`) and `.kr-input-muted` (`input input-bordered w-full bg-base-200`) primitives to `assets/css/tailwind.css`, mirroring `.kr-textarea`/`.kr-textarea-muted`'s convention for the same full-width bordered shape on a single-line text input.
- Added `utils/scripts/codemods/kr_input_codemod.py`, following the `kr_textarea_codemod.py` subset-match pattern exactly (static `class="..."` attrs only, extra utility tokens preserved verbatim).
- Migrated 55 occurrences across 15 files (8 `kr-input`, 47 `kr-input-muted`).

### How I verified
- Surveyed the full candidate pool first (`input input-bordered w-full` + `bg-base-100`/`bg-base-200`, subset-match) — 55 occurrences across 15 files, a clean bounded family the same shape as the just-completed textarea slice.
- No regression-guard hits: grepped `utils/scripts/*.{mjs,ts,js}` for the literal class strings being replaced — none found.
- `ui-gallery.vue`'s style-guide demo input has no `bg-base-*` token, so it doesn't match either family — no manual exclusion needed.
- `vue-tsc --noEmit`: clean.
- `eslint` on all 16 changed `.vue` files: 2 pre-existing errors confirmed via `git stash` (add-bot.vue `no-extra-boolean-cast`, add-checkpoint.vue unused `props`), 0 new.
- `test:layout-contract`: held at 207 baseline, no new violations.
- `test:lint-ratchet`: held at 333 problems/-59, no rule got worse.
- `prettier --check` on all changed files: 9 files flagged, all 9 confirmed pre-existing via `git stash` — 0 newly-flagged, no `--write` needed this slice.

### Stakes
reversible

### Flags for Reviewer
none

### Kaizen suggestion
Next bounded slice candidate: none of the remaining hand-rolled families surveyed this session (radio, avatar, tooltip, divider, stat, checkbox non-sm/primary, modal-box) are large/coherent enough for a clean mechanical codemod — they're all under ~10 occurrences and highly varied. A future slice should re-survey once more of the app has landed, or consider a card/panel-shape audit (15 files use hand-rolled `card` classes, not yet surveyed for a common bounded pattern).

### Notes for reviewer

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEmWH6kwsFN75uztNF7vUz

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEmWH6kwsFN75uztNF7vUz)_