### PR TITLE
style: migrate hand-rolled panel shapes to kr-panel-muted-sm / kr-panel-muted-md

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -533,6 +533,24 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-2xl border border-base-300 bg-base-200 p-6;
   }
 
+  /* The most-repeated hand-rolled nested-panel shape (interface-vision
+   * t-104 slice 117): the same rounded-2xl/border-base-300/bg-base-200
+   * surface as .kr-panel-muted, but at the compact `p-3` padding used for
+   * dense nested rows/cards/list items rather than a full panel --
+   * previously hand-rolled across 19 occurrences, the larger of the two
+   * padding pools found. Named as a size variant of .kr-panel-muted, same
+   * convention as the .kr-btn-ghost/-md size ladder. */
+  .kr-panel-muted-sm {
+    @apply rounded-2xl border border-base-300 bg-base-200 p-3;
+  }
+
+  /* The `p-4` counterpart to .kr-panel-muted-sm (interface-vision t-104
+   * slice 117): same rounded-2xl/border-base-300/bg-base-200 surface, one
+   * padding step up from -sm — previously hand-rolled (14 occurrences). */
+  .kr-panel-muted-md {
+    @apply rounded-2xl border border-base-300 bg-base-200 p-4;
+  }
+
   /* Flat bordered surface for dense lists, rows, and inboxes. */
   .kr-panel-flat {
     @apply rounded-2xl border border-base-300 bg-base-100;

--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -2,7 +2,7 @@
 <template>
   <section class="flex flex-col gap-4">
     <header
-      class="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-200 p-4"
+      class="flex flex-wrap items-center justify-between gap-2 kr-panel-muted-md"
     >
       <div class="flex flex-col gap-1">
         <h2

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -65,7 +65,7 @@
         <article
           v-for="effect in store.galleryItems"
           :key="effect.id"
-          class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3 transition-shadow hover:shadow-lg"
+          class="flex flex-col gap-3 kr-panel-muted-sm transition-shadow hover:shadow-lg"
           :class="store.selectedSlug === effect.id ? 'ring-2 ring-primary' : ''"
         >
           <button

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -1,8 +1,6 @@
 <!-- /components/content/art/art-interact.vue -->
 <template>
-  <section
-    class="flex h-full min-h-0 w-full flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
-  >
+  <section class="flex h-full min-h-0 w-full flex-col gap-3 kr-panel-muted-sm">
     <header
       class="flex shrink-0 flex-col gap-2 kr-panel-flat p-3 md:flex-row md:items-center md:justify-between"
     >
@@ -197,7 +195,7 @@
       <main class="kr-pane-scroll kr-panel-flat">
         <div class="grid gap-3 p-3">
           <!-- Quick Edit -->
-          <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
+          <section class="kr-panel-muted-sm">
             <div class="mb-3 flex items-center justify-between gap-2">
               <div class="min-w-0">
                 <h2 class="truncate text-base font-black text-base-content">
@@ -363,9 +361,7 @@
           <!-- Collections / Tags / Remix -->
           <section class="grid grid-cols-1 gap-3 xl:grid-cols-3">
             <!-- Collections -->
-            <div
-              class="relative rounded-2xl border border-base-300 bg-base-200 p-3"
-            >
+            <div class="relative kr-panel-muted-sm">
               <div class="mb-2 flex items-center justify-between gap-2">
                 <div class="min-w-0">
                   <h2 class="truncate text-base font-black text-base-content">

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -713,7 +713,7 @@ onMounted(async () => {
   <div class="flex min-h-full w-full flex-col gap-6">
     <div
       v-if="showHeader"
-      class="rounded-2xl border border-base-300 bg-base-200 p-4 shadow-lg md:p-6"
+      class="kr-panel-muted-md shadow-lg md:p-6"
     >
       <div
         class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"
@@ -747,7 +747,7 @@ onMounted(async () => {
 
     <div class="grid gap-6 xl:grid-cols-[340px_1fr]">
       <aside class="flex flex-col gap-6">
-        <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <div class="kr-panel-muted-md">
           <div
             class="mb-3 text-sm font-bold uppercase tracking-widest opacity-60"
           >
@@ -776,7 +776,7 @@ onMounted(async () => {
           </div>
         </div>
 
-        <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <div class="kr-panel-muted-md">
           <div
             class="mb-3 text-sm font-bold uppercase tracking-widest opacity-60"
           >
@@ -815,7 +815,7 @@ onMounted(async () => {
           </div>
         </div>
 
-        <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <div class="kr-panel-muted-md">
           <div
             class="mb-3 text-sm font-bold uppercase tracking-widest opacity-60"
           >
@@ -966,7 +966,7 @@ onMounted(async () => {
           </div>
         </div>
 
-        <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <div class="kr-panel-muted-md">
           <div
             class="mb-3 text-sm font-bold uppercase tracking-widest opacity-60"
           >
@@ -996,7 +996,7 @@ onMounted(async () => {
       </aside>
 
       <main class="flex flex-col gap-6">
-        <div class="rounded-2xl border border-base-300 bg-base-200 p-4 md:p-6">
+        <div class="kr-panel-muted-md md:p-6">
           <div class="mb-4 text-lg font-bold">Test Builder</div>
 
           <div v-if="endpointDef.mode === 'text'" class="flex flex-col gap-6">
@@ -1211,7 +1211,7 @@ onMounted(async () => {
           </div>
         </div>
 
-        <div class="rounded-2xl border border-base-300 bg-base-200 p-4 md:p-6">
+        <div class="kr-panel-muted-md md:p-6">
           <div class="mb-3 flex items-center justify-between gap-3">
             <div class="text-lg font-bold">Built Prompt</div>
             <div class="text-sm opacity-60">{{ endpointDef.label }}</div>
@@ -1227,7 +1227,7 @@ onMounted(async () => {
 
         <div
           v-if="showPayload"
-          class="rounded-2xl border border-base-300 bg-base-200 p-4 md:p-6"
+          class="kr-panel-muted-md md:p-6"
         >
           <div class="mb-3 text-lg font-bold">Payload Preview</div>
           <pre
@@ -1236,7 +1236,7 @@ onMounted(async () => {
           >
         </div>
 
-        <div class="rounded-2xl border border-base-300 bg-base-200 p-4 md:p-6">
+        <div class="kr-panel-muted-md md:p-6">
           <div class="mb-3 flex flex-wrap items-center justify-between gap-3">
             <div>
               <div class="text-lg font-bold">Generate</div>
@@ -1282,7 +1282,7 @@ onMounted(async () => {
           </div>
         </div>
 
-        <div class="rounded-2xl border border-base-300 bg-base-200 p-4 md:p-6">
+        <div class="kr-panel-muted-md md:p-6">
           <div class="mb-4 flex items-center justify-between gap-3">
             <div class="text-lg font-bold">Result</div>
 
@@ -1339,7 +1339,7 @@ onMounted(async () => {
 
         <div
           v-if="showRawResult && resultData"
-          class="rounded-2xl border border-base-300 bg-base-200 p-4 md:p-6"
+          class="kr-panel-muted-md md:p-6"
         >
           <div class="mb-3 text-lg font-bold">Raw API / Store Result</div>
           <pre

--- a/components/art/hair-studio-manager.vue
+++ b/components/art/hair-studio-manager.vue
@@ -1,9 +1,7 @@
 <!-- /components/art/hair-studio-manager.vue -->
 <template>
   <section class="flex h-full min-h-0 w-full flex-col gap-3">
-    <header
-      class="flex flex-wrap items-center gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
-    >
+    <header class="flex flex-wrap items-center gap-3 kr-panel-muted-sm">
       <span
         class="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/15 text-primary"
       >

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -1,8 +1,6 @@
 <!-- /components/art/image-upload.vue -->
 <template>
-  <section
-    class="flex w-full flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4"
-  >
+  <section class="flex w-full flex-col gap-4 kr-panel-muted-md">
     <input
       ref="fileInput"
       type="file"

--- a/components/art/stylist-client-gallery.vue
+++ b/components/art/stylist-client-gallery.vue
@@ -1,6 +1,6 @@
 <!-- /components/art/stylist-client-gallery.vue -->
 <template>
-  <section class="mt-3 rounded-2xl border border-base-300 bg-base-200 p-3">
+  <section class="mt-3 kr-panel-muted-sm">
     <header class="mb-3 flex flex-wrap items-center gap-2">
       <Icon name="kind-icon:image" class="size-4 text-primary" />
       <h3 class="font-black">{{ client.name }}’s gallery</h3>

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -182,7 +182,7 @@
             </label>
 
             <div
-              class="flex items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+              class="flex items-center justify-between gap-3 kr-panel-muted-sm"
             >
               <span class="text-sm font-bold">Keep avatar</span>
 
@@ -240,7 +240,7 @@
           <div
             v-for="field in aiFields"
             :key="field.key"
-            class="rounded-2xl border border-base-300 bg-base-200 p-3"
+            class="kr-panel-muted-sm"
           >
             <div class="flex items-start justify-between gap-3">
               <div>

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -354,7 +354,7 @@
           <div
             v-for="field in aiFields"
             :key="field.key"
-            class="rounded-2xl border border-base-300 bg-base-200 p-3"
+            class="kr-panel-muted-sm"
           >
             <div class="flex items-start justify-between gap-3">
               <div>
@@ -442,7 +442,7 @@
           </label>
 
           <label
-            class="flex items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+            class="flex items-center justify-between gap-3 kr-panel-muted-sm"
           >
             <span class="font-bold">Public</span>
             <input
@@ -453,7 +453,7 @@
           </label>
 
           <label
-            class="flex items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+            class="flex items-center justify-between gap-3 kr-panel-muted-sm"
           >
             <span class="font-bold">Mature</span>
             <input

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -114,7 +114,7 @@
             <div
               v-for="stat in selectedCharacterStats"
               :key="stat.key"
-              class="rounded-2xl border border-base-300 bg-base-200 p-3"
+              class="kr-panel-muted-sm"
             >
               <p class="text-xs font-bold uppercase text-base-content/50">
                 {{ stat.label }}
@@ -226,7 +226,7 @@
                  never auto-scrolled -- so adopting the shared window fixes a
                  live bug, not just a duplication. -->
             <kr-chat-window
-              class="mb-3 max-h-96 min-h-40 rounded-2xl border border-base-300 bg-base-200 p-3"
+              class="mb-3 max-h-96 min-h-40 kr-panel-muted-sm"
               :turns="chatTurns"
               :label="`${selectedCharacterName} conversation`"
               :is-streaming="isSendingChat"
@@ -251,9 +251,7 @@
               </button>
             </div>
 
-            <details
-              class="mb-3 rounded-2xl border border-base-300 bg-base-200 p-3"
-            >
+            <details class="mb-3 kr-panel-muted-sm">
               <summary
                 class="cursor-pointer text-sm font-bold text-base-content"
               >
@@ -356,7 +354,7 @@
             </h2>
 
             <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
-              <div class="rounded-2xl border border-base-300 bg-base-200 p-3">
+              <div class="kr-panel-muted-sm">
                 <scenario-gallery
                   variant="dropdown"
                   title="Scenario"
@@ -366,7 +364,7 @@
                 />
               </div>
 
-              <div class="rounded-2xl border border-base-300 bg-base-200 p-3">
+              <div class="kr-panel-muted-sm">
                 <reward-gallery
                   variant="dropdown"
                   title="Reward"
@@ -402,10 +400,7 @@
               </button>
             </div>
 
-            <section
-              v-if="adventurePrompt"
-              class="mt-4 rounded-2xl border border-base-300 bg-base-200 p-4"
-            >
+            <section v-if="adventurePrompt" class="mt-4 kr-panel-muted-md">
               <h2 class="mb-3 text-lg font-bold text-base-content">
                 Adventure Prompt Preview
               </h2>

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -120,7 +120,7 @@
             </div>
 
             <div
-              class="mb-3 flex max-h-96 min-h-40 flex-col gap-3 overflow-y-auto rounded-2xl border border-base-300 bg-base-200 p-3"
+              class="mb-3 flex max-h-96 min-h-40 flex-col gap-3 overflow-y-auto kr-panel-muted-sm"
             >
               <div
                 v-if="chatMessages.length === 0"
@@ -248,7 +248,7 @@
             </h2>
 
             <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
-              <div class="rounded-2xl border border-base-300 bg-base-200 p-3">
+              <div class="kr-panel-muted-sm">
                 <scenario-gallery
                   variant="dropdown"
                   title="Scenario"
@@ -258,7 +258,7 @@
                 />
               </div>
 
-              <div class="rounded-2xl border border-base-300 bg-base-200 p-3">
+              <div class="kr-panel-muted-sm">
                 <reward-gallery
                   variant="dropdown"
                   title="Reward"

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -209,7 +209,7 @@
 
           <div
             v-if="characterStore.selectedCharacter"
-            class="rounded-2xl border border-base-300 bg-base-200 p-3 text-xs text-base-content/70"
+            class="kr-panel-muted-sm text-xs text-base-content/70"
           >
             <p class="line-clamp-3">
               {{ selectedCharacterDescription }}

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -3,7 +3,7 @@
   <section class="flex flex-col gap-4">
     <template v-if="!openDefinition">
       <header
-        class="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-200 p-4"
+        class="flex flex-wrap items-center justify-between gap-2 kr-panel-muted-md"
       >
         <div class="flex flex-col gap-1">
           <h2
@@ -97,7 +97,7 @@
 
     <template v-else>
       <header
-        class="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-200 p-3"
+        class="flex flex-wrap items-center justify-between gap-2 kr-panel-muted-sm"
       >
         <div class="flex items-center gap-2">
           <button

--- a/components/dreams/dream-art-chooser.vue
+++ b/components/dreams/dream-art-chooser.vue
@@ -1,6 +1,6 @@
 <!-- /components/dreams/dream-art-chooser.vue -->
 <template>
-  <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
+  <section class="kr-panel-muted-sm">
     <div class="flex flex-wrap items-start justify-between gap-2">
       <div class="min-w-0">
         <div class="flex flex-wrap items-center gap-2">

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -1,7 +1,7 @@
 <!-- /components/dreams/dream-brainstorm.vue -->
 <template>
   <section
-    class="kr-surface rounded-2xl border border-base-300 bg-base-200 p-3"
+    class="kr-surface kr-panel-muted-sm"
   >
     <header class="shrink-0 kr-panel-flat p-4">
       <div
@@ -207,7 +207,7 @@
         </section>
 
         <section class="kr-pane-scroll p-3">
-          <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
+          <section class="kr-panel-muted-sm">
             <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
               <div>
                 <h2 class="text-lg font-black">Fresh Ideas</h2>
@@ -396,7 +396,7 @@
       </main>
 
       <aside class="kr-pane gap-3 kr-panel-flat p-3">
-        <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
+        <section class="kr-panel-muted-sm">
           <h2 class="mb-3 text-lg font-black">Text Server</h2>
           <div class="grid gap-3">
             <label class="form-control">
@@ -447,7 +447,7 @@
           </div>
         </section>
 
-        <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
+        <section class="kr-panel-muted-sm">
           <h2 class="mb-3 text-lg font-black">Examples</h2>
           <div class="flex flex-wrap gap-2">
             <button

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -370,7 +370,7 @@
 
           <div
             v-if="dreamStore.selectedDream"
-            class="rounded-2xl border border-base-300 bg-base-200 p-3 text-xs text-base-content/70"
+            class="kr-panel-muted-sm text-xs text-base-content/70"
           >
             <p class="line-clamp-3">
               {{ selectedDreamDescription }}

--- a/components/dreams/dream-list.vue
+++ b/components/dreams/dream-list.vue
@@ -133,7 +133,7 @@
         <article
           v-for="entry in entries"
           :key="entry.key"
-          class="flex gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+          class="flex gap-3 kr-panel-muted-sm"
         >
           <img
             v-if="entry.image"

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -331,7 +331,7 @@
           <section class="kr-panel-flat p-4">
             <h2 class="text-lg font-black">Preview</h2>
             <div
-              class="mt-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+              class="mt-3 kr-panel-muted-sm"
             >
               <div class="flex items-start gap-3">
                 <Icon

--- a/components/dreams/dream-narration.vue
+++ b/components/dreams/dream-narration.vue
@@ -1,8 +1,6 @@
 <!-- /components/dreams/dream-narration.vue -->
 <template>
-  <section
-    class="kr-surface rounded-2xl border border-base-300 bg-base-200 p-3"
-  >
+  <section class="kr-surface kr-panel-muted-sm">
     <header class="shrink-0 kr-panel-flat p-3">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div class="min-w-0">
@@ -79,7 +77,7 @@
           @edit="editDream"
         />
 
-        <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
+        <section class="kr-panel-muted-sm">
           <h2 class="font-black">Organic Assets</h2>
           <p class="mt-1 text-sm text-base-content/60">
             The selected Dream is the anchor. Use these panels to move through
@@ -111,7 +109,7 @@
         v-else-if="workspaceStore.dreamPanel === 'characters'"
         class="grid gap-3"
       >
-        <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
+        <section class="kr-panel-muted-sm">
           <h2 class="font-black">Dream Cast</h2>
           <p class="mt-1 text-sm text-base-content/60">
             Characters connected to this Dream.
@@ -124,7 +122,7 @@
         v-else-if="workspaceStore.dreamPanel === 'rewards'"
         class="grid gap-3"
       >
-        <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
+        <section class="kr-panel-muted-sm">
           <h2 class="font-black">Dream Rewards</h2>
           <p class="mt-1 text-sm text-base-content/60">
             Rewards and narrative items connected to this Dream.
@@ -143,7 +141,7 @@
       </div>
 
       <div v-else class="grid gap-3">
-        <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
+        <section class="kr-panel-muted-sm">
           <h2 class="font-black">Dream Chat</h2>
           <p class="mt-1 text-sm text-base-content/60">
             Conversation threads attached to this Dream.

--- a/components/giftshop/giftshop-interact.vue
+++ b/components/giftshop/giftshop-interact.vue
@@ -40,7 +40,7 @@
           <article
             v-for="feature in giftshopFeatures"
             :key="feature.title"
-            class="rounded-2xl border border-base-300 bg-base-200 p-4 transition hover:border-primary/50 hover:bg-primary/10"
+            class="kr-panel-muted-md transition hover:border-primary/50 hover:bg-primary/10"
           >
             <Icon :name="feature.icon" class="mb-3 h-7 w-7 text-secondary" />
 
@@ -135,7 +135,7 @@
           <article
             v-for="item in showcaseItems"
             :key="item.title"
-            class="rounded-2xl border border-base-300 bg-base-200 p-4"
+            class="kr-panel-muted-md"
           >
             <div class="flex items-start justify-between gap-3">
               <div class="space-y-1">
@@ -179,7 +179,7 @@
       </div>
 
       <div class="mt-4 grid gap-3">
-        <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <div class="kr-panel-muted-md">
           <div class="text-sm text-base-content/60">Items</div>
 
           <div class="text-3xl font-black text-primary">
@@ -187,7 +187,7 @@
           </div>
         </div>
 
-        <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <div class="kr-panel-muted-md">
           <div class="text-sm text-base-content/60">Total</div>
 
           <div class="text-3xl font-black text-secondary">

--- a/components/lora/add-lora.vue
+++ b/components/lora/add-lora.vue
@@ -197,7 +197,7 @@
     </label>
 
     <div
-      class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3 sm:flex-row sm:items-center sm:justify-between"
+      class="flex flex-col gap-3 kr-panel-muted-sm sm:flex-row sm:items-center sm:justify-between"
     >
       <label class="label cursor-pointer justify-start gap-3">
         <input

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -11,7 +11,7 @@
     class="flex h-full min-h-0 w-full flex-col gap-3 rounded-2xl bg-base-300 p-3"
   >
     <header
-      class="flex shrink-0 flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+      class="flex shrink-0 flex-col gap-3 kr-panel-muted-sm"
     >
       <div class="min-w-0">
         <h2 class="truncate text-lg font-bold text-base-content">

--- a/components/navigation/server-selector.vue
+++ b/components/navigation/server-selector.vue
@@ -90,7 +90,7 @@
             </button>
           </section>
 
-          <section class="rounded-2xl border border-base-300 bg-base-200 p-3">
+          <section class="kr-panel-muted-sm">
             <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div class="min-w-0">
                 <h3 class="font-black text-primary">Connections</h3>

--- a/components/pages/portos-page.vue
+++ b/components/pages/portos-page.vue
@@ -15,13 +15,13 @@
       </header>
 
       <div class="grid gap-3 md:grid-cols-2">
-        <article class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <article class="kr-panel-muted-md">
           <h3 class="font-bold">Planned flow</h3>
           <p class="mt-2 text-sm leading-relaxed text-base-content/70">
             Let the user add a Porto server address, validate that the endpoint responds, then save the server metadata through the normal server records instead of hiding it in component state.
           </p>
         </article>
-        <article class="rounded-2xl border border-base-300 bg-base-200 p-4">
+        <article class="kr-panel-muted-md">
           <h3 class="font-bold">Not built yet</h3>
           <p class="mt-2 text-sm leading-relaxed text-base-content/70">
             The UI here is intentionally a placeholder so the Conductor tab split can land without inventing the Porto persistence contract too early. Tiny robot bureaucracy, but make it safe.

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -156,10 +156,7 @@
             </div>
           </article>
 
-          <div
-            v-else
-            class="rounded-2xl border border-base-300 bg-base-200 p-4 text-sm text-base-content/60"
-          >
+          <div v-else class="kr-panel-muted-md text-sm text-base-content/60">
             No reward selected. Head back to the gallery and pick something.
           </div>
         </div>

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -258,7 +258,7 @@
 
           <div
             v-if="rewardStore.selectedReward"
-            class="rounded-2xl border border-base-300 bg-base-200 p-3 text-xs text-base-content/70"
+            class="kr-panel-muted-sm text-xs text-base-content/70"
           >
             <p class="line-clamp-3">
               {{ selectedRewardDescription }}

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -189,7 +189,7 @@
           <div
             v-for="(intro, index) in intros"
             :key="`${intro}-${index}`"
-            class="flex items-start justify-between gap-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+            class="flex items-start justify-between gap-3 kr-panel-muted-sm"
           >
             <p class="text-sm text-base-content">
               {{ intro }}

--- a/components/screenfx/animation-selector.vue
+++ b/components/screenfx/animation-selector.vue
@@ -95,7 +95,7 @@
       <label
         v-for="control in controls"
         :key="control.key"
-        class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-200 p-3"
+        class="flex flex-col gap-2 kr-panel-muted-sm"
       >
         <span class="flex items-center justify-between gap-2 text-xs">
           <span class="font-black text-base-content/70">{{ control.label }}</span>

--- a/components/servers/add-checkpoint.vue
+++ b/components/servers/add-checkpoint.vue
@@ -202,7 +202,7 @@
     </label>
 
     <div
-      class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3 sm:flex-row sm:items-center sm:justify-between"
+      class="flex flex-col gap-3 kr-panel-muted-sm sm:flex-row sm:items-center sm:justify-between"
     >
       <label class="label cursor-pointer justify-start gap-3">
         <input

--- a/components/servers/add-server.vue
+++ b/components/servers/add-server.vue
@@ -125,7 +125,7 @@
         </label>
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-200 p-4">
+      <section class="kr-panel-muted-md">
         <h3
           class="mb-3 text-sm font-black uppercase tracking-wide text-base-content/60"
         >
@@ -192,7 +192,7 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-base-300 bg-base-200 p-4">
+      <section class="kr-panel-muted-md">
         <h3
           class="mb-3 text-sm font-black uppercase tracking-wide text-base-content/60"
         >

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -288,7 +288,7 @@
             </div>
 
             <!-- Performer gallery toggle -->
-            <div class="rounded-2xl border border-base-300 bg-base-200 p-3">
+            <div class="kr-panel-muted-sm">
               <button
                 type="button"
                 class="flex items-center gap-2 text-sm font-semibold text-base-content/70 hover:text-base-content"

--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -1,7 +1,7 @@
 <!-- /components/content/user/avatar-picker.vue -->
 <template>
   <section
-    class="flex h-full min-h-0 w-full flex-col gap-3 rounded-2xl border border-base-300 bg-base-200 p-3 sm:p-4"
+    class="flex h-full min-h-0 w-full flex-col gap-3 kr-panel-muted-sm sm:p-4"
   >
     <!-- ── Header ──────────────────────────────────────────────────────── -->
     <header

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -1,7 +1,7 @@
 <!-- /components/content/user/chat-gallery.vue -->
 <template>
   <section
-    class="flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden rounded-2xl border border-base-300 bg-base-200 p-3"
+    class="flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden kr-panel-muted-sm"
   >
     <header class="flex shrink-0 flex-col gap-3">
       <div class="flex items-start justify-between gap-3">
@@ -101,7 +101,7 @@
             v-for="thread in visibleThreads"
             :key="thread.threadKey"
             type="button"
-            class="group flex w-full items-start gap-3 rounded-2xl border border-base-300 bg-base-200 p-3 text-left transition hover:border-primary hover:bg-base-300"
+            class="group flex w-full items-start gap-3 kr-panel-muted-sm text-left transition hover:border-primary hover:bg-base-300"
             @click="openThread(thread)"
           >
             <div

--- a/components/user/user-galleries.vue
+++ b/components/user/user-galleries.vue
@@ -1,7 +1,7 @@
 <!-- /components/content/user/user-galleries.vue -->
 <template>
   <section
-    class="flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden rounded-2xl border border-base-300 bg-base-200 p-4"
+    class="flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden kr-panel-muted-md"
   >
     <header class="shrink-0 kr-panel-flat p-4">
       <h2 class="text-xl font-black">User Galleries</h2>
@@ -84,7 +84,7 @@
 
           <div
             v-if="expandedSections[section.key]"
-            class="mt-3 rounded-2xl border border-base-300 bg-base-200 p-3"
+            class="mt-3 kr-panel-muted-sm"
           >
             <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
               <p class="text-sm font-bold">Inline {{ section.label }} preview</p>

--- a/components/user/user-panel.vue
+++ b/components/user/user-panel.vue
@@ -1,7 +1,7 @@
 <!-- /components/content/user/user-panel.vue -->
 <template>
   <section
-    class="flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden rounded-2xl border border-base-300 bg-base-200 p-4"
+    class="flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden kr-panel-muted-md"
   >
     <header
       class="flex shrink-0 flex-col gap-3 kr-panel-flat p-4 md:flex-row md:items-center md:justify-between"

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -174,9 +174,7 @@
       </aside>
 
       <main class="kr-pane-scroll kr-panel-flat p-4">
-        <div
-          class="rounded-2xl border border-base-300 bg-base-200 p-3 shadow-inner"
-        >
+        <div class="kr-panel-muted-sm shadow-inner">
           <coloring-canvas
             ref="canvasRef"
             :page="pageDefinition"
@@ -191,7 +189,7 @@
         </div>
 
         <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
-          <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
+          <div class="kr-panel-muted-md">
             <p
               class="text-xs font-bold uppercase tracking-wide text-base-content/45"
             >
@@ -202,7 +200,7 @@
             </p>
           </div>
 
-          <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
+          <div class="kr-panel-muted-md">
             <p
               class="text-xs font-bold uppercase tracking-wide text-base-content/45"
             >
@@ -213,7 +211,7 @@
             </p>
           </div>
 
-          <div class="rounded-2xl border border-base-300 bg-base-200 p-4">
+          <div class="kr-panel-muted-md">
             <p
               class="text-xs font-bold uppercase tracking-wide text-base-content/45"
             >
@@ -265,7 +263,7 @@
             <article
               v-for="group in groups"
               :key="group.id"
-              class="rounded-2xl border border-base-300 bg-base-200 p-3"
+              class="kr-panel-muted-sm"
             >
               <div class="flex items-start justify-between gap-3">
                 <div>

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
 kr_panel_codemod.py — mechanical, byte-exact substitution of the hand-rolled
-kr-panel / kr-panel-muted / kr-panel-flat utility sequences for the shared
-class, in static `class="..."` attributes inside .vue templates only.
+kr-panel / kr-panel-muted / kr-panel-muted-sm / kr-panel-muted-md /
+kr-panel-flat utility sequences for the shared class, in static
+`class="..."` attributes inside .vue templates only.
 
 Scope, deliberately narrow (interface-vision/t-115's "if (b)" instruction):
   - Only static `class="..."` attributes (never `:class=`, `v-bind:class=`,
@@ -38,6 +39,13 @@ VARIANTS = [
     # (name, token sequence, longest first)
     ("kr-panel", ["rounded-2xl", "border", "border-base-300", "bg-base-100", "p-6", "shadow-sm"]),
     ("kr-panel-muted", ["rounded-2xl", "border", "border-base-300", "bg-base-200", "p-6"]),
+    # t-104 slice 117: the -sm/-md padding variants of kr-panel-muted, for
+    # the dense-nested-panel shape found at p-3/p-4 instead of the base p-6.
+    # Only the trailing padding token differs between these two and the base
+    # kr-panel-muted sequence above, so they're mutually exclusive at any
+    # given position -- order between them doesn't matter for correctness.
+    ("kr-panel-muted-sm", ["rounded-2xl", "border", "border-base-300", "bg-base-200", "p-3"]),
+    ("kr-panel-muted-md", ["rounded-2xl", "border", "border-base-300", "bg-base-200", "p-4"]),
     ("kr-panel-flat", ["rounded-2xl", "border", "border-base-300", "bg-base-100"]),
 ]
 


### PR DESCRIPTION
interface-vision/t-104 slice 117 (front-end consistency umbrella).

Adds two new `-sm`/`-md` padding-size variants of `.kr-panel-muted`
(`rounded-2xl border border-base-300 bg-base-200`), for the previously
hand-rolled `p-3` and `p-4` padding variants of the same surface, mirroring
the existing `.kr-panel` / `.kr-panel-muted` / `.kr-panel-flat` convention.
Extended `kr_panel_codemod.py`'s `VARIANTS` list following the existing
subset-match convention exactly (exact contiguous token match, extra
utilities preserved verbatim, DaisyUI-component-class-adjacent matches
skipped for manual review).

**Detail**
- Surveyed hand-rolled card/panel classes first (the candidate flagged by
  slice 116); found the daisyUI `card`/`card-body` family too scattered to
  be a clean bounded target, but a fresh, larger family underneath it:
  `rounded-2xl border border-base-300 bg-base-200` at `p-3` (19 exact
  occurrences) and `p-4` (14 exact occurrences) — the existing
  `kr_panel_codemod.py`'s subset-match found 48 and 29 total occurrences
  respectively once extra per-instance utilities are counted in.
- Migrated 77 occurrences across 36 files. 7 occurrences skipped for
  manual review across 6 files where the element also carries a
  non-utility custom class (e.g. `stylist-calculator`, `art-styler`) not on
  the codemod's safe-extras allowlist.
- No regression-guard hits (`utils/scripts/*.{mjs,ts,js}` searched for the
  literal shape strings).

**Verification**
- `vue-tsc --noEmit`: clean.
- `eslint` on all 36 changed `.vue` files: 27 pre-existing errors confirmed
  via `git stash` (across 8 files — no-dynamic-delete, no-extra-boolean-cast,
  3× no-unused-vars, unified-signatures ×2 files, import/no-duplicates,
  no-deprecated-slot-attribute), 0 new.
- `test:layout-contract`: held at 207 baseline.
- `test:lint-ratchet`: held at 333 problems / -59.
- `prettier --check`: 18 pre-existing warnings confirmed via `git stash`
  (17 `.vue` + `tailwind.css`); 7 newly-flagged from class-string shortening,
  fixed with a scoped `--write` on just those 7 files (re-verified clean
  against the same baseline afterward).

Next bounded slice candidate per this survey: the `p-3`/`p-4` variant of
`.kr-panel` itself (base-100, not base-200) wasn't surveyed this pass —
worth checking once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ufc9aZEoqdRtvc6q7GnE5J

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ufc9aZEoqdRtvc6q7GnE5J)_