### PR TITLE
style: migrate hand-rolled compact panel shapes to kr-panel-compact

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -551,6 +551,18 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-2xl border border-base-300 bg-base-200 p-4;
   }
 
+  /* The compact bordered surface on the "plain" base-100 background
+   * (interface-vision t-104 slice 118): a smaller radius than .kr-panel
+   * (rounded-xl, not rounded-2xl) at the dense `p-3` padding used for
+   * nested rows/cards/list items — the base-100 counterpart to
+   * .kr-panel-muted-sm's base-200 shape, previously hand-rolled across 29
+   * occurrences, the largest bounded pool surveyed this slice. Named
+   * distinctly from the -sm/-md ladder above since the radius itself
+   * differs, not just the padding. */
+  .kr-panel-compact {
+    @apply rounded-xl border border-base-300 bg-base-100 p-3;
+  }
+
   /* Flat bordered surface for dense lists, rows, and inboxes. */
   .kr-panel-flat {
     @apply rounded-2xl border border-base-300 bg-base-100;

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -20,9 +20,7 @@
       </button>
     </div>
 
-    <div
-      class="flex flex-col gap-2 rounded-xl border border-base-300 bg-base-100 p-3"
-    >
+    <div class="flex flex-col gap-2 kr-panel-compact">
       <div class="flex items-center gap-2">
         <Icon name="kind-icon:image" class="h-4 w-4 text-primary" />
         <span class="text-xs font-black text-base-content">Source Image</span>
@@ -292,7 +290,7 @@
     <Transition name="slide-fade">
       <div
         v-if="selectedSourceImage || resultImage"
-        class="flex items-center gap-3 rounded-xl border border-base-300 bg-base-100 p-3"
+        class="flex items-center gap-3 kr-panel-compact"
       >
         <div
           class="relative h-20 w-20 shrink-0 overflow-hidden rounded-xl border border-base-300"

--- a/components/art/stylist-calculator.vue
+++ b/components/art/stylist-calculator.vue
@@ -61,7 +61,7 @@
     </div>
 
     <!-- Time spent -->
-    <div class="flex flex-col gap-2 rounded-xl border border-base-300 bg-base-100 p-3">
+    <div class="flex flex-col gap-2 kr-panel-compact">
       <span class="text-xs font-black text-base-content">Time spent</span>
       <div class="flex flex-wrap gap-1">
         <button

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -7,7 +7,7 @@
       <span class="kr-badge-ghost-sm">{{ superkate.sortedCustomers.length }}</span>
     </header>
 
-    <form class="flex flex-wrap items-end gap-2 rounded-xl border border-base-300 bg-base-100 p-3" @submit.prevent="save">
+    <form class="flex flex-wrap items-end gap-2 kr-panel-compact" @submit.prevent="save">
       <label class="flex min-w-40 flex-1 flex-col gap-1">
         <span class="text-xs font-black">Name</span>
         <input v-model="name" type="text" placeholder="Client name" class="input input-sm input-bordered w-full" />

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -30,7 +30,7 @@
     </header>
 
     <!-- Client -->
-    <div class="rounded-xl border border-base-300 bg-base-100 p-3">
+    <div class="kr-panel-compact">
       <label class="flex flex-col gap-1">
         <span class="text-xs font-black text-base-content">Client</span>
         <input
@@ -51,7 +51,7 @@
     </div>
 
     <!-- Source image -->
-    <div class="flex flex-col gap-2 rounded-xl border border-base-300 bg-base-100 p-3">
+    <div class="flex flex-col gap-2 kr-panel-compact">
       <div class="flex items-center gap-2">
         <Icon name="kind-icon:image" class="h-4 w-4 text-primary" />
         <span class="text-xs font-black text-base-content">Client Photo</span>
@@ -152,7 +152,7 @@
     </div>
 
     <!-- What to change -->
-    <div class="flex flex-col gap-3 rounded-xl border border-base-300 bg-base-100 p-3">
+    <div class="flex flex-col gap-3 kr-panel-compact">
       <span class="text-xs font-black text-base-content">What are we changing?</span>
 
       <label class="flex items-start gap-2">
@@ -207,7 +207,7 @@
     </div>
 
     <!-- How much to keep them looking like themselves -->
-    <div class="flex flex-col gap-2 rounded-xl border border-base-300 bg-base-100 p-3">
+    <div class="flex flex-col gap-2 kr-panel-compact">
       <div class="flex items-center justify-between">
         <span class="text-xs font-black text-base-content">How much should it still look like them?</span>
         <span class="text-xs font-bold text-primary">{{ preserveLabel }}</span>

--- a/components/art/stylist-settings.vue
+++ b/components/art/stylist-settings.vue
@@ -47,7 +47,7 @@
       </label>
     </div>
 
-    <div class="flex flex-col gap-1 rounded-xl border border-base-300 bg-base-100 p-3">
+    <div class="flex flex-col gap-1 kr-panel-compact">
       <span class="text-xs font-black text-base-content">Receipt preview</span>
       <pre class="whitespace-pre-wrap text-xs text-base-content/70">{{ preview }}</pre>
     </div>

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -575,26 +575,24 @@
             {{ store.session.bible.title }} · Story bible
           </summary>
           <div class="mt-3 grid gap-2 text-xs leading-relaxed sm:grid-cols-2">
-            <p
-              class="rounded-xl border border-base-300 bg-base-100 p-3 sm:col-span-2"
-            >
+            <p class="kr-panel-compact sm:col-span-2">
               {{ store.session.bible.premise }}
             </p>
-            <p class="rounded-xl border border-base-300 bg-base-100 p-3">
+            <p class="kr-panel-compact">
               <span class="font-bold">Cast:</span>
               {{
                 store.session.bible.cast.map((item) => item.title).join(', ') ||
                 'Invented as needed'
               }}
             </p>
-            <p class="rounded-xl border border-base-300 bg-base-100 p-3">
+            <p class="kr-panel-compact">
               <span class="font-bold">World:</span>
               {{
                 store.session.bible.location?.title ||
                 'Invented from the premise'
               }}
             </p>
-            <p class="rounded-xl border border-base-300 bg-base-100 p-3">
+            <p class="kr-panel-compact">
               <span class="font-bold">Facets:</span>
               {{
                 store.session.bible.facets
@@ -602,7 +600,7 @@
                   .join(', ') || 'None selected'
               }}
             </p>
-            <p class="rounded-xl border border-base-300 bg-base-100 p-3">
+            <p class="kr-panel-compact">
               <span class="font-bold">Reward pool:</span>
               {{
                 store.session.bible.rewards

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -207,7 +207,7 @@
           <div
             v-for="entry in tankStore.stock"
             :key="entry.id"
-            class="rounded-xl border border-base-300 bg-base-100 p-3"
+            class="kr-panel-compact"
           >
             <div class="flex items-start justify-between gap-2">
               <div>
@@ -336,7 +336,7 @@
           <div
             v-for="entry in tankStore.catalog"
             :key="entry.id"
-            class="flex items-start gap-2 rounded-xl border border-base-300 bg-base-100 p-3"
+            class="flex items-start gap-2 kr-panel-compact"
           >
             <kr-art-plate
               :source="entry"
@@ -414,7 +414,7 @@
             <div
               v-for="entry in tankStore.bestiary"
               :key="entry.id"
-              class="flex items-start gap-2 rounded-xl border border-base-300 bg-base-100 p-3"
+              class="flex items-start gap-2 kr-panel-compact"
               :class="{ 'opacity-60': !entry.collected }"
             >
               <kr-art-plate
@@ -502,7 +502,7 @@
             <div
               v-for="entry in tankStore.setCatalog"
               :key="entry.kind"
-              class="flex flex-col gap-1 rounded-xl border border-base-300 bg-base-100 p-3"
+              class="flex flex-col gap-1 kr-panel-compact"
               :class="{ 'border-primary/60': entry.equipped }"
             >
               <div class="flex items-start justify-between gap-2">
@@ -581,7 +581,7 @@
             <div
               v-for="entry in tankStore.decorCatalog"
               :key="entry.kind"
-              class="flex flex-col gap-1 rounded-xl border border-base-300 bg-base-100 p-3"
+              class="flex flex-col gap-1 kr-panel-compact"
               :class="{
                 'border-primary/60': tankStore.pendingDecorKind === entry.kind,
               }"
@@ -691,7 +691,7 @@
             <div
               v-for="entry in tankStore.eggCatalog"
               :key="`${entry.rarity}-${entry.size}`"
-              class="flex items-start gap-2 rounded-xl border border-base-300 bg-base-100 p-3"
+              class="flex items-start gap-2 kr-panel-compact"
             >
               <span class="text-3xl leading-none" aria-hidden="true">{{
                 entry.icon

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -186,7 +186,7 @@
 
           <details
             v-if="fish.curation.inspirations.length"
-            class="rounded-xl border border-base-300 bg-base-100 p-3"
+            class="kr-panel-compact"
           >
             <summary class="cursor-pointer text-xs font-black">
               All inspiration art
@@ -214,7 +214,7 @@
             </div>
           </details>
 
-          <div class="rounded-xl border border-base-300 bg-base-100 p-3">
+          <div class="kr-panel-compact">
             <div class="flex flex-wrap gap-3">
               <label class="form-control min-w-52 flex-1 gap-1">
                 <span class="text-xs font-black">Render preset</span>

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -454,10 +454,7 @@
             </button>
           </div>
 
-          <details
-            v-if="selectedRow.changes.length"
-            class="rounded-xl border border-base-300 bg-base-100 p-3"
-          >
+          <details v-if="selectedRow.changes.length" class="kr-panel-compact">
             <summary class="cursor-pointer text-xs font-black">
               Audit history · {{ selectedRow.changes.length }} recent change{{
                 selectedRow.changes.length === 1 ? '' : 's'

--- a/components/mandarin/mandarin-voice-coach.vue
+++ b/components/mandarin/mandarin-voice-coach.vue
@@ -111,7 +111,7 @@
           <div
             v-for="observation in toneAnalysis.observations"
             :key="`${observation.syllable}:${observation.expectedTone}`"
-            class="rounded-xl border border-base-300 bg-base-100 p-3"
+            class="kr-panel-compact"
           >
             <div class="flex flex-wrap items-center gap-2">
               <span class="text-lg font-bold">{{ observation.syllable }}</span>

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -680,7 +680,7 @@
                     <div
                       v-for="item in sessionRecap"
                       :key="item.label"
-                      class="rounded-xl border border-base-300 bg-base-100 p-3"
+                      class="kr-panel-compact"
                     >
                       <dt class="font-bold text-base-content/70">{{ item.label }}</dt>
                       <dd class="mt-0.5 text-base-content/60">{{ item.value }}</dd>
@@ -706,7 +706,7 @@
                   <article
                     v-for="item in store.pendingWriteBacks"
                     :key="item.beatId"
-                    class="rounded-xl border border-base-300 bg-base-100 p-3 text-xs leading-relaxed"
+                    class="kr-panel-compact text-xs leading-relaxed"
                   >
                     <div class="flex items-start gap-2">
                       <div class="min-w-0 flex-1">

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -117,7 +117,7 @@
               </span>
             </label>
 
-            <label class="flex cursor-pointer items-center justify-between gap-4 rounded-xl border border-base-300 bg-base-100 p-3">
+            <label class="flex cursor-pointer items-center justify-between gap-4 kr-panel-compact">
               <div>
                 <span class="block text-sm font-black">Mature batch</span>
                 <span class="block text-xs text-base-content/50">
@@ -133,7 +133,7 @@
               />
             </label>
 
-            <details class="rounded-xl border border-base-300 bg-base-100 p-3 text-sm">
+            <details class="kr-panel-compact text-sm">
               <summary class="cursor-pointer font-black">Automatic motion direction</summary>
               <p class="mt-2 leading-relaxed text-base-content/60">
                 Bring this still scene naturally to life with subtle coherent motion. Preserve the

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -2,8 +2,8 @@
 """
 kr_panel_codemod.py — mechanical, byte-exact substitution of the hand-rolled
 kr-panel / kr-panel-muted / kr-panel-muted-sm / kr-panel-muted-md /
-kr-panel-flat utility sequences for the shared class, in static
-`class="..."` attributes inside .vue templates only.
+kr-panel-flat / kr-panel-compact utility sequences for the shared class, in
+static `class="..."` attributes inside .vue templates only.
 
 Scope, deliberately narrow (interface-vision/t-115's "if (b)" instruction):
   - Only static `class="..."` attributes (never `:class=`, `v-bind:class=`,
@@ -47,6 +47,11 @@ VARIANTS = [
     ("kr-panel-muted-sm", ["rounded-2xl", "border", "border-base-300", "bg-base-200", "p-3"]),
     ("kr-panel-muted-md", ["rounded-2xl", "border", "border-base-300", "bg-base-200", "p-4"]),
     ("kr-panel-flat", ["rounded-2xl", "border", "border-base-300", "bg-base-100"]),
+    # t-104 slice 118: the base-100 counterpart to kr-panel-muted-sm, at a
+    # smaller rounded-xl radius rather than rounded-2xl -- the leading
+    # radius token never overlaps with any other variant above, so list
+    # position doesn't matter for correctness here.
+    ("kr-panel-compact", ["rounded-xl", "border", "border-base-300", "bg-base-100", "p-3"]),
 ]
 
 CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 118: extend the kr-* consistency sweep with a new bounded shape family (kind: software)

### What changed / what I produced
- Added `.kr-panel-compact` (`rounded-xl border border-base-300 bg-base-100 p-3`) to `assets/css/tailwind.css` — the base-100 counterpart to `.kr-panel-muted-sm`, at a smaller `rounded-xl` radius rather than `rounded-2xl` (named distinctly from the `-sm`/`-md` ladder since the radius itself differs, not just the padding).
- Extended `utils/scripts/codemods/kr_panel_codemod.py`'s `VARIANTS` list with the new sequence.
- Ran the codemod across the repo: 28 occurrences migrated across 12 files (`components/art/*`, `components/conductor/storybook-page.vue`, `components/cthulhuquarium/*`, `components/curation/*`, `components/mandarin/mandarin-voice-coach.vue`, `components/pages/taskmaster-page.vue`, `pages/admin/scene-animator.vue`).
- No regression-guard hits (`utils/scripts/*.{mjs,ts,js}` searched for the literal class strings).
- Skipped 8 occurrences across 7 files where the element also carries a non-utility custom class not on the codemod's safe-extras allowlist (manual review only, untouched).

### How I verified
- `vue-tsc --noEmit`: clean.
- `eslint` on all 12 changed files: 2 pre-existing errors in `stylist-clients.vue` (`@typescript-eslint/no-dynamic-delete`) confirmed via `git stash` diff against baseline `main`; 0 new.
- `test:layout-contract`: held at 207 baseline, no new violations.
- `prettier --check`: 8 pre-existing warns confirmed via `git stash` (unchanged from baseline); 3 newly-flagged from class-shortening (multi-line tag collapsing to one line) fixed with scoped `--write` (`art-styler.vue`, `storybook-page.vue`, `mandarin-curation.vue`).

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Next bounded slice candidate: `components/pages/conductor-project-gallery-page.vue`'s `kr-scroll rounded-xl border border-base-300 bg-base-100 p-3` combo was skipped this slice (mixes `kr-panel-compact`'s geometry with the `kr-scroll` primitive, not on the safe-extras allowlist) — worth a manual look, or add `kr-scroll` to the allowlist if it's confirmed to carry no conflicting background/border of its own (same empirical-check convention as the other kr-* primitives already on the list).

### Notes for reviewer
Recurring task (interface-vision/t-104) — same convention as slices 109-117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7w1thyYcCtrjNu8srJWPr

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7w1thyYcCtrjNu8srJWPr)_