### PR TITLE
style: allowlist kr-scroll, migrate conductor-project-gallery-page.vue to kr-panel-compact

### DIFF
--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -146,7 +146,7 @@
       </div>
     </section>
 
-    <main class="kr-scroll rounded-xl border border-base-300 bg-base-100 p-3">
+    <main class="kr-scroll kr-panel-compact">
       <kr-gallery
         :items="galleryItems"
         :mode="galleryMode"

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -95,9 +95,17 @@ SAFE_EXTRA_RE = re.compile(
     r"(mx-auto|my-auto|mt-auto|mb-auto|ml-auto|mr-auto)|"
     r"aspect-\S+|"
     r"group|"
-    r"kr-(pane|pane-scroll|surface|stage|unbound|container|container-wide|section|toolbar)"
+    r"kr-(pane|pane-scroll|surface|stage|unbound|container|container-wide|section|toolbar|scroll)"
     r")$"
 )
+# 2026-09-06 (t-104 slice 119) addition: `kr-scroll` -- `@apply min-h-0 flex-1
+# overflow-y-auto overscroll-contain` in tailwind.css; pure layout/scroll
+# behavior, same verified-empty-of-bg/border/radius category as the other
+# listed kr-* primitives. Unblocks the one occurrence this slice's own note
+# (t-104 slice 118) flagged as the next candidate:
+# components/pages/conductor-project-gallery-page.vue's
+# `kr-scroll rounded-xl border border-base-300 bg-base-100 p-3` (kr-panel-compact).
+#
 # 2026-08-09 (t-104 slice 15) additions, each verified against the compiled
 # Tailwind output (`npx @tailwindcss/cli -i assets/css/tailwind.css -o -`)
 # to declare NO background-color/border-color/border-radius of its own, so


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 119 — recurring kr-* consistency sweep (Conductor scheduled Agent run).

### What changed / what I produced
- Added `kr-scroll` to `kr_panel_codemod.py`'s `SAFE_EXTRA_RE` safe-extras allowlist. `kr-scroll` is `@apply min-h-0 flex-1 overflow-y-auto overscroll-contain` in `tailwind.css` — verified to declare no background/border/radius of its own, the same category as the other `kr-*` layout primitives already allowlisted (`kr-pane`, `kr-surface`, `kr-stage`, `kr-toolbar`, etc.).
- This unblocks the one occurrence flagged by slice 118's own note as the next candidate: `components/pages/conductor-project-gallery-page.vue`'s `<main>` root now uses `kr-scroll kr-panel-compact` instead of the hand-rolled `kr-scroll rounded-xl border border-base-300 bg-base-100 p-3`. No geometry or behavior change.

### How I verified
- `npx vue-tsc --noEmit`: clean.
- `npx eslint components/pages/conductor-project-gallery-page.vue`: 0 errors.
- `npm run test:layout-contract`: held at baseline (207 pre-existing, unchanged bucket), no new violations.
- `npx prettier --check` on the changed `.vue` file: pre-existing warning confirmed present on `origin/main` via `git stash` (unrelated to this change, not newly introduced).

### Stakes
Reversible — a single class-attribute substitution that resolves to the exact same CSS declarations; no visual or behavioral change.

### Flags for Reviewer
None. Remaining skipped occurrences in the codemod's dry-run (5 `art-*`/`stylist-*` component-identifier root classes, 2 DaisyUI `btn` occurrences in `chat-gallery.vue`) are left for a future slice per the bounded-scope convention — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015abiC5i6NgX7AYfLP2w4Lp

---
_Generated by [Claude Code](https://claude.ai/code/session_015abiC5i6NgX7AYfLP2w4Lp)_