### PR TITLE
style: migrate 5 dead-identifier panel roots to kr-panel-muted-md

### DIFF
--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -1,8 +1,6 @@
 <!-- /components/art/art-styler.vue -->
 <template>
-  <section
-    class="art-styler flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4"
-  >
+  <section class="flex flex-col gap-4 kr-panel-muted-md">
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-2">
         <Icon name="kind-icon:magic" class="h-5 w-5 text-primary" />

--- a/components/art/stylist-calculator.vue
+++ b/components/art/stylist-calculator.vue
@@ -5,9 +5,7 @@
   Time is hours/minutes with preset chips; product cost defaults to $0.00.
 -->
 <template>
-  <section
-    class="stylist-calculator flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4"
-  >
+  <section class="flex flex-col gap-4 kr-panel-muted-md">
     <header class="flex items-center gap-2">
       <Icon name="kind-icon:sparkles" class="h-5 w-5 text-primary" />
       <h2 class="text-base font-black text-base-content">New Appointment</h2>

--- a/components/art/stylist-history.vue
+++ b/components/art/stylist-history.vue
@@ -4,9 +4,7 @@
   by date, review totals, and open the warm receipt email for any appointment.
 -->
 <template>
-  <section
-    class="stylist-history flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4"
-  >
+  <section class="flex flex-col gap-4 kr-panel-muted-md">
     <header class="flex items-center gap-2">
       <Icon name="kind-icon:book" class="h-5 w-5 text-primary" />
       <h2 class="text-base font-black text-base-content">Appointments</h2>

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -11,9 +11,7 @@
   superkate-hairstyle-ai t-007 (navigable async) and t-008 (durable per-client gallery).
 -->
 <template>
-  <section
-    class="stylist-restyle flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4"
-  >
+  <section class="flex flex-col gap-4 kr-panel-muted-md">
     <header class="flex items-center gap-2">
       <Icon name="kind-icon:magic" class="h-5 w-5 text-primary" />
       <h2 class="text-base font-black text-base-content">Hair Studio</h2>

--- a/components/art/stylist-settings.vue
+++ b/components/art/stylist-settings.vue
@@ -5,9 +5,7 @@
   booking/contact link, and reply contact. Live receipt preview included.
 -->
 <template>
-  <section
-    class="stylist-settings flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4"
-  >
+  <section class="flex flex-col gap-4 kr-panel-muted-md">
     <header class="flex items-center gap-2">
       <Icon name="kind-icon:adjust" class="h-5 w-5 text-primary" />
       <h2 class="text-base font-black text-base-content">Receipt Settings</h2>


### PR DESCRIPTION
## Summary

`interface-vision/t-104` slice 120. Migrates 5 hand-rolled panel roots to the shared `kr-panel-muted-md` class.

`art-styler.vue`, `stylist-calculator.vue`, `stylist-history.vue`, `stylist-restyle.vue`, and `stylist-settings.vue` each had a root:

```
<section class="<name> flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-200 p-4">
```

where `<name>` is a dead component-identifier class (e.g. `art-styler`, `stylist-calculator`) — verified to have zero CSS rules and zero selector references anywhere in the repo. This slice removes the dead identifier and substitutes the trailing utility sequence with the shared `kr-panel-muted-md` class (`rounded-2xl border border-base-300 bg-base-200 p-4` in `assets/css/tailwind.css`) — an exact match, so no geometry or behavior change.

This was the "next bounded slice candidate" flagged by t-104 slice 119's own note.

## Verification

- `vue-tsc --noEmit` — clean
- `eslint` on the 5 changed files — 0 errors
- `test:layout-contract` — held at 207 baseline, no new violations
- `test:lint-ratchet` — held at 333/-59, no rule got worse
- `prettier --check` — same 5 pre-existing warnings on these files, confirmed present on baseline `main` before this change (unrelated, not newly introduced)
- Manually confirmed the removed identifier classnames (`art-styler`, `stylist-calculator`, `stylist-history`, `stylist-restyle`, `stylist-settings`) have no CSS selector or dynamic (`classList`/`querySelector`) references anywhere in the repo — the only other occurrences are Vue component-tag usages (`<art-styler />`, `<stylist-calculator />`, ...), which are unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wm3KD4JQm3d9mhqY1Emj5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wm3KD4JQm3d9mhqY1Emj5f)_