### PR TITLE
style: migrate ui-gallery hand-rolled badges to kr-badge-warning-sm/kr-badge-ghost-sm

### DIFF
--- a/components/ui/ui-gallery.vue
+++ b/components/ui/ui-gallery.vue
@@ -551,12 +551,12 @@
               <tr>
                 <td>Wire desired-features list</td>
                 <td>global-ui</td>
-                <td><span class="badge badge-warning badge-sm">ready</span></td>
+                <td><span class="kr-badge-warning-sm">ready</span></td>
               </tr>
               <tr>
                 <td>Site-audit agent</td>
                 <td>global-ui</td>
-                <td><span class="badge badge-ghost badge-sm">claimed</span></td>
+                <td><span class="kr-badge-ghost-sm">claimed</span></td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (slice 121) (kind: software)

### What changed / what I produced
- `components/ui/ui-gallery.vue`: mechanically migrated the last two unconverted hand-rolled badge occurrences the codemod's exact-match scan found in `components/`:
  - `badge badge-warning badge-sm` → `kr-badge-warning-sm` (task-status table, "ready" row)
  - `badge badge-ghost badge-sm` → `kr-badge-ghost-sm` (same table, "claimed" row)
- Applied via `utils/scripts/codemods/kr_badge_codemod.py --write` (existing, unmodified codemod from an earlier slice). Both target classes already exist in `assets/css/tailwind.css`.

### How I verified
- `npx vue-tsc --noEmit`: clean
- `npx eslint components/ui/ui-gallery.vue`: 0 errors
- `npm run test:layout-contract`: 207 baseline held, no new violations
- `npm run test:lint-ratchet`: 333/-59 held, no rule worsened
- `git diff` reviewed: 2-line change, no geometry/behavior change

### Stakes
reversible

### Flags for Reviewer
- Ran every codemod in `utils/scripts/codemods/` across `components/` and `pages/` looking for a new bounded pool this slice; every other codemod (panel, input, textarea, checkbox, input-select, panel-section) reported zero remaining candidates. `kr_badge_codemod.py` was the only one with anything left (these 2 occurrences), so the slice is small by necessity — the mechanical pool for this consistency task is close to exhausted for now.
- Also surveyed for the "dead custom root identifier + hand-rolled panel utilities" pattern (this task's other recurring shape) and for `mx-auto ... max-w-*` roots missing `w-full`; found one candidate (`components/screenfx/animation-tester.vue`'s `.animation-tester-container`) but it carries its own scoped CSS rule (`max-width: 400px`) that actually overrides the `max-w-lg` utility in the template — not a dead identifier, and no existing `kr-container*` variant matches 400px, so migrating it would be a real geometry change out of this slice's "no visual delta" scope. Left alone; noted for a future slice if a narrower container variant is ever introduced.

### Kaizen suggestion
The mechanical codemod pool (exact-token-sequence matches with only "safe extra" utilities) is now nearly exhausted across `components/`+`pages/`. The next slice(s) will likely need to either (a) extend an existing codemod to handle opacity variants (`bg-base-200/40`, etc. — currently explicitly out of scope, see `kr_panel_codemod.py`'s docstring) as a deliberate scope decision, or (b) move to manual per-file review of the remaining "unsafe extra tokens" pool (DaisyUI component-root class combinations) the codemods already skip and report. Worth deciding which direction before the next slice so it isn't rediscovered from scratch.

### Notes for reviewer
Branch `claude/eager-bohr-z499eq` was already at `origin/main`'s tip (previous slice 120 PR #2468 had just merged) before this commit, so this diff is exactly the one new commit's content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrMftKaXomGkch1ftyJMCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrMftKaXomGkch1ftyJMCo)_