### PR TITLE
model-builder/t-029 cycle 101: close guard coverage gap on autoBuildAllDisabled

### DIFF
--- a/utils/scripts/verifyModelBuilderAutoBuildBatchExclusionGuard.test.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildBatchExclusionGuard.test.ts
@@ -8,9 +8,18 @@
 // state.autoBuilding), the fixed shape (all five functions), a partial fix
 // that leaves one batch function behind, and all five target functions
 // being absent entirely.
+//
+// Also exercises checkProgressMatrixAutoBuildAllDisabledGuard() (cycle 101),
+// added to close the coverage gap cycle 100 noted: the store-side checks
+// above never read model-builder-progress-matrix.vue's own
+// autoBuildAllDisabled computed, which reimplements the same "in flight"
+// condition for the UI rather than calling the store's helper.
 import assert from 'node:assert/strict'
 
-import { checkAutoBuildBatchExclusionGuard } from './verifyModelBuilderAutoBuildBatchExclusionGuard.js'
+import {
+  checkAutoBuildBatchExclusionGuard,
+  checkProgressMatrixAutoBuildAllDisabledGuard,
+} from './verifyModelBuilderAutoBuildBatchExclusionGuard.js'
 
 const BUGGY_FIXTURE = `
   function isRunOperationInFlight(): boolean {
@@ -283,4 +292,68 @@ console.log(
     'state.autoBuilding bail-out, clears the fixed shape, flags a partial ' +
     'fix that leaves one batch function behind, and flags all five target ' +
     'functions being absent.',
+)
+
+const PROGRESS_MATRIX_FIXED_FIXTURE = `
+  const batchInProgress = computed(() => store.batchingOutputKey !== null)
+  const autoBuildAllDisabled = computed(
+    () => store.autoBuilding || batchInProgress.value,
+  )
+`
+
+const PROGRESS_MATRIX_REGRESSED_FIXTURE = `
+  const batchInProgress = computed(() => store.batchingOutputKey !== null)
+  const autoBuildAllDisabled = computed(() => store.autoBuilding)
+`
+
+const PROGRESS_MATRIX_MISSING_FIXTURE = `
+  const busyCount = computed(
+    () =>
+      run.value?.items.filter((item) => store.isItemManualActionInFlight(item.id))
+        .length ?? 0,
+  )
+`
+
+const progressMatrixFixedErrors = checkProgressMatrixAutoBuildAllDisabledGuard(
+  PROGRESS_MATRIX_FIXED_FIXTURE,
+)
+assert.equal(
+  progressMatrixFixedErrors.length,
+  0,
+  'expected the fixed progress-matrix shape to raise no errors, got: ' +
+    JSON.stringify(progressMatrixFixedErrors),
+)
+
+const progressMatrixRegressedErrors =
+  checkProgressMatrixAutoBuildAllDisabledGuard(
+    PROGRESS_MATRIX_REGRESSED_FIXTURE,
+  )
+assert.equal(
+  progressMatrixRegressedErrors.length,
+  1,
+  'expected the regressed progress-matrix shape (missing batchInProgress) ' +
+    `to raise exactly 1 error, got ${progressMatrixRegressedErrors.length}: ` +
+    JSON.stringify(progressMatrixRegressedErrors),
+)
+assert.ok(
+  progressMatrixRegressedErrors[0]!.includes('batchInProgress'),
+  'expected the error to call out the missing batchInProgress check',
+)
+
+const progressMatrixMissingErrors =
+  checkProgressMatrixAutoBuildAllDisabledGuard(PROGRESS_MATRIX_MISSING_FIXTURE)
+assert.equal(
+  progressMatrixMissingErrors.length,
+  1,
+  'expected the missing-computed shape to raise exactly 1 "could not find" ' +
+    `error, got ${progressMatrixMissingErrors.length}: ` +
+    JSON.stringify(progressMatrixMissingErrors),
+)
+assert.ok(progressMatrixMissingErrors[0]!.startsWith('Could not find'))
+
+console.log(
+  'model-builder-progress-matrix.vue autoBuildAllDisabled guard checker ' +
+    'verified: clears the fixed shape (both store.autoBuilding and ' +
+    'batchInProgress), flags a regression that drops the batchInProgress ' +
+    'check, and flags the computed being absent entirely.',
 )

--- a/utils/scripts/verifyModelBuilderAutoBuildBatchExclusionGuard.ts
+++ b/utils/scripts/verifyModelBuilderAutoBuildBatchExclusionGuard.ts
@@ -40,6 +40,20 @@
 // if a future refactor drops either side, the two orchestration loops can
 // run concurrently again with no error and no warning until a user
 // happens to trigger both from the UI at once.
+//
+// Coverage gap closed (cycle 101): the store-side checks above only assert
+// isRunOperationInFlight()/autoBuildRun()/the four batch functions --
+// nothing here ever read model-builder-progress-matrix.vue's own
+// `autoBuildAllDisabled` computed, which independently reimplements the
+// same "is a run operation in flight" condition for the UI (`store.
+// autoBuilding || batchInProgress.value`, batchInProgress itself `store.
+// batchingOutputKey !== null`) rather than calling the store's helper. A
+// regression dropping `|| batchInProgress.value` from that computed would
+// leave the whole-run "Auto-build all" button clickable while a group batch
+// operation is running -- reintroducing the exact concurrent-loop race this
+// guard exists to prevent -- and every store-side check above would still
+// pass. checkProgressMatrixAutoBuildAllDisabledGuard() below asserts the
+// computed's text still references both flags.
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -50,6 +64,13 @@ const scriptDirectory = dirname(fileURLToPath(import.meta.url))
 const repositoryRoot = resolve(scriptDirectory, '../..')
 
 const STORE_PATH = join(repositoryRoot, 'stores/modelBuilderStore.ts')
+const PROGRESS_MATRIX_PATH = join(
+  repositoryRoot,
+  'components/model-builder/model-builder-progress-matrix.vue',
+)
+
+const AUTO_BUILD_ALL_DISABLED_PATTERN =
+  /const\s+autoBuildAllDisabled\s*=\s*computed\(\s*\(\)\s*=>\s*([^)]+)\)/
 
 const BATCH_FUNCTIONS = [
   'batchDraftField',
@@ -133,14 +154,62 @@ export function checkAutoBuildBatchExclusionGuard(content: string): string[] {
   return errors
 }
 
+// Checks model-builder-progress-matrix.vue's own `autoBuildAllDisabled`
+// computed against the full source text of that file. Exported separately
+// from checkAutoBuildBatchExclusionGuard (rather than folded into it) since
+// it reads a different file and the self-test below exercises it against
+// its own synthetic .vue-shaped fixtures.
+export function checkProgressMatrixAutoBuildAllDisabledGuard(
+  content: string,
+): string[] {
+  const errors: string[] = []
+
+  const match = AUTO_BUILD_ALL_DISABLED_PATTERN.exec(content)
+  if (!match) {
+    errors.push(
+      'Could not find a `const autoBuildAllDisabled = computed(() => ...)` ' +
+        'definition in model-builder-progress-matrix.vue -- has it been ' +
+        'renamed, removed, or restructured? If so, this guard (and the ' +
+        'button-disabled half of the fix it protects) needs to move with it.',
+    )
+    return errors
+  }
+
+  const body = match[1] ?? ''
+  if (!/store\.autoBuilding/.test(body)) {
+    errors.push(
+      'autoBuildAllDisabled does not check store.autoBuilding -- the ' +
+        '"Auto-build all" button would stay clickable while a whole-run ' +
+        'auto-build is already in progress.',
+    )
+  }
+  if (!/batchInProgress/.test(body)) {
+    errors.push(
+      'autoBuildAllDisabled does not check batchInProgress -- the ' +
+        '"Auto-build all" button would stay clickable while a group batch ' +
+        'operation (Draft pitches/fields/prompts, Approve fields, or ' +
+        'Auto-build group) is already running for this run, letting a ' +
+        "user start a second, fully concurrent walk over the same run's " +
+        'items.',
+    )
+  }
+
+  return errors
+}
+
 function main(): void {
   const content = readFileSync(STORE_PATH, 'utf8')
   const errors = checkAutoBuildBatchExclusionGuard(content)
 
+  const progressMatrixContent = readFileSync(PROGRESS_MATRIX_PATH, 'utf8')
+  errors.push(
+    ...checkProgressMatrixAutoBuildAllDisabledGuard(progressMatrixContent),
+  )
+
   if (errors.length) {
     console.error(
       'Model Builder auto-build/batch mutual-exclusion guard contract ' +
-        'failed in modelBuilderStore.ts:',
+        'failed:',
     )
     for (const error of errors) console.error(`- ${error}`)
     process.exitCode = 1
@@ -150,8 +219,10 @@ function main(): void {
   console.log(
     'Model Builder auto-build/batch mutual-exclusion guard contract ' +
       'passed: autoBuildRun() refuses to start while a group batch ' +
-      'operation is in flight, and every group batch operation refuses to ' +
-      'start while a whole-run auto-build is in flight.',
+      'operation is in flight, every group batch operation refuses to ' +
+      'start while a whole-run auto-build is in flight, and ' +
+      "model-builder-progress-matrix.vue's own autoBuildAllDisabled " +
+      'computed still gates the UI button on both flags.',
   )
 }
 


### PR DESCRIPTION
## Summary

Cycle 100's cross-reference audit (model-builder/t-029) found that `verifyModelBuilderAutoBuildBatchExclusionGuard.ts` only ever asserted the store-side half of the cycle-25 fix (`isRunOperationInFlight()` and the `autoBuildRun`/`batchXxx` functions in `modelBuilderStore.ts`) and never read `model-builder-progress-matrix.vue`'s own `autoBuildAllDisabled` computed, which independently reimplements the same "run operation in flight" condition for the UI (`store.autoBuilding || batchInProgress.value`) rather than calling the store's helper.

A regression dropping `|| batchInProgress.value` from that computed would leave the "Auto-build all" button clickable while a group batch operation is running — reintroducing the exact concurrent-loop race this guard exists to prevent — while every store-side check kept passing silently.

## Changes

- Adds `checkProgressMatrixAutoBuildAllDisabledGuard()` to `verifyModelBuilderAutoBuildBatchExclusionGuard.ts`, wired into `main()` alongside the existing store check.
- Adds self-test coverage in the `.test.ts` file for the fixed, regressed (missing `batchInProgress`), and missing-computed shapes.
- No behavior/UI change — the current code was already confirmed correct in cycle 100; this only closes the detection gap so a future regression here is caught.

## Verification

- `npx tsx utils/scripts/verifyModelBuilderAutoBuildBatchExclusionGuard.test.ts` — passes, including new fixture cases
- `npx tsx utils/scripts/verifyModelBuilderAutoBuildBatchExclusionGuard.ts` — passes against real files
- `eslint` — 0 errors on changed files
- `vue-tsc --noEmit` — clean
- `prettier --check` — clean
- Both scripts are already wired into `.github/workflows/contract-tests.yml` (selftest + guard), no CI wiring changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsJDYvm7bQCwTkoimjzLCV

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsJDYvm7bQCwTkoimjzLCV)_