### PR TITLE
style: migrate hand-rolled toggle-row labels to kr-toggle-row/-sm

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -568,6 +568,24 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-2xl border border-base-300 bg-base-100;
   }
 
+  /* The hand-rolled toggle-row label: a bordered muted strip pairing a
+   * label with a DaisyUI `toggle` input (Public/Mature/Active-style
+   * checkboxes) — same rounded-2xl/border-base-300/bg-base-200 surface as
+   * .kr-panel-muted, but with asymmetric row padding instead of a uniform
+   * `p-*` (interface-vision t-104 slice 122: previously hand-rolled across
+   * 9 occurrences at this padding, in add-bot.vue, add-reward.vue,
+   * add-scenario.vue, and add-collection.vue). */
+  .kr-toggle-row {
+    @apply label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-4 py-3;
+  }
+
+  /* The denser counterpart to .kr-toggle-row (interface-vision t-104 slice
+   * 122): same shape, one padding step down — previously hand-rolled across
+   * 4 occurrences in dream-maker.vue. */
+  .kr-toggle-row-sm {
+    @apply label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-3 py-2;
+  }
+
   /* Larger-radius page-section surface: coloring-book studio panels and
    * conductor-app project pages. Approved by Silas (interface-vision/t-123)
    * as the named primitive for the previously hand-rolled

--- a/components/art/add-collection.vue
+++ b/components/art/add-collection.vue
@@ -44,9 +44,7 @@
       </label>
 
       <div v-if="showFlags" class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-        <label
-          class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
-        >
+        <label class="kr-toggle-row">
           <span class="label-text font-bold">Public</span>
 
           <input
@@ -57,9 +55,7 @@
           />
         </label>
 
-        <label
-          class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
-        >
+        <label class="kr-toggle-row">
           <span class="label-text font-bold">Mature</span>
 
           <input

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -404,9 +404,7 @@
         </div>
 
         <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
-          <label
-            class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
-          >
+          <label class="kr-toggle-row">
             <span class="label-text font-bold">Public</span>
 
             <input
@@ -416,9 +414,7 @@
             />
           </label>
 
-          <label
-            class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
-          >
+          <label class="kr-toggle-row">
             <span class="label-text font-bold">Under Construction</span>
 
             <input
@@ -428,9 +424,7 @@
             />
           </label>
 
-          <label
-            class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
-          >
+          <label class="kr-toggle-row">
             <span class="label-text font-bold">Can Delete</span>
 
             <input

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -275,9 +275,7 @@
           <section class="kr-panel-flat p-4">
             <h2 class="text-lg font-black">Visibility</h2>
             <div class="mt-3 grid gap-2">
-              <label
-                class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-3 py-2"
-              >
+              <label class="kr-toggle-row-sm">
                 <span class="label-text font-bold">Public</span>
                 <input
                   v-model="dreamStore.dreamForm.isPublic"
@@ -286,9 +284,7 @@
                 />
               </label>
 
-              <label
-                class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-3 py-2"
-              >
+              <label class="kr-toggle-row-sm">
                 <span class="label-text font-bold">Mature</span>
                 <input
                   v-model="dreamStore.dreamForm.isMature"
@@ -303,9 +299,7 @@
                 control; Dream's owners could not reach their own allowReviews
                 column from the UI at all.
               -->
-              <label
-                class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-3 py-2"
-              >
+              <label class="kr-toggle-row-sm">
                 <span class="label-text font-bold">Reviews</span>
                 <input
                   v-model="dreamStore.dreamForm.allowReviews"
@@ -314,9 +308,7 @@
                 />
               </label>
 
-              <label
-                class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-3 py-2"
-              >
+              <label class="kr-toggle-row-sm">
                 <span class="label-text font-bold">Active</span>
                 <input
                   v-model="dreamStore.dreamForm.isActive"

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -156,9 +156,7 @@
         </div>
 
         <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
-          <label
-            class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
-          >
+          <label class="kr-toggle-row">
             <span class="label-text font-bold">Public</span>
             <input
               v-model="rewardStore.rewardForm.isPublic"
@@ -167,9 +165,7 @@
             />
           </label>
 
-          <label
-            class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
-          >
+          <label class="kr-toggle-row">
             <span class="label-text font-bold">Mature</span>
             <input
               v-model="rewardStore.rewardForm.isMature"

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -123,9 +123,7 @@
         </div>
 
         <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
-          <label
-            class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
-          >
+          <label class="kr-toggle-row">
             <span class="label-text font-bold">Public</span>
             <input
               v-model="scenarioStore.scenarioForm.isPublic"
@@ -134,9 +132,7 @@
             />
           </label>
 
-          <label
-            class="label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
-          >
+          <label class="kr-toggle-row">
             <span class="label-text font-bold">Mature</span>
             <input
               v-model="scenarioStore.scenarioForm.isMature"


### PR DESCRIPTION
## Summary
Full survey of all 9 kr-* migration codemods (panel, input, checkbox, textarea, panel-section, badge, btn-order-variant, btn-xs, input-select) confirms every mechanical pool is now exhausted (0 candidates each).

Manual survey found one clean remaining pool: 13 occurrences of an identical hand-rolled toggle-row label (`label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200`) at two padding sizes:
- `px-4 py-3` (9 occurrences) — `add-bot.vue`, `add-reward.vue`, `add-scenario.vue`, `add-collection.vue`
- `px-3 py-2` (4 occurrences) — `dream-maker.vue`

Named two new primitives following the existing `kr-panel-muted-*`/`kr-checkbox-*-sm` size-ladder convention: `.kr-toggle-row` and `.kr-toggle-row-sm`. No geometry or behavior change.

Confirmed no source-text contract script (`utils/scripts/*.mjs`) hardcodes either literal class string as a regression guard (the `verifyBrainstormWorkbench.mjs` lesson from an earlier slice).

## Verification
- `vue-tsc --noEmit` — clean
- `eslint` on changed files — 0 new errors (2 pre-existing errors confirmed present on baseline `main` at shifted line numbers, unrelated)
- `npm run test:layout-contract` — held at 207 baseline, no new violations
- `npm run test:lint-ratchet` — holds (334/-58), no rule got worse
- `prettier --check` — same 4 pre-existing warnings confirmed present on baseline `main`, unrelated to this change

Conductor: `interface-vision/t-104` slice 122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeTHzY1zprU14atoDofszn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeTHzY1zprU14atoDofszn)_