### PR TITLE
style: add kr-panel-tint-sm/-md opacity-variant primitives, migrate 12 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -551,6 +551,21 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-2xl border border-base-300 bg-base-200 p-4;
   }
 
+  /* The first opacity-variant primitive in the .kr-panel-muted family
+   * (interface-vision t-104 slice 123): identical rounded-2xl/border-base-300
+   * shape, but the recessed background sits at 40% opacity (bg-base-200/40)
+   * instead of the solid bg-base-200 -- a lighter-weight "tint" used for
+   * nested informational rows rather than a full secondary panel. Reuses the
+   * -sm/-md size-ladder suffixes for the same p-3/p-4 padding split as the
+   * solid family, previously hand-rolled across 10 occurrences (4 at -sm,
+   * 6 at -md). */
+  .kr-panel-tint-sm {
+    @apply rounded-2xl border border-base-300 bg-base-200/40 p-3;
+  }
+  .kr-panel-tint-md {
+    @apply rounded-2xl border border-base-300 bg-base-200/40 p-4;
+  }
+
   /* The compact bordered surface on the "plain" base-100 background
    * (interface-vision t-104 slice 118): a smaller radius than .kr-panel
    * (rounded-xl, not rounded-2xl) at the dense `p-3` padding used for

--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -190,7 +190,7 @@
             </label>
 
             <details
-              class="rounded-2xl border border-base-300 bg-base-200/40 p-3"
+              class="kr-panel-tint-sm"
             >
               <summary class="cursor-pointer text-sm font-semibold select-none">
                 Raw job JSON
@@ -210,7 +210,7 @@
           </div>
 
           <aside class="flex flex-col gap-3">
-            <div class="rounded-2xl border border-base-300 bg-base-200/40 p-3">
+            <div class="kr-panel-tint-sm">
               <label class="flex flex-col gap-1 text-sm">
                 <span class="font-semibold">Engine preset</span>
                 <select

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -175,7 +175,7 @@
             />
           </div>
 
-          <div class="rounded-2xl border border-base-300 bg-base-200/40 p-3">
+          <div class="kr-panel-tint-sm">
             <label class="form-control">
               <div class="label py-1">
                 <span class="label-text text-xs font-black uppercase tracking-wide">
@@ -224,7 +224,7 @@
           :href="revision.archivedUrl || undefined"
           :target="revision.archivedUrl ? '_blank' : undefined"
           rel="noopener noreferrer"
-          class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-200/40 p-3"
+          class="flex flex-col gap-2 kr-panel-tint-sm"
           :class="revision.archivedUrl ? 'transition hover:border-primary hover:shadow-sm' : ''"
         >
           <img

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -97,7 +97,7 @@
         <article
           v-for="stage in stages"
           :key="stage.label"
-          class="rounded-2xl border border-base-300 bg-base-200/40 p-4"
+          class="kr-panel-tint-md"
         >
           <div class="flex items-center justify-between gap-2">
             <icon :name="stage.icon" class="size-6" :class="stage.ready ? 'text-success' : 'text-warning'" />

--- a/components/coloring/coloring-book-production-toolbar.vue
+++ b/components/coloring/coloring-book-production-toolbar.vue
@@ -76,7 +76,7 @@
 
     <div
       v-if="production?.bwUrl || proposal.bwUrl"
-      class="grid gap-4 rounded-2xl border border-base-300 bg-base-200/40 p-4 lg:grid-cols-[10rem_minmax(0,1fr)]"
+      class="grid gap-4 kr-panel-tint-md lg:grid-cols-[10rem_minmax(0,1fr)]"
     >
       <img
         :src="production?.bwUrl || proposal.bwUrl || ''"

--- a/components/coloring/coloring-book-readiness.vue
+++ b/components/coloring/coloring-book-readiness.vue
@@ -80,7 +80,7 @@
 
     <div v-if="selectedBook && selectedSummary" class="flex flex-col gap-4">
       <div
-        class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/40 p-4 lg:flex-row lg:items-center lg:justify-between"
+        class="flex flex-col gap-3 kr-panel-tint-md lg:flex-row lg:items-center lg:justify-between"
       >
         <div>
           <h4 class="text-xl font-black">{{ selectedBook.title }} interiors</h4>

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -279,7 +279,7 @@
 
               <div
                 v-else-if="currentChapter"
-                class="flex flex-col gap-3 rounded-2xl border border-base-300 bg-base-200/40 p-4"
+                class="flex flex-col gap-3 kr-panel-tint-md"
               >
                 <h4 v-if="currentChapter.title" class="text-base font-black">
                   {{ currentChapter.title }}

--- a/components/conductor/packmaker-pack-editor.vue
+++ b/components/conductor/packmaker-pack-editor.vue
@@ -9,7 +9,7 @@
 -->
 <template>
   <div
-    class="flex flex-col gap-4 rounded-2xl border border-base-300 bg-base-200/40 p-4"
+    class="flex flex-col gap-4 kr-panel-tint-md"
   >
     <div class="flex items-center justify-between gap-2">
       <h4 class="text-sm font-black text-base-content">

--- a/components/mandarin/mandarin-voice-coach.vue
+++ b/components/mandarin/mandarin-voice-coach.vue
@@ -72,7 +72,7 @@
     </p>
     <p v-if="error" class="mt-3 text-sm text-error" role="alert">{{ error }}</p>
 
-    <div v-if="audioUrl" class="mt-4 rounded-2xl border border-base-300 bg-base-200/40 p-4">
+    <div v-if="audioUrl" class="mt-4 kr-panel-tint-md">
       <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <p class="text-xs font-semibold uppercase tracking-wide opacity-55">Your attempt</p>
@@ -87,7 +87,7 @@
       class="mt-4 grid grid-cols-[repeat(auto-fit,minmax(min(100%,20rem),1fr))] gap-4"
       aria-live="polite"
     >
-      <div class="rounded-2xl border border-base-300 bg-base-200/40 p-4">
+      <div class="kr-panel-tint-md">
         <p class="text-xs font-semibold uppercase tracking-wide opacity-55">What I heard</p>
         <p v-if="transcript" class="mt-2 text-2xl font-bold">{{ transcript }}</p>
         <p v-else class="mt-2 text-sm opacity-60">The transcript was unavailable.</p>
@@ -105,7 +105,7 @@
         </p>
       </div>
 
-      <div class="rounded-2xl border border-base-300 bg-base-200/40 p-4">
+      <div class="kr-panel-tint-md">
         <p class="text-xs font-semibold uppercase tracking-wide opacity-55">Tone shape</p>
         <div v-if="toneAnalysis?.observations.length" class="mt-2 space-y-2">
           <div

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -2,8 +2,9 @@
 """
 kr_panel_codemod.py — mechanical, byte-exact substitution of the hand-rolled
 kr-panel / kr-panel-muted / kr-panel-muted-sm / kr-panel-muted-md /
-kr-panel-flat / kr-panel-compact utility sequences for the shared class, in
-static `class="..."` attributes inside .vue templates only.
+kr-panel-tint-sm / kr-panel-tint-md / kr-panel-flat / kr-panel-compact
+utility sequences for the shared class, in static `class="..."` attributes
+inside .vue templates only.
 
 Scope, deliberately narrow (interface-vision/t-115's "if (b)" instruction):
   - Only static `class="..."` attributes (never `:class=`, `v-bind:class=`,
@@ -46,6 +47,13 @@ VARIANTS = [
     # given position -- order between them doesn't matter for correctness.
     ("kr-panel-muted-sm", ["rounded-2xl", "border", "border-base-300", "bg-base-200", "p-3"]),
     ("kr-panel-muted-md", ["rounded-2xl", "border", "border-base-300", "bg-base-200", "p-4"]),
+    # t-104 slice 123: the bg-base-200/40 opacity-variant counterparts of
+    # kr-panel-muted-sm/-md above. The leading tokens are identical; only the
+    # background token differs (bg-base-200 vs bg-base-200/40), so these are
+    # tried alongside the solid variants at the same list position -- a given
+    # token run matches exactly one of the two, never both.
+    ("kr-panel-tint-sm", ["rounded-2xl", "border", "border-base-300", "bg-base-200/40", "p-3"]),
+    ("kr-panel-tint-md", ["rounded-2xl", "border", "border-base-300", "bg-base-200/40", "p-4"]),
     ("kr-panel-flat", ["rounded-2xl", "border", "border-base-300", "bg-base-100"]),
     # t-104 slice 118: the base-100 counterpart to kr-panel-muted-sm, at a
     # smaller rounded-xl radius rather than rounded-2xl -- the leading


### PR DESCRIPTION
## Summary

interface-vision/t-104 slice 123: adds the first opacity-variant primitives in the `.kr-panel-muted` family — `.kr-panel-tint-sm` / `.kr-panel-tint-md` — for the previously hand-rolled `rounded-2xl border border-base-300 bg-base-200/40 p-3`/`p-4` shape (a lighter-weight "tint" surface at 40% background opacity, distinct from the solid `.kr-panel-muted-sm`/`-md`).

Extends `utils/scripts/codemods/kr_panel_codemod.py`'s `VARIANTS` with the two new token sequences (mechanical, exact-match substitution only) and runs it to migrate all 12 safe candidates found across 8 files.

## Changes

- `assets/css/tailwind.css`: new `.kr-panel-tint-sm` / `.kr-panel-tint-md` classes, documented alongside the existing `.kr-panel-muted-sm`/`-md`.
- `utils/scripts/codemods/kr_panel_codemod.py`: two new `VARIANTS` entries + docstring update.
- 8 component files: mechanical class substitution only (`artjob-editor.vue`, `coloring-book-cover-studio.vue`, `coloring-book-package-readiness.vue`, `coloring-book-production-toolbar.vue`, `coloring-book-readiness.vue`, `davinci-page.vue`, `packmaker-pack-editor.vue`, `mandarin-voice-coach.vue`).

No geometry or behavior change — the new classes compile to the exact same declarations as the previously hand-rolled sequence.

Skipped (unrelated to this change, pre-existing codemod behavior): `chat-gallery.vue`'s two `btn` + `bg-base-100` occurrences, which carry DaisyUI `btn` classes the codemod's safe-extras allowlist deliberately excludes from automatic substitution.

## Verification

- `vue-tsc --noEmit`: clean (0 errors)
- `eslint`: 0 errors on changed files
- `npm run test:layout-contract`: held at 207 baseline, no new violations
- `npm run test:lint-ratchet`: held at 334/-58 (confirmed via `git stash` against baseline — identical count, no rule worsened)
- `prettier --check`: flagged the same 7 pre-existing warnings confirmed present on baseline `main` (unrelated formatting drift, not newly introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFf5PENrsqqpU42Vr6VGVR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFf5PENrsqqpU42Vr6VGVR)_