### PR TITLE
style: add kr-panel-tint-compact opacity-variant primitive, migrate 6 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -566,6 +566,21 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-2xl border border-base-300 bg-base-200/40 p-4;
   }
 
+  /* Second tint-family primitive (interface-vision t-104 slice 124): the
+   * rounded-xl/p-3 radius-and-padding shape already named by .kr-panel-compact,
+   * but at the recessed bg-base-200 background from the -muted/-tint families
+   * instead of .kr-panel-compact's own solid bg-base-100 -- and at 60%
+   * opacity rather than a solid fill. Named by composing both halves of what
+   * it is (tint family + compact shape) since it doesn't extend either
+   * existing size ladder cleanly: it shares .kr-panel-tint-sm/-md's opacity
+   * concept but not their radius, and .kr-panel-compact's radius but not its
+   * color or opacity. Previously hand-rolled across 6 occurrences in 3 files
+   * (cthulhuquarium-game.vue, ruler-hooked-fishing-encounter.vue,
+   * serendipity-page.vue x4). */
+  .kr-panel-tint-compact {
+    @apply rounded-xl border border-base-300 bg-base-200/60 p-3;
+  }
+
   /* The compact bordered surface on the "plain" base-100 background
    * (interface-vision t-104 slice 118): a smaller radius than .kr-panel
    * (rounded-xl, not rounded-2xl) at the dense `p-3` padding used for

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -35,7 +35,7 @@
            dismissible notice of what happened. -->
       <div
         v-if="tankStore.lastRareEvent"
-        class="flex items-start gap-2 rounded-xl border border-base-300 bg-base-200/60 p-3 text-sm"
+        class="flex items-start gap-2 kr-panel-tint-compact text-sm"
       >
         <Icon
           name="kind-icon:sparkles"

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -53,9 +53,7 @@
     </header>
 
     <!-- Relay endpoint -->
-    <div
-      class="flex flex-wrap items-end gap-3 rounded-xl border border-base-300 bg-base-200/60 p-3"
-    >
+    <div class="flex flex-wrap items-end gap-3 kr-panel-tint-compact">
       <label class="flex-1">
         <span
           class="mb-1 block text-xs font-bold uppercase text-base-content/60"
@@ -75,7 +73,7 @@
     </div>
 
     <!-- Simulate an Echo utterance -->
-    <div class="rounded-xl border border-base-300 bg-base-200/60 p-3">
+    <div class="kr-panel-tint-compact">
       <p class="mb-2 text-xs font-bold uppercase text-base-content/60">
         Speak to Serendipity (or simulate)
       </p>
@@ -135,9 +133,7 @@
       </div>
 
       <!-- Live animation state -->
-      <aside
-        class="flex flex-col gap-3 rounded-xl border border-base-300 bg-base-200/60 p-3"
-      >
+      <aside class="flex flex-col gap-3 kr-panel-tint-compact">
         <div>
           <p class="text-xs font-bold uppercase text-base-content/60">
             Active animations
@@ -184,10 +180,7 @@
     </div>
 
     <!-- Art drafts (surfaced from voice; never generated or published here) -->
-    <div
-      v-if="voice.artRequests.length > 0"
-      class="rounded-xl border border-base-300 bg-base-200/60 p-3"
-    >
+    <div v-if="voice.artRequests.length > 0" class="kr-panel-tint-compact">
       <p class="mb-2 text-xs font-bold uppercase text-base-content/60">
         Art drafts from voice ({{ voice.artRequests.length }})
       </p>

--- a/components/ruler-hooked/ruler-hooked-fishing-encounter.vue
+++ b/components/ruler-hooked/ruler-hooked-fishing-encounter.vue
@@ -30,7 +30,7 @@
     </div>
 
     <div
-      class="mt-4 rounded-xl border border-base-300 bg-base-200/60 p-3 text-sm font-semibold"
+      class="mt-4 kr-panel-tint-compact text-sm font-semibold"
       role="status"
       aria-live="polite"
     >

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -2,9 +2,9 @@
 """
 kr_panel_codemod.py — mechanical, byte-exact substitution of the hand-rolled
 kr-panel / kr-panel-muted / kr-panel-muted-sm / kr-panel-muted-md /
-kr-panel-tint-sm / kr-panel-tint-md / kr-panel-flat / kr-panel-compact
-utility sequences for the shared class, in static `class="..."` attributes
-inside .vue templates only.
+kr-panel-tint-sm / kr-panel-tint-md / kr-panel-tint-compact / kr-panel-flat /
+kr-panel-compact utility sequences for the shared class, in static
+`class="..."` attributes inside .vue templates only.
 
 Scope, deliberately narrow (interface-vision/t-115's "if (b)" instruction):
   - Only static `class="..."` attributes (never `:class=`, `v-bind:class=`,
@@ -54,6 +54,10 @@ VARIANTS = [
     # token run matches exactly one of the two, never both.
     ("kr-panel-tint-sm", ["rounded-2xl", "border", "border-base-300", "bg-base-200/40", "p-3"]),
     ("kr-panel-tint-md", ["rounded-2xl", "border", "border-base-300", "bg-base-200/40", "p-4"]),
+    # t-104 slice 124: the rounded-xl/p-3 counterpart of kr-panel-tint-sm's
+    # shape, at 60% opacity instead of 40% -- distinct radius from the -sm/-md
+    # pair above, so it can't collide with either at the same list position.
+    ("kr-panel-tint-compact", ["rounded-xl", "border", "border-base-300", "bg-base-200/60", "p-3"]),
     ("kr-panel-flat", ["rounded-2xl", "border", "border-base-300", "bg-base-100"]),
     # t-104 slice 118: the base-100 counterpart to kr-panel-muted-sm, at a
     # smaller rounded-xl radius rather than rounded-2xl -- the leading


### PR DESCRIPTION
## Summary
interface-vision/t-104 slice 124 — continues the recurring front-end consistency umbrella.

- Adds `.kr-panel-tint-compact` to `assets/css/tailwind.css`: `rounded-xl border border-base-300 bg-base-200/60 p-3`, the `rounded-xl` counterpart of the `.kr-panel-tint-sm`/`-md` family (which use `rounded-2xl`) at a different opacity — named by composing "tint" (opacity family) with "compact" (the `rounded-xl`/`p-3` shape already named by `.kr-panel-compact`), since it doesn't extend either existing size ladder cleanly.
- Extends `utils/scripts/codemods/kr_panel_codemod.py`'s `VARIANTS` with the new exact-match token sequence and runs it to migrate all 6 safe candidates found: `cthulhuquarium-game.vue` (1), `ruler-hooked-fishing-encounter.vue` (1), `serendipity-page.vue` (4).
- No geometry or behavior change — this is a pure markup substitution to the shared class; a couple of `serendipity-page.vue` occurrences that had wrapped onto their own line under the old longer class string now fit on one line, so `prettier --write` re-collapsed them (confirmed byte-identical output otherwise).

## Verification
- `vue-tsc --noEmit` — clean
- `eslint` on changed files — 0 errors
- `test:layout-contract` — 207 baseline, unchanged
- `test:lint-ratchet` — held at 334/-58, confirmed identical against baseline `main` via `git stash`
- `prettier --check` on changed files — same 2 pre-existing warnings present on baseline `main` (`tailwind.css`, `ruler-hooked-fishing-encounter.vue`), nothing new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UB3RKts6sS2ZptFYY1MxNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01UB3RKts6sS2ZptFYY1MxNU)_