### PR TITLE
style: add kr-panel-tint-sm-50/-compact-50/-compact-70 opacity primitives, migrate 8 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -581,6 +581,25 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-xl border border-base-300 bg-base-200/60 p-3;
   }
 
+  /* A second opacity step in the .kr-panel-tint-sm shape (interface-vision
+   * t-104 slice 125): identical rounded-2xl/border-base-300/p-3 shape, but
+   * at 50% background opacity instead of .kr-panel-tint-sm's 40% -- a
+   * distinct hand-rolled pool (4 occurrences), not a drifting duplicate of
+   * the 40% one (both appear side-by-side in different components).
+   * Suffixed with the literal opacity since -sm/-md are already spoken for
+   * as the padding ladder within a single opacity. */
+  .kr-panel-tint-sm-50 {
+    @apply rounded-2xl border border-base-300 bg-base-200/50 p-3;
+  }
+
+  /* The .kr-panel-tint-compact radius/padding shape (rounded-xl/p-3) at 50%
+   * opacity instead of .kr-panel-tint-compact's 60% (interface-vision t-104
+   * slice 125) -- previously hand-rolled across 2 occurrences. Same
+   * opacity-suffix naming as .kr-panel-tint-sm-50 above. */
+  .kr-panel-tint-compact-50 {
+    @apply rounded-xl border border-base-300 bg-base-200/50 p-3;
+  }
+
   /* The compact bordered surface on the "plain" base-100 background
    * (interface-vision t-104 slice 118): a smaller radius than .kr-panel
    * (rounded-xl, not rounded-2xl) at the dense `p-3` padding used for
@@ -591,6 +610,14 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
    * differs, not just the padding. */
   .kr-panel-compact {
     @apply rounded-xl border border-base-300 bg-base-100 p-3;
+  }
+
+  /* .kr-panel-compact's own bg-base-100 at 70% opacity instead of a solid
+   * fill (interface-vision t-104 slice 125) -- same opacity-suffix
+   * convention as the tint-family additions above, previously hand-rolled
+   * across 2 occurrences. */
+  .kr-panel-compact-70 {
+    @apply rounded-xl border border-base-300 bg-base-100/70 p-3;
   }
 
   /* Flat bordered surface for dense lists, rows, and inboxes. */

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -94,7 +94,7 @@
         </div>
       </div>
 
-      <aside v-if="history.length" class="rounded-xl border border-base-300 bg-base-200/50 p-3">
+      <aside v-if="history.length" class="kr-panel-tint-compact-50">
         <div class="mb-2 flex items-center gap-2">
           <Icon name="kind-icon:history" class="size-3.5 text-base-content/50" />
           <h4 class="text-xs font-black uppercase tracking-wide text-base-content/55">
@@ -314,7 +314,7 @@
 
       <div
         v-if="showCheckpointSelector"
-        class="grid gap-3 rounded-xl border border-base-300 bg-base-100/70 p-3 sm:grid-cols-[minmax(0,1fr)_auto]"
+        class="grid gap-3 kr-panel-compact-70 sm:grid-cols-[minmax(0,1fr)_auto]"
       >
         <label class="form-control gap-1">
           <span class="text-xs font-semibold text-base-content/60">SDXL checkpoint</span>

--- a/components/coloring/production-stage-card.vue
+++ b/components/coloring/production-stage-card.vue
@@ -1,7 +1,5 @@
 <template>
-  <article
-    class="flex min-h-28 flex-col gap-2 rounded-2xl border border-base-300 bg-base-200/50 p-3"
-  >
+  <article class="flex min-h-28 flex-col gap-2 kr-panel-tint-sm-50">
     <div class="flex items-center justify-between gap-2">
       <icon
         :name="iconName"

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -120,7 +120,7 @@
         <article
           v-for="item in selectedPack.items"
           :key="item.id"
-          class="flex flex-col gap-2 rounded-2xl border border-base-300 bg-base-200/50 p-3 sm:flex-row sm:items-center sm:justify-between"
+          class="flex flex-col gap-2 kr-panel-tint-sm-50 sm:flex-row sm:items-center sm:justify-between"
         >
           <div class="min-w-0 flex-1">
             <div class="flex flex-wrap items-center gap-2">

--- a/components/conductor/voice-lab-page.vue
+++ b/components/conductor/voice-lab-page.vue
@@ -56,7 +56,7 @@
 
         <div
           v-if="voice.recentMessages.length"
-          class="flex max-h-40 flex-col gap-1 overflow-y-auto rounded-2xl border border-base-300 bg-base-200/50 p-3"
+          class="flex max-h-40 flex-col gap-1 overflow-y-auto kr-panel-tint-sm-50"
         >
           <p
             v-for="message in voice.recentMessages.slice(-6)"

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -132,7 +132,7 @@
           </span>
         </label>
 
-        <label class="flex cursor-pointer items-start gap-3 rounded-xl border border-base-300 bg-base-100/70 p-3">
+        <label class="flex cursor-pointer items-start gap-3 kr-panel-compact-70">
           <input
             v-model="preserveOriginal"
             type="checkbox"

--- a/components/narrative/narrative-response-composer.vue
+++ b/components/narrative/narrative-response-composer.vue
@@ -1,7 +1,7 @@
 <!-- /components/narrative/narrative-response-composer.vue -->
 <template>
   <form
-    class="space-y-2 rounded-2xl border border-base-300 bg-base-200/50 p-3"
+    class="space-y-2 kr-panel-tint-sm-50"
     :aria-busy="loading"
     @submit.prevent="submit()"
   >

--- a/components/ruler-hooked/ruler-hooked-fishopedia.vue
+++ b/components/ruler-hooked/ruler-hooked-fishopedia.vue
@@ -14,7 +14,7 @@
         <article
           v-for="fish in roster"
           :key="fish.slug"
-          class="min-h-32 rounded-xl border border-base-300 bg-base-200/50 p-3"
+          class="min-h-32 kr-panel-tint-compact-50"
         >
           <template v-if="entryFor(fish.slug)">
             <div class="flex flex-wrap items-center gap-2">

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -58,12 +58,21 @@ VARIANTS = [
     # shape, at 60% opacity instead of 40% -- distinct radius from the -sm/-md
     # pair above, so it can't collide with either at the same list position.
     ("kr-panel-tint-compact", ["rounded-xl", "border", "border-base-300", "bg-base-200/60", "p-3"]),
+    # t-104 slice 125: a second opacity step (50%) of the two shapes above --
+    # bg-base-200/50 never collides with bg-base-200/40 or bg-base-200/60 at
+    # the same list position since the opacity token itself differs.
+    ("kr-panel-tint-sm-50", ["rounded-2xl", "border", "border-base-300", "bg-base-200/50", "p-3"]),
+    ("kr-panel-tint-compact-50", ["rounded-xl", "border", "border-base-300", "bg-base-200/50", "p-3"]),
     ("kr-panel-flat", ["rounded-2xl", "border", "border-base-300", "bg-base-100"]),
     # t-104 slice 118: the base-100 counterpart to kr-panel-muted-sm, at a
     # smaller rounded-xl radius rather than rounded-2xl -- the leading
     # radius token never overlaps with any other variant above, so list
     # position doesn't matter for correctness here.
     ("kr-panel-compact", ["rounded-xl", "border", "border-base-300", "bg-base-100", "p-3"]),
+    # t-104 slice 125: kr-panel-compact's own shape at 70% background opacity
+    # instead of a solid fill -- bg-base-100/70 never collides with the solid
+    # bg-base-100 token above.
+    ("kr-panel-compact-70", ["rounded-xl", "border", "border-base-300", "bg-base-100/70", "p-3"]),
 ]
 
 CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 125: continue the recurring front-end-consistency umbrella (kind: software)

### What changed / what I produced
- Added three new opacity-step primitives to `assets/css/tailwind.css`:
  - `.kr-panel-tint-sm-50` — `rounded-2xl border border-base-300 bg-base-200/50 p-3` (50% counterpart to `.kr-panel-tint-sm`'s 40%)
  - `.kr-panel-tint-compact-50` — `rounded-xl border border-base-300 bg-base-200/50 p-3` (50% counterpart to `.kr-panel-tint-compact`'s 60%)
  - `.kr-panel-compact-70` — `rounded-xl border border-base-300 bg-base-100/70 p-3` (70%-opacity counterpart to `.kr-panel-compact`'s solid fill)
- Extended `utils/scripts/codemods/kr_panel_codemod.py`'s `VARIANTS` list with the three new sequences (exact, contiguous, longest-first token matching — same mechanism as every prior t-104 slice).
- Ran the codemod and applied its 8 mechanical substitutions across 7 files: `components/art/entity-art-manager.vue` (×2), `components/coloring/production-stage-card.vue`, `components/conductor/packmaker-admin-panel.vue`, `components/conductor/voice-lab-page.vue`, `components/dreams/daily-dream-object-art-workbench.vue`, `components/narrative/narrative-response-composer.vue`, `components/ruler-hooked/ruler-hooked-fishopedia.vue`.
- No geometry or behavior change — each substitution computes to the exact same declarations the old hand-rolled class list produced.

### How I verified
- Dry-run of the codemod confirmed exactly the counts flagged as remaining scope by the prior slice's note (4 at `bg-base-200/50`/rounded-2xl, 2 at `bg-base-200/50`/rounded-xl, 2 at `bg-base-100/70`/rounded-xl) before applying.
- Grepped `utils/scripts/*.mjs` (and the whole repo) for the literal class strings being replaced — none found, avoiding slice 69's source-text-guard miss (kind_robots#2386).
- `vue-tsc --noEmit`: clean (`npm run test`, twice).
- `eslint` on all 7 changed `.vue` files: same 4 pre-existing errors present on baseline `main` (`vue/no-mutating-props` in entity-art-manager.vue/daily-dream-object-art-workbench.vue, 2×`no-empty` in entity-art-manager.vue) — confirmed via `git stash` diff against baseline, identical.
- `npm run test:lint-ratchet`: holds at 334 problems / -58, unchanged from baseline.
- `npm run test:layout-contract`: holds at 207 baseline violations, no new ones.
- `prettier --check` on all changed files: 6 pre-existing warnings (tailwind.css, entity-art-manager.vue, voice-lab-page.vue, daily-dream-object-art-workbench.vue, narrative-response-composer.vue, ruler-hooked-fishopedia.vue) confirmed identical to baseline `main` via `git stash`; `production-stage-card.vue`'s single-line `<article class="...">` re-collapse (shorter class string no longer needs to wrap) applied with `prettier --write` before committing, matching the precedent from slice 121's serendipity-page.vue note.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
`kr_panel_codemod.py`'s `SAFE_EXTRA_RE` allowlist currently treats `px-*`/`py-*` (asymmetric padding) as safe extras, but no VARIANT sequence uses them (all use a single `p-*` token) — so the `px-3 py-2` rows found this slice (content-visibility-controls.vue, artjob-trainer-redo-controls.vue) silently fall through to "no match" rather than "skipped, needs review." A future slice extending VARIANTS to cover a `px-3 py-2` padding step should double check the substitution mechanism actually matches token-run boundaries (`p-3` is one token, `px-3 py-2` is two) rather than assuming it's a drop-in generalization.

### Notes for reviewer
Continues the `kr-panel*` opacity-variant family started in slices 123/124. Umbrella task returns to `ready` for the next bounded slice per the roadmap note (dashed-placeholder family and the asymmetric-padding rows called out above are explicitly left for a future slice, not silently dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjUnh29Bk1GZLx8wavUp26

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUnh29Bk1GZLx8wavUp26)_