### PR TITLE
style: add kr-panel-dashed/-compact dashed-placeholder primitives, migrate 5 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -625,6 +625,23 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-2xl border border-base-300 bg-base-100;
   }
 
+  /* The empty-state dashed placeholder shape (interface-vision t-104 slice
+   * 126): a dashed border distinguishes it from every solid-border kr-panel*
+   * surface above -- used for "nothing here yet" galleries/lists. Previously
+   * hand-rolled across 3 occurrences (dream-relationship-gallery.vue,
+   * scenario-relationship-gallery.vue, scenario-gallery.vue). */
+  .kr-panel-dashed {
+    @apply rounded-2xl border border-dashed border-base-300 bg-base-200/50 p-6;
+  }
+
+  /* The .kr-panel-dashed shape at .kr-panel-compact's rounded-xl/p-3
+   * radius-and-padding step instead of the base rounded-2xl/p-6 (interface-
+   * vision t-104 slice 126) -- previously hand-rolled across 2 occurrences
+   * (art-lora-picker.vue). */
+  .kr-panel-dashed-compact {
+    @apply rounded-xl border border-dashed border-base-300 bg-base-200/50 p-3;
+  }
+
   /* The hand-rolled toggle-row label: a bordered muted strip pairing a
    * label with a DaisyUI `toggle` input (Public/Mature/Active-style
    * checkboxes) — same rounded-2xl/border-base-300/bg-base-200 surface as

--- a/components/art/art-lora-picker.vue
+++ b/components/art/art-lora-picker.vue
@@ -34,7 +34,7 @@
 
     <p
       v-if="!supported"
-      class="rounded-xl border border-dashed border-base-300 bg-base-200/50 p-3 text-xs text-base-content/60"
+      class="kr-panel-dashed-compact text-xs text-base-content/60"
     >
       {{ engineLabel }} builds its model into the workflow and ignores LoRAs.
       Switch to a preset that supports them to use this.
@@ -145,7 +145,7 @@
 
       <p
         v-else-if="!rankedLoras.length"
-        class="rounded-xl border border-dashed border-base-300 bg-base-200/50 p-3 text-center text-xs text-base-content/60"
+        class="kr-panel-dashed-compact text-center text-xs text-base-content/60"
       >
         No compatible LoRA Resources are available for {{ compatibilityLabel }}.
         Switch the model/checkpoint, add a compatible Resource, or enable mature

--- a/components/dreams/dream-relationship-gallery.vue
+++ b/components/dreams/dream-relationship-gallery.vue
@@ -58,7 +58,7 @@
 
       <div
         v-else-if="filteredDreams.length === 0"
-        class="flex h-full min-h-48 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 bg-base-200/50 p-6 text-center text-base-content/60"
+        class="flex h-full min-h-48 flex-col items-center justify-center gap-3 kr-panel-dashed text-center text-base-content/60"
       >
         <Icon name="kind-icon:dream" class="h-10 w-10 opacity-50" />
         <div>

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -248,7 +248,7 @@
 
       <div
         v-else-if="filteredScenarios.length === 0"
-        class="flex h-full min-h-48 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 bg-base-200/50 p-6 text-center text-base-content/60"
+        class="flex h-full min-h-48 flex-col items-center justify-center gap-3 kr-panel-dashed text-center text-base-content/60"
       >
         <Icon name="kind-icon:map" class="h-10 w-10 opacity-50" />
 

--- a/components/scenarios/scenario-relationship-gallery.vue
+++ b/components/scenarios/scenario-relationship-gallery.vue
@@ -111,7 +111,7 @@
 
       <div
         v-else-if="filteredScenarios.length === 0"
-        class="flex h-full min-h-48 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 bg-base-200/50 p-6 text-center text-base-content/60"
+        class="flex h-full min-h-48 flex-col items-center justify-center gap-3 kr-panel-dashed text-center text-base-content/60"
       >
         <Icon name="kind-icon:map" class="h-10 w-10 opacity-50" />
         <div>

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -73,6 +73,12 @@ VARIANTS = [
     # instead of a solid fill -- bg-base-100/70 never collides with the solid
     # bg-base-100 token above.
     ("kr-panel-compact-70", ["rounded-xl", "border", "border-base-300", "bg-base-100/70", "p-3"]),
+    # t-104 slice 126: the dashed-border empty-state placeholder family.
+    # `border-dashed` sits between `border` and `border-base-300`, so these
+    # sequences never overlap any solid-border variant above at the same
+    # position (token 3 differs: `border-dashed` vs `border-base-300`).
+    ("kr-panel-dashed", ["rounded-2xl", "border", "border-dashed", "border-base-300", "bg-base-200/50", "p-6"]),
+    ("kr-panel-dashed-compact", ["rounded-xl", "border", "border-dashed", "border-base-300", "bg-base-200/50", "p-3"]),
 ]
 
 CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 126: continue the recurring front-end-consistency umbrella (kind: software)

### What changed / what I produced
- Added two new primitives to `assets/css/tailwind.css` for the empty-state dashed-border placeholder shape:
  - `.kr-panel-dashed` — `rounded-2xl border border-dashed border-base-300 bg-base-200/50 p-6`
  - `.kr-panel-dashed-compact` — `rounded-xl border border-dashed border-base-300 bg-base-200/50 p-3`
- Extended `utils/scripts/codemods/kr_panel_codemod.py`'s `VARIANTS` list with both sequences (the `border-dashed` token at position 3 means these can never collide with any solid-border variant already in the list).
- Ran the codemod and applied its 5 mechanical substitutions: `.kr-panel-dashed` × 3 (`dream-relationship-gallery.vue`, `scenario-relationship-gallery.vue`, `scenario-gallery.vue`), `.kr-panel-dashed-compact` × 2 (`art-lora-picker.vue`).
- No geometry or behavior change.
- `video-lora-picker.vue`'s near-identical `rounded-lg`/`p-5` dashed placeholder is a singleton (not a bounded pool of 2+) and left hand-rolled, consistent with this project's convention of only naming a shared primitive for repeated shapes.

### How I verified
- Dry-run of the codemod confirmed exactly 3 + 2 = 5 occurrences before applying.
- Grepped `utils/scripts/*` for the literal class strings being replaced — none found.
- `vue-tsc --noEmit`: clean.
- `eslint` on all 4 changed `.vue` files: 0 errors.
- `npm run test:lint-ratchet`: holds at 334 problems / -58, unchanged from baseline.
- `npm run test:layout-contract`: holds at 207 baseline violations, no new ones.
- `prettier --check`: 2 warnings (`tailwind.css`, `art-lora-picker.vue`) confirmed identical to baseline `main` via `git stash` — nothing new.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Same one as kind_robots#2478: `kr_panel_codemod.py`'s `SAFE_EXTRA_RE` allowlist treats `px-*`/`py-*` as safe extras even though no `VARIANT` currently uses them — worth a close read when a future slice adds a `px-3 py-2` variant (content-visibility-controls.vue, artjob-trainer-redo-controls.vue are the next candidates).

### Notes for reviewer
Continues the `kr-panel*` primitive family from slices 123–125. Umbrella task returns to `ready` for the next bounded slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjUnh29Bk1GZLx8wavUp26

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUnh29Bk1GZLx8wavUp26)_