### PR TITLE
style: add kr-panel-tint-compact-50-row/-compact-70-row asymmetric-padding primitives

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -600,6 +600,16 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-xl border border-base-300 bg-base-200/50 p-3;
   }
 
+  /* .kr-panel-tint-compact-50's own shape at the asymmetric row padding used
+   * for clickable list rows (interface-vision t-104 slice 127) -- `px-3
+   * py-2` rather than a uniform `p-3`, same two-token padding shape as
+   * .kr-toggle-row/-sm below. Suffixed `-row` for the same reason: it's a
+   * denser horizontal strip, not a boxier padded panel. Previously
+   * hand-rolled across 2 occurrences (content-visibility-controls.vue). */
+  .kr-panel-tint-compact-50-row {
+    @apply rounded-xl border border-base-300 bg-base-200/50 px-3 py-2;
+  }
+
   /* The compact bordered surface on the "plain" base-100 background
    * (interface-vision t-104 slice 118): a smaller radius than .kr-panel
    * (rounded-xl, not rounded-2xl) at the dense `p-3` padding used for
@@ -618,6 +628,15 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
    * across 2 occurrences. */
   .kr-panel-compact-70 {
     @apply rounded-xl border border-base-300 bg-base-100/70 p-3;
+  }
+
+  /* .kr-panel-compact-70's own shape at the asymmetric row padding used for
+   * clickable list rows (interface-vision t-104 slice 127) -- `px-3 py-2`
+   * rather than a uniform `p-3`, same -row suffix convention as
+   * .kr-panel-tint-compact-50-row above. Previously hand-rolled across 1
+   * occurrence (artjob-trainer-redo-controls.vue). */
+  .kr-panel-compact-70-row {
+    @apply rounded-xl border border-base-300 bg-base-100/70 px-3 py-2;
   }
 
   /* Flat bordered surface for dense lists, rows, and inboxes. */

--- a/components/art/artjob-trainer-redo-controls.vue
+++ b/components/art/artjob-trainer-redo-controls.vue
@@ -44,7 +44,7 @@
 
         <div
           v-else
-          class="rounded-xl border border-base-300 bg-base-100/70 px-3 py-2 text-xs text-base-content/55"
+          class="kr-panel-compact-70-row text-xs text-base-content/55"
         >
           <span class="font-semibold">Model:</span> SDXL · prompt only
         </div>

--- a/components/content-visibility-controls.vue
+++ b/components/content-visibility-controls.vue
@@ -18,7 +18,7 @@
 
     <div class="grid gap-2 sm:grid-cols-2">
       <label
-        class="flex cursor-pointer items-center justify-between gap-3 rounded-xl border border-base-300 bg-base-200/50 px-3 py-2"
+        class="flex cursor-pointer items-center justify-between gap-3 kr-panel-tint-compact-50-row"
       >
         <span>
           <span class="block text-sm font-semibold">Mature</span>
@@ -34,7 +34,7 @@
       </label>
 
       <label
-        class="flex cursor-pointer items-center justify-between gap-3 rounded-xl border border-base-300 bg-base-200/50 px-3 py-2"
+        class="flex cursor-pointer items-center justify-between gap-3 kr-panel-tint-compact-50-row"
       >
         <span>
           <span class="block text-sm font-semibold">Public</span>

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -63,6 +63,13 @@ VARIANTS = [
     # the same list position since the opacity token itself differs.
     ("kr-panel-tint-sm-50", ["rounded-2xl", "border", "border-base-300", "bg-base-200/50", "p-3"]),
     ("kr-panel-tint-compact-50", ["rounded-xl", "border", "border-base-300", "bg-base-200/50", "p-3"]),
+    # t-104 slice 127: the same shape as kr-panel-tint-compact-50 above, but
+    # at the asymmetric row padding (px-3 py-2, TWO trailing tokens) used for
+    # clickable list rows rather than a uniform p-3. This sequence is one
+    # token longer and diverges from kr-panel-tint-compact-50's at the final
+    # token (px-3 vs p-3), so an exact-match attempt on either sequence at a
+    # given position can only ever succeed for one of them -- no collision.
+    ("kr-panel-tint-compact-50-row", ["rounded-xl", "border", "border-base-300", "bg-base-200/50", "px-3", "py-2"]),
     ("kr-panel-flat", ["rounded-2xl", "border", "border-base-300", "bg-base-100"]),
     # t-104 slice 118: the base-100 counterpart to kr-panel-muted-sm, at a
     # smaller rounded-xl radius rather than rounded-2xl -- the leading
@@ -73,6 +80,11 @@ VARIANTS = [
     # instead of a solid fill -- bg-base-100/70 never collides with the solid
     # bg-base-100 token above.
     ("kr-panel-compact-70", ["rounded-xl", "border", "border-base-300", "bg-base-100/70", "p-3"]),
+    # t-104 slice 127: kr-panel-compact-70's own shape at the asymmetric row
+    # padding (px-3 py-2) instead of a uniform p-3 -- same reasoning as
+    # kr-panel-tint-compact-50-row above; the extra trailing token means this
+    # never collides with kr-panel-compact-70's own 5-token sequence.
+    ("kr-panel-compact-70-row", ["rounded-xl", "border", "border-base-300", "bg-base-100/70", "px-3", "py-2"]),
     # t-104 slice 126: the dashed-border empty-state placeholder family.
     # `border-dashed` sits between `border` and `border-base-300`, so these
     # sequences never overlap any solid-border variant above at the same


### PR DESCRIPTION
interface-vision/t-104 slice 127.

Slice 126's note flagged the next candidates as `content-visibility-controls.vue`'s `px-3/py-2 bg-base-200/50` rows and `artjob-trainer-redo-controls.vue`'s `px-3/py-2 bg-base-100/70` row — asymmetric padding (two tokens: `px-3 py-2`) rather than the single `p-3` token every prior `kr-panel-*` variant has used, so `kr_panel_codemod.py`'s `VARIANTS` sequences needed a deliberate new entry rather than a drop-in copy of the p-3 pattern.

**Added** (same `-row` suffix convention `.kr-toggle-row`/`-sm` already established for asymmetric-row-padding primitives):
- `.kr-panel-tint-compact-50-row` — `rounded-xl border border-base-300 bg-base-200/50 px-3 py-2`, the row-padding counterpart of slice 125's `.kr-panel-tint-compact-50`
- `.kr-panel-compact-70-row` — `rounded-xl border border-base-300 bg-base-100/70 px-3 py-2`, the row-padding counterpart of slice 125's `.kr-panel-compact-70`

**Migrated** (3 occurrences, exact-match dry-run confirmed before applying):
- `components/content-visibility-controls.vue` — Mature/Public toggle rows (2× `kr-panel-tint-compact-50-row`)
- `components/art/artjob-trainer-redo-controls.vue` — model-info row (1× `kr-panel-compact-70-row`)

Both new `VARIANTS` sequences are one token longer than their `p-3` counterparts and diverge at the final token (`px-3` vs `p-3`), so an exact contiguous match against either sequence at a given position can only ever succeed for one — no collision with `kr-panel-tint-compact-50`/`kr-panel-compact-70`. No geometry or behavior change.

**Verification:**
- `vue-tsc` — clean
- `eslint` — 0 errors on changed files
- `npm run test:layout-contract` — 207 baseline, unchanged
- `npm run test:lint-ratchet` — 334/-58, held
- `prettier --check` — same 3 pre-existing warnings as baseline `main` (confirmed via `git stash`)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEQyZ84XmYBas7SG1zWeV4

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEQyZ84XmYBas7SG1zWeV4)_