### PR TITLE
style: add kr-panel-compact-xs primitive, migrate 10 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -622,6 +622,17 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-xl border border-base-300 bg-base-100 p-3;
   }
 
+  /* .kr-panel-compact's own shape at a tighter `p-2` padding step instead of
+   * `p-3` (interface-vision t-104 slice 128) -- one step down the padding
+   * ladder, same `-xs` suffix already used by the .kr-btn-ghost-xs family
+   * for the smallest size in a ladder. Previously hand-rolled across 10
+   * occurrences in 8 files (navigation-trimmed.vue, stylist-clients.vue,
+   * stylist-restyle.vue, collection-card.vue x2, stylist-history.vue,
+   * image-card.vue x3, mandarin.vue). */
+  .kr-panel-compact-xs {
+    @apply rounded-xl border border-base-300 bg-base-100 p-2;
+  }
+
   /* .kr-panel-compact's own bg-base-100 at 70% opacity instead of a solid
    * fill (interface-vision t-104 slice 125) -- same opacity-suffix
    * convention as the tint-family additions above, previously hand-rolled

--- a/components/art/collection-card.vue
+++ b/components/art/collection-card.vue
@@ -145,7 +145,7 @@
       </div>
       <div
         v-if="showStats && activeSelected"
-        class="grid grid-cols-2 gap-1.5 rounded-xl border border-base-300 bg-base-100 p-2 text-xs"
+        class="grid grid-cols-2 gap-1.5 kr-panel-compact-xs text-xs"
       >
         <div>
           <p class="font-bold uppercase text-base-content/40">Images</p>
@@ -182,11 +182,7 @@
         </button>
       </div>
 
-      <details
-        v-if="showDebug"
-        class="rounded-xl border border-base-300 bg-base-100 p-2"
-        @click.stop
-      >
+      <details v-if="showDebug" class="kr-panel-compact-xs" @click.stop>
         <summary class="cursor-pointer text-xs font-bold text-base-content/70">
           Debug
         </summary>

--- a/components/art/image-card.vue
+++ b/components/art/image-card.vue
@@ -154,7 +154,7 @@
 
       <div
         v-if="showImageStatus && selected"
-        class="rounded-xl border border-base-300 bg-base-100 p-2 text-xs"
+        class="kr-panel-compact-xs text-xs"
       >
         <div class="flex flex-wrap gap-1.5">
           <span class="kr-badge-info-xs" :title="`Image #${displayImage.id}`">
@@ -208,7 +208,7 @@
 
       <div
         v-if="showGenerationMeta && size === 'lg'"
-        class="grid grid-cols-2 gap-2 rounded-xl border border-base-300 bg-base-100 p-2 text-xs"
+        class="grid grid-cols-2 gap-2 kr-panel-compact-xs text-xs"
       >
         <div>
           <p
@@ -278,11 +278,7 @@
         </button>
       </div>
 
-      <details
-        v-if="showDebug"
-        class="rounded-xl border border-base-300 bg-base-100 p-2"
-        @click.stop
-      >
+      <details v-if="showDebug" class="kr-panel-compact-xs" @click.stop>
         <summary class="cursor-pointer text-xs font-bold text-base-content/70">
           Debug
         </summary>

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -31,7 +31,7 @@
       <li
         v-for="customer in superkate.sortedCustomers"
         :key="customer.id"
-        class="rounded-xl border border-base-300 bg-base-100 p-2"
+        class="kr-panel-compact-xs"
       >
         <div class="flex flex-wrap items-center gap-3">
           <div class="flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-base-300 bg-base-200">

--- a/components/art/stylist-history.vue
+++ b/components/art/stylist-history.vue
@@ -41,7 +41,7 @@
       <li
         v-for="appointment in results"
         :key="appointment.id"
-        class="flex flex-col gap-2 rounded-xl border border-base-300 bg-base-100 p-2"
+        class="flex flex-col gap-2 kr-panel-compact-xs"
       >
         <div class="flex flex-wrap items-center gap-2">
           <div class="flex min-w-0 flex-1 flex-col">

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -308,7 +308,7 @@
         <article
           v-for="job in visibleJobs"
           :key="job.id"
-          class="flex flex-col gap-2 rounded-xl border border-base-300 bg-base-100 p-2"
+          class="flex flex-col gap-2 kr-panel-compact-xs"
         >
           <div class="flex items-center gap-2 text-xs">
             <span class="font-bold">{{ job.client || 'Unnamed client' }}</span>

--- a/components/navigation/navigation-trimmed.vue
+++ b/components/navigation/navigation-trimmed.vue
@@ -69,7 +69,7 @@
         <li v-for="tab in channel.visibleTabs" :key="tab.tabKey">
           <NuxtLink
             :to="tabTo(channel, tab)"
-            class="flex h-full items-center gap-3 rounded-xl border border-base-300 bg-base-100 p-2 transition-all hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-md"
+            class="flex h-full items-center gap-3 kr-panel-compact-xs transition-all hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-md"
           >
             <span
               class="relative flex h-11 w-11 shrink-0 overflow-hidden rounded-lg bg-base-200"

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -145,7 +145,7 @@
                   v-for="card in searchResults"
                   :key="card.key"
                   type="button"
-                  class="rounded-xl border border-base-300 bg-base-100 p-2 text-left transition hover:border-accent"
+                  class="kr-panel-compact-xs text-left transition hover:border-accent"
                   @click="focusSearchCard(card.key)"
                 >
                   <span class="text-xl font-semibold">{{ card.simplified }}</span>

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -76,6 +76,11 @@ VARIANTS = [
     # radius token never overlaps with any other variant above, so list
     # position doesn't matter for correctness here.
     ("kr-panel-compact", ["rounded-xl", "border", "border-base-300", "bg-base-100", "p-3"]),
+    # t-104 slice 128: kr-panel-compact's own shape at a tighter p-2 padding
+    # step. This sequence's trailing token (p-2) differs from kr-panel-
+    # compact's own p-3, so an exact-match attempt at a given position can
+    # only ever succeed for one of them -- no collision.
+    ("kr-panel-compact-xs", ["rounded-xl", "border", "border-base-300", "bg-base-100", "p-2"]),
     # t-104 slice 125: kr-panel-compact's own shape at 70% background opacity
     # instead of a solid fill -- bg-base-100/70 never collides with the solid
     # bg-base-100 token above.


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 128: continue the recurring front-end-consistency umbrella (kind: software)

### What changed / what I produced
- Added `.kr-panel-compact-xs` to `assets/css/tailwind.css` for the `rounded-xl border border-base-300 bg-base-100 p-2` shape — the `p-2` padding step of `.kr-panel-compact`'s own shape (which is `p-3`), same `-xs` suffix convention already used by the `.kr-btn-ghost-xs` family for the smallest size in a ladder.
- Extended `utils/scripts/codemods/kr_panel_codemod.py`'s `VARIANTS` list with the new sequence (diverges from `.kr-panel-compact`'s own sequence at the trailing token — `p-2` vs `p-3` — so no collision).
- Ran the codemod and applied its 10 mechanical substitutions across 8 files: `navigation-trimmed.vue`, `stylist-clients.vue`, `stylist-restyle.vue`, `collection-card.vue` (×2), `stylist-history.vue`, `image-card.vue` (×3), `mandarin.vue`.
- No geometry or behavior change.

### How I verified
- Surveyed the pool by exact contiguous token window across all `.vue` files, confirmed 10 occurrences, then confirmed the codemod dry-run matched exactly before applying.
- `vue-tsc --noEmit` (via `npm run test`): clean.
- `eslint` on all 7 changed `.vue` files: 0 new errors (`stylist-clients.vue`'s 2 pre-existing `no-dynamic-delete` errors at lines unrelated to this change, confirmed identical to baseline via `git stash`).
- `npm run test:layout-contract`: holds at 207 baseline violations, no new ones.
- `npm run test:lint-ratchet`: holds at 334 problems / -58, unchanged from baseline.
- `prettier --check`: introduced 2 new warnings (`collection-card.vue`, `image-card.vue`) from shorter class strings letting tags re-collapse to one line — ran `prettier --write` on just those two files, re-check then matched the same 5 pre-existing baseline warnings (confirmed via `git stash`) with nothing new.

### Stakes
reversible

### Flags for Reviewer
None.

### Notes for reviewer
Continues the `kr-panel*` primitive family from slices 117–127. The codemod's own dry-run now reports 0 remaining automatic candidates (only `chat-gallery.vue`'s 2 DaisyUI `btn` occurrences remain flagged for manual review, out of scope per the codemod's own DaisyUI-component-class policy). The `rounded-3xl/p-5` surface pool remains explicitly gated on `interface-vision/t-124` (naming decision pending) and was left untouched. Umbrella task returns to `ready` for the next bounded slice — a fresh manual survey (rather than the exhausted mechanical `VARIANTS` list) will be needed to find it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y42e9YgGJqBTrDUfjW5BvP