### PR TITLE
style: add kr-panel-muted-compact-xs primitive, migrate 6 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -650,6 +650,19 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-xl border border-base-300 bg-base-100/70 px-3 py-2;
   }
 
+  /* .kr-panel-muted's recessed solid bg-base-200 background at
+   * .kr-panel-compact's rounded-xl radius instead of .kr-panel-muted's own
+   * rounded-2xl (interface-vision t-104 slice 129) -- the muted family's
+   * first rounded-xl member, at the tightest `p-2` padding step (same -xs
+   * suffix as .kr-panel-compact-xs for the smallest size in a ladder).
+   * Distinct from .kr-panel-tint-compact/-50 (60%/50% opacity) since this
+   * background is a solid fill, not a tint. Previously hand-rolled across 6
+   * occurrences in 3 files (art-interact.vue x4, character-card.vue,
+   * first-launch-intro.vue). */
+  .kr-panel-muted-compact-xs {
+    @apply rounded-xl border border-base-300 bg-base-200 p-2;
+  }
+
   /* Flat bordered surface for dense lists, rows, and inboxes. */
   .kr-panel-flat {
     @apply rounded-2xl border border-base-300 bg-base-100;

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -159,7 +159,7 @@
           </summary>
 
           <div class="mt-3 grid gap-2 text-xs">
-            <div class="rounded-xl border border-base-300 bg-base-200 p-2">
+            <div class="kr-panel-muted-compact-xs">
               <p class="font-bold uppercase text-base-content/45">Checkpoint</p>
               <p class="mt-1 break-all font-semibold">
                 {{ currentArtImage.checkpoint || 'n/a' }}
@@ -167,13 +167,13 @@
             </div>
 
             <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-              <div class="rounded-xl border border-base-300 bg-base-200 p-2">
+              <div class="kr-panel-muted-compact-xs">
                 <p class="font-bold uppercase text-base-content/45">Sampler</p>
                 <p class="mt-1 truncate font-semibold">
                   {{ currentArtImage.sampler || 'n/a' }}
                 </p>
               </div>
-              <div class="rounded-xl border border-base-300 bg-base-200 p-2">
+              <div class="kr-panel-muted-compact-xs">
                 <p class="font-bold uppercase text-base-content/45">Seed</p>
                 <p class="mt-1 truncate font-mono">
                   {{ currentArtImage.seed ?? 'n/a' }}
@@ -181,7 +181,7 @@
               </div>
             </div>
 
-            <div class="rounded-xl border border-base-300 bg-base-200 p-2">
+            <div class="kr-panel-muted-compact-xs">
               <p class="font-bold uppercase text-base-content/45">Server</p>
               <p class="mt-1 truncate font-semibold">
                 {{ currentArtImage.serverName || 'n/a' }}

--- a/components/characters/character-card.vue
+++ b/components/characters/character-card.vue
@@ -93,7 +93,7 @@
           <div
             v-for="stat in statRows"
             :key="stat.key"
-            class="rounded-xl border border-base-300 bg-base-200 p-2 text-center"
+            class="kr-panel-muted-compact-xs text-center"
           >
             <div
               class="truncate text-[10px] font-bold uppercase text-base-content/60"

--- a/components/user/first-launch-intro.vue
+++ b/components/user/first-launch-intro.vue
@@ -45,7 +45,7 @@
           <li
             v-for="item in currentStep.items"
             :key="item.label"
-            class="flex flex-col items-center gap-1 rounded-xl border border-base-300 bg-base-200 p-2 text-center"
+            class="flex flex-col items-center gap-1 kr-panel-muted-compact-xs text-center"
           >
             <Icon :name="item.icon" class="h-5 w-5 text-secondary" />
             <span class="text-xs font-bold">{{ item.label }}</span>

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -96,6 +96,12 @@ VARIANTS = [
     # position (token 3 differs: `border-dashed` vs `border-base-300`).
     ("kr-panel-dashed", ["rounded-2xl", "border", "border-dashed", "border-base-300", "bg-base-200/50", "p-6"]),
     ("kr-panel-dashed-compact", ["rounded-xl", "border", "border-dashed", "border-base-300", "bg-base-200/50", "p-3"]),
+    # t-104 slice 129: .kr-panel-muted's solid bg-base-200 fill at
+    # .kr-panel-compact's rounded-xl radius and p-2 padding -- diverges from
+    # kr-panel-compact-xs at the background token (bg-base-200 vs
+    # bg-base-100) and from kr-panel-tint-compact/-50 at the background
+    # token (solid vs opacity), so no collision at this list position.
+    ("kr-panel-muted-compact-xs", ["rounded-xl", "border", "border-base-300", "bg-base-200", "p-2"]),
 ]
 
 CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 129: continue the recurring front-end-consistency umbrella (kind: software)

### What changed / what I produced
- Added `.kr-panel-muted-compact-xs` to `assets/css/tailwind.css` for the `rounded-xl border border-base-300 bg-base-200 p-2` shape — the muted family's (solid `bg-base-200`) first `rounded-xl` member, at the tightest `p-2` padding step (same `-xs` suffix convention as `.kr-panel-compact-xs`). Distinct from `.kr-panel-tint-compact`/`-50` (60%/50% opacity variants) since this background is a solid fill, not a tint.
- Extended `utils/scripts/codemods/kr_panel_codemod.py`'s `VARIANTS` list with the new sequence (diverges from every existing sequence at the background token — `bg-base-200` vs `bg-base-100`/`bg-base-200/40`/`bg-base-200/50`/`bg-base-200/60` — so no collision).
- Ran a fresh token-set (order-independent) survey since the codemod's own dry-run reported 0 candidates going in (all 9 `kr-*` migration codemods confirmed exhausted per slice 128's note). Found 6 occurrences across 3 files, confirmed the codemod dry-run matched exactly, then applied: `components/art/art-interact.vue` (×4), `components/characters/character-card.vue` (×1, coexisting `text-center` extra), `components/user/first-launch-intro.vue` (×1, coexisting `flex flex-col items-center gap-1`/`text-center` extras — all safe per the codemod's own `SAFE_EXTRA_RE` allowlist).
- No geometry or behavior change.

### How I verified
- Surveyed the pool by exact contiguous token window across all `.vue` files (excluding `abandonware/**`), confirmed 6 occurrences, then confirmed the codemod dry-run matched exactly before applying.
- `vue-tsc` (via `npm run test`): clean.
- `eslint` on all 3 changed `.vue` files: 0 errors.
- `npm run test:layout-contract`: holds at 207 baseline violations, no new ones.
- `npm run test:lint-ratchet`: holds at 334 problems / -58, unchanged from baseline.
- `prettier --check`: flagged `tailwind.css` and `character-card.vue`, both confirmed pre-existing baseline drift via `git stash` (identical warnings on `main` before this change).

### Stakes
reversible

### Flags for Reviewer
None.

### Notes for reviewer
Continues the `kr-panel*` primitive family from slices 117–128. `chat-gallery.vue`'s 2 DaisyUI `btn` occurrences remain correctly skipped (mixed component-root class, per the codemod's own policy). Umbrella task returns to `ready` for the next bounded slice — a fresh manual survey will again be needed since the mechanical `VARIANTS` list is exhausted after this addition.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDztpo9yqdBZdaYHsUDU7R

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDztpo9yqdBZdaYHsUDU7R)_