### PR TITLE
style: add kr-panel-muted-row/-compact-row primitives, migrate 13 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -663,6 +663,30 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-xl border border-base-300 bg-base-200 p-2;
   }
 
+  /* .kr-panel-muted's solid bg-base-200 fill at the asymmetric row padding
+   * (px-3 py-2) used for plain (non-toggle) list rows (interface-vision
+   * t-104 slice 130) -- distinct from .kr-toggle-row-sm below, which shares
+   * this exact box-model but always bundles `label cursor-pointer
+   * justify-between` for a DaisyUI toggle strip; this variant is for rows
+   * with no such extras. Previously hand-rolled across 8 occurrences in 8
+   * files (bot-gallery.vue, reward-gallery.vue, add-reward.vue,
+   * add-scenario.vue, scenario-story.vue, server-gallery.vue,
+   * checkpoint-gallery.vue, mural-manager.vue). */
+  .kr-panel-muted-row {
+    @apply rounded-2xl border border-base-300 bg-base-200 px-3 py-2;
+  }
+
+  /* .kr-panel-muted-row's own shape at .kr-panel-compact's rounded-xl
+   * radius instead of rounded-2xl (interface-vision t-104 slice 130) -- the
+   * row-padding counterpart to .kr-panel-muted-compact-xs, same `-row`
+   * suffix convention as .kr-panel-compact-70-row. Previously hand-rolled
+   * across 5 occurrences (art-gallery.vue, art-interact.vue,
+   * project-detail.vue, project-placement-manager.vue, user-dashboard.vue).
+   */
+  .kr-panel-muted-compact-row {
+    @apply rounded-xl border border-base-300 bg-base-200 px-3 py-2;
+  }
+
   /* Flat bordered surface for dense lists, rows, and inboxes. */
   .kr-panel-flat {
     @apply rounded-2xl border border-base-300 bg-base-100;

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -5,7 +5,7 @@
   >
     <header
       v-if="showHeader"
-      class="shrink-0 rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+      class="shrink-0 kr-panel-muted-compact-row"
     >
       <div class="flex items-center gap-2">
         <Icon name="kind-icon:gallery" class="h-5 w-5 shrink-0 text-primary" />

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -440,7 +440,7 @@
                   <label
                     v-for="collection in visibleCollectionOptions"
                     :key="collection.id"
-                    class="mb-1 flex cursor-pointer items-center justify-between gap-3 rounded-xl border border-base-300 bg-base-200 px-3 py-2 transition hover:bg-base-300"
+                    class="mb-1 flex cursor-pointer items-center justify-between gap-3 kr-panel-muted-compact-row transition hover:bg-base-300"
                   >
                     <span class="min-w-0">
                       <span class="block truncate text-sm font-semibold">{{

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -5,7 +5,7 @@
   >
     <header
       v-if="showHeader"
-      class="flex shrink-0 flex-col gap-2 rounded-2xl border border-base-300 bg-base-200 px-3 py-2"
+      class="flex shrink-0 flex-col gap-2 kr-panel-muted-row"
     >
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0">

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -456,7 +456,7 @@
         <div
           v-for="milestone in selectedProject.milestones"
           :key="milestone.id"
-          class="flex items-center gap-3 rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+          class="flex items-center gap-3 kr-panel-muted-compact-row"
         >
           <div
             class="flex size-6 shrink-0 items-center justify-center rounded-full border"

--- a/components/projects/project-placement-manager.vue
+++ b/components/projects/project-placement-manager.vue
@@ -72,7 +72,7 @@
 
           <div class="flex flex-wrap items-center gap-2">
             <label
-              class="flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 bg-base-200 px-3 py-2 text-sm font-bold"
+              class="flex cursor-pointer items-center gap-2 kr-panel-muted-compact-row text-sm font-bold"
             >
               <input
                 v-model="overwriteLiveUrl"

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -225,7 +225,7 @@
 
             <div
               v-if="rewardStore.rewardForm.artImageId"
-              class="w-full rounded-2xl border border-base-300 bg-base-200 px-3 py-2 text-xs text-base-content/60"
+              class="w-full kr-panel-muted-row text-xs text-base-content/60"
             >
               Linked ArtImage #{{ rewardStore.rewardForm.artImageId }}
             </div>

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -5,7 +5,7 @@
   >
     <header
       v-if="showHeader"
-      class="flex shrink-0 flex-col gap-2 rounded-2xl border border-base-300 bg-base-200 px-3 py-2"
+      class="flex shrink-0 flex-col gap-2 kr-panel-muted-row"
     >
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0">

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -229,7 +229,7 @@
 
             <div
               v-if="scenarioStore.scenarioForm.artImageId"
-              class="w-full rounded-2xl border border-base-300 bg-base-200 px-3 py-2 text-xs text-base-content/60"
+              class="w-full kr-panel-muted-row text-xs text-base-content/60"
             >
               Linked ArtImage #{{ scenarioStore.scenarioForm.artImageId }}
             </div>

--- a/components/scenarios/scenario-story.vue
+++ b/components/scenarios/scenario-story.vue
@@ -318,7 +318,7 @@
         />
 
         <div
-          class="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-200 px-3 py-2 text-smart-caption text-base-content/60"
+          class="flex flex-wrap items-center justify-between gap-2 kr-panel-muted-row text-smart-caption text-base-content/60"
         >
           <span class="font-bold text-base-content/70">Text server</span>
           <span class="truncate">{{ activeServerLabel }}</span>

--- a/components/servers/checkpoint-gallery.vue
+++ b/components/servers/checkpoint-gallery.vue
@@ -18,7 +18,7 @@
     -->
     <header
       v-if="showHeader"
-      class="flex shrink-0 items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-200 px-3 py-2"
+      class="flex shrink-0 items-center justify-between gap-2 kr-panel-muted-row"
     >
       <div class="min-w-0">
         <h2 class="truncate text-sm font-bold text-base-content">

--- a/components/servers/server-gallery.vue
+++ b/components/servers/server-gallery.vue
@@ -9,7 +9,7 @@
          list, so they ride the shell's toolbar line instead. -->
     <header
       v-if="showHeader"
-      class="flex shrink-0 items-center justify-between gap-2 rounded-2xl border border-base-300 bg-base-200 px-3 py-2"
+      class="flex shrink-0 items-center justify-between gap-2 kr-panel-muted-row"
     >
       <div class="min-w-0">
         <h2 class="truncate text-sm font-bold text-base-content">

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -277,7 +277,7 @@
                   </p>
 
                   <label
-                    class="flex items-center justify-between gap-2 rounded-xl border border-base-300 bg-base-200 px-3 py-2"
+                    class="flex items-center justify-between gap-2 kr-panel-muted-compact-row"
                   >
                     <span class="text-xs font-bold">
                       {{ showMature ? 'On' : 'Off' }}

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -55,9 +55,7 @@
             Save image
           </button>
 
-          <div
-            class="rounded-2xl border border-base-300 bg-base-200 px-3 py-2 text-sm"
-          >
+          <div class="kr-panel-muted-row text-sm">
             <span class="font-bold text-base-content/60">Active:</span>
             <span class="ml-2 font-black text-primary">
               {{ activeColor?.name || 'None' }}

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -102,6 +102,19 @@ VARIANTS = [
     # bg-base-100) and from kr-panel-tint-compact/-50 at the background
     # token (solid vs opacity), so no collision at this list position.
     ("kr-panel-muted-compact-xs", ["rounded-xl", "border", "border-base-300", "bg-base-200", "p-2"]),
+    # t-104 slice 130: .kr-panel-muted's solid bg-base-200 fill at the
+    # asymmetric row padding (px-3 py-2) used for plain (non-toggle) list
+    # rows -- distinct from .kr-toggle-row-sm, which shares this exact
+    # box-model but always bundles `label cursor-pointer justify-between`
+    # for a DaisyUI toggle strip; this variant is for rows with no such
+    # extras. Six trailing tokens diverge from every p-*/px-*-only sequence
+    # above at the padding position, so no collision.
+    ("kr-panel-muted-row", ["rounded-2xl", "border", "border-base-300", "bg-base-200", "px-3", "py-2"]),
+    # Same shape at .kr-panel-compact's rounded-xl radius instead of
+    # rounded-2xl (t-104 slice 130) -- the row-padding counterpart to
+    # .kr-panel-muted-compact-xs, same naming relationship as
+    # .kr-panel-compact-xs -> .kr-panel-compact-70-row's `-row` suffix.
+    ("kr-panel-muted-compact-row", ["rounded-xl", "border", "border-base-300", "bg-base-200", "px-3", "py-2"]),
 ]
 
 CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')


### PR DESCRIPTION
## Summary

interface-vision t-104 slice 130: adds the asymmetric row-padding (`px-3 py-2`) counterpart to `.kr-panel-muted`, for plain (non-toggle) list rows — distinct from `.kr-toggle-row-sm`, which shares the exact box-model but always bundles `label cursor-pointer justify-between` for a DaisyUI toggle strip.

- `.kr-panel-muted-row`: `rounded-2xl border border-base-300 bg-base-200 px-3 py-2`
- `.kr-panel-muted-compact-row`: same shape at `rounded-xl`

Migrated via `kr_panel_codemod.py` (extended with these two new variants):
- 8 occurrences of `-row` (bot-gallery.vue, reward-gallery.vue, add-reward.vue, add-scenario.vue, scenario-story.vue, server-gallery.vue, checkpoint-gallery.vue, mural-manager.vue)
- 5 occurrences of `-compact-row` (art-gallery.vue, art-interact.vue, project-detail.vue, project-placement-manager.vue, user-dashboard.vue)

No geometry or behavior change. `image-upload.vue`'s 3 near-identical occurrences are left hand-rolled — they bundle a DaisyUI `label` class not on the codemod's safe-extras allowlist (same conservative policy documented in the codemod's header).

## Verification

- `vue-tsc --noEmit`: clean
- `eslint` on changed files: 0 new errors (2 pre-existing on `art-gallery.vue`, confirmed identical via `git stash` against baseline `main`)
- `npm run test:layout-contract`: holds at 207 (unchanged)
- `npm run test:lint-ratchet`: holds at 334/-58 (unchanged)
- `prettier --check`: 4 pre-existing warnings unchanged, nothing new (`mural-manager.vue`'s shorter class string re-collapsed a multi-line attribute onto one line; fixed with a targeted `prettier --write` on that file only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAKPLpZHUmZs7m6iQSEsd6

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAKPLpZHUmZs7m6iQSEsd6)_