### PR TITLE
style: add kr-panel-section-flat primitive, migrate 10 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -735,6 +735,22 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm;
   }
 
+  /* .kr-panel-section's own rounded-3xl/border-base-300/bg-base-100 radius
+   * family, but at .kr-panel-muted-md's p-4 padding step and with no
+   * shadow-sm (interface-vision t-104 slice 131) -- a distinct, separately
+   * hand-rolled shape from .kr-panel-section, not a drifting duplicate
+   * (both p-4 and p-5 rounded-3xl panels appear in the same files, e.g.
+   * coloring-book-studio.vue). The `-flat` suffix follows .kr-panel-flat's
+   * convention of "same shape family, no shadow" even though this variant
+   * also differs by one padding step, since that is the actual repeated
+   * shape found in the codebase (10 occurrences across 6 files:
+   * watchlist-browse.vue x4, coloring-book-package-readiness.vue x2,
+   * coloring-book-cover-studio.vue, coloring-book-studio.vue x2,
+   * coloring-book-readiness.vue). */
+  .kr-panel-section-flat {
+    @apply rounded-3xl border border-base-300 bg-base-100 p-4;
+  }
+
   /*
    * Status callouts — inline tinted notices (the most-repeated surface in
    * the app, previously written by hand with drifting opacities like

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -75,7 +75,7 @@
         </div>
       </article>
 
-      <article class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-4">
+      <article class="flex flex-col gap-4 kr-panel-section-flat">
         <div>
           <h4 class="text-xl font-black">Cover art prompt</h4>
           <p v-if="cover.sourceRef" class="mt-1 break-all text-xs text-base-content/45">

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -113,7 +113,7 @@
       </div>
 
       <div class="grid gap-4 xl:grid-cols-2">
-        <article class="rounded-3xl border border-base-300 bg-base-100 p-4">
+        <article class="kr-panel-section-flat">
           <h4 class="text-lg font-black">Source-production blockers</h4>
           <p class="mt-1 text-xs text-base-content/50">
             {{ selectedPackage.finalPairCount }}/{{ selectedPackage.expectedInteriorCount }} final pairs ·
@@ -143,7 +143,7 @@
           </div>
         </article>
 
-        <article class="rounded-3xl border border-base-300 bg-base-100 p-4">
+        <article class="kr-panel-section-flat">
           <h4 class="text-lg font-black">Layout and export blockers</h4>
           <p class="mt-1 text-xs text-base-content/50">
             These fields stay unresolved until a printer, trim, binding, and template are chosen.

--- a/components/coloring/coloring-book-readiness.vue
+++ b/components/coloring/coloring-book-readiness.vue
@@ -109,7 +109,7 @@
           v-for="entry in filteredEntries"
           :key="entry.proposal.id"
           type="button"
-          class="flex flex-col gap-3 rounded-3xl border border-base-300 bg-base-100 p-4 text-left transition hover:-translate-y-0.5 hover:border-primary hover:shadow-md"
+          class="flex flex-col gap-3 kr-panel-section-flat text-left transition hover:-translate-y-0.5 hover:border-primary hover:shadow-md"
           @click="openProposal(entry.proposal.id)"
         >
           <div class="flex items-start justify-between gap-3">

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -186,7 +186,7 @@
 
       <div v-if="activeMode === 'pages'" class="flex flex-col gap-4">
         <div
-          class="flex flex-col gap-3 rounded-3xl border border-base-300 bg-base-100 p-4 sm:flex-row sm:items-center sm:justify-between"
+          class="flex flex-col gap-3 kr-panel-section-flat sm:flex-row sm:items-center sm:justify-between"
         >
           <div>
             <h4 class="text-xl font-black">{{ studio.selectedBook?.title }}</h4>
@@ -558,7 +558,7 @@
 
       <div
         v-if="activeMode === 'color'"
-        class="rounded-3xl border border-base-300 bg-base-100 p-4"
+        class="kr-panel-section-flat"
       >
         <div class="mb-4">
           <h4 class="text-xl font-black">End-user coloring preview</h4>

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -54,10 +54,7 @@
       </p>
 
       <!-- Recent entries (BROWSE-UX.md §1) -- fixed global view, no filters -->
-      <div
-        v-if="recentEntries.length"
-        class="rounded-3xl border border-base-300 bg-base-100 p-4"
-      >
+      <div v-if="recentEntries.length" class="kr-panel-section-flat">
         <p class="mb-2 text-xs font-semibold uppercase text-base-content/50">
           Recent entries
         </p>
@@ -84,7 +81,7 @@
       <!-- Stats strip -->
       <div
         v-if="stats"
-        class="grid grid-cols-2 gap-2 rounded-3xl border border-base-300 bg-base-100 p-4 sm:grid-cols-3 lg:grid-cols-6"
+        class="grid grid-cols-2 gap-2 kr-panel-section-flat sm:grid-cols-3 lg:grid-cols-6"
       >
         <div
           class="flex flex-col items-center gap-0.5 rounded-2xl p-2 text-center"
@@ -151,7 +148,7 @@
       <!-- By media type / by month / top starred (BROWSE-UX.md §4) -->
       <div
         v-if="stats && (mediaTypeBreakdown.length || stats.topStarred.length)"
-        class="grid grid-cols-[repeat(auto-fit,minmax(16rem,1fr))] gap-4 rounded-3xl border border-base-300 bg-base-100 p-4"
+        class="grid grid-cols-[repeat(auto-fit,minmax(16rem,1fr))] gap-4 kr-panel-section-flat"
       >
         <div v-if="mediaTypeBreakdown.length" class="flex flex-col gap-2">
           <p class="text-xs font-semibold uppercase text-base-content/50">
@@ -237,7 +234,7 @@
       <!-- Year-over-year comparison (BROWSE-UX.md §4) -->
       <div
         v-if="stats && showYearComparison"
-        class="overflow-x-auto rounded-3xl border border-base-300 bg-base-100 p-4"
+        class="overflow-x-auto kr-panel-section-flat"
       >
         <p class="mb-2 text-xs font-semibold uppercase text-base-content/50">
           Year over year

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -115,6 +115,16 @@ VARIANTS = [
     # .kr-panel-muted-compact-xs, same naming relationship as
     # .kr-panel-compact-xs -> .kr-panel-compact-70-row's `-row` suffix.
     ("kr-panel-muted-compact-row", ["rounded-xl", "border", "border-base-300", "bg-base-200", "px-3", "py-2"]),
+    # t-104 slice 131: the rounded-3xl/bg-base-100 radius family already named
+    # by .kr-panel-section (rounded-3xl/border-base-300/bg-base-100/p-5/
+    # shadow-sm), but at .kr-panel-muted-md's p-4 padding step and with no
+    # shadow -- a distinct, separately hand-rolled shape (10 occurrences
+    # across 6 files), not a drifting duplicate of -section (both p-4 and
+    # p-5 rounded-3xl panels appear in the same files, e.g.
+    # coloring-book-studio.vue). Five tokens, one shorter than -section's
+    # six (no shadow-sm), so an exact-match attempt at a given position can
+    # only ever succeed for one of them -- no collision.
+    ("kr-panel-section-flat", ["rounded-3xl", "border", "border-base-300", "bg-base-100", "p-4"]),
 ]
 
 CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')


### PR DESCRIPTION
interface-vision/t-104 slice 131: the rounded-3xl/border-base-300/bg-base-100 radius family already named by `.kr-panel-section` (rounded-3xl/p-5/shadow-sm), but at `.kr-panel-muted-md`'s p-4 padding step and with no shadow — a distinct, separately hand-rolled shape (10 occurrences across 6 files), not a drifting duplicate of `-section` (both p-4 and p-5 rounded-3xl panels appear in the same file, e.g. `coloring-book-studio.vue`).

Migrated via `kr_panel_codemod.py`: `watchlist-browse.vue` x4, `coloring-book-package-readiness.vue` x2, `coloring-book-cover-studio.vue`, `coloring-book-studio.vue` x2, `coloring-book-readiness.vue`. `image-upload.vue` and `chat-gallery.vue`'s remaining `border-base-300` occurrences stay hand-rolled (bundle a DaisyUI `label`/`btn` root class outside the codemod's safe-extras allowlist). No geometry or behavior change.

**Verified locally:**
- `vue-tsc --noEmit` clean
- `eslint` 0 new errors on changed files
- `test:layout-contract` holds at 207 (unchanged)
- `test:lint-ratchet` holds at 334/-58 (unchanged)
- `prettier --check` clean (5 pre-existing warnings unchanged; `watchlist-browse.vue`'s shorter class strings let several `<div>`s re-collapse onto one line, fixed via a targeted `prettier --write` on that one file)

Part of the recurring interface-vision/t-104 layout-consistency umbrella (conductor).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY9kyQPnb7CaSEHr8NYoJT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SY9kyQPnb7CaSEHr8NYoJT)_