### PR TITLE
style: add kr-panel-footer primitive, migrate 5 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -751,6 +751,19 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-3xl border border-base-300 bg-base-100 p-4;
   }
 
+  /* The sticky-footer action-bar shape at the bottom of full-height
+   * chat/narrator panes (interface-vision t-104 slice 132): a single top
+   * divider (border-t, not the all-sides `border` every other kr-panel*
+   * variant above uses) plus a solid bg-base-100 backing and compact `p-3`
+   * padding -- no border-radius, since this sits flush against its parent
+   * pane's own edges rather than floating as a boxed panel. Previously
+   * hand-rolled across 5 occurrences in 5 files (bot-chat.vue, workspace-
+   * narrator.vue, dream-brainstorm.vue, reward-encounter.vue, scenario-
+   * story.vue). */
+  .kr-panel-footer {
+    @apply border-t border-base-300 bg-base-100 p-3;
+  }
+
   /*
    * Status callouts — inline tinted notices (the most-repeated surface in
    * the app, previously written by hand with drifting opacities like

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -133,7 +133,7 @@
         </template>
       </kr-chat-window>
 
-      <div class="shrink-0 border-t border-base-300 bg-base-100 p-3">
+      <div class="shrink-0 kr-panel-footer">
         <!-- Starter prompts were a sixth hand-rolled pick-one row. -->
         <kr-choice-list
           class="mb-3"

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -357,7 +357,7 @@
         </section>
 
         <footer
-          class="grid shrink-0 grid-cols-1 gap-2 border-t border-base-300 bg-base-100 p-3 lg:grid-cols-[minmax(0,1fr)_auto_auto_auto]"
+          class="grid shrink-0 grid-cols-1 gap-2 kr-panel-footer lg:grid-cols-[minmax(0,1fr)_auto_auto_auto]"
         >
           <textarea
             v-model="globalFeedback"

--- a/components/navigation/workspace-narrator.vue
+++ b/components/navigation/workspace-narrator.vue
@@ -397,7 +397,7 @@
                 </template>
               </kr-chat-window>
 
-              <footer class="shrink-0 border-t border-base-300 bg-base-100 p-3">
+              <footer class="shrink-0 kr-panel-footer">
                 <section
                   v-if="statusMessage"
                   class="mb-2 rounded-2xl border p-2 text-sm"

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -215,7 +215,7 @@
           </template>
         </kr-chat-window>
 
-        <div class="shrink-0 border-t border-base-300 bg-base-100 p-3">
+        <div class="shrink-0 kr-panel-footer">
           <div
             class="flex flex-wrap items-center gap-2"
             :class="sessionChats.length === 0 ? 'mb-2' : ''"

--- a/components/scenarios/scenario-story.vue
+++ b/components/scenarios/scenario-story.vue
@@ -272,7 +272,7 @@
       @choose="handleReplyChosen"
     />
 
-    <footer class="shrink-0 border-t border-base-300 bg-base-100 p-3">
+    <footer class="shrink-0 kr-panel-footer">
       <div class="mx-auto flex max-w-3xl flex-col gap-2">
         <div
           v-if="storyStore.customDirection"

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -125,6 +125,17 @@ VARIANTS = [
     # six (no shadow-sm), so an exact-match attempt at a given position can
     # only ever succeed for one of them -- no collision.
     ("kr-panel-section-flat", ["rounded-3xl", "border", "border-base-300", "bg-base-100", "p-4"]),
+    # t-104 slice 132: the sticky-footer action-bar shape used at the bottom
+    # of full-height chat/narrator panes -- a single top divider (border-t,
+    # not the all-sides `border` every kr-panel* variant above uses) plus a
+    # solid backing and compact padding, no border-radius at all since this
+    # sits flush against its parent pane's own edges rather than floating as
+    # a boxed panel. Previously hand-rolled across 5 occurrences in 5 files
+    # (bot-chat.vue, workspace-narrator.vue, dream-brainstorm.vue, reward-
+    # encounter.vue, scenario-story.vue). Distinct token 1 (`border-t` vs
+    # `border`) means this can never collide with any solid-border variant
+    # above at the same list position.
+    ("kr-panel-footer", ["border-t", "border-base-300", "bg-base-100", "p-3"]),
 ]
 
 CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')


### PR DESCRIPTION
Slice 132 of the recurring `interface-vision/t-104` layout-consistency umbrella.

Adds a new `.kr-panel-footer` primitive (`border-t border-base-300 bg-base-100 p-3`) — a single top-divider bar distinct from every prior `kr-panel-*` variant (which use an all-sides `border`), used as the sticky footer/action-bar at the bottom of full-height chat/narrator panes.

**Migrated (5 occurrences, exact token match `border-t border-base-300 bg-base-100 p-3`):**
- `components/bots/bot-chat.vue`
- `components/navigation/workspace-narrator.vue`
- `components/dreams/dream-brainstorm.vue`
- `components/rewards/reward-encounter.vue`
- `components/scenarios/scenario-story.vue`

**Skipped** (bundle a DaisyUI `btn`/`label` root class outside the codemod's safe-extras allowlist): `components/user/chat-gallery.vue`, `components/art/image-upload.vue`.

No geometry or behavior change — pure class-string substitution via `kr_panel_codemod.py`.

**Verification:**
- `vue-tsc --noEmit` — clean
- `eslint` on changed files — 0 new errors
- `test:layout-contract` — holds at 207
- `test:lint-ratchet` — holds at 334/-58
- `prettier --check` — no new warnings

Part of `interface-vision/t-104` (conductor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p3fXxKsPsb2FStgaXBA9L

---
_Generated by [Claude Code](https://claude.ai/code/session_013p3fXxKsPsb2FStgaXBA9L)_