### PR TITLE
style: add kr-panel-compact-row primitive, migrate 5 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -650,6 +650,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-xl border border-base-300 bg-base-100/70 px-3 py-2;
   }
 
+  /* .kr-panel-compact's own shape at the asymmetric row padding (px-3 py-2)
+   * used for plain (non-toggle) list rows on the "plain" base-100 background
+   * (interface-vision t-104 slice 133) -- the base-100 counterpart to
+   * .kr-panel-muted-compact-row below, same `-row` suffix convention.
+   * Distinct from .kr-panel-compact-70-row (bg-base-100/70 opacity) since
+   * this background is a solid fill, not a tint. Previously hand-rolled
+   * across 5 occurrences in 4 files (facet-manager.vue, art-gallery.vue,
+   * art-test.vue x2, for-you-manager.vue); 2 further occurrences in
+   * art-interact.vue left hand-rolled (bundle a DaisyUI `label` root class
+   * outside the codemod's safe-extras allowlist). */
+  .kr-panel-compact-row {
+    @apply rounded-xl border border-base-300 bg-base-100 px-3 py-2;
+  }
+
   /* .kr-panel-muted's recessed solid bg-base-200 background at
    * .kr-panel-compact's rounded-xl radius instead of .kr-panel-muted's own
    * rounded-2xl (interface-vision t-104 slice 129) -- the muted family's

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -206,7 +206,7 @@
 
       <div v-else class="flex min-h-0 flex-col gap-2">
         <div
-          class="flex items-center gap-2 rounded-xl border border-base-300 bg-base-100 px-3 py-2"
+          class="flex items-center gap-2 kr-panel-compact-row"
         >
           <Icon
             :name="activeGroup.isVirtual ? 'kind-icon:archive' : 'kind-icon:folder'"

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -737,7 +737,7 @@ onMounted(async () => {
             {{ endpointDef.engine }}
           </div>
           <div
-            class="rounded-xl border border-base-300 bg-base-100 px-3 py-2 text-xs"
+            class="kr-panel-compact-row text-xs"
           >
             {{ endpointDef.route }}
           </div>
@@ -808,7 +808,7 @@ onMounted(async () => {
 
             <div
               v-if="serverId"
-              class="rounded-xl border border-base-300 bg-base-100 px-3 py-2 text-xs opacity-70"
+              class="kr-panel-compact-row text-xs opacity-70"
             >
               {{ serverStore.getServerById(serverId)?.baseUrl }}
             </div>

--- a/components/facets/facet-manager.vue
+++ b/components/facets/facet-manager.vue
@@ -86,7 +86,7 @@
         <div
           v-for="taxonomy in populatedTaxonomies"
           :key="taxonomy"
-          class="flex items-center justify-between rounded-xl border border-base-300 bg-base-100 px-3 py-2"
+          class="flex items-center justify-between kr-panel-compact-row"
         >
           <dt class="truncate text-sm">{{ taxonomyLabel(taxonomy) }}</dt>
           <dd class="kr-badge-ghost-sm shrink-0">

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -107,7 +107,7 @@
               <div class="flex flex-wrap items-center gap-2">
                 <label
                   v-if="conductorStore.pausedHumanGates.length"
-                  class="flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 bg-base-100 px-3 py-2 text-xs font-bold shadow-sm"
+                  class="flex cursor-pointer items-center gap-2 kr-panel-compact-row text-xs font-bold shadow-sm"
                 >
                   <input
                     v-model="showPausedProjects"

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -136,6 +136,12 @@ VARIANTS = [
     # `border`) means this can never collide with any solid-border variant
     # above at the same list position.
     ("kr-panel-footer", ["border-t", "border-base-300", "bg-base-100", "p-3"]),
+    # t-104 slice 133: kr-panel-compact's own shape at the asymmetric row
+    # padding (px-3 py-2) instead of a uniform p-3 -- the base-100 counterpart
+    # to kr-panel-muted-compact-row, same reasoning as kr-panel-compact-70-row
+    # above (one token longer than kr-panel-compact's own sequence, diverging
+    # at the final token, so no collision).
+    ("kr-panel-compact-row", ["rounded-xl", "border", "border-base-300", "bg-base-100", "px-3", "py-2"]),
 ]
 
 CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')


### PR DESCRIPTION
### Task
interface-vision/t-104 (consistency umbrella), slice 133 — fresh manual survey for the next hand-rolled panel pool.

### What changed / what I produced
Added `.kr-panel-compact-row` (`rounded-xl border border-base-300 bg-base-100 px-3 py-2`) — the asymmetric row-padding counterpart to `.kr-panel-compact` on the plain base-100 background, and the base-100 sibling of `.kr-panel-muted-compact-row`. Migrated via `kr_panel_codemod.py`: 5 occurrences across 4 files (facet-manager.vue, art-gallery.vue, art-test.vue x2, for-you-manager.vue). 2 further occurrences in art-interact.vue left hand-rolled (bundle a DaisyUI `label` root class outside the codemod's safe-extras allowlist, same skip category as prior slices). No geometry or behavior change.

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint` on touched files: 0 new errors (3 pre-existing `no-dynamic-delete` errors confirmed via `git stash` to predate this change)
- `verifyLayoutContract.ts`: holds at 207 (unchanged)
- `verifyLintRatchet.ts`: holds at 334/-58 (unchanged)
- `prettier --check` on touched files: 4 pre-existing warnings, confirmed unchanged via `git stash`

### Stakes
Reversible, scoped, mechanical class substitution only.

### Flags for Reviewer
None — standard slice of the recurring consistency umbrella.

### Kaizen suggestion
None new this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwDGtSZUVu2nXXeHZD9aQ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwDGtSZUVu2nXXeHZD9aQ9)_