### PR TITLE
style: add kr-panel-header primitive, migrate 6 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -778,6 +778,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply border-t border-base-300 bg-base-100 p-3;
   }
 
+  /* The header-bar counterpart to .kr-panel-footer above (interface-vision
+   * t-104 slice 134): a single bottom divider (border-b, matching the
+   * distinct-token-1 reasoning that keeps .kr-panel-footer's border-t from
+   * colliding with any all-sides `border` variant) at the wider `p-4`
+   * padding step, with no background fill -- these header bars sit flush
+   * against a parent surface that already supplies its own background,
+   * unlike .kr-panel-footer which needs bg-base-100 to sit opaquely over
+   * scrollable content beneath it. Previously hand-rolled across 6
+   * occurrences in 6 files (bot-chat.vue, reward-encounter.vue,
+   * mural-manager.vue x2, navigation-health.vue, artjob-editor.vue). */
+  .kr-panel-header {
+    @apply border-b border-base-300 p-4;
+  }
+
   /*
    * Status callouts — inline tinted notices (the most-repeated surface in
    * the app, previously written by hand with drifting opacities like

--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -11,7 +11,7 @@
       class="flex max-h-[94vh] w-full max-w-4xl flex-col overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-2xl"
     >
       <header
-        class="flex items-start justify-between gap-3 border-b border-base-300 p-4"
+        class="flex items-start justify-between gap-3 kr-panel-header"
       >
         <div>
           <h3 id="artjob-editor-title" class="text-lg font-semibold">

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -49,7 +49,7 @@
     <div
       class="grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden kr-panel-flat"
     >
-      <div class="shrink-0 border-b border-base-300 p-4">
+      <div class="shrink-0 kr-panel-header">
         <div
           v-if="botStore.currentBot"
           class="flex flex-col gap-4 sm:flex-row sm:items-center"

--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -122,7 +122,7 @@
         :key="channel.channelKey"
         class="overflow-hidden kr-panel p-0"
       >
-        <header class="relative overflow-hidden border-b border-base-300 p-4">
+        <header class="relative overflow-hidden kr-panel-header">
           <img
             v-if="channel.image"
             :src="channel.image"

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -84,7 +84,7 @@
       <div
         class="grid min-h-[70vh] grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden kr-panel-flat xl:min-h-0"
       >
-        <div class="shrink-0 border-b border-base-300 p-4">
+        <div class="shrink-0 kr-panel-header">
           <article v-if="rewardStore.selectedReward">
             <div class="flex flex-col gap-4 sm:flex-row">
               <div

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -77,7 +77,7 @@
       class="kr-panes grid-cols-1 xl:grid-cols-[minmax(280px,360px)_minmax(0,1fr)_minmax(280px,360px)]"
     >
       <aside class="kr-pane kr-panel-flat">
-        <div class="shrink-0 border-b border-base-300 p-4">
+        <div class="shrink-0 kr-panel-header">
           <h2 class="text-lg font-black">Saved Colors</h2>
           <p class="mt-1 text-sm text-base-content/60">
             Pick one, then click a section or flood a group.
@@ -223,7 +223,7 @@
       </main>
 
       <aside class="kr-pane kr-panel-flat">
-        <div class="shrink-0 border-b border-base-300 p-4">
+        <div class="shrink-0 kr-panel-header">
           <h2 class="text-lg font-black">Sections & Groups</h2>
           <p class="mt-1 text-sm text-base-content/60">
             Use groups for shared paint IDs, then click exact sections for

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -142,6 +142,14 @@ VARIANTS = [
     # above (one token longer than kr-panel-compact's own sequence, diverging
     # at the final token, so no collision).
     ("kr-panel-compact-row", ["rounded-xl", "border", "border-base-300", "bg-base-100", "px-3", "py-2"]),
+    # t-104 slice 134: the header-bar counterpart to kr-panel-footer -- a
+    # single bottom divider (border-b, not the all-sides `border` every
+    # other kr-panel* variant uses) at a wider p-4 padding step, with no
+    # background fill. Distinct token 1 (`border-b` vs `border`) means this
+    # can never collide with any solid-border variant above, and it's one
+    # token shorter than kr-panel-footer's own sequence (no bg-base-100), so
+    # it can't collide with that either.
+    ("kr-panel-header", ["border-b", "border-base-300", "p-4"]),
 ]
 
 CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 134: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- Surveyed the codebase for the next hand-rolled panel pool via the same exact-contiguous-token-window method as prior slices (tokenize every `class` attribute containing `border-base-300`, count fixed-width windows around it).
- Found a clean 6-occurrence candidate: `border-b border-base-300 p-4` — the header-bar counterpart to `.kr-panel-footer` (`border-t border-base-300 bg-base-100 p-3`), using `border-b` instead and with no background fill, since these header bars sit flush against a parent surface that already supplies its own background.
- Added `kr-panel-header` to `VARIANTS` in `kr_panel_codemod.py` and the matching primitive to `tailwind.css`.
- Applied the codemod, migrating all 6 occurrences across 5 files: `artjob-editor.vue`, `bot-chat.vue`, `navigation-health.vue`, `reward-encounter.vue`, `mural-manager.vue` (×2).
- No geometry or behavior change — pure mechanical class substitution.

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint` on changed `.vue` files: 0 errors
- `npm run test:layout-contract`: holds at 207 (unchanged)
- `npm run test:lint-ratchet`: holds at 334/-58 (unchanged)
- `prettier --check`: 3 pre-existing warnings (`artjob-editor.vue`, `navigation-health.vue`, `tailwind.css`), confirmed unchanged via `git stash` against baseline before this diff

### Stakes
reversible

### Kaizen suggestion
None new this slice — the pool found (6 occurrences) sits at the same viability floor as recent slices; continuing the same survey method next slice is the right call.

### Notes for reviewer
Standard recurring umbrella slice, same shape as slices 130–133 documented in `projects/interface-vision/TALKBACK.md` and the conductor root `TALKBACK.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABwbzJfrHikzyYHyNqc7fh

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABwbzJfrHikzyYHyNqc7fh)_