### PR TITLE
style: add kr-panel-divider primitive, migrate 16 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -792,6 +792,24 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply border-b border-base-300 p-4;
   }
 
+  /* An inline section divider (interface-vision t-104 slice 135): a top
+   * border rule with top-only spacing (`pt-3`, no bottom/left/right padding)
+   * used inside a flex-col stack to separate a trailing block (actions,
+   * meta, a secondary list) from the content above it -- distinct from
+   * .kr-panel-footer/.kr-panel-header, which are full-padding bars flush
+   * against a pane's own edges; this sits inline within a parent that
+   * already supplies its own outer padding and vertical gap. `pt-3` as the
+   * third token (vs. `bg-base-100`/`p-4`) means this can never collide with
+   * .kr-panel-footer's or .kr-panel-header's own sequences at the same list
+   * position. Previously hand-rolled across 16 occurrences in 9 files
+   * (agent-credentials-panel.vue, cthulhuquarium-game.vue x6,
+   * reaction-card.vue, animation-selector.vue, kr-card-back.vue,
+   * coloring-book-manager.vue, image-upload.vue, lora-triage.vue,
+   * mandarin.vue x3). */
+  .kr-panel-divider {
+    @apply border-t border-base-300 pt-3;
+  }
+
   /*
    * Status callouts — inline tinted notices (the most-repeated surface in
    * the app, previously written by hand with drifting opacities like

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -143,7 +143,7 @@
           </p>
         </div>
 
-        <div class="border-t border-base-300 pt-3">
+        <div class="kr-panel-divider">
           <!-- Metadata section header -->
           <div class="mb-3 flex items-center gap-2">
             <icon name="kind-icon:settings" class="h-4 w-4 text-primary" />

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -223,7 +223,7 @@
 
           <div
             v-if="groupNames.length"
-            class="flex flex-col gap-1.5 border-t border-base-300 pt-3"
+            class="flex flex-col gap-1.5 kr-panel-divider"
           >
             <p
               class="text-xs font-black uppercase tracking-wide text-base-content/60"

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -380,7 +380,7 @@
            completionist book, not part of the tank's own poll loop. Formal
            name on the cover; Charlotte and Wilbur would just call it "the
            book" (SYSTEMS.md). -->
-      <div class="flex flex-col gap-2 border-t border-base-300 pt-3">
+      <div class="flex flex-col gap-2 kr-panel-divider">
         <button
           type="button"
           class="flex items-center justify-between gap-2 text-left"
@@ -472,7 +472,7 @@
            combos (SYSTEMS.md's own framing) -- so unlike the bestiary this
            panel is about a small, legible, COUNTED choice (setSlotsCap),
            not a big collected list. -->
-      <div class="flex flex-col gap-2 border-t border-base-300 pt-3">
+      <div class="flex flex-col gap-2 kr-panel-divider">
         <button
           type="button"
           class="flex items-center justify-between gap-2 text-left"
@@ -550,7 +550,7 @@
            buying the same item twice is fine). Choosing an item here sets
            pendingDecorKind; the next tap on the tank places and pays for it.
            An already-placed item can be dragged directly on the canvas. -->
-      <div class="flex flex-col gap-2 border-t border-base-300 pt-3">
+      <div class="flex flex-col gap-2 kr-panel-divider">
         <button
           type="button"
           class="flex items-center justify-between gap-2 text-left"
@@ -623,7 +623,7 @@
            COMMON egg are both real, separately-priced offers. Buying is the
            decision (the cost is seen up front); hatching is free and
            always shown, never silent. -->
-      <div class="flex flex-col gap-2 border-t border-base-300 pt-3">
+      <div class="flex flex-col gap-2 kr-panel-divider">
         <button
           type="button"
           class="flex items-center justify-between gap-2 text-left"
@@ -731,7 +731,7 @@
            icon-plus-text layout above. -->
       <div
         v-if="tankStore.finaleConfig"
-        class="flex items-start gap-2 border-t border-base-300 pt-3"
+        class="flex items-start gap-2 kr-panel-divider"
       >
         <kr-art-plate
           :source="{ imagePath: setLastAquariumArt }"
@@ -772,7 +772,7 @@
            change that. Read-only for visitors either way: the toggle only
            ever writes the owner's own tank. -->
       <div
-        class="flex flex-wrap items-center justify-between gap-2 border-t border-base-300 pt-3"
+        class="flex flex-wrap items-center justify-between gap-2 kr-panel-divider"
       >
         <label class="flex cursor-pointer items-center gap-2">
           <input

--- a/components/gallery/kr-card-back.vue
+++ b/components/gallery/kr-card-back.vue
@@ -214,10 +214,7 @@
           edit and review. That matches the three abilities verifyCardActionContract
           already names as the card's job.
         -->
-        <div
-          v-if="$slots.reviews && reviewsOpen"
-          class="mt-4 border-t border-base-300 pt-3"
-        >
+        <div v-if="$slots.reviews && reviewsOpen" class="mt-4 kr-panel-divider">
           <slot name="reviews" />
         </div>
       </template>

--- a/components/screenfx/animation-selector.vue
+++ b/components/screenfx/animation-selector.vue
@@ -121,7 +121,7 @@
     </div>
 
     <footer
-      class="flex flex-wrap items-center justify-between gap-2 border-t border-base-300 pt-3 text-[0.68rem] text-base-content/45"
+      class="flex flex-wrap items-center justify-between gap-2 kr-panel-divider text-[0.68rem] text-base-content/45"
     >
       <span>Nothing here is sent to the server or attached to your account.</span>
       <code class="rounded-lg bg-base-200 px-2 py-1">

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -133,7 +133,7 @@
     </div>
 
     <form
-      class="mt-4 flex flex-col gap-3 border-t border-base-300 pt-3"
+      class="mt-4 flex flex-col gap-3 kr-panel-divider"
       @submit.prevent="createCredential"
     >
       <div class="flex items-center justify-between gap-3">

--- a/components/wonderlab/reaction-card.vue
+++ b/components/wonderlab/reaction-card.vue
@@ -146,7 +146,7 @@
 
       <div
         v-if="showShare"
-        class="flex flex-wrap justify-center gap-2 border-t border-base-300 pt-3"
+        class="flex flex-wrap justify-center gap-2 kr-panel-divider"
       >
         <button
           v-for="platform in sharePlatforms"

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -133,9 +133,7 @@
             </label>
           </div>
 
-          <div
-            class="flex flex-wrap items-center gap-2 border-t border-base-300 pt-3"
-          >
+          <div class="flex flex-wrap items-center gap-2 kr-panel-divider">
             <span class="text-sm font-bold"
               >{{ triageStore.selectedCount }} selected</span
             >

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -88,7 +88,7 @@
             </button>
           </div>
 
-          <form class="border-t border-base-300 pt-3" @submit.prevent="createSet">
+          <form class="kr-panel-divider" @submit.prevent="createSet">
             <label class="form-control gap-1">
               <span class="text-xs font-semibold opacity-65">New custom deck</span>
               <div class="join w-full max-w-xl">
@@ -330,7 +330,7 @@
                   </details>
                 </div>
 
-                <div class="flex items-center justify-between gap-2 border-t border-base-300 pt-3">
+                <div class="flex items-center justify-between gap-2 kr-panel-divider">
                   <button type="button" class="kr-btn-ghost-plain" :disabled="focusNavigationLocked" @click="store.previousCard()">
                     <Icon name="kind-icon:back" class="size-4" />
                     Previous
@@ -391,7 +391,7 @@
                   </div>
                 </div>
 
-                <div class="flex items-center justify-between gap-2 border-t border-base-300 pt-3">
+                <div class="flex items-center justify-between gap-2 kr-panel-divider">
                   <button type="button" class="kr-btn-ghost-plain" :disabled="focusNavigationLocked" @click="store.previousCard()">Previous</button>
                   <button type="button" class="kr-btn-outline-plain" @click="store.toggleDetails()">{{ detailsVisible ? 'Hide parts' : 'Parts & history' }}</button>
                   <button type="button" class="kr-btn-ghost-plain" :disabled="focusNavigationLocked" @click="store.nextCard()">Next</button>

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -150,6 +150,12 @@ VARIANTS = [
     # token shorter than kr-panel-footer's own sequence (no bg-base-100), so
     # it can't collide with that either.
     ("kr-panel-header", ["border-b", "border-base-300", "p-4"]),
+    # t-104 slice 135: an inline section divider -- a top border rule with
+    # top-only spacing (pt-3, no other padding) used inside a flex-col stack
+    # to separate a trailing block from the content above it. `pt-3` as the
+    # third token means this can never collide with kr-panel-footer's
+    # (`bg-base-100`) or kr-panel-header's (`p-4`) own sequences.
+    ("kr-panel-divider", ["border-t", "border-base-300", "pt-3"]),
 ]
 
 CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 135: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- Surveyed the codebase for the next hand-rolled panel pool via the same exact-contiguous-token-window method as prior slices, this time using a small script to systematically enumerate all candidate windows around `border-base-300` rather than eyeballing the raw frequency list.
- Found a clean 16-occurrence candidate: `border-t border-base-300 pt-3` — an inline section divider (a top border rule with top-only spacing, no bottom/left/right padding) used inside a `flex-col` stack to separate a trailing block (actions, meta, a secondary list) from the content above it. Distinct from `.kr-panel-footer`/`.kr-panel-header`, which are full-padding bars flush against a pane's own edges.
- Added `kr-panel-divider` to `VARIANTS` in `kr_panel_codemod.py` and the matching primitive to `tailwind.css`.
- Applied the codemod, migrating all 16 occurrences across 9 files: `agent-credentials-panel.vue`, `cthulhuquarium-game.vue` (×6), `reaction-card.vue`, `animation-selector.vue`, `kr-card-back.vue`, `coloring-book-manager.vue`, `image-upload.vue`, `lora-triage.vue`, `mandarin.vue` (×3).
- No geometry or behavior change — pure mechanical class substitution.

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint` on changed `.vue` files: 0 errors
- `npm run test:layout-contract`: holds at 207 (unchanged)
- `npm run test:lint-ratchet`: holds at 334/-58 (unchanged)
- `prettier --check`: initially flagged `kr-card-back.vue` and `lora-triage.vue` as newly warning — the shortened class string now fits on one line, so prettier wants to collapse the multi-line attribute (same pattern as slice 130's `mural-manager.vue`). Fixed with a targeted `prettier --write` on those two files; the remaining 6 warnings are pre-existing, confirmed unchanged via `git stash` against baseline.

### Stakes
reversible

### Kaizen suggestion
None new this slice — a small enumeration script (tries every contiguous window length around `border-base-300`, filters to windows not already in `VARIANTS` with all-safe surrounding tokens) surfaced this candidate faster and more systematically than eyeballing the raw frequency dump. Worth keeping as a mental note for future slices, not worth formalizing into a checked-in script yet since each slice's judgment call on naming/semantics still needs a human-in-the-loop-shaped read.

### Notes for reviewer
Second recurring-umbrella slice landed in this session (after slice 134 / kind_robots#2487). Same shape as prior slices documented in `projects/interface-vision/TALKBACK.md` and the conductor root `TALKBACK.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABwbzJfrHikzyYHyNqc7fh

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABwbzJfrHikzyYHyNqc7fh)_