### PR TITLE
Make ArtQueue load immediately and diversify loading copy

### DIFF
--- a/components/art/art-manager.vue
+++ b/components/art/art-manager.vue
@@ -2,19 +2,21 @@
 <template>
   <section class="kr-surface gap-0">
     <div
-      v-if="isLoadingManager"
+      v-if="isLoadingManager && activeTab !== 'artjob'"
       class="flex h-full min-h-0 flex-1 items-center justify-center kr-panel"
     >
       <div class="flex flex-col items-center gap-3 text-center">
         <span class="loading loading-spinner loading-lg text-primary" />
         <p class="text-sm text-base-content/70">
-          Loading images, collections, checkpoints, and pixel goblin
-          infrastructure...
+          {{ managerLoadMessage }}
         </p>
       </div>
     </div>
 
-    <div v-else-if="managerError" class="kr-stage kr-note kr-note-error">
+    <div
+      v-else-if="managerError && activeTab !== 'artjob'"
+      class="kr-stage kr-note kr-note-error"
+    >
       <div class="flex flex-wrap items-center justify-between gap-3">
         <span>{{ managerError }}</span>
         <button
@@ -219,6 +221,7 @@ import { useArtJobStore } from '@/stores/artJobStore'
 import { useArtStore } from '@/stores/artStore'
 import { useCheckpointStore } from '@/stores/checkpointStore'
 import { useCollectionStore } from '@/stores/collectionStore'
+import { useLoadStore } from '@/stores/loadStore'
 import { useNavStore } from '@/stores/navStore'
 import { useServerStore } from '@/stores/serverStore'
 import { useUserStore } from '@/stores/userStore'
@@ -244,6 +247,7 @@ const artJobStore = useArtJobStore()
 const artStore = useArtStore()
 const checkpointStore = useCheckpointStore()
 const collectionStore = useCollectionStore()
+const loadStore = useLoadStore()
 const navStore = useNavStore()
 const serverStore = useServerStore()
 const userStore = useUserStore()
@@ -264,7 +268,9 @@ const validTabs: LegacyArtTab[] = [
 ]
 
 const isLoadingManager = ref(false)
+const managerDataLoaded = ref(false)
 const managerError = ref<string | null>(null)
+const managerLoadMessage = ref(loadStore.randomLoadMessage())
 const artJobWorkspaceTab = ref<ArtJobWorkspaceTab>('queue')
 const artPreviewDialog = ref<HTMLDialogElement | null>(null)
 const artPreviewSrc = ref('')
@@ -307,8 +313,11 @@ const pendingTrainerCount = computed(() => {
 })
 
 async function loadManagerData(force = false) {
+  if (!force && (managerDataLoaded.value || isLoadingManager.value)) return
+
   isLoadingManager.value = true
   managerError.value = null
+  managerLoadMessage.value = loadStore.randomLoadMessage()
 
   try {
     await Promise.all([
@@ -327,6 +336,7 @@ async function loadManagerData(force = false) {
     if (!checkpointStore.selectedSampler) {
       checkpointStore.selectSamplerByName('Euler a')
     }
+    managerDataLoaded.value = true
   } catch (error) {
     managerError.value =
       error instanceof Error ? error.message : 'Failed to load image manager.'
@@ -424,6 +434,11 @@ function clearArtPreview(): void {
 }
 
 watch(shouldLiveRefreshArtJobs, syncArtJobLiveRefresh, { immediate: true })
+watch(activeTab, (tab) => {
+  if (tab !== 'artjob') {
+    void loadManagerData()
+  }
+})
 
 /**
  * Open the gallery on the ArtImage named in the route.
@@ -443,7 +458,9 @@ async function syncArtFromRoute(): Promise<void> {
 
 onMounted(async () => {
   document.addEventListener('visibilitychange', handleVisibilityChange)
-  await loadManagerData()
+  if (activeTab.value !== 'artjob') {
+    await loadManagerData()
+  }
   await syncArtFromRoute()
 
   watch(

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -310,7 +310,15 @@
           </div>
         </div>
 
-        <div class="mt-3 grid gap-3 xl:grid-cols-2">
+        <div
+          v-if="artJobStore.loadingJobs && !artJobStore.jobs.length"
+          class="mt-3 flex min-h-40 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 p-8 text-center"
+        >
+          <span class="loading loading-spinner loading-md text-primary" />
+          <p class="text-sm text-base-content/70">{{ queueLoadMessage }}</p>
+        </div>
+
+        <div v-else class="mt-3 grid gap-3 xl:grid-cols-2">
           <artjob-queue-card
             v-for="job in artJobStore.jobs"
             :key="job.id"
@@ -379,6 +387,7 @@ import {
   type ArtJobStatus,
   type UptimeSample,
 } from '@/stores/artJobStore'
+import { useLoadStore } from '@/stores/loadStore'
 import { useServerStore } from '@/stores/serverStore'
 import { useUserStore } from '@/stores/userStore'
 import type { Server } from '@/stores/serverStore'
@@ -386,12 +395,14 @@ import type { Server } from '@/stores/serverStore'
 type EditorAction = 'EDIT' | 'NEW_OUTPUT' | 'OVERWRITE'
 
 const artJobStore = useArtJobStore()
+const loadStore = useLoadStore()
 const serverStore = useServerStore()
 const userStore = useUserStore()
 
 const selectedWindow = ref(24)
 const pageSizeInput = ref('20')
 const pageInput = ref('1')
+const queueLoadMessage = ref(loadStore.randomLoadMessage())
 const editorJob = ref<ArtJobRecord | null>(null)
 const slideshowOpen = ref(false)
 const editorAction = ref<EditorAction>('EDIT')
@@ -410,9 +421,6 @@ const summaryStatuses: ArtJobStatus[] = ['PENDING', 'RUNNING', 'FAILED', 'DONE']
 const stats = computed(() => artJobStore.stats)
 const uptime = computed(() => artJobStore.uptime)
 const windowHours = computed(() => artJobStore.windowHours)
-// Only self-hosted render servers (ComfyUI / Automatic1111). Cloud providers
-// like OpenAI are omitted — this panel mirrors the private servers the uptime
-// endpoint tracks, so no "OpenAI is up" indicators appear here.
 const privateArtServers = computed<Server[]>(() =>
   serverStore.artServers.filter(
     (server: Server) =>
@@ -483,7 +491,6 @@ async function refreshServer(id: number): Promise<void> {
   refreshingServerIds.value = [...refreshingServerIds.value, id]
   try {
     await serverStore.testServerHealth(id)
-    // Pull the freshly recorded health sample into the uptime graph.
     await artJobStore.fetchUptime()
   } finally {
     refreshingServerIds.value = refreshingServerIds.value.filter(
@@ -539,16 +546,19 @@ function openEditor(job: ArtJobRecord, action: EditorAction): void {
 }
 
 async function changeStatus(status: ArtJobStatus | 'ALL'): Promise<void> {
+  queueLoadMessage.value = loadStore.randomLoadMessage()
   await artJobStore.fetchJobs(status, 1)
 }
 
 async function applyPageSize(): Promise<void> {
   const size = Number(pageSizeInput.value)
+  queueLoadMessage.value = loadStore.randomLoadMessage()
   await artJobStore.setJobPageSize(Number.isFinite(size) ? size : 20)
 }
 
 async function applyPage(): Promise<void> {
   const page = Number(pageInput.value)
+  queueLoadMessage.value = loadStore.randomLoadMessage()
   await artJobStore.setJobPage(Number.isFinite(page) ? page : 1)
 }
 
@@ -558,7 +568,19 @@ function onWindowChange(): void {
 }
 
 async function refresh(): Promise<void> {
+  queueLoadMessage.value = loadStore.randomLoadMessage()
   await artJobStore.refreshAll()
+}
+
+async function loadSecondaryDashboardData(): Promise<void> {
+  await Promise.all([
+    ...(serverStore.hasLoaded
+      ? []
+      : [serverStore.initialize({ force: false, fetchRemote: true })]),
+    artJobStore.fetchStats(),
+    artJobStore.fetchUptime(),
+    artJobStore.fetchQueueControl(),
+  ])
 }
 
 onMounted(async () => {
@@ -566,9 +588,15 @@ onMounted(async () => {
   selectedWindow.value = artJobStore.windowHours
   pageSizeInput.value = String(artJobStore.jobPageSize || 20)
   pageInput.value = String(artJobStore.jobPage || 1)
-  await Promise.all([
-    serverStore.initialize({ force: false, fetchRemote: true }),
-    artJobStore.refreshAll(),
-  ])
+
+  if (artJobStore.jobs.length) {
+    void artJobStore.fetchJobs()
+    void loadSecondaryDashboardData()
+    return
+  }
+
+  queueLoadMessage.value = loadStore.randomLoadMessage()
+  await artJobStore.fetchJobs()
+  void loadSecondaryDashboardData()
 })
 </script>

--- a/stores/loadStore.ts
+++ b/stores/loadStore.ts
@@ -6,59 +6,148 @@ import { useButterflyStore } from './butterflyStore'
 export const useLoadStore = defineStore('loadStore', () => {
   const desktopRevealStarted = ref(false)
   const recentLoadMessages = ref<string[]>([])
+  const remainingLoadMessages = ref<string[]>([])
 
   const loadMessages = [
     'Brewing tea...',
     'Releasing digital butterflies...',
-    'Whispering to the cloud. No...the other one.',
-    'Writing bad poetry',
+    'Whispering to the cloud. No, the other one.',
+    'Writing bad poetry...',
     'Pretending this is taking longer on purpose...',
     'Loading creativity...',
     'Reticulating splines...',
-    "Messaging Greta Thunberg about AI's impact on the environment...",
     'Prank calling Elon Musk...',
     'Debating deontology versus digital determinism...',
     'Stalling for dramatic effect...',
-    'Mining crypto on your computer...',
     'Downloading charm...',
     'Debugging reality...',
     'Syncing with the mothership...',
     'Last time on Kind Robots...',
-    'Downloading conscience, press any key to skip...',
-    'adding oxford commas...',
+    'Downloading conscience. Press any key to skip...',
+    'Adding Oxford commas...',
     'Adding a splash of existential dread...',
     'Loading irony...',
-    'clicking this link I just found...',
-    'Training bots to procrastinate.',
+    'Clicking this link I just found...',
+    'Training bots to procrastinate...',
     'Plotting the digital takeover...',
     "Analyzing the meaning of 'almost there'...",
     'Coding whimsy...',
-    'Buying useless junk on ebay',
+    'Buying useless junk on eBay...',
     'Questioning my life choices...',
     'This is the part where you wait...',
     'Rolling dice behind a screen...',
     'Lowering expectations...',
-    'Editing wikipedia...',
+    'Editing Wikipedia...',
     'Loading failed successfully...',
+    'Checking whether the moon is still there...',
+    'Looking under the couch for missing semicolons...',
+    'Teaching a Roomba about boundaries...',
+    'Rewinding the internet with a pencil...',
+    'Counting backwards from 37 for no reason...',
+    'Turning it off and on again, spiritually...',
+    'Calling dibs on the good pixels...',
+    "Making one tiny change that definitely won't matter...",
+    "Asking the server what it meant by 'fine'...",
+    'This seemed faster in my head...',
+    'Feeding quarters into the algorithm...',
+    'Putting the tiny hats back on the tiny robots...',
+    'Waiting for the dramatic music cue...',
+    'Finding a rhyme for asynchronous...',
+    'Checking the trapdoor under production...',
+    'Convincing one last byte to get in the van...',
+    'Sorting socks by checksum...',
+    'Borrowing a cup of RAM from next door...',
+    'Giving the database a stern but fair look...',
+    'Untangling a cable that exists only emotionally...',
+    'Rehearsing our alibi for the logs...',
+    'Polishing the emergency button...',
+    'Making sure the robots have snacks...',
+    'Replacing the smoke in the smoke test...',
+    'Checking the manual. Briefly.',
+    "Trying the key labeled 'probably'...",
+    'Folding a fitted stylesheet...',
+    'Looking busy while the cache warms up...',
+    'Negotiating with a very small daemon...',
+    'Waiting for the hamsters to reach cruising speed...',
+    'Putting the bits in alphabetical order...',
+    'Finding out who moved the cheese constant...',
+    'Running with scissors in a sandbox...',
+    'Turning the internet upside down and shaking it...',
+    'Blaming latency on Mercury retrograde...',
+    'Making the pixels stand in a straighter line...',
+    'Checking the back of the fridge for lost packets...',
+    'Installing a cup holder on the stack trace...',
+    'Sharpening the rubber duck...',
+    'Teaching the spinner a second trick...',
+    'Moving the goalposts back where we found them...',
+    'Consulting the ancient forum post from 2014...',
+    "Checking whether 'temporary' has expired yet...",
+    'Taking the scenic route through localhost...',
+    'Bribing the cache with fresh cookies...',
+    'Removing one unnecessary flourish...',
+    'Putting the loading bar on salary...',
+    'Checking for monsters under the dependency tree...',
+    'Making a backup of the backup plan...',
+    'Waiting for someone else to press Enter...',
+    'Counting pixels. Lost count. Starting over...',
+    'Reconnecting the red string on the corkboard...',
+    'Doing science to a perfectly good button...',
+    'Checking if the bug is load-bearing...',
+    'Putting the fun back in function call...',
+    'Moving one comma and changing history...',
+    'Making sure nobody divided by Tuesday...',
+    'Testing the emergency confetti...',
+    'Sending a strongly worded packet...',
+    'Finding the least cursed code path...',
+    'Looking for the instruction we ignored last time...',
+    'Letting the electrons finish their union break...',
+    'Checking that the vibes compile...',
+    'Trying not to wake the legacy code...',
+    'Giving the progress bar privacy...',
+    'Making room for one more improbable success...',
+    'Reading the error message all the way to the end...',
+    'Waiting for causality to catch up...',
+    'Returning borrowed parentheses...',
+    'Almost there. Legally, this time...',
   ]
 
   function rememberLoadMessage(message: string) {
-    recentLoadMessages.value = [message, ...recentLoadMessages.value].slice(
-      0,
-      4,
-    )
+    recentLoadMessages.value = [message, ...recentLoadMessages.value].slice(0, 4)
+  }
+
+  function refillLoadMessageDeck() {
+    const shuffled = [...loadMessages]
+
+    for (let index = shuffled.length - 1; index > 0; index -= 1) {
+      const swapIndex = Math.floor(Math.random() * (index + 1))
+      const current = shuffled[index]
+      shuffled[index] = shuffled[swapIndex] as string
+      shuffled[swapIndex] = current as string
+    }
+
+    const lastMessage = recentLoadMessages.value[0]
+    if (
+      lastMessage &&
+      shuffled.length > 1 &&
+      shuffled[shuffled.length - 1] === lastMessage
+    ) {
+      const swapIndex = Math.floor(Math.random() * (shuffled.length - 1))
+      const lastIndex = shuffled.length - 1
+      const current = shuffled[lastIndex]
+      shuffled[lastIndex] = shuffled[swapIndex] as string
+      shuffled[swapIndex] = current as string
+    }
+
+    remainingLoadMessages.value = shuffled
   }
 
   function randomLoadMessage() {
-    const availableMessages = loadMessages.filter(
-      (message) => !recentLoadMessages.value.includes(message),
-    )
+    if (!remainingLoadMessages.value.length) {
+      refillLoadMessageDeck()
+    }
 
-    const messagePool = availableMessages.length
-      ? availableMessages
-      : loadMessages
-    const randomIndex = Math.floor(Math.random() * messagePool.length)
-    const message = messagePool[randomIndex] ?? 'Loading failed successfully...'
+    const message =
+      remainingLoadMessages.value.pop() ?? 'Loading failed successfully...'
 
     rememberLoadMessage(message)
     return message

--- a/stores/loadStore.ts
+++ b/stores/loadStore.ts
@@ -6,7 +6,7 @@ import { useButterflyStore } from './butterflyStore'
 export const useLoadStore = defineStore('loadStore', () => {
   const desktopRevealStarted = ref(false)
   const recentLoadMessages = ref<string[]>([])
-  const remainingLoadMessages = ref<string[]>([])
+  let remainingLoadMessages: string[] = []
 
   const loadMessages = [
     'Brewing tea...',
@@ -120,9 +120,9 @@ export const useLoadStore = defineStore('loadStore', () => {
 
     for (let index = shuffled.length - 1; index > 0; index -= 1) {
       const swapIndex = Math.floor(Math.random() * (index + 1))
-      const current = shuffled[index]
+      const current = shuffled[index] as string
       shuffled[index] = shuffled[swapIndex] as string
-      shuffled[swapIndex] = current as string
+      shuffled[swapIndex] = current
     }
 
     const lastMessage = recentLoadMessages.value[0]
@@ -133,21 +133,20 @@ export const useLoadStore = defineStore('loadStore', () => {
     ) {
       const swapIndex = Math.floor(Math.random() * (shuffled.length - 1))
       const lastIndex = shuffled.length - 1
-      const current = shuffled[lastIndex]
+      const current = shuffled[lastIndex] as string
       shuffled[lastIndex] = shuffled[swapIndex] as string
-      shuffled[swapIndex] = current as string
+      shuffled[swapIndex] = current
     }
 
-    remainingLoadMessages.value = shuffled
+    remainingLoadMessages = shuffled
   }
 
   function randomLoadMessage() {
-    if (!remainingLoadMessages.value.length) {
+    if (!remainingLoadMessages.length) {
       refillLoadMessageDeck()
     }
 
-    const message =
-      remainingLoadMessages.value.pop() ?? 'Loading failed successfully...'
+    const message = remainingLoadMessages.pop() ?? 'Loading failed successfully...'
 
     rememberLoadMessage(message)
     return message


### PR DESCRIPTION
## What changed
- let the ArtJob workspace render without waiting for the general art manager to load gallery images, collections, checkpoints, and servers
- load the first paginated queue page first, then fetch stats, uptime, queue control, and server metadata behind it
- keep cached queue rows visible while refreshing on revisits instead of blanking the surface
- expand the shared loading-message pool to 100 unique lines and consume it as a shuffled deck before repeating
- replace the ArtManager's hard-coded `pixel goblin infrastructure` loading copy with the shared loading-message pool

## Why
ArtQueue already paginates the API at 20 jobs by default. The long wait was primarily a front-end sequencing problem: the parent ArtManager blocked the ArtJob tab on unrelated art/gallery initialization, and the queue browser then awaited secondary dashboard data alongside the useful job rows.

## Verification
CI/typecheck and repository checks are expected to verify the Vue/TypeScript changes. No schema or migration changes. Production is self-hosted; merge is not a production deploy.