### PR TITLE
style: add kr-panel-footer-bare primitive, migrate 9 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -810,6 +810,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply border-t border-base-300 pt-3;
   }
 
+  /* .kr-panel-footer's own shape (border-t, uniform p-3) with no background
+   * fill (interface-vision t-104 slice 136) -- used as a flush footer/action
+   * bar inside a parent surface that already supplies its own background,
+   * same reasoning as .kr-panel-header dropping .kr-panel-footer's
+   * bg-base-100. Distinct from .kr-panel-divider's own sequence at the third
+   * token (`p-3` vs `pt-3`), so it can't collide with that either.
+   * Previously hand-rolled across 9 occurrences in 7 files (messenger.vue,
+   * mural-manager.vue, facet-picker.vue, home-object-sheet.vue,
+   * coloring-book-studio.vue x2, artjob-queue-card.vue, taskmaster-page.vue
+   * x2). */
+  .kr-panel-footer-bare {
+    @apply border-t border-base-300 p-3;
+  }
+
   /*
    * Status callouts — inline tinted notices (the most-repeated surface in
    * the app, previously written by hand with drifting opacities like

--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -216,7 +216,7 @@
         <summary class="cursor-pointer px-3 py-2 text-xs font-semibold">
           Full brief and generation fields
         </summary>
-        <div class="flex flex-col gap-3 border-t border-base-300 p-3 text-xs">
+        <div class="flex flex-col gap-3 kr-panel-footer-bare text-xs">
           <div
             v-if="!canShowJobContent"
             class="rounded-xl border border-warning/30 bg-warning/10 p-3 text-warning-content"

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -342,7 +342,7 @@
                 </div>
               </div>
               <figcaption
-                class="border-t border-base-300 p-3 text-center font-black"
+                class="kr-panel-footer-bare text-center font-black"
               >
                 Current color master
               </figcaption>
@@ -367,7 +367,7 @@
                 </div>
               </div>
               <figcaption
-                class="border-t border-base-300 p-3 text-center font-black"
+                class="kr-panel-footer-bare text-center font-black"
               >
                 Current black &amp; white
               </figcaption>

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -107,7 +107,7 @@
       >
         Create a new Facet
       </summary>
-      <div class="grid gap-2 border-t border-base-300 p-3 sm:grid-cols-2">
+      <div class="grid gap-2 kr-panel-footer-bare sm:grid-cols-2">
         <input
           v-model="newTitle"
           type="text"

--- a/components/home/home-object-sheet.vue
+++ b/components/home/home-object-sheet.vue
@@ -244,7 +244,7 @@
           </div>
         </section>
 
-        <footer class="kr-toolbar justify-between border-t border-base-300 p-3">
+        <footer class="kr-toolbar justify-between kr-panel-footer-bare">
           <p class="text-[0.65rem] text-base-content/45">
             {{ createdLabel }}
           </p>

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -257,7 +257,7 @@
                       class="size-4 text-base-content/45 transition-transform group-open:rotate-180"
                     />
                   </summary>
-                  <div class="border-t border-base-300 p-3">
+                  <div class="kr-panel-footer-bare">
                     <NarrativeIngredientPicker
                       v-model="selectedLocationSlug"
                       :items="locationOptions"
@@ -301,7 +301,7 @@
                       class="size-4 text-base-content/45 transition-transform group-open:rotate-180"
                     />
                   </summary>
-                  <div class="border-t border-base-300 p-3">
+                  <div class="kr-panel-footer-bare">
                     <NarrativeIngredientPicker
                       v-model="selectedGrammarSlug"
                       :items="grammarOptions"

--- a/components/user/messenger.vue
+++ b/components/user/messenger.vue
@@ -108,7 +108,7 @@
         </div>
 
         <form
-          class="flex items-center gap-2 border-t border-base-300 p-3"
+          class="flex items-center gap-2 kr-panel-footer-bare"
           @submit.prevent="onSend"
         >
           <input

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -132,10 +132,7 @@
           </div>
         </div>
 
-        <form
-          class="shrink-0 border-t border-base-300 p-3"
-          @submit.prevent="addColor"
-        >
+        <form class="shrink-0 kr-panel-footer-bare" @submit.prevent="addColor">
           <div class="grid gap-2">
             <input
               v-model="newColorName"

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -156,6 +156,14 @@ VARIANTS = [
     # third token means this can never collide with kr-panel-footer's
     # (`bg-base-100`) or kr-panel-header's (`p-4`) own sequences.
     ("kr-panel-divider", ["border-t", "border-base-300", "pt-3"]),
+    # t-104 slice 136: the .kr-panel-footer shape (border-t, uniform p-3) but
+    # with no background fill -- used as a flush footer/action bar inside a
+    # parent surface that already supplies its own background (same reasoning
+    # as .kr-panel-header dropping .kr-panel-footer's bg-base-100). Distinct
+    # from .kr-panel-divider's own 3-token sequence at the third token (`p-3`
+    # vs `pt-3`), so an exact-match attempt at a given position can only ever
+    # succeed for one of them -- no collision.
+    ("kr-panel-footer-bare", ["border-t", "border-base-300", "p-3"]),
 ]
 
 CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 136 (recurring layout-consistency umbrella).

### What changed / what I produced
Added `.kr-panel-footer-bare` to `tailwind.css`'s `@layer components` and to `kr_panel_codemod.py`'s `VARIANTS`: the `.kr-panel-footer` shape (`border-t border-base-300 p-3`) with no background fill — a flush footer/action bar used inside a parent surface that already supplies its own background (same reasoning as `.kr-panel-header` dropping `.kr-panel-footer`'s `bg-base-100`). Ran the codemod to migrate all 9 hand-rolled occurrences across 7 files: `artjob-queue-card.vue`, `coloring-book-studio.vue` (x2), `facet-picker.vue`, `home-object-sheet.vue`, `taskmaster-page.vue` (x2), `messenger.vue`, `mural-manager.vue`. No geometry or behavior change.

### How I verified
- `vue-tsc` (via `npm run test`): clean
- `eslint` on changed files: 0 errors
- `npm run test:layout-contract`: holds at 207 (unchanged)
- `npm run test:lint-ratchet`: holds at 334/-58 (unchanged)
- `prettier --check`: 4 pre-existing warnings only (unchanged from baseline, confirmed via `git stash`); fixed one new collapse-to-one-line warning in `mural-manager.vue` with a targeted `prettier --write` before pushing

### Stakes
Reversible, scoped, zero-visual-delta style consolidation.

### Flags for Reviewer
None — mechanical, byte-exact substitution only (existing codemod's safety checks unchanged).

### Kaizen suggestion
None new this slice — same survey methodology as recent slices continues to find viable pools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8NxN97QZfPXnjjW4qCzdB

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8NxN97QZfPXnjjW4qCzdB)_