### PR TITLE
style: add kr-panel-section-plain primitive, migrate 7 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -824,6 +824,22 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply border-t border-base-300 p-3;
   }
 
+  /* .kr-panel-section's own rounded-3xl/border-base-300/bg-base-100/p-5
+   * shape (interface-vision t-104 slice 137), but with no shadow-sm --
+   * .kr-panel-section itself had never actually been added to the codemod
+   * this file's other primitives are migrated with, so this is the FIRST
+   * VARIANTS entry covering that shape family. Occurrences found carry three
+   * different trailing shadow states -- none, shadow-lg, or shadow-xl, the
+   * latter two as a plain utility token after this class -- and a bare
+   * utility-layer shadow-* always overrides this components-layer class's
+   * lack of one, so all three stay zero-visual-delta under this one
+   * primitive. Previously hand-rolled across 7 occurrences in 4 files
+   * (coloring-book-studio.vue x4, aquarium browse/[username]/[slug].vue,
+   * aquarium leaderboard/index.vue, play/challenges/[slug].vue). */
+  .kr-panel-section-plain {
+    @apply rounded-3xl border border-base-300 bg-base-100 p-5;
+  }
+
   /*
    * Status callouts — inline tinted notices (the most-repeated surface in
    * the app, previously written by hand with drifting opacities like

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -136,7 +136,7 @@
         <article
           v-for="book in studio.books"
           :key="book.slug"
-          class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5"
+          class="flex flex-col gap-4 kr-panel-section-plain"
         >
           <div class="flex items-start justify-between gap-3">
             <div>
@@ -297,7 +297,7 @@
         class="grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(22rem,0.9fr)]"
       >
         <article
-          class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5"
+          class="flex flex-col gap-4 kr-panel-section-plain"
         >
           <div
             class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"
@@ -397,7 +397,7 @@
         </article>
 
         <aside
-          class="flex flex-col gap-4 rounded-3xl border border-base-300 bg-base-100 p-5"
+          class="flex flex-col gap-4 kr-panel-section-plain"
         >
           <div>
             <h4 class="text-xl font-black">Canonical production prompt</h4>
@@ -500,7 +500,7 @@
 
       <div v-if="activeMode === 'queue'" class="flex flex-col gap-4">
         <div
-          class="flex flex-col gap-2 rounded-3xl border border-base-300 bg-base-100 p-5 sm:flex-row sm:items-center sm:justify-between"
+          class="flex flex-col gap-2 kr-panel-section-plain sm:flex-row sm:items-center sm:justify-between"
         >
           <div>
             <h4 class="text-xl font-black">Queue &amp; review problems</h4>

--- a/pages/play/aquarium/browse/[username]/[slug].vue
+++ b/pages/play/aquarium/browse/[username]/[slug].vue
@@ -46,7 +46,7 @@
 
       <template v-else-if="tank">
         <header
-          class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-lg sm:p-7"
+          class="kr-panel-section-plain shadow-lg sm:p-7"
         >
           <div class="flex items-center gap-3">
             <div

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -17,9 +17,7 @@
         </NuxtLink>
       </nav>
 
-      <header
-        class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-lg sm:p-7"
-      >
+      <header class="kr-panel-section-plain shadow-lg sm:p-7">
         <p class="text-xs font-black uppercase tracking-[0.25em] text-primary">
           Cthulhuquarium
         </p>

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -430,7 +430,7 @@
 
         <section
           v-if="challenge.leaderboard.length"
-          class="rounded-3xl border border-base-300 bg-base-100 p-5 shadow-lg sm:p-7"
+          class="kr-panel-section-plain shadow-lg sm:p-7"
         >
           <div class="flex flex-wrap items-end justify-between gap-3">
             <div>

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -164,6 +164,26 @@ VARIANTS = [
     # vs `pt-3`), so an exact-match attempt at a given position can only ever
     # succeed for one of them -- no collision.
     ("kr-panel-footer-bare", ["border-t", "border-base-300", "p-3"]),
+    # t-104 slice 137: .kr-panel-section's own rounded-3xl/border-base-300/
+    # bg-base-100/p-5 shape, but matched WITHOUT its trailing shadow-sm token
+    # -- found while enumerating remaining border-base-300 windows for the
+    # next slice, .kr-panel-section itself (approved interface-vision/t-123)
+    # was never added to this codemod's VARIANTS, so this is the FIRST entry
+    # covering that shape family at all. A 5-token sequence, not .kr-panel-
+    # section's own 6-token shadow-sm sequence, because real occurrences carry
+    # three different trailing shadow states -- none (coloring-book-
+    # studio.vue x4), shadow-lg, or shadow-xl (both as a separate SAFE_EXTRA
+    # token after this sequence, e.g. aquarium leaderboard/browse pages) --
+    # and matching shadow-sm specifically would find none of them. The
+    # no-shadow files stay genuinely zero-visual-delta (bare 5-token
+    # replacement); the shadow-lg/shadow-xl ones are equally zero-visual-delta
+    # by this codemod's own established policy (a bare utility-layer shadow-*
+    # token always overrides the components-layer shadow-sm .kr-panel-section
+    # applies, per this file's SAFE_EXTRA_RE header comment) -- confirmed by
+    # this slice's own dry run, which substituted both cases identically. One
+    # token shorter than .kr-panel-section-flat's own 5-token p-4 sequence but
+    # diverging at the final token (p-5 vs p-4), so no collision with it.
+    ("kr-panel-section-plain", ["rounded-3xl", "border", "border-base-300", "bg-base-100", "p-5"]),
 ]
 
 CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 137: continue the recurring kr-* component consistency sweep (recurring umbrella task, tracked in conductor).

### What changed / what I produced
- `.kr-panel-section` (approved interface-vision/t-123: `rounded-3xl border border-base-300 bg-base-100 p-5 shadow-sm`) was defined in `tailwind.css` but had never actually been added to `utils/scripts/codemods/kr_panel_codemod.py`'s `VARIANTS` list, so its shape family had no automated migration coverage at all.
- Added `.kr-panel-section-plain` — the same shape but matched as a 5-token sequence with **no** trailing `shadow-sm`, because every real occurrence found carries a different trailing shadow state (none at all, `shadow-lg`, or `shadow-xl` as a separate safe utility token after the class). All three stay zero-visual-delta under one primitive: a bare utility-layer `shadow-*` token always overrides this components-layer class's own lack of a shadow declaration (same policy this codemod already documents for every other primitive).
- Ran the codemod, migrating 7 occurrences across 4 files: `coloring-book-studio.vue` (x4), `aquarium/browse/[username]/[slug].vue`, `aquarium/leaderboard/index.vue`, `play/challenges/[slug].vue`.
- No geometry or behavior change.

### How I verified
- `vue-tsc` (`npm run test`): clean.
- `eslint` on all changed `.vue` files: 0 new errors.
- `npm run test:layout-contract`: holds at 207 (unchanged).
- `npm run test:lint-ratchet`: holds at 334 problems / -58 (unchanged).
- `prettier --check`: confirmed baseline via `git stash` (4 pre-existing warnings: `tailwind.css`, `coloring-book-studio.vue`, `browse/[username]/[slug].vue`, `challenges/[slug].vue`); this diff introduced one new warning in `leaderboard/index.vue` (shortened class string now fit on one line) — fixed with a targeted `prettier --write` before pushing, back to the same 4-warning baseline.

### Stakes
reversible

### Notes for reviewer
No new gap-scan tooling — the enumeration was the same ad-hoc "every contiguous token window containing `border-base-300`, filtered through the codemod's own `substitute_tokens`" method prior slices (135/136) used, run by hand this session rather than checked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSqTvj8VHqvokSahRCa3Sf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSqTvj8VHqvokSahRCa3Sf)_