### PR TITLE
style: add kr-panel-dashed-plain primitive, migrate 4 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -840,6 +840,17 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-3xl border border-base-300 bg-base-100 p-5;
   }
 
+  /* A third padding step of the dashed empty-state family (.kr-panel-dashed's
+   * p-6, .kr-panel-dashed-compact's p-3), but with NO background fill at all
+   * (interface-vision t-104 slice 138) -- unlike both of those, which carry
+   * bg-base-200/50. A visually distinct shape, not just another padding size
+   * of the same tint. Previously hand-rolled across 4 occurrences in 3 files
+   * (facet-gallery.vue, stylist-relay-status.vue, artjob-queue-browser.vue x2),
+   * all "nothing here yet" placeholder blocks. */
+  .kr-panel-dashed-plain {
+    @apply rounded-2xl border border-dashed border-base-300 p-8;
+  }
+
   /*
    * Status callouts — inline tinted notices (the most-repeated surface in
    * the app, previously written by hand with drifting opacities like

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -312,7 +312,7 @@
 
         <div
           v-if="artJobStore.loadingJobs && !artJobStore.jobs.length"
-          class="mt-3 flex min-h-40 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 p-8 text-center"
+          class="mt-3 flex min-h-40 flex-col items-center justify-center gap-3 kr-panel-dashed-plain text-center"
         >
           <span class="loading loading-spinner loading-md text-primary" />
           <p class="text-sm text-base-content/70">{{ queueLoadMessage }}</p>
@@ -328,7 +328,7 @@
 
           <div
             v-if="!artJobStore.jobs.length && !artJobStore.loadingJobs"
-            class="rounded-2xl border border-dashed border-base-300 p-8 text-center text-sm text-base-content/50 xl:col-span-2"
+            class="kr-panel-dashed-plain text-center text-sm text-base-content/50 xl:col-span-2"
           >
             No {{ artJobStore.jobStatusFilter }} jobs on this page.
           </div>

--- a/components/art/stylist-relay-status.vue
+++ b/components/art/stylist-relay-status.vue
@@ -46,7 +46,7 @@
 
       <div
         v-if="!loading && !error && !agents.length"
-        class="rounded-2xl border border-dashed border-base-300 p-8 text-center text-xs text-base-content/50"
+        class="kr-panel-dashed-plain text-center text-xs text-base-content/50"
       >
         No relay has polled since the server last restarted.
       </div>

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -92,7 +92,7 @@
 
       <p
         v-if="!catalog.loading && !visibleGroups.length"
-        class="rounded-2xl border border-dashed border-base-300 p-8 text-center text-sm text-base-content/50"
+        class="kr-panel-dashed-plain text-center text-sm text-base-content/50"
       >
         No facets match these filters.
       </p>

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -184,6 +184,18 @@ VARIANTS = [
     # token shorter than .kr-panel-section-flat's own 5-token p-4 sequence but
     # diverging at the final token (p-5 vs p-4), so no collision with it.
     ("kr-panel-section-plain", ["rounded-3xl", "border", "border-base-300", "bg-base-100", "p-5"]),
+    # t-104 slice 138: a third padding step of the dashed empty-state family
+    # (kr-panel-dashed's p-6, kr-panel-dashed-compact's p-3), but with NO
+    # background fill at all -- unlike both of those, which carry
+    # bg-base-200/50. This is a visually distinct shape (no tint), not just
+    # another padding size of the same fill, found across 4 occurrences in 3
+    # files (facet-gallery.vue, stylist-relay-status.vue,
+    # artjob-queue-browser.vue x2), all "no results yet" placeholder blocks
+    # with text-center + muted text-base-content/50 copy. Diverges from
+    # kr-panel-dashed's own 6-token sequence at position 5 (p-8 vs
+    # bg-base-200/50), so an exact-match attempt at a given position can only
+    # ever succeed for one of them -- no collision.
+    ("kr-panel-dashed-plain", ["rounded-2xl", "border", "border-dashed", "border-base-300", "p-8"]),
 ]
 
 CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')


### PR DESCRIPTION
### Task
interface-vision/t-104 (conductor roadmap) slice 138 — the recurring kr-* design-token
consistency sweep.

### What changed / what I produced
- Added `.kr-panel-dashed-plain` (`rounded-2xl border border-dashed border-base-300 p-8`)
  to `tailwind.css`'s `@layer components` and `utils/scripts/codemods/kr_panel_codemod.py`'s
  `VARIANTS` list: a third padding step of the dashed empty-state family
  (`.kr-panel-dashed`'s p-6, `.kr-panel-dashed-compact`'s p-3), but with **no background
  fill** — a visually distinct shape, not just another padding size of the same tint.
- Ran the codemod, migrating the 4 previously hand-rolled occurrences across
  `facet-gallery.vue`, `stylist-relay-status.vue`, and `artjob-queue-browser.vue` (×2),
  all "nothing here yet" empty-state placeholder blocks.

### How I verified
- `npx vue-tsc --noEmit` — clean.
- `npx eslint` on all changed `.vue` files — 0 new errors.
- `npm run test:layout-contract` — holds at 207, unchanged.
- `npm run test:lint-ratchet` — holds at 334/-58, unchanged.
- `npx prettier --check` on all 3 changed files — same pre-existing baseline warnings
  before and after (confirmed via `git stash`), no new warnings introduced.
- Read every occurrence's surrounding markup directly before migrating, confirming a
  single coherent visual shape (dashed border, generous padding, centered muted text)
  used consistently for "no results" states, not a coincidental token match across
  unrelated structural roles.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Enumerating remaining `border-base-300` windows again turns up mostly the same
bare-radius-no-padding candidate pools the prior slice (137) already flagged as risky
(21/17/15/13/11 occurrences at various rounded/bg combos with no padding token, used
across structurally unrelated roles — icon avatars, thumbnails, full containers). A
smaller, cleaner candidate this slice also found but did not migrate:
`border border-base-300 px-4 py-2` (6 occurrences, all `<th>`/`<td>` cells in
`leaderboard-table.vue`'s single HTML `<table>`) — deliberately left alone since these
are table-cell borders under `border-collapse`, a semantically different category from
the floating "panel" shapes this codemod's `kr-panel-*` naming scheme represents, not a
drifting duplicate of any existing primitive.

### Notes for reviewer
Byte-exact substitution, confirmed by diff — no geometry or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9Wt4bm7Yxdh2sSJWipEt6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9Wt4bm7Yxdh2sSJWipEt6)_