### PR TITLE
style: add kr-table-cell primitive, migrate 6 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -851,6 +851,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-2xl border border-dashed border-base-300 p-8;
   }
 
+  /* A distinct family from the kr-panel-* surfaces above: individual
+   * <table> cell borders rather than a floating panel shape (no radius, no
+   * background) -- flagged explicitly in slice 138's note as a candidate
+   * left for its own name rather than forced into kr-panel-*. Previously
+   * hand-rolled across 6 occurrences in one file (leaderboard-table.vue's
+   * single <table>, shared by click-leaderboard.vue and match-leaderboard.vue
+   * per that component's own header comment) -- both <th> and <td> cells use
+   * the identical border/padding shape, differing only by an optional
+   * trailing text-center utility preserved verbatim after this class
+   * (interface-vision t-104 slice 139). */
+  .kr-table-cell {
+    @apply border border-base-300 px-4 py-2;
+  }
+
   /*
    * Status callouts — inline tinted notices (the most-repeated surface in
    * the app, previously written by hand with drifting opacities like

--- a/components/achievements/leaderboard-table.vue
+++ b/components/achievements/leaderboard-table.vue
@@ -5,18 +5,18 @@
   >
     <thead>
       <tr class="bg-base-200">
-        <th class="border border-base-300 px-4 py-2">Rank</th>
-        <th class="border border-base-300 px-4 py-2">Username</th>
-        <th class="border border-base-300 px-4 py-2">{{ scoreLabel }}</th>
+        <th class="kr-table-cell">Rank</th>
+        <th class="kr-table-cell">Username</th>
+        <th class="kr-table-cell">{{ scoreLabel }}</th>
       </tr>
     </thead>
     <tbody>
       <tr v-for="(row, index) in rows" :key="row.id" class="hover:bg-base-100">
-        <td class="border border-base-300 px-4 py-2 text-center">
+        <td class="kr-table-cell text-center">
           {{ index + 1 }}
         </td>
-        <td class="border border-base-300 px-4 py-2">{{ row.username }}</td>
-        <td class="border border-base-300 px-4 py-2 text-center">
+        <td class="kr-table-cell">{{ row.username }}</td>
+        <td class="kr-table-cell text-center">
           {{ row[scoreKey] ?? 'N/A' }}
         </td>
       </tr>


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 139: extend front-end consistency onto shared `kr-*` components (kind: software)

### What changed / what I produced
- Added `.kr-table-cell` to `assets/css/tailwind.css` — a new family distinct from `kr-panel-*` (no radius, no background; a table-cell border, not a floating panel). Flagged explicitly in slice 138's note as a candidate left for its own name.
- Migrated all 6 occurrences of the hand-rolled `border border-base-300 px-4 py-2` shape in `components/achievements/leaderboard-table.vue` (shared by `click-leaderboard.vue` and `match-leaderboard.vue`) to `kr-table-cell`, preserving the trailing `text-center` utility verbatim on the two `<td>` cells that carry it.
- No geometry or behavior change.

### How I verified
- `vue-tsc --noEmit` clean
- `eslint` on the changed file: 0 errors
- `npm run test:layout-contract`: holds at 207 (unchanged)
- `npm run test:lint-ratchet`: holds at 334/-58 (unchanged)
- `prettier --check` on both changed files: `tailwind.css` warning confirmed pre-existing via `git stash` (unchanged before/after); `leaderboard-table.vue` clean

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
None new this slice — the remaining `border-base-300` window pools are the bare-radius-no-padding candidates already flagged in slice 136/137/138 as spanning incoherent structural roles (icon avatars, thumbnails, full containers), not a single safe mechanical substitution.

### Notes for reviewer
Companion conductor roadmap update (task note + `status: ready` re-arm) will follow in `silasfelinus/conductor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M451Y3XsYQmHjGGpd1X4NE

---
_Generated by [Claude Code](https://claude.ai/code/session_01M451Y3XsYQmHjGGpd1X4NE)_