### PR TITLE
style: add kr-panel-dashed-tint primitive, migrate 3 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -723,6 +723,18 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-xl border border-dashed border-base-300 bg-base-200/50 p-3;
   }
 
+  /* The .kr-panel-dashed shape at 40% opacity instead of 50% (interface-vision
+   * t-104 slice 140) -- a distinct tint step of the same dashed empty-state
+   * family, not a drifting duplicate: bg-base-200/40 never collides with
+   * .kr-panel-dashed's own bg-base-200/50 token. Previously hand-rolled
+   * across 3 occurrences in 3 files (daily-dream-object-art-workbench.vue,
+   * art-generator.vue, academy-remix.vue), all "generate something" empty
+   * states pairing flex-col/items-center/justify-center/gap-2/text-center
+   * with this exact border/background/padding shape. */
+  .kr-panel-dashed-tint {
+    @apply rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-6;
+  }
+
   /* The hand-rolled toggle-row label: a bordered muted strip pairing a
    * label with a DaisyUI `toggle` input (Public/Mature/Active-style
    * checkboxes) — same rounded-2xl/border-base-300/bg-base-200 surface as

--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -47,7 +47,7 @@
 
         <div
           v-else
-          class="flex min-h-40 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-6 text-center"
+          class="flex min-h-40 flex-col items-center justify-center gap-2 kr-panel-dashed-tint text-center"
         >
           <span class="text-3xl" aria-hidden="true">🏛️</span>
           <p class="text-sm font-semibold text-base-content/60">

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -544,7 +544,7 @@
         />
         <div
           v-else
-          class="flex min-h-40 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-6 text-center"
+          class="flex min-h-40 flex-col items-center justify-center gap-2 kr-panel-dashed-tint text-center"
         >
           <Icon name="kind-icon:image" class="h-8 w-8 text-base-content/25" />
           <p class="text-sm text-base-content/55">

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -175,7 +175,7 @@
 
       <div
         v-else
-        class="flex min-h-64 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-6 text-center"
+        class="flex min-h-64 flex-col items-center justify-center gap-2 kr-panel-dashed-tint text-center"
       >
         <Icon name="kind-icon:lock" class="size-8 text-base-content/25" />
         <p class="font-black text-base-content/65">Artwork is view-only.</p>

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -196,6 +196,10 @@ VARIANTS = [
     # bg-base-200/50), so an exact-match attempt at a given position can only
     # ever succeed for one of them -- no collision.
     ("kr-panel-dashed-plain", ["rounded-2xl", "border", "border-dashed", "border-base-300", "p-8"]),
+    # t-104 slice 140: the .kr-panel-dashed shape at 40% background opacity
+    # instead of 50% -- bg-base-200/40 never collides with kr-panel-dashed's
+    # own bg-base-200/50 token at the same list position.
+    ("kr-panel-dashed-tint", ["rounded-2xl", "border", "border-dashed", "border-base-300", "bg-base-200/40", "p-6"]),
 ]
 
 CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 140: extend the kr-* design-token consistency sweep (kind: software)

### What changed / what I produced
- Added `.kr-panel-dashed-tint` (`rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-6`) to `tailwind.css`'s `@layer components` and `utils/scripts/codemods/kr_panel_codemod.py`'s `VARIANTS` list — the `.kr-panel-dashed` shape at 40% background opacity instead of 50%, a distinct tint step of the same dashed empty-state family (never collides with `.kr-panel-dashed`'s own `bg-base-200/50` token).
- Ran the codemod, migrating the 3 previously hand-rolled occurrences across `academy-remix.vue`, `art-generator.vue`, and `daily-dream-object-art-workbench.vue`, all "generate something" empty-state placeholders sharing the identical `flex-col`/`items-center`/`justify-center`/`gap-2`/`text-center` wrapper.
- No geometry or behavior change.

### How I verified
- `npx vue-tsc --noEmit` — clean.
- `npx eslint` on all 3 changed `.vue` files — 0 new errors (1 pre-existing, unrelated `vue/no-mutating-props` error in `daily-dream-object-art-workbench.vue` line 419, confirmed identical via `git stash` before/after).
- `npm run test:layout-contract` — holds at 207, unchanged.
- `npm run test:lint-ratchet` — holds at 334/-58, unchanged.
- `npx prettier --check` on all 3 changed `.vue` files plus `tailwind.css` — same pre-existing baseline warnings before and after (confirmed via `git stash`), no new warnings introduced.
- Grepped the repo for any source-text contract script (`utils/scripts/*.mjs`, `*.py`) hardcoding the replaced literal class string — none found.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Enumerating remaining `border-base-300` windows again turns up mostly the same bare-radius-no-padding candidate pools prior slices (136-139) already flagged as risky (26/22/12/10 occurrence pools at various rounded/bg combos spanning structurally unrelated roles — icon avatars, thumbnails, full containers), not a single safe mechanical substitution. A smaller, cleaner remaining candidate: `border-t border-base-300` alone (17 occurrences, no padding token) and `border-b border-base-300` alone (10 occurrences) — both need per-occurrence review since the padding varies by context, unlike this slice's fixed-shape find.

### Notes for reviewer
Companion conductor roadmap update (task note + `status: ready` re-arm) will follow in `silasfelinus/conductor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcJZTFTbYuRmpMRcA9nJCz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcJZTFTbYuRmpMRcA9nJCz)_