### PR TITLE
style: allowlist isolate in kr-panel codemod, migrate 1 occurrence

### DIFF
--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -46,7 +46,7 @@
 
       <template v-else-if="challenge">
         <header
-          class="relative isolate overflow-hidden rounded-3xl border border-base-300 bg-base-100 p-5 shadow-xl sm:p-8"
+          class="relative isolate overflow-hidden kr-panel-section-plain shadow-xl sm:p-8"
         >
           <div
             class="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/20 via-transparent to-secondary/20"

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -235,7 +235,7 @@ SAFE_EXTRA_RE = re.compile(
     r"shadow(-\S+)?|"
     r"(text|font|leading|tracking|whitespace|break)-\S+|"
     r"overflow(-\S+)?|"
-    r"(relative|absolute|fixed|sticky|static)|"
+    r"(relative|absolute|fixed|sticky|static|isolate)|"
     r"(inset|top|left|right|bottom|z)-\S+|"
     r"(opacity|transition|duration|ease|animate)-\S+|"
     r"transition|"
@@ -246,6 +246,17 @@ SAFE_EXTRA_RE = re.compile(
     r"kr-(pane|pane-scroll|surface|stage|unbound|container|container-wide|section|toolbar|scroll)"
     r")$"
 )
+# 2026-09-07 (t-104 slice 141) addition: `isolate` -- sets only `isolation:
+# isolate` (a new stacking context), no background/border-color/radius
+# declaration of its own, so it can't affect the cascade question this
+# allowlist polices. Unblocks the one occurrence this slice found while
+# re-running the codemod's own skip report: pages/play/challenges/[slug].vue's
+# `relative isolate overflow-hidden rounded-3xl border border-base-300
+# bg-base-100 p-5 shadow-xl sm:p-8` (kr-panel-section-plain, added t-104 slice
+# 137; `isolate` was the only unsafe token blocking the match, `sm:p-8` and
+# `shadow-xl` were already covered by the responsive-prefix and bare-shadow
+# allowlist entries above).
+#
 # 2026-09-06 (t-104 slice 119) addition: `kr-scroll` -- `@apply min-h-0 flex-1
 # overflow-y-auto overscroll-contain` in tailwind.css; pure layout/scroll
 # behavior, same verified-empty-of-bg/border/radius category as the other


### PR DESCRIPTION
interface-vision/t-104 slice 141.

Added `isolate` to `kr_panel_codemod.py`'s `SAFE_EXTRA_RE` allowlist — it's a pure `isolation: isolate` (stacking-context) utility with no background/border-color/border-radius declaration of its own, so it can't affect the cascade question that allowlist polices. Re-running the codemod then cleanly migrated `pages/play/challenges/[slug].vue`'s header to `.kr-panel-section-plain` (the primitive added in slice 137) — `isolate` was the only unsafe token blocking that match; `sm:p-8` and `shadow-xl` were already covered by existing allowlist entries. No geometry or behavior change.

**Verified:**
- `vue-tsc` (`npm run test`): clean, no new errors
- `eslint`: 0 new errors on changed files
- `test:layout-contract`: holds at 207 (unchanged)
- `test:lint-ratchet`: holds at 334/-58 (unchanged)
- `prettier --check`: same pre-existing baseline warning on this file (confirmed via `git stash` before/after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWtgWgjEw9qkRBjZzFR2NM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWtgWgjEw9qkRBjZzFR2NM)_