### PR TITLE
Make conductorSlug immutable once linked to Conductor

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -278,6 +278,12 @@ jobs:
       - name: AppMaker scaffold-collision guard
         run: npm run test:appmaker-scaffold-collision-guard
 
+      - name: Project conductorSlug immutability guard self-test
+        run: npm run test:project-conductor-slug-immutability-guard-selftest
+
+      - name: Project conductorSlug immutability guard
+        run: npm run test:project-conductor-slug-immutability-guard
+
       - name: AppMaker pending-scaffold-pattern guard self-test
         run: npm run test:appmaker-pending-scaffold-pattern-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "test:appmaker-fleet-description-guard": "tsx utils/scripts/verifyAppmakerFleetDescriptionGuard.ts",
     "test:appmaker-scaffold-collision-guard-selftest": "tsx utils/scripts/verifyAppmakerScaffoldCollisionGuard.test.ts",
     "test:appmaker-scaffold-collision-guard": "tsx utils/scripts/verifyAppmakerScaffoldCollisionGuard.ts",
+    "test:project-conductor-slug-immutability-guard-selftest": "tsx utils/scripts/verifyProjectConductorSlugImmutabilityGuard.test.ts",
+    "test:project-conductor-slug-immutability-guard": "tsx utils/scripts/verifyProjectConductorSlugImmutabilityGuard.ts",
     "test:appmaker-pending-scaffold-pattern-guard-selftest": "tsx utils/scripts/verifyAppmakerPendingScaffoldPatternGuard.test.ts",
     "test:appmaker-pending-scaffold-pattern-guard": "tsx utils/scripts/verifyAppmakerPendingScaffoldPatternGuard.ts",
     "test:comment-prefix": "tsx utils/scripts/verifyPartialPublishPrefix.ts",

--- a/server/api/projects/[id].patch.ts
+++ b/server/api/projects/[id].patch.ts
@@ -1,5 +1,5 @@
 // /server/api/projects/[id].patch.ts
-import { defineEventHandler, readBody } from 'h3'
+import { createError, defineEventHandler, readBody } from 'h3'
 import type {
   Prisma,
   ProjectPriority,
@@ -87,7 +87,23 @@ export default defineEventHandler(async (event) => {
     }
     if (body.goal !== undefined) data.goal = normalizeOptionalText(body.goal)
     if (body.conductorSlug !== undefined) {
-      data.conductorSlug = normalizeSlug(body.conductorSlug)
+      const nextConductorSlug = normalizeSlug(body.conductorSlug)
+      // conductorSlug is the join key between this row and its
+      // projects/<slug>/roadmap.yaml directory in Conductor (PROJECT-
+      // CREATION.md). It is assigned once, exactly like
+      // conductor/sync.post.ts's own `existing.conductorSlug ?? project.slug`
+      // write path, and immutable thereafter -- otherwise Conductor and this
+      // app could silently disagree about which project a row belongs to.
+      if (
+        existing.conductorSlug &&
+        nextConductorSlug !== existing.conductorSlug
+      ) {
+        throw createError({
+          statusCode: 409,
+          message: `conductorSlug is immutable once set (already linked to '${existing.conductorSlug}').`,
+        })
+      }
+      data.conductorSlug = nextConductorSlug
     }
     if (body.lastSyncedAt !== undefined) {
       data.lastSyncedAt = normalizeNullableDateTime(body.lastSyncedAt)

--- a/utils/scripts/verifyProjectConductorSlugImmutabilityGuard.test.ts
+++ b/utils/scripts/verifyProjectConductorSlugImmutabilityGuard.test.ts
@@ -1,0 +1,109 @@
+// /utils/scripts/verifyProjectConductorSlugImmutabilityGuard.test.ts
+//
+// Self-test for checkConductorSlugImmutabilityGuard() in
+// verifyProjectConductorSlugImmutabilityGuard.ts (kind-robots/t-061).
+// Exercises the real check against synthetic route-shaped fixtures: the
+// fixed shape (reads `existing.conductorSlug`, throws 409 on a mismatch),
+// the pre-fix shape (accepts any new value unconditionally), and a partial
+// regression (still reads `existing.conductorSlug` but no longer throws).
+import assert from 'node:assert/strict'
+
+import { checkConductorSlugImmutabilityGuard } from './verifyProjectConductorSlugImmutabilityGuard.js'
+
+const FIXED = `
+export default defineEventHandler(async (event) => {
+  try {
+    if (body.conductorSlug !== undefined) {
+      const nextConductorSlug = normalizeSlug(body.conductorSlug)
+      if (
+        existing.conductorSlug &&
+        nextConductorSlug !== existing.conductorSlug
+      ) {
+        throw createError({
+          statusCode: 409,
+          message: \`conductorSlug is immutable once set (already linked to '\${existing.conductorSlug}').\`,
+        })
+      }
+      data.conductorSlug = nextConductorSlug
+    }
+  } catch (error) {
+    return errorHandler(error)
+  }
+})
+`
+
+// Pre-fix shape: any owner-supplied conductorSlug is accepted unconditionally,
+// even once the project is already linked to Conductor.
+const BUGGY = `
+export default defineEventHandler(async (event) => {
+  try {
+    if (body.conductorSlug !== undefined) {
+      data.conductorSlug = normalizeSlug(body.conductorSlug)
+    }
+  } catch (error) {
+    return errorHandler(error)
+  }
+})
+`
+
+// Partial regression: the already-set value is still read (maybe for a log
+// line or unrelated check), but the block no longer rejects a mismatch.
+const PARTIALLY_REGRESSED = `
+export default defineEventHandler(async (event) => {
+  try {
+    if (body.conductorSlug !== undefined) {
+      const nextConductorSlug = normalizeSlug(body.conductorSlug)
+      console.log('existing.conductorSlug was', existing.conductorSlug)
+      data.conductorSlug = nextConductorSlug
+    }
+  } catch (error) {
+    return errorHandler(error)
+  }
+})
+`
+
+function run(): void {
+  const fixedErrors = checkConductorSlugImmutabilityGuard(FIXED)
+  assert.deepEqual(
+    fixedErrors,
+    [],
+    `expected the fixed fixture to pass, got: ${JSON.stringify(fixedErrors)}`,
+  )
+
+  const buggyErrors = checkConductorSlugImmutabilityGuard(BUGGY)
+  assert.equal(
+    buggyErrors.length,
+    2,
+    'expected the pre-fix fixture (no existing.conductorSlug read, no 409) ' +
+      `to fail both checks, got: ${JSON.stringify(buggyErrors)}`,
+  )
+  assert.ok(
+    buggyErrors.some((e) => /no longer reads `existing\.conductorSlug`/.test(e)),
+  )
+  assert.ok(buggyErrors.some((e) => /no longer throws a 409/.test(e)))
+
+  const regressedErrors = checkConductorSlugImmutabilityGuard(
+    PARTIALLY_REGRESSED,
+  )
+  assert.equal(
+    regressedErrors.length,
+    1,
+    'expected a fixture that reads existing.conductorSlug but never throws ' +
+      `to fail only the 409 check, got: ${JSON.stringify(regressedErrors)}`,
+  )
+  assert.ok(regressedErrors.some((e) => /no longer throws a 409/.test(e)))
+
+  const missingBlock = checkConductorSlugImmutabilityGuard(
+    'export default defineEventHandler(async (event) => {\n  return {}\n})\n',
+  )
+  assert.equal(missingBlock.length, 1)
+  assert.ok(missingBlock.some((e) => /Could not find/.test(e)))
+
+  console.log(
+    'conductorSlug immutability guard self-test passed: fails on the ' +
+      'buggy fixture, passes on the fixed fixture, and the partially ' +
+      'regressed fixture fails only the missing-409 check.',
+  )
+}
+
+run()

--- a/utils/scripts/verifyProjectConductorSlugImmutabilityGuard.ts
+++ b/utils/scripts/verifyProjectConductorSlugImmutabilityGuard.ts
@@ -1,0 +1,103 @@
+// /utils/scripts/verifyProjectConductorSlugImmutabilityGuard.ts
+//
+// Regression guard (kind-robots/t-061, pitches/2026-08-10-kind-robots-slug-
+// integrity.md) -- `conductorSlug` is the join key between a kind_robots
+// `Project` row and its `projects/<slug>/roadmap.yaml` directory in
+// Conductor (PROJECT-CREATION.md). `server/api/conductor/sync.post.ts`
+// already treats it as set-once (`existing.conductorSlug ?? project.slug`),
+// but `PATCH /api/projects/:id` originally put `conductorSlug` in the
+// general owner-facing mutation allowlist with no immutability guard, so
+// any project owner could silently rewrite it -- letting Conductor and this
+// app disagree about which project a row belongs to with no error anywhere.
+//
+// Fixed by rejecting (409) any PATCH that would change an already-set
+// `conductorSlug` to a different value, mirroring sync.post.ts's own
+// set-once pattern. This asserts the textual shape of that guard stays in
+// place in the PATCH handler: it still reads `existing.conductorSlug`
+// before accepting a new value, and still throws a 409 when the two
+// disagree -- not a bare passthrough that silently accepts the rewrite
+// again.
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../..')
+
+export const PROJECT_PATCH_ROUTE_PATH = join(
+  repositoryRoot,
+  'server/api/projects/[id].patch.ts',
+)
+
+function extractConductorSlugBlock(content: string): string | null {
+  const signature = /if\s*\(\s*body\.conductorSlug\s*!==\s*undefined\s*\)\s*\{/
+  const match = signature.exec(content)
+  if (!match) return null
+
+  const braceOpen = match.index + match[0].length - 1
+  let depth = 0
+  let i = braceOpen
+  for (; i < content.length; i++) {
+    if (content[i] === '{') depth++
+    else if (content[i] === '}') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  if (depth !== 0) return null
+  return content.slice(braceOpen, i + 1)
+}
+
+export function checkConductorSlugImmutabilityGuard(content: string): string[] {
+  const errors: string[] = []
+
+  const block = extractConductorSlugBlock(content)
+  if (!block) {
+    errors.push(
+      'Could not find `if (body.conductorSlug !== undefined) { ... }` in ' +
+        'the PATCH /api/projects/:id handler -- has the conductorSlug ' +
+        'field handling been renamed, removed, or restructured? If so, ' +
+        'this guard (and the immutability check it protects) needs to ' +
+        'move with it.',
+    )
+    return errors
+  }
+
+  if (!/existing\.conductorSlug/.test(block)) {
+    errors.push(
+      'the conductorSlug block no longer reads `existing.conductorSlug` -- ' +
+        'has the already-set check been dropped, letting any owner ' +
+        'silently rewrite conductorSlug once it is linked to Conductor?',
+    )
+  }
+
+  if (!/statusCode:\s*409/.test(block)) {
+    errors.push(
+      'the conductorSlug block no longer throws a 409 -- an attempt to ' +
+        'change an already-linked conductorSlug is no longer rejected.',
+    )
+  }
+
+  return errors
+}
+
+function main(): void {
+  const content = readFileSync(PROJECT_PATCH_ROUTE_PATH, 'utf8')
+  const errors = checkConductorSlugImmutabilityGuard(content)
+
+  if (errors.length) {
+    console.error('conductorSlug immutability guard contract failed:')
+    for (const error of errors) console.error(`- ${error}`)
+    process.exitCode = 1
+  } else {
+    console.log(
+      'conductorSlug immutability guard contract passed: PATCH ' +
+        '/api/projects/:id rejects an attempt to change an already-linked ' +
+        'conductorSlug instead of silently accepting the rewrite.',
+    )
+  }
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
### Task
kind-robots/t-061 (pitches/2026-08-10-kind-robots-slug-integrity.md, first fix, Silas-approved)

### What changed
- `PATCH /api/projects/:id` previously put `conductorSlug` in the general owner-facing mutation allowlist with no immutability guard, so any project owner could silently rewrite it. `conductorSlug` is the join key between a `Project` row and its `projects/<slug>/roadmap.yaml` directory in Conductor (`PROJECT-CREATION.md`) — a silent rewrite would let Conductor and this app disagree about which project a row belongs to with no error anywhere.
- Mirrors `server/api/conductor/sync.post.ts`'s existing set-once pattern (`existing.conductorSlug ?? project.slug`): once `conductorSlug` is non-null, a PATCH attempting to change it to a different value is rejected with 409 instead of silently applied. Setting it for the first time, or re-sending the same value, is unaffected.
- Added a source-text regression guard (`utils/scripts/verifyProjectConductorSlugImmutabilityGuard.ts` + `.test.ts`), following the repo's existing `verifyAppmakerScaffoldCollisionGuard.ts` convention, and wired both the self-test and the real guard into `contract-tests.yml`.

### Scope note
The pitch's second fix — consolidating the three independently-maintained slug-collision implementations (`scaffold-request.post.ts`, `create-app.post.ts`, `sync.post.ts`) into one shared helper — is split off into a new follow-up, conductor `kind-robots/t-094`. The pitch's own "Suggested first task" section already described these as two separate tasks, and the existing `verifyAppmakerScaffoldCollisionGuard.ts` test asserts the exact inline shape of the two AppMaker routes' collision checks, so extracting that logic needs its own careful pass (updating that guard in the same PR) rather than folding into this smaller, lower-risk change.

### How I verified
- `npx eslint "server/api/projects/[id].patch.ts" utils/scripts/verifyProjectConductorSlugImmutabilityGuard.ts utils/scripts/verifyProjectConductorSlugImmutabilityGuard.test.ts` — clean.
- `npm run test` (`vue-tsc --noEmit`, full project) — exits clean.
- `npx tsx utils/scripts/verifyProjectConductorSlugImmutabilityGuard.test.ts` — self-test passes (fails on the pre-fix/partially-regressed fixtures, passes on the fixed one).
- `npx tsx utils/scripts/verifyProjectConductorSlugImmutabilityGuard.ts` — the real guard passes against the actual merged route file.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
`kind-robots/t-094` (filed this session) covers the collision-helper consolidation half of the same pitch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDc9vGHnyfLG6cAtGdCBF2

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDc9vGHnyfLG6cAtGdCBF2)_