### PR TITLE
style: add kr-panel-compact-2xs primitive, migrate 4 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -633,6 +633,15 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-xl border border-base-300 bg-base-100 p-2;
   }
 
+  /* .kr-panel-compact-xs's own shape one step tighter still (interface-vision
+   * t-104 slice 142) -- `p-1` instead of `p-2`, the floating search-results
+   * dropdown panel shared identically by every facet-picker component
+   * (character-facet-picker.vue, reward-facet-picker.vue, facet-picker.vue,
+   * art-facet-selector.vue). Previously hand-rolled across all 4. */
+  .kr-panel-compact-2xs {
+    @apply rounded-xl border border-base-300 bg-base-100 p-1;
+  }
+
   /* .kr-panel-compact's own bg-base-100 at 70% opacity instead of a solid
    * fill (interface-vision t-104 slice 125) -- same opacity-suffix
    * convention as the tint-family additions above, previously hand-rolled

--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -63,7 +63,7 @@
       />
       <div
         v-if="open"
-        class="absolute z-40 mt-1 max-h-80 w-full overflow-y-auto rounded-xl border border-base-300 bg-base-100 p-1 shadow-xl"
+        class="absolute z-40 mt-1 max-h-80 w-full overflow-y-auto kr-panel-compact-2xs shadow-xl"
       >
         <template v-for="group in groupedResults" :key="group.taxonomy">
           <div

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -48,7 +48,7 @@
       />
       <div
         v-if="showResults && search.trim()"
-        class="absolute z-30 mt-1 max-h-64 w-full overflow-y-auto rounded-xl border border-base-300 bg-base-100 p-1 shadow-xl"
+        class="absolute z-30 mt-1 max-h-64 w-full overflow-y-auto kr-panel-compact-2xs shadow-xl"
       >
         <button
           v-for="facet in searchResults"

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -53,7 +53,7 @@
 
       <div
         v-if="showResults && search.trim()"
-        class="absolute z-30 mt-1 max-h-64 w-full overflow-y-auto rounded-xl border border-base-300 bg-base-100 p-1 shadow-xl"
+        class="absolute z-30 mt-1 max-h-64 w-full overflow-y-auto kr-panel-compact-2xs shadow-xl"
       >
         <button
           v-for="facet in searchResults"

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -48,7 +48,7 @@
       />
       <div
         v-if="showResults && search.trim()"
-        class="absolute z-30 mt-1 max-h-64 w-full overflow-y-auto rounded-xl border border-base-300 bg-base-100 p-1 shadow-xl"
+        class="absolute z-30 mt-1 max-h-64 w-full overflow-y-auto kr-panel-compact-2xs shadow-xl"
       >
         <button
           v-for="facet in searchResults"

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -200,6 +200,15 @@ VARIANTS = [
     # instead of 50% -- bg-base-200/40 never collides with kr-panel-dashed's
     # own bg-base-200/50 token at the same list position.
     ("kr-panel-dashed-tint", ["rounded-2xl", "border", "border-dashed", "border-base-300", "bg-base-200/40", "p-6"]),
+    # t-104 slice 142: .kr-panel-compact's own shape one step tighter than
+    # .kr-panel-compact-xs's p-2 -- p-1, the floating search-results dropdown
+    # shape shared by every facet-picker component. Previously hand-rolled
+    # identically across 4 occurrences (character-facet-picker.vue,
+    # reward-facet-picker.vue, facet-picker.vue, art-facet-selector.vue), each
+    # wrapped in `absolute z-30/z-40 mt-1 max-h-64/max-h-80 w-full
+    # overflow-y-auto ... shadow-xl` -- all on the safe-extras allowlist, none
+    # of which touches background/border/radius.
+    ("kr-panel-compact-2xs", ["rounded-xl", "border", "border-base-300", "bg-base-100", "p-1"]),
 ]
 
 CLASS_ATTR_RE = re.compile(r'(?<![:\w-])class="([^"]*)"')


### PR DESCRIPTION
interface-vision/t-104 slice 142.

Adds `.kr-panel-compact-2xs` (`rounded-xl border border-base-300 bg-base-100 p-1`) to `kr_panel_codemod.py`'s `VARIANTS` and `tailwind.css` — one padding step tighter than the existing `.kr-panel-compact-xs` (`p-2`). Migrates the floating search-results dropdown panel shared identically by:
- `components/characters/character-facet-picker.vue`
- `components/rewards/reward-facet-picker.vue`
- `components/facets/facet-picker.vue`
- `components/art/art-facet-selector.vue`

All four had byte-identical `rounded-xl border border-base-300 bg-base-100 p-1` sequences wrapped in `absolute z-30/z-40 mt-1 max-h-64/max-h-80 w-full overflow-y-auto ... shadow-xl` — every surrounding token is on the codemod's safe-extras allowlist (positioning/sizing/overflow/shadow utilities, none of which touches background/border/radius). No geometry or behavior change.

**Verified:**
- `vue-tsc` (`npm run test`): clean, no new errors
- `eslint`: 0 new errors on changed files
- `test:layout-contract`: holds at 207 (unchanged)
- `test:lint-ratchet`: holds at 334/-58 (unchanged)
- `prettier --check`: pre-existing baseline warnings only on the 4 touched `.vue`/css files (confirmed via `git stash` before/after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXeCdudGiww3b3a6Q23z18

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXeCdudGiww3b3a6Q23z18)_