### PR TITLE
style: add kr-panel-header-sm primitive, migrate 5 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -813,6 +813,18 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply border-b border-base-300 p-4;
   }
 
+  /* .kr-panel-header's own shape at a tighter `p-3` padding step instead of
+   * `p-4` (interface-vision t-104 slice 143) -- same -sm suffix convention
+   * as the muted/tint padding ladders elsewhere in this file (p-3 = -sm,
+   * p-4 = -md). Previously hand-rolled identically across 5 occurrences in
+   * 5 files (messenger.vue x2, home-object-sheet.vue,
+   * artjob-feedback-manager.vue, mandarin.vue), all header rows with a
+   * bottom divider and no background fill, sitting atop a bordered
+   * panel/pane. */
+  .kr-panel-header-sm {
+    @apply border-b border-base-300 p-3;
+  }
+
   /* An inline section divider (interface-vision t-104 slice 135): a top
    * border rule with top-only spacing (`pt-3`, no bottom/left/right padding)
    * used inside a flex-col stack to separate a trailing block (actions,

--- a/components/art/artjob-feedback-manager.vue
+++ b/components/art/artjob-feedback-manager.vue
@@ -3,7 +3,7 @@
   <section
     class="flex h-full min-h-0 flex-col overflow-hidden kr-panel-flat"
   >
-    <div class="border-b border-base-300 p-3">
+    <div class="kr-panel-header-sm">
       <div class="flex flex-wrap items-start justify-between gap-2">
         <div>
           <div class="flex items-center gap-2">

--- a/components/home/home-object-sheet.vue
+++ b/components/home/home-object-sheet.vue
@@ -40,7 +40,7 @@
         class="modal-box flex max-h-[88dvh] w-[min(94vw,58rem)] max-w-none flex-col overflow-hidden rounded-3xl border-2 border-primary/60 bg-base-100 p-0 shadow-2xl"
       >
         <header
-          class="flex shrink-0 items-start gap-3 border-b border-base-300 p-3 sm:p-4"
+          class="flex shrink-0 items-start gap-3 kr-panel-header-sm sm:p-4"
         >
           <div class="min-w-0 flex-1">
             <p

--- a/components/user/messenger.vue
+++ b/components/user/messenger.vue
@@ -10,9 +10,7 @@
   >
     <!-- Conversation list -->
     <aside class="kr-pane w-full max-w-xs kr-panel-flat sm:w-72">
-      <header
-        class="flex items-center justify-between border-b border-base-300 p-3"
-      >
+      <header class="flex items-center justify-between kr-panel-header-sm">
         <h2 class="font-black">Messages</h2>
         <button
           class="kr-btn-ghost-xs-plain"
@@ -66,7 +64,7 @@
     <!-- Active thread -->
     <div class="kr-pane min-w-0 kr-panel-flat">
       <template v-if="convo.activeId">
-        <header class="flex items-center gap-2 border-b border-base-300 p-3">
+        <header class="flex items-center gap-2 kr-panel-header-sm">
           <div class="avatar">
             <div class="h-8 w-8 rounded-full bg-base-300">
               <img

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -198,7 +198,7 @@
             ref="cardPanel"
             class="overflow-hidden rounded-3xl border border-base-300 bg-base-100 shadow-lg"
           >
-            <div class="flex flex-wrap items-center justify-between gap-2 border-b border-base-300 p-3">
+            <div class="flex flex-wrap items-center justify-between gap-2 kr-panel-header-sm">
               <div class="flex flex-wrap items-center gap-2 text-xs">
                 <span v-if="currentCard.hskLevel" class="kr-badge-outline-sm">HSK {{ currentCard.hskLevel }}</span>
                 <span class="kr-badge-ghost-sm">{{ currentPositionLabel }}</span>

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -150,6 +150,16 @@ VARIANTS = [
     # token shorter than kr-panel-footer's own sequence (no bg-base-100), so
     # it can't collide with that either.
     ("kr-panel-header", ["border-b", "border-base-300", "p-4"]),
+    # t-104 slice 143: .kr-panel-header's own shape at a tighter p-3 padding
+    # step instead of p-4 -- same -sm suffix convention as the muted/tint
+    # ladders above (p-3 = -sm, p-4 = -md). Previously hand-rolled
+    # identically across 5 occurrences in 5 files (messenger.vue x2,
+    # home-object-sheet.vue, artjob-feedback-manager.vue, mandarin.vue), all
+    # header rows with a bottom divider and no background fill, sitting atop
+    # a bordered panel/pane. One token shorter than kr-panel-header's own
+    # sequence only in padding value, not length, so an exact-match attempt
+    # at a given position can only ever succeed for one of them.
+    ("kr-panel-header-sm", ["border-b", "border-base-300", "p-3"]),
     # t-104 slice 135: an inline section divider -- a top border rule with
     # top-only spacing (pt-3, no other padding) used inside a flex-col stack
     # to separate a trailing block from the content above it. `pt-3` as the


### PR DESCRIPTION
interface-vision/t-104 slice 143.

Adds `.kr-panel-header-sm` (`border-b border-base-300 p-3`) to `kr_panel_codemod.py`'s `VARIANTS` and `tailwind.css` — `.kr-panel-header`'s own shape (`border-b border-base-300 p-4`) at a tighter `p-3` padding step, same `-sm` suffix convention as the muted/tint padding ladders elsewhere in the file (p-3 = -sm, p-4 = -md).

Migrates the header-divider row shared identically by:
- `components/user/messenger.vue` (×2)
- `components/home/home-object-sheet.vue`
- `components/art/artjob-feedback-manager.vue`
- `pages/play/mandarin.vue`

All 5 are header rows with a bottom divider and no background fill, sitting atop a bordered panel/pane. No geometry or behavior change.

**Verified:**
- `vue-tsc` (`npm run test`): clean, no new errors
- `eslint`: 0 new errors on changed files
- `test:layout-contract`: holds at 207 (unchanged)
- `test:lint-ratchet`: holds at 334/-58 (unchanged)
- `prettier --check`: baseline warnings only on the touched files (confirmed via `git stash` before/after; `messenger.vue` picked up a new collapse-to-one-line warning from the shortened class string, fixed with a targeted `prettier --write` before committing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXeCdudGiww3b3a6Q23z18

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXeCdudGiww3b3a6Q23z18)_