### PR TITLE
style: add kr-panel-header-muted primitive, migrate 4 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -825,6 +825,17 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply border-b border-base-300 p-3;
   }
 
+  /* The solid bg-base-200 filled counterpart to .kr-panel-header-sm
+   * (interface-vision t-104 slice 144): same border-b/p-3 shape but with a
+   * recessed background, used for sticky/shrink-0 header rows atop a
+   * scrollable list rather than sitting flush against a parent that already
+   * supplies its own background. Previously hand-rolled identically across
+   * 4 occurrences in 3 files (chat-gallery.vue, dream-brainstorm.vue x2,
+   * dream-list.vue). */
+  .kr-panel-header-muted {
+    @apply border-b border-base-300 bg-base-200 p-3;
+  }
+
   /* An inline section divider (interface-vision t-104 slice 135): a top
    * border rule with top-only spacing (`pt-3`, no bottom/left/right padding)
    * used inside a flex-col stack to separate a trailing block (actions,

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -66,7 +66,7 @@
 
     <div class="kr-panes grid-cols-1 xl:grid-cols-[22rem_minmax(0,1fr)_22rem]">
       <aside class="kr-pane kr-panel-flat">
-        <div class="shrink-0 border-b border-base-300 bg-base-200 p-3">
+        <div class="shrink-0 kr-panel-header-muted">
           <div class="flex items-center justify-between gap-2">
             <div>
               <h2 class="font-black">Source Dreams</h2>
@@ -135,7 +135,7 @@
       </aside>
 
       <main class="kr-pane kr-panel-flat">
-        <section class="shrink-0 border-b border-base-300 bg-base-200 p-3">
+        <section class="shrink-0 kr-panel-header-muted">
           <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_14rem]">
             <label class="form-control">
               <span class="label py-1"

--- a/components/dreams/dream-list.vue
+++ b/components/dreams/dream-list.vue
@@ -2,7 +2,7 @@
 <template>
   <section class="flex min-h-0 flex-col overflow-hidden kr-panel-flat">
     <header
-      class="flex shrink-0 items-start justify-between gap-2 border-b border-base-300 bg-base-200 p-3"
+      class="flex shrink-0 items-start justify-between gap-2 kr-panel-header-muted"
     >
       <div class="min-w-0">
         <h3 class="truncate text-lg font-black text-primary">{{ title }}</h3>

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -178,9 +178,7 @@
     </section>
 
     <section v-else class="kr-stage kr-panel-flat">
-      <div
-        class="flex shrink-0 items-center gap-3 border-b border-base-300 bg-base-200 p-3"
-      >
+      <div class="flex shrink-0 items-center gap-3 kr-panel-header-muted">
         <div
           class="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-primary/15 text-base font-black text-primary"
         >

--- a/utils/scripts/codemods/kr_panel_codemod.py
+++ b/utils/scripts/codemods/kr_panel_codemod.py
@@ -160,6 +160,16 @@ VARIANTS = [
     # sequence only in padding value, not length, so an exact-match attempt
     # at a given position can only ever succeed for one of them.
     ("kr-panel-header-sm", ["border-b", "border-base-300", "p-3"]),
+    # t-104 slice 144: the solid bg-base-200 filled counterpart to
+    # .kr-panel-header-sm -- same border-b/p-3 shape but with a recessed
+    # background instead of sitting flush against a parent that already
+    # supplies one. One token longer than kr-panel-header-sm's own sequence
+    # (the inserted bg-base-200), diverging at position 3, so an exact-match
+    # attempt at a given position can only ever succeed for one of them.
+    # Previously hand-rolled identically across 4 occurrences in 3 files
+    # (chat-gallery.vue, dream-brainstorm.vue x2, dream-list.vue), all
+    # sticky/shrink-0 header rows atop a scrollable list.
+    ("kr-panel-header-muted", ["border-b", "border-base-300", "bg-base-200", "p-3"]),
     # t-104 slice 135: an inline section divider -- a top border rule with
     # top-only spacing (pt-3, no other padding) used inside a flex-col stack
     # to separate a trailing block from the content above it. `pt-3` as the


### PR DESCRIPTION
interface-vision/t-104 slice 144.

Adds `.kr-panel-header-muted` (`border-b border-base-300 bg-base-200 p-3`) to `kr_panel_codemod.py`'s `VARIANTS` and `tailwind.css` — the solid `bg-base-200` filled counterpart to `.kr-panel-header-sm` (added slice 143), used where a sticky/shrink-0 header row needs its own recessed background rather than sitting flush against a parent surface that already supplies one.

Migrates the header row shared identically by:
- `components/user/chat-gallery.vue`
- `components/dreams/dream-brainstorm.vue` (×2)
- `components/dreams/dream-list.vue`

No geometry or behavior change.

**Verified:**
- `vue-tsc` (`npm run test`): clean, no new errors
- `eslint`: 0 new errors on changed files (confirmed the 17 pre-existing errors in `dream-list.vue` are identical before/after via `git stash`, unrelated to this diff)
- `test:layout-contract`: holds at 207 (unchanged)
- `test:lint-ratchet`: holds at 334/-58 (unchanged)
- `prettier --check`: baseline warnings only on the touched files (confirmed via `git stash` before/after; `chat-gallery.vue` picked up a new collapse-to-one-line warning from the shortened class string, fixed with a targeted `prettier --write` before committing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXeCdudGiww3b3a6Q23z18

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXeCdudGiww3b3a6Q23z18)_