### PR TITLE
fix(showcase): stop selecting art columns the slot collapse dropped

### DIFF
--- a/server/api/showcase/detail.get.ts
+++ b/server/api/showcase/detail.get.ts
@@ -24,6 +24,7 @@ import type { H3Event } from 'h3'
 import { createError, defineEventHandler, getQuery, setHeader } from 'h3'
 import prisma from '@/server/utils/prisma'
 import { errorHandler } from '@/server/utils/error'
+import type { Prisma } from '~/prisma/generated/prisma/client'
 import type { ShowcaseArt, ShowcaseKind } from '@/utils/homeShowcase'
 
 /** Public showcase gate, applied to every table this endpoint reads. */
@@ -33,13 +34,72 @@ const PUBLIC = {
   isMature: false,
 } as const
 
-/** The art columns kr-art-plate reads, shared by every entity table. */
-const ENTITY_ART = {
-  imagePath: true,
+/**
+ * The art columns kr-art-plate reads.
+ *
+ * Only `imagePath` is still an entity column. The entity-art slot collapse
+ * (1e4ca2a, 2026-09-06) dropped cardPath/heroPath/iconPath from Dream,
+ * Character, Bot, Reward, Scenario and Facet -- one primary render per object,
+ * cropped per frame on the ArtImage it points at -- so the crops are read
+ * through that relation now. Selecting them as entity columns raised
+ * "Unknown field `cardPath` for select statement on model `Dream`", a Prisma
+ * VALIDATION error that answered 400 for all six kinds while `art` and
+ * `project` kept working (2026-09-07).
+ */
+const ENTITY_ART_COLUMNS = { imagePath: true } as const
+
+/** Where the crops live now: the object's primary render. */
+const PRIMARY_RENDER = {
+  ArtImage: {
+    select: {
+      imagePath: true,
+      cardPath: true,
+      heroPath: true,
+      iconPath: true,
+      fileType: true,
+    },
+  },
+} as const
+
+const ENTITY_ART = { ...ENTITY_ART_COLUMNS, ...PRIMARY_RENDER } as const
+
+/** Project is the one model that kept its own four slots. */
+const PROJECT_ART_COLUMNS = {
+  ...ENTITY_ART_COLUMNS,
   cardPath: true,
   heroPath: true,
   iconPath: true,
 } as const
+
+const PROJECT_ART = { ...PROJECT_ART_COLUMNS, ...PRIMARY_RENDER } as const
+
+/**
+ * Every column above must exist on every model that selects it.
+ *
+ * `satisfies Prisma.DreamSelect` CANNOT express this: the generated Select
+ * types are wrapped in the client's `GetSelect<>` and carry an index signature
+ * for client extensions, so they accept any key at all
+ * (`'madeUpField' extends keyof Prisma.DreamSelect` is true). `SelectScalar` is
+ * the plain columns-only form with no index signature, and is checked one model
+ * at a time -- an intersection would accept a field present on only ONE member,
+ * which is exactly how Project's surviving cardPath vouched for six models that
+ * had lost it. Each entry is `never` while valid and resolves to the offending
+ * field name when not, so the assignment fails naming the field.
+ */
+type UnknownOn<Keys, Model> = Exclude<Keys, keyof Model>
+type EntityArtColumn = keyof typeof ENTITY_ART_COLUMNS
+
+const _artColumnsAreValid: [never, never, never, never, never, never, never] =
+  [] as unknown as [
+    UnknownOn<EntityArtColumn, Prisma.DreamSelectScalar>,
+    UnknownOn<EntityArtColumn, Prisma.CharacterSelectScalar>,
+    UnknownOn<EntityArtColumn, Prisma.BotSelectScalar>,
+    UnknownOn<EntityArtColumn, Prisma.RewardSelectScalar>,
+    UnknownOn<EntityArtColumn, Prisma.ScenarioSelectScalar>,
+    UnknownOn<EntityArtColumn, Prisma.FacetSelectScalar>,
+    UnknownOn<keyof typeof PROJECT_ART_COLUMNS, Prisma.ProjectSelectScalar>,
+  ]
+void _artColumnsAreValid
 
 export type ShowcaseFact = { label: string; value: string }
 
@@ -97,15 +157,27 @@ function facts(entries: Array<[string, unknown]>): ShowcaseFact[] {
   return out
 }
 
+/**
+ * The object's own art columns, filled in per field from its primary render.
+ *
+ * Merged rather than "own or else the relation": since the slot collapse the
+ * six non-Project entities carry only `imagePath` themselves and their crops
+ * live on the ArtImage they point at, so both halves are needed to describe one
+ * plate. Project's own values simply win each field, and an ArtImage row (the
+ * `art`/`animation` kinds) has no relation to merge and is unaffected.
+ */
 function art(
-  row: Partial<Record<keyof ShowcaseArt, string | null>>,
+  row: Partial<Record<keyof ShowcaseArt, string | null>> & {
+    ArtImage?: Partial<Record<keyof ShowcaseArt, string | null>> | null
+  },
 ): ShowcaseArt {
+  const primary = row.ArtImage
   return {
-    imagePath: row.imagePath ?? null,
-    cardPath: row.cardPath ?? null,
-    heroPath: row.heroPath ?? null,
-    iconPath: row.iconPath ?? null,
-    fileType: row.fileType ?? null,
+    imagePath: row.imagePath || primary?.imagePath || null,
+    cardPath: row.cardPath || primary?.cardPath || null,
+    heroPath: row.heroPath || primary?.heroPath || null,
+    iconPath: row.iconPath || primary?.iconPath || null,
+    fileType: row.fileType || primary?.fileType || null,
   }
 }
 
@@ -463,7 +535,7 @@ async function loadDetail(event: H3Event): Promise<ShowcaseDetail> {
       conductorSlug: true,
       liveUrl: true,
       repoUrl: true,
-      ...ENTITY_ART,
+      ...PROJECT_ART,
     },
   })
   if (!row) throw missing()

--- a/server/api/showcase/home.get.ts
+++ b/server/api/showcase/home.get.ts
@@ -116,16 +116,34 @@ function artOf(record: ArtPathRecord | null | undefined): ShowcaseArt {
 }
 
 /**
- * An object's own art fields first, then its linked primary ArtImage. Objects
- * are backfilled with cardPath/heroPath directly (interface-vision t-007), but
- * older rows still carry their art only through the relation.
+ * An object's own art fields, filled in per field from its linked primary
+ * ArtImage. Project still carries all four slots itself; the other six models
+ * carry only `imagePath` and get their crops from the primary render.
  */
 function artOfEntity(
   entity: ArtPathRecord & { ArtImage?: ArtPathRecord | null },
 ): ShowcaseArt {
   const own = artOf(entity)
-  if (own.imagePath || own.cardPath || own.heroPath || own.iconPath) return own
-  return artOf(entity.ArtImage)
+  const primary = artOf(entity.ArtImage)
+
+  /*
+   * MERGED PER FIELD, not "own or else the relation". Since the slot collapse
+   * the six non-Project models carry only `imagePath`; their crops live on the
+   * primary ArtImage the object points at (Dream.ArtImage is literally the
+   * `DreamPrimaryArtImage` relation), so the same render supplies the frame.
+   * Returning `own` whole the moment it had an imagePath -- what this did
+   * before -- would now discard every crop those objects still have.
+   *
+   * Project is unaffected: it kept its own four slots, so its values simply win
+   * each field.
+   */
+  return {
+    imagePath: own.imagePath || primary.imagePath,
+    cardPath: own.cardPath || primary.cardPath,
+    heroPath: own.heroPath || primary.heroPath,
+    iconPath: own.iconPath || primary.iconPath,
+    fileType: own.fileType || primary.fileType,
+  }
 }
 
 function hasArt(art: ShowcaseArt): boolean {
@@ -250,39 +268,88 @@ const artImageRelationSelect = {
 } as const satisfies Prisma.ArtImageSelect
 
 /**
- * The art columns the seven showcase OBJECTS carry. Only the four *Path fields:
- * `path` and `fileType` are ArtImage-only columns.
+ * The art columns the seven showcase OBJECTS still carry: `imagePath` and
+ * nothing else. `path` and `fileType` are ArtImage-only columns, and
+ * cardPath/heroPath/iconPath were dropped from the six collapsed models by the
+ * entity-art slot collapse (1e4ca2a, 2026-09-06) -- one primary render per
+ * object, cropped per frame on the ArtImage it points at. Project is the lone
+ * holdout that kept its own four slots, so it selects them separately below.
  *
- * THIS CONSTANT SHIPPED WRONG AND BROKE THE WHOLE ENDPOINT (2026-08-29). It
- * included `path` and `fileType`, so every entity query raised
- * "Unknown field `path` for select statement on model `Dream`" -- a Prisma
- * VALIDATION error, thrown before any connection is attempted -- and because
- * the handler fans out through Promise.all, one bad select 500'd all ten
- * queries. The home page rendered its error note and nothing else.
+ * THIS CONSTANT HAS NOW SHIPPED WRONG TWICE, THE SAME WAY, AND 400'd THE WHOLE
+ * ENDPOINT BOTH TIMES.
  *
- * WHY TYPESCRIPT DIDN'T CATCH IT, AND WHY THIS LINE IS THE FIX. Excess-property
- * checking only applies to FRESH object literals. Spreading a variable
- * (`select: { id: true, ...entityArtSelect }`) launders its properties past that
- * check, so `vue-tsc` passed a query Prisma rejects at runtime. Adding
- * `satisfies` at each call site does not help either -- the spread is still not
- * fresh. Constraining the shared constant itself is what works: the
- * intersection below means a field must exist on ALL SEVEN models to live here,
- * and adding an eighth model to the union is what forces the next person to
- * check. Verified by reverting this line locally -- `path` and `fileType` are
- * reported as excess properties.
+ *   - 2026-08-29: it included `path`/`fileType`, so every entity query raised
+ *     "Unknown field `path` for select statement on model `Dream`".
+ *   - 2026-09-07: the entity-art slot collapse (1e4ca2a) dropped
+ *     cardPath/heroPath/iconPath from six models and updated 43 files, but not
+ *     this one. Same validation error, same 400, same blank front page.
+ *
+ * Both are Prisma VALIDATION errors, thrown before any connection is attempted,
+ * and because the handler fans out through Promise.all one bad select takes all
+ * ten queries down with it. Neither is a 500, which is worth knowing when one
+ * happens again: errorHandler has no branch for PrismaClientValidationError
+ * (it is not a PrismaClientKnownRequestError), so it lands in the generic
+ * `Error` case and answers 400.
+ *
+ * WHY TYPESCRIPT DIDN'T CATCH EITHER ONE. Two separate reasons, and the second
+ * one is why the 2026-08-29 fix did not hold:
+ *
+ *   1. Excess-property checking only applies to FRESH object literals, so
+ *      spreading a variable (`select: { id: true, ...entityArtSelect }`)
+ *      launders its properties past the check at every call site.
+ *   2. `Prisma.DreamSelect` AND FRIENDS CANNOT REJECT AN UNKNOWN FIELD AT ALL.
+ *      They are wrapped in the client's `GetSelect<>`, which carries an index
+ *      signature so client extensions can add their own keys -- verified
+ *      directly: `'totallyMadeUpField' extends keyof Prisma.DreamSelect` is
+ *      TRUE. So the 2026-08-29 fix's `satisfies DreamSelect & CharacterSelect &
+ *      ... & ProjectSelect` was inert. It never checked anything, which is
+ *      exactly why it sat there looking like a guard while three freshly
+ *      dropped columns walked past it.
+ *
+ * `Prisma.DreamSelectScalar` is the plain, un-extended, columns-only form and
+ * has NO index signature (same probe returns FALSE), so it is what the keys are
+ * checked against below -- one model at a time, since an intersection would
+ * additionally accept a field present on only ONE member and Project still has
+ * the three columns the other six lost.
  */
 const entityArtSelect = {
   imagePath: true,
+} as const
+
+/**
+ * Project keeps the four-slot shape the other six models gave up.
+ */
+const projectArtSelect = {
+  ...entityArtSelect,
   cardPath: true,
   heroPath: true,
   iconPath: true,
-} as const satisfies Prisma.DreamSelect &
-  Prisma.CharacterSelect &
-  Prisma.BotSelect &
-  Prisma.RewardSelect &
-  Prisma.ScenarioSelect &
-  Prisma.FacetSelect &
-  Prisma.ProjectSelect
+} as const
+
+/**
+ * The guard that actually holds: every key of `entityArtSelect` must be a real
+ * column on EVERY model that spreads it, and every key of `projectArtSelect` a
+ * real column on Project.
+ *
+ * Each entry below is `never` while its constant is valid for that model and
+ * resolves to the offending field name when it is not, so reintroducing a
+ * dropped column fails the assignment naming the exact field. Adding an eighth
+ * showcase model is a line here, which is what forces the next person to check.
+ */
+type UnknownOn<Keys, Model> = Exclude<Keys, keyof Model>
+type EntityArtKey = keyof typeof entityArtSelect
+
+const _artSelectsAreValid: [never, never, never, never, never, never, never] =
+  [] as unknown as [
+    UnknownOn<EntityArtKey, Prisma.DreamSelectScalar>,
+    UnknownOn<EntityArtKey, Prisma.CharacterSelectScalar>,
+    UnknownOn<EntityArtKey, Prisma.BotSelectScalar>,
+    UnknownOn<EntityArtKey, Prisma.RewardSelectScalar>,
+    UnknownOn<EntityArtKey, Prisma.ScenarioSelectScalar>,
+    UnknownOn<EntityArtKey, Prisma.FacetSelectScalar>,
+    UnknownOn<keyof typeof projectArtSelect, Prisma.ProjectSelectScalar>,
+  ]
+void _artSelectsAreValid
 
 /* ── hero ────────────────────────────────────────────────────────────────── */
 
@@ -319,6 +386,9 @@ const heroCastSelect = {
   slug: true,
   theme: true,
   ...entityArtSelect,
+  // The cast's crops live on each member's primary render now, exactly as the
+  // rails' do -- without this the strip falls back to uncropped full renders.
+  ArtImage: { select: artImageRelationSelect },
 } as const
 
 const heroDreamInclude = {
@@ -423,7 +493,7 @@ function buildHeroCast(dream: HeroDream): ShowcaseCard[] {
           theme: location.theme,
           badge: 'Location',
           createdAt: location.createdAt,
-          art: artOf(location),
+          art: artOfEntity(location),
         }),
       )
     }
@@ -444,7 +514,7 @@ function buildHeroCast(dream: HeroDream): ShowcaseCard[] {
         theme: character.theme,
         badge: 'Character',
         createdAt: character.createdAt,
-        art: artOf(character),
+        art: artOfEntity(character),
       }),
     )
   }
@@ -459,7 +529,7 @@ function buildHeroCast(dream: HeroDream): ShowcaseCard[] {
         theme: reward.theme,
         badge: reward.rewardType === 'SKILL' ? 'Skill' : 'Item',
         createdAt: reward.createdAt,
-        art: artOf(reward),
+        art: artOfEntity(reward),
       }),
     )
   }
@@ -474,7 +544,7 @@ function buildHeroCast(dream: HeroDream): ShowcaseCard[] {
         theme: scenario.theme,
         badge: 'Scenario',
         createdAt: scenario.createdAt,
-        art: artOf(scenario),
+        art: artOfEntity(scenario),
       }),
     )
   }
@@ -497,7 +567,7 @@ function buildHeroCast(dream: HeroDream): ShowcaseCard[] {
         theme: facet.theme,
         badge: 'Facet',
         createdAt: facet.createdAt,
-        art: artOf(facet),
+        art: artOfEntity(facet),
       }),
     )
   }
@@ -871,7 +941,7 @@ async function loadProjects(): Promise<ShowcaseCard[]> {
       priority: true,
       conductorSlug: true,
       liveUrl: true,
-      ...entityArtSelect,
+      ...projectArtSelect,
       ArtImage: { select: artImageRelationSelect },
     },
   })


### PR DESCRIPTION
## What broke

The home page shows **"The showcase couldn't be loaded just now."** over empty rails, and clicking any card fails. Live right now on `main`:

```
GET /api/showcase/home                    -> 400
GET /api/showcase/detail?kind=art&id=1    -> 200
GET /api/showcase/detail?kind=project&id=1-> 200
GET /api/showcase/detail?kind=dream&id=1  -> 400
GET /api/showcase/detail?kind=character&id=1 -> 400
```

That split is the diagnosis. `art` (ArtImage) and `project` work; the six models touched by the entity-art slot collapse fail.

## Root cause

1e4ca2a (2026-09-06) dropped `cardPath`/`heroPath`/`iconPath` from Dream, Character, Bot, Reward, Scenario and Facet and updated 43 files — but not the two showcase endpoints. Both still selected those columns, so Prisma raised `Unknown field 'cardPath' for select statement on model 'Dream'`, a validation error thrown before any connection is attempted.

`home.get.ts` fans its ten loaders out through `Promise.all`, so six bad selects took the entire payload down. `detail.get.ts` failed per kind, which is what the probe above shows.

Neither is a 500: `errorHandler` has no branch for `PrismaClientValidationError` (it is not a `PrismaClientKnownRequestError`), so it falls into the generic `Error` case and answers **400**. Worth knowing next time.

## The fix

- Both endpoints select `imagePath` from entities and read crops from the primary `ArtImage` each object points at, which is where the collapse put them. Project is untouched by the collapse and keeps its own four slots, so it gets its own constant in each file.
- `artOfEntity` / `art` now merge the object's own columns with its primary render **per field**, instead of returning the object's whole record as soon as it has an `imagePath` — after the collapse that path would discard every crop these objects still have. Project's own values still win each field; an ArtImage row has no relation to merge and is unaffected.
- The hero cast carries its primary render too and resolves art through it. Cast tiles read only their own columns before, and would otherwise have fallen back to uncropped full renders.

## The guard that was supposed to catch this

This constant shipped wrong the same way on 2026-08-29. That fix constrained it with `satisfies DreamSelect & CharacterSelect & ... & ProjectSelect` and documented it as *"a field must exist on ALL SEVEN models to live here."*

**It was inert.** The generated Select types are wrapped in the client's `GetSelect<>` and carry an index signature so client extensions can add keys, so they accept anything — verified directly: `'totallyMadeUpField' extends keyof Prisma.DreamSelect` is `true`. It never checked a single field.

`SelectScalar` is the plain, columns-only form with no index signature, and is now checked **one model at a time**. An intersection additionally accepts a field present on only *one* member — which is exactly how Project's surviving `cardPath` would have vouched for the six models that had just lost it.

## Verification

Run against the real generated client (`prisma/generated`), since no full install is available in this environment:

- Fixed constants typecheck clean.
- Reintroducing `cardPath` now **fails both files**, naming the field, with Project correctly still valid:
  `Type '["cardPath", ..., never]' is not assignable to type '[never, ..., never]'`
- Full-file typecheck of both endpoints: 13 errors before and after, all `TS7006`/`TS7031` implicit-any artifacts of the stubbed Prisma extension in the harness — **no new errors from this change**.
- `prettier --check` clean on both files.

## Follow-up, not in this PR

The same migration left `cardPath`/`heroPath`/`iconPath` in the request-body allowlists of `server/api/dreams/mutation.ts`, `server/api/rewards/mutation.ts`, `server/api/scenarios/mutation.ts` and `server/api/facets/index.post.ts`. Those are latent rather than broken — they only raise if a client still submits one of those fields — but they are dead config on columns that no longer exist, and worth a separate pass with the write-path tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGb4quwjzWKjbgxAC6pgDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGb4quwjzWKjbgxAC6pgDx)_