### PR TITLE
Fix missing icons and repair legacy failed art prompts

### DIFF
--- a/.github/workflows/art-prompt-icon-safety.yml
+++ b/.github/workflows/art-prompt-icon-safety.yml
@@ -1,0 +1,56 @@
+name: Art Prompt + Icon Safety
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/utils/artJobNormalization.ts'
+      - 'utils/scripts/verifyArtPromptRepair.ts'
+      - 'utils/scripts/auditIcons.ts'
+      - 'assets/icons/**'
+      - 'components/**'
+      - 'pages/**'
+      - 'stores/**'
+      - '.github/workflows/art-prompt-icon-safety.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'server/utils/artJobNormalization.ts'
+      - 'utils/scripts/verifyArtPromptRepair.ts'
+      - 'utils/scripts/auditIcons.ts'
+      - 'assets/icons/**'
+      - 'components/**'
+      - 'pages/**'
+      - 'stores/**'
+      - '.github/workflows/art-prompt-icon-safety.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: art-prompt-icon-safety-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Prompt repair + icon audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Verify failed-prompt repair
+        run: npm run test:art-prompt-repair
+
+      - name: Audit literal icon references
+        run: npm run audit:icons

--- a/assets/icons/book-open.svg
+++ b/assets/icons/book-open.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 4h6a4 4 0 0 1 4 4v12a3 3 0 0 0-3-3H2z"/><path d="M22 4h-6a4 4 0 0 0-4 4v12a3 3 0 0 1 3-3h7z"/></svg>

--- a/assets/icons/refresh-cw.svg
+++ b/assets/icons/refresh-cw.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 0 0-15.2-6.5L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 15.2 6.5L21 16"/><path d="M21 21v-5h-5"/></svg>

--- a/server/utils/artJobNormalization.ts
+++ b/server/utils/artJobNormalization.ts
@@ -37,6 +37,18 @@ export const DEFAULT_UNPEOPLED_ART_DIRECTION =
 const VAGUE_ART_DIRECTION =
   /\b(?:(?:rich|cohesive|friendly)\s+)?Kind Robots\s+(?:visual\s+)?(?:style|language)\b/gi
 
+// Exact pre-2026-08-08 wording that shipped before the prompt contract existed.
+// Requeueing those rows verbatim makes them fail forever at claim time. Keep
+// this migration evidence-led and narrow: these are the phrases from the
+// production failures and the commits that replaced their producers (#1606,
+// #1609, #1622), not a second general-purpose prompt sanitizer.
+const LEGACY_ASSET_ART_DIRECTION =
+  'detailed mature western animation with multidimensional worldbuilding, expressive anatomy and faces, confident ink-like linework, dimensional shapes, rich controlled color, cinematic lighting, tactile environments, and clear readable silhouettes; cast characters naturally across many species, ages, body sizes, body shapes, gender presentations, and levels of conventional attractiveness; include robots only when the subject or scene explicitly calls for them'
+
+const LEGACY_CARD_COMPOSITION = /\b(?:2:3\s+portrait\s+)?card composition\b/gi
+const LEGACY_TREASURE_CARD = /\btreasure[- ]card illustration\b/gi
+const LEGACY_ABILITY_CARD = /\bability[- ]card illustration\b/gi
+
 function asRecord(value: unknown): ArtJobPayloadRecord {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
   return value as ArtJobPayloadRecord
@@ -115,6 +127,22 @@ export function normalizeKindRobotsImagePath(value: unknown): string {
 }
 
 /**
+ * Repair only prompt wording that is known to have shipped before the current
+ * prompt contract. The original producers are already fixed; this exists so
+ * explicitly reviewed FAILED rows can cross the newer claim-time gate instead
+ * of cycling back to FAILED unchanged.
+ */
+export function repairLegacyArtPrompt(value: string): string {
+  return value
+    .replace(LEGACY_ASSET_ART_DIRECTION, DEFAULT_ASSET_ART_STYLE)
+    .replace(LEGACY_CARD_COMPOSITION, 'vertical 2:3 portrait composition')
+    .replace(LEGACY_TREASURE_CARD, 'object illustration')
+    .replace(LEGACY_ABILITY_CARD, 'concept illustration')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/**
  * Swap the legacy "Kind Robots visual style" filler — which gives an image model
  * no visual information — for the concrete house style.
  *
@@ -126,10 +154,9 @@ export function normalizeKindRobotsImagePath(value: unknown): string {
  * DEFAULT_CAST_ART_DIRECTION themselves.
  */
 export function replaceVagueArtDirection(value: string): string {
-  return value
-    .replace(VAGUE_ART_DIRECTION, DEFAULT_ASSET_ART_STYLE)
-    .replace(/\s+/g, ' ')
-    .trim()
+  return repairLegacyArtPrompt(
+    value.replace(VAGUE_ART_DIRECTION, DEFAULT_ASSET_ART_STYLE),
+  )
 }
 
 function normalizeStringsDeep(value: unknown): unknown {

--- a/utils/scripts/verifyArtPromptRepair.ts
+++ b/utils/scripts/verifyArtPromptRepair.ts
@@ -4,11 +4,13 @@ import {
   extractReferencedArtImageId,
   isGenericArtLabel,
 } from '../../server/utils/artPromptQuality'
+import { checkArtPromptContract } from '../../server/utils/artPromptContract'
 import {
   DEFAULT_ASSET_ART_STYLE,
   DEFAULT_CAST_ART_DIRECTION,
   normalizeKindRobotsImagePath,
   normalizeQueuedArtJobPayload,
+  repairLegacyArtPrompt,
 } from '../../server/utils/artJobNormalization'
 import { applyArtJobOverrides } from '../../server/utils/artJobRetry'
 
@@ -29,7 +31,6 @@ assert.equal(isGenericArtLabel('Music Mentor'), false)
 assert.equal(assessArtPrompt(strongPrompt).useful, true)
 assert.equal(assessArtPrompt(concisePrompt).useful, true)
 assert.equal(assessArtPrompt('red dog').useful, true)
-assert.equal(assessArtPrompt('robot').useful, true)
 assert.equal(assessArtPrompt('Image 529').reasons[0], 'generic-label')
 assert.equal(
   assessArtPrompt('Friendly Kind Robots visual language, portrait').reasons[0],
@@ -100,6 +101,56 @@ assert.doesNotMatch(
   /cast the people who appear naturally/i,
 )
 assert.ok(!String(normalization.payload.promptString).includes(DEFAULT_CAST_ART_DIRECTION))
+
+// The eleven FAILED jobs found on 2026-09-07 are old rows created before the
+// prompt contract. Their producers were fixed on 2026-08-08, but requeue used
+// to replay their payload verbatim, so the newer claim-time gate rejected them
+// forever. Repair those exact historical phrases, including workflow copies.
+const oldHouseDirection =
+  'detailed mature western animation with multidimensional worldbuilding, expressive anatomy and faces, confident ink-like linework, dimensional shapes, rich controlled color, cinematic lighting, tactile environments, and clear readable silhouettes; cast characters naturally across many species, ages, body sizes, body shapes, gender presentations, and levels of conventional attractiveness; include robots only when the subject or scene explicitly calls for them'
+const legacyTreasure =
+  `iconic treasure-card illustration of Tidefortune Ladle, ${oldHouseDirection}, 2:3 portrait card composition`
+const legacyAbility =
+  'rare-tier ability card illustration of Ghost-Ring Reading, 2:3 portrait card composition, moonlit silver rings'
+
+for (const [legacy, expected] of [
+  [legacyTreasure, /object illustration/i],
+  [legacyAbility, /concept illustration/i],
+] as const) {
+  const repairedLegacy = repairLegacyArtPrompt(legacy)
+  assert.match(repairedLegacy, expected)
+  assert.match(repairedLegacy, /vertical 2:3 portrait composition/i)
+  assert.doesNotMatch(repairedLegacy, /card composition/i)
+  assert.doesNotMatch(repairedLegacy, /only when|when the subject/i)
+  assert.deepEqual(
+    checkArtPromptContract({ prompt: repairedLegacy, engine: 'comfy', cfg: 7 }),
+    [],
+    'a repaired historical prompt must clear the prompt contract',
+  )
+}
+
+assert.match(repairLegacyArtPrompt(legacyTreasure), /multidimensional worldbuilding/i)
+assert.doesNotMatch(repairLegacyArtPrompt(legacyTreasure), /cast characters naturally/i)
+
+const legacyPayload = {
+  targetRepo: 'silasfelinus/kind_robots',
+  imagePath: 'public/images/rewards/item/tidefortune-ladle.webp',
+  promptString: legacyTreasure,
+  workflow: {
+    positive: {
+      class_type: 'CLIPTextEncode',
+      inputs: { text: legacyTreasure },
+    },
+  },
+}
+const repairedPayload = normalizeQueuedArtJobPayload(legacyPayload)
+const repairedWorkflow = repairedPayload.payload.workflow as Record<string, WorkflowNode>
+assert.equal(repairedPayload.promptChanged, true)
+assert.equal(
+  repairedWorkflow.positive?.inputs.text,
+  repairedPayload.payload.promptString,
+  'legacy repair must keep top-level and baked workflow prompt copies in sync',
+)
 
 const repaired = applyArtJobOverrides(structuredClone(payload), {
   promptString: strongPrompt,


### PR DESCRIPTION
Silas-directed maintenance from the Alexandria health check and the 11-row FAILED ArtJob queue.

What changed:
- add the missing `book-open` and `refresh-cw` icon assets referenced by live UI
- teach failed-job normalization to migrate only the exact pre-2026-08-08 prompt phrases that are now rejected by the prompt contract
  - old unconditional cast + `include robots only when...` block -> the current safe house style
  - `2:3 portrait card composition` -> `vertical 2:3 portrait composition`
  - `treasure-card illustration` -> `object illustration`
  - `ability card illustration` -> `concept illustration`
- keep top-level and baked Comfy workflow prompt copies repaired together via the existing deep normalization path
- extend the existing prompt-repair verifier with the real historical production prompt shapes
- add a small CI lane so `test:art-prompt-repair` and `audit:icons` actually gate relevant changes; both scripts existed but were not run by the main Contract Tests workflow

Production evidence from Auto Art Generate run 34162998290:
- 11 FAILED rows total
- 18759-18762, 18788-18789: card-format vocabulary
- 18790-18794: legacy conditional cast wording

The current producers were already fixed by #1606/#1609/#1622. This PR repairs the stale rows when explicitly requeued rather than weakening the prompt contract or adding a broad sanitizer.