### PR TITLE
fix(home): admin-gate "Needs you" and give the newsfeed the room back

### DIFF
--- a/components/home/home-attention.vue
+++ b/components/home/home-attention.vue
@@ -39,14 +39,34 @@
   coordination system of record; answering hands it onward. The second is the
   one Silas asked for and the safer default, so it is the one in reach.
 
-  ADMIN-ONLY BY DATA, not by a check here: conductorStore only has gates when
+  ADMIN-ONLY BY AN EXPLICIT CHECK, because "by data" was never true.
+
+  This used to claim the panel gated itself: "conductorStore only has gates when
   the projection is readable, and /api/conductor/task-action is behind
-  requireAdminApiUser -- so a signed-out visitor sees the empty branch and the
-  column collapses out of the layout entirely.
+  requireAdminApiUser -- so a signed-out visitor sees the empty branch." Only
+  the second half held. `/api/conductor/task-action` is indeed admin-only, so a
+  stranger could never ACT on a gate -- but `/api/conductor/projects` is fully
+  public and returns every project's whole task list, `needs-human` rows
+  included. Verified against production 2026-09-08 while signed out: 52
+  projects, 44 needs-human tasks, 36 of them on active/continuous projects --
+  which is exactly the "NEEDS YOU · 36" a logged-out visitor was seeing.
+
+  So every stranger got Silas's personal decision queue on the front page.
+  Silas, 2026-09-08: "unlogged in users should not even see a 'needs you'
+  section as those are explicit to my user admin account."
+
+  The gate list is not secret -- the same rows are on /conductor, which is a
+  public page on purpose -- but it is not a front door for a visitor either:
+  it is one person's inbox, it is the tallest thing in the column, and it
+  pushes the newsfeed (which IS for visitors) into a sliver.
+
+  `userStore.isAdmin` is the check, matching how the rest of the app gates
+  admin-only affordances, and it renders nothing at all for anyone else rather
+  than an empty panel -- the column then gives that height to the newsfeed.
 -->
 <template>
   <section
-    v-if="gates.length || isLoading"
+    v-if="isAdmin && (gates.length || isLoading)"
     class="flex min-h-0 flex-col gap-1 kr-panel-flat p-2"
   >
     <header class="flex shrink-0 items-baseline justify-between gap-2">
@@ -229,8 +249,17 @@ import {
   type ConductorHumanGate,
   type ConductorTaskAction,
 } from '@/stores/conductorStore'
+import { useUserStore } from '@/stores/userStore'
 
 const conductorStore = useConductorStore()
+const userStore = useUserStore()
+
+/*
+ * The whole panel hangs off this. See the note above: the projection these
+ * gates come from is public, so without an explicit check every signed-out
+ * visitor saw Silas's decision queue.
+ */
+const isAdmin = computed(() => userStore.isAdmin)
 
 const gates = computed(() => conductorStore.humanGates)
 const isLoading = computed(() => !conductorStore.hasLoaded)

--- a/components/home/home-page.vue
+++ b/components/home/home-page.vue
@@ -165,10 +165,15 @@
       </div>
 
       <!--
-        THE RIGHT COLUMN: the three things that are lists rather than pictures.
-        Needs-you and the newsfeed both scroll and share the leftover height;
-        the project strip sits between them at its natural height because it is
-        six short rows and scrolling it would be silly.
+        THE RIGHT COLUMN: the things that are lists rather than pictures.
+
+        Three of them for Silas, two for everyone else -- "Needs you" is his own
+        decision queue and is admin-gated (see home-attention.vue). What is left
+        divides like this: the projects strip keeps its own height up to a third
+        of the column and scrolls past that, and the newsfeed takes twice the
+        flexible share "Needs you" does, or all of it when "Needs you" is not
+        there. Silas, 2026-09-08: "the news section is too small, it could be
+        twice as big, eating in the what we're building."
       -->
       <div class="flex min-w-0 flex-col gap-2 xl:min-h-0 xl:w-[22%]">
         <!--
@@ -194,14 +199,14 @@
           class="flex shrink-0 gap-1 kr-panel-flat p-1 xl:hidden"
         >
           <button
-            v-for="pane in RIGHT_PANES"
+            v-for="pane in visiblePanes"
             :key="pane.key"
             type="button"
             role="tab"
-            :aria-selected="activePane === pane.key"
+            :aria-selected="currentPane === pane.key"
             class="flex-1 rounded-lg px-2 py-1.5 text-[0.7rem] font-black uppercase tracking-[0.1em] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
             :class="
-              activePane === pane.key
+              currentPane === pane.key
                 ? 'bg-primary text-primary-content'
                 : 'text-base-content/55 hover:text-primary'
             "
@@ -211,7 +216,7 @@
           </button>
         </div>
 
-        <div :class="paneClass('attention')">
+        <div v-if="isAdmin" :class="paneClass('attention')">
           <home-attention class="xl:min-h-0 xl:flex-1" />
         </div>
 
@@ -368,6 +373,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useConductorStore } from '@/stores/conductorStore'
 import { useHomeShowcaseStore } from '@/stores/homeShowcaseStore'
+import { useUserStore } from '@/stores/userStore'
 import {
   showcaseHref,
   type RailItem,
@@ -390,7 +396,36 @@ const RIGHT_PANES = [
 
 type RightPane = (typeof RIGHT_PANES)[number]['key']
 
+const userStore = useUserStore()
+
+/*
+ * "Needs you" is Silas's own decision queue and is admin-only (see
+ * home-attention.vue -- the projection behind it is public, so it needs a real
+ * check). It drops out of the column entirely for everyone else, tab included.
+ *
+ * The wrapper has to go with it, not just the panel: the wrapper carries
+ * `xl:flex-1`, so leaving it in place for a signed-out visitor would hold half
+ * the column's flexible height open around a section rendering nothing -- which
+ * is most of why the newsfeed was a sliver.
+ */
+const isAdmin = computed(() => userStore.isAdmin)
+
+const visiblePanes = computed(() =>
+  RIGHT_PANES.filter((pane) => pane.key !== 'attention' || isAdmin.value),
+)
+
 const activePane = ref<RightPane>('attention')
+
+/*
+ * The selected tab, corrected for panes that are not there. A signed-out
+ * visitor would otherwise land on the default 'attention' tab and see a blank
+ * pane, since the tab it belongs to is gone but the ref still names it.
+ */
+const currentPane = computed<RightPane>(() =>
+  visiblePanes.value.some((pane) => pane.key === activePane.value)
+    ? activePane.value
+    : (visiblePanes.value[0]?.key ?? 'news'),
+)
 
 /**
  * Show this pane on a phone only when it is the selected tab; always show it
@@ -402,8 +437,31 @@ const activePane = ref<RightPane>('attention')
  */
 function paneClass(pane: RightPane): string {
   const shared = 'min-w-0 flex-col xl:flex xl:min-h-0'
-  const grow = pane === 'projects' ? 'xl:shrink-0' : 'xl:flex-1'
-  return `${activePane.value === pane ? 'flex' : 'hidden'} ${shared} ${grow}`
+
+  /*
+   * Silas, 2026-09-08: "the news section is too small, it could be twice as
+   * big, eating in the what we're building."
+   *
+   * Two changes, because the newsfeed was losing height at both ends. It now
+   * takes twice the share "Needs you" does instead of splitting the flexible
+   * height evenly with it, and the projects strip is capped at a third of the
+   * column and scrolls past that rather than taking its natural height
+   * whatever that turns out to be -- six projects at their natural height were
+   * pushing the feed down to a couple of rows. Capped, not flexed: the strip
+   * is short rows and reads best whole, so it keeps its own height right up to
+   * the cap.
+   *
+   * For a signed-out visitor "Needs you" is gone entirely, so the feed simply
+   * takes all of the flexible height the projects strip does not.
+   */
+  const grow =
+    pane === 'projects'
+      ? 'xl:shrink-0 xl:max-h-[34%] xl:overflow-y-auto'
+      : pane === 'news'
+        ? 'xl:flex-[2]'
+        : 'xl:flex-1'
+
+  return `${currentPane.value === pane ? 'flex' : 'hidden'} ${shared} ${grow}`
 }
 
 type RailDefinition = {
@@ -565,5 +623,15 @@ function fallbackFor(card: ShowcaseCard): string {
 
 onMounted(() => {
   void showcaseStore.load()
+
+  /*
+   * The projects strip's progress bars read conductorStore, and this page is
+   * now the only thing that reliably asks for it. home-attention used to own
+   * this fetch, but it no longer mounts for a signed-out visitor -- who still
+   * sees the strip, and whose bars would otherwise all resolve to null and
+   * disappear. Cached in the store (FRESH_DATA_MS), so it stays a no-op when
+   * anything else on the session has already asked.
+   */
+  void conductorStore.fetchProjects()
 })
 </script>


### PR DESCRIPTION
Two problems in the home page's right-hand column, one causing the other.

## "Needs you" was showing to everyone

`home-attention.vue` documented itself as **"admin-only by data"** — `conductorStore` only has gates when the projection is readable, so a signed-out visitor supposedly saw the empty branch and the panel collapsed out of the layout.

Only half of that was true. `/api/conductor/task-action` *is* admin-only, so a stranger could never **act** on a gate. But `/api/conductor/projects` is fully public and returns every project's whole task list, `needs-human` rows included. Measured against production while signed out:

```
52 projects · 44 needs-human tasks · 36 on active/continuous projects
```

That 36 is exactly the **"NEEDS YOU · 36"** a logged-out visitor was seeing.

This is not a leak — `/conductor` is a public page on purpose and serves the same rows (verified: 200 while signed out). But it is one person's decision queue on a stranger's front door, and it was the tallest thing in the column.

It's now gated on `userStore.isAdmin`, matching how the rest of the app gates admin-only affordances. Three parts:

- The panel itself (`home-attention.vue`).
- **The wrapper too, not just the panel.** The wrapper carries `xl:flex-1`, so leaving it in place would hold half the column's flexible height open around a section rendering nothing — which is most of why the newsfeed was a sliver.
- The phone tab drops out of the switcher, and the selected tab falls back to a pane that exists instead of defaulting to a "Needs you" tab that is no longer there.

## The newsfeed was losing height at both ends

> "the news section is too small, it could be twice as big, eating in the what we're building"

The feed now takes **twice** the flexible share "Needs you" does instead of splitting evenly with it, and the projects strip is **capped at a third of the column** and scrolls past that rather than taking whatever its natural height happens to be. Capped rather than flexed on purpose: it's short rows and reads best whole, so it keeps its own height right up to the cap.

Roughly, as a share of the column:

| | before | after |
|---|---|---|
| **signed out** | news ≈ 33% | **news ≈ 66%** (≈2×) |
| **signed in** | news ≈ 33% | news ≈ 44% (≈1.35×) |

Signed out, both effects compound and the feed roughly doubles — that's the view this report came from. Signed in, "Needs you" still needs its room, so the feed gains about a third rather than doubling. Say the word if you want it more aggressive in your own view.

## One regression this had to avoid

`conductorStore.fetchProjects()` lived in `home-attention`'s `onMounted`. That component no longer mounts for a signed-out visitor — who still sees the projects strip, whose progress bars (88%, 65%, 92%…) read that same store and would all have resolved to `null` and disappeared. The fetch moved to `home-page`'s `onMounted`, the component that always renders and actually needs it. It's cached in the store, so it stays a no-op when anything else already asked.

## Verification

- Production probe of `/api/conductor/projects` while signed out reproduces the exact 36 the screenshot shows, and `/conductor` confirmed 200 anonymously.
- `prettier --check` clean on both files.
- Full `vue-tsc` and the layout contract run in CI — no local install is available in this environment, so I'm relying on those rather than claiming a local pass. The new classes are `xl:`-prefixed arbitrary values applied through the existing `paneClass` helper, the same shape as the `xl:h-[46%]` / `xl:w-[22%]` values already in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGb4quwjzWKjbgxAC6pgDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGb4quwjzWKjbgxAC6pgDx)_