### PR TITLE
fix(icons): add all 38 referenced missing icon assets

### DIFF
--- a/assets/icons/alert-triangle.svg
+++ b/assets/icons/alert-triangle.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#FDE68A"/>
+  <path d="M32 13 53 49H11L32 13Z" fill="#F59E0B"/>
+  <path d="M32 25v11" stroke="#FFFFFF" stroke-width="5" stroke-linecap="round"/>
+  <circle cx="32" cy="43" r="3" fill="#FFFFFF"/>
+</svg>

--- a/assets/icons/array.svg
+++ b/assets/icons/array.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#BFDBFE"/>
+  <rect x="13" y="19" width="10" height="10" rx="3" fill="#3B82F6"/>
+  <rect x="27" y="19" width="10" height="10" rx="3" fill="#253047"/>
+  <rect x="41" y="19" width="10" height="10" rx="3" fill="#3B82F6"/>
+  <rect x="13" y="35" width="10" height="10" rx="3" fill="#253047"/>
+  <rect x="27" y="35" width="10" height="10" rx="3" fill="#3B82F6"/>
+  <rect x="41" y="35" width="10" height="10" rx="3" fill="#253047"/>
+</svg>

--- a/assets/icons/briefcase.svg
+++ b/assets/icons/briefcase.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#C4B5FD"/>
+  <path d="M24 20v-4h16v4" stroke="#253047" stroke-width="4" stroke-linecap="round"/>
+  <rect x="13" y="20" width="38" height="28" rx="5" fill="#8B5CF6"/>
+  <path d="M13 31c8 5 30 5 38 0" stroke="#FFFFFF" stroke-width="3"/>
+  <rect x="28" y="30" width="8" height="7" rx="2" fill="#253047"/>
+</svg>

--- a/assets/icons/calendar.svg
+++ b/assets/icons/calendar.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#A7F3D0"/>
+  <rect x="14" y="16" width="36" height="34" rx="6" fill="#FFFFFF"/>
+  <path d="M14 26h36" stroke="#10B981" stroke-width="5"/>
+  <path d="M22 12v9M42 12v9" stroke="#253047" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="24" cy="35" r="3" fill="#10B981"/>
+  <circle cx="34" cy="35" r="3" fill="#253047"/>
+  <circle cx="44" cy="35" r="3" fill="#10B981"/>
+  <circle cx="24" cy="44" r="3" fill="#253047"/>
+  <circle cx="34" cy="44" r="3" fill="#10B981"/>
+</svg>

--- a/assets/icons/chart.svg
+++ b/assets/icons/chart.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#FBCFE8"/>
+  <path d="M14 48h37" stroke="#253047" stroke-width="4" stroke-linecap="round"/>
+  <rect x="18" y="34" width="7" height="12" rx="2" fill="#EC4899"/>
+  <rect x="30" y="26" width="7" height="20" rx="2" fill="#253047"/>
+  <rect x="42" y="18" width="7" height="28" rx="2" fill="#EC4899"/>
+  <path d="m17 27 10-8 9 5 13-11" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/icons/check-square.svg
+++ b/assets/icons/check-square.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#FED7AA"/>
+  <rect x="14" y="14" width="36" height="36" rx="7" fill="#FFFFFF" stroke="#F97316" stroke-width="4"/>
+  <path d="m22 32 7 7 14-16" stroke="#253047" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/icons/dance.svg
+++ b/assets/icons/dance.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#BAE6FD"/>
+  <circle cx="31" cy="16" r="6" fill="#0EA5E9"/>
+  <path d="m31 23-7 12 8 4 8-10" stroke="#253047" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="m25 30-9-5M38 29l9-7M32 39l-9 12M32 39l10 10" stroke="#0EA5E9" stroke-width="4" stroke-linecap="round"/>
+  <path d="M48 14c3 2 3 6 0 8" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/document.svg
+++ b/assets/icons/document.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#DDD6FE"/>
+  <path d="M18 12h20l10 10v30H18V12Z" fill="#FFFFFF"/>
+  <path d="M38 12v11h10" fill="#7C3AED"/>
+  <path d="M24 31h18M24 38h18M24 45h12" stroke="#253047" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/file-plus.svg
+++ b/assets/icons/file-plus.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#FDE68A"/>
+  <path d="M17 12h21l10 10v30H17V12Z" fill="#FFFFFF"/>
+  <path d="M38 12v11h10" fill="#F59E0B"/>
+  <path d="M32 31v14M25 38h14" stroke="#253047" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/file-sparkles.svg
+++ b/assets/icons/file-sparkles.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#BFDBFE"/>
+  <path d="M16 12h22l10 10v30H16V12Z" fill="#FFFFFF"/>
+  <path d="M38 12v11h10" fill="#3B82F6"/>
+  <path d="m30 27 2 5 5 2-5 2-2 5-2-5-5-2 5-2 2-5Z" fill="#3B82F6"/>
+  <path d="m42 34 1.5 3.5L47 39l-3.5 1.5L42 44l-1.5-3.5L37 39l3.5-1.5L42 34Z" fill="#253047"/>
+</svg>

--- a/assets/icons/forward.svg
+++ b/assets/icons/forward.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#C4B5FD"/>
+  <path d="m19 18 18 14-18 14V18Z" fill="#253047"/>
+  <path d="m34 18 18 14-18 14V18Z" fill="#8B5CF6"/>
+</svg>

--- a/assets/icons/git-branch.svg
+++ b/assets/icons/git-branch.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#A7F3D0"/>
+  <circle cx="20" cy="16" r="6" fill="#10B981"/>
+  <circle cx="20" cy="48" r="6" fill="#10B981"/>
+  <circle cx="45" cy="24" r="6" fill="#253047"/>
+  <path d="M20 22v20M26 40c10 0 19-5 19-10" stroke="#253047" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/h2.svg
+++ b/assets/icons/h2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#FBCFE8"/>
+  <path d="M15 20v25M31 20v25M15 32h16" stroke="#253047" stroke-width="5" stroke-linecap="round"/>
+  <path d="M38 29c1-6 15-6 15 1 0 7-14 8-14 15h14" stroke="#EC4899" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/icons/hammer.svg
+++ b/assets/icons/hammer.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#FED7AA"/>
+  <path d="m18 20 11-8 10 10-8 11-13-13Z" fill="#F97316"/>
+  <path d="m31 29 18 18" stroke="#253047" stroke-width="7" stroke-linecap="round"/>
+  <path d="m14 24 11-11" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/handshake.svg
+++ b/assets/icons/handshake.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#BAE6FD"/>
+  <path d="m13 30 9-9 10 5 8-5 11 10-14 14c-3 3-7 3-10 0L13 30Z" fill="#0EA5E9"/>
+  <path d="m24 27 8 8 7-7" stroke="#FFFFFF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="m13 30 6 6M51 31l-6 6" stroke="#253047" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/history.svg
+++ b/assets/icons/history.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#DDD6FE"/>
+  <path d="M17 23a19 19 0 1 1-2 18" stroke="#7C3AED" stroke-width="5" stroke-linecap="round"/>
+  <path d="M17 13v12h12" stroke="#253047" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M32 22v12l9 5" stroke="#253047" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/image-off.svg
+++ b/assets/icons/image-off.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#FDE68A"/>
+  <rect x="12" y="16" width="40" height="32" rx="6" fill="#FFFFFF"/>
+  <circle cx="24" cy="27" r="5" fill="#F59E0B"/>
+  <path d="m15 44 11-11 8 7 6-6 9 10" stroke="#253047" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M14 14 50 50" stroke="#EF4444" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/key.svg
+++ b/assets/icons/key.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#BFDBFE"/>
+  <circle cx="24" cy="28" r="10" fill="#3B82F6"/>
+  <circle cx="24" cy="28" r="4" fill="#FFFFFF"/>
+  <path d="m31 34 18 18M42 45l5-5M47 50l5-5" stroke="#253047" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/language.svg
+++ b/assets/icons/language.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#C4B5FD"/>
+  <path d="M15 19h24M27 14v5M18 25c3 8 9 14 19 18M37 25c-4 10-11 17-21 21" stroke="#253047" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="45" cy="40" r="11" fill="#8B5CF6"/>
+  <path d="m40 44 5-12 5 12M42 40h6" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/icons/layout-dashboard.svg
+++ b/assets/icons/layout-dashboard.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#A7F3D0"/>
+  <rect x="13" y="13" width="16" height="16" rx="4" fill="#10B981"/>
+  <rect x="35" y="13" width="16" height="25" rx="4" fill="#253047"/>
+  <rect x="13" y="35" width="16" height="16" rx="4" fill="#253047"/>
+  <rect x="35" y="44" width="16" height="7" rx="3" fill="#10B981"/>
+</svg>

--- a/assets/icons/map-pin.svg
+++ b/assets/icons/map-pin.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#FBCFE8"/>
+  <path d="M32 11c-10 0-18 8-18 18 0 13 18 25 18 25s18-12 18-25c0-10-8-18-18-18Z" fill="#EC4899"/>
+  <circle cx="32" cy="29" r="7" fill="#FFFFFF"/>
+</svg>

--- a/assets/icons/message-square-magic.svg
+++ b/assets/icons/message-square-magic.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#BAE6FD"/>
+  <path d="M11 17h36v25H26l-10 8v-8h-5V17Z" fill="#FFFFFF"/>
+  <path d="m35 22 2 5 5 2-5 2-2 5-2-5-5-2 5-2 2-5Z" fill="#0EA5E9"/>
+  <path d="m49 37 1.5 3.5L54 42l-3.5 1.5L49 47l-1.5-3.5L44 42l3.5-1.5L49 37Z" fill="#253047"/>
+</svg>

--- a/assets/icons/message-square.svg
+++ b/assets/icons/message-square.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#FED7AA"/>
+  <path d="M12 16h40v29H27l-11 8v-8h-4V16Z" fill="#FFFFFF"/>
+  <circle cx="24" cy="31" r="3" fill="#F97316"/>
+  <circle cx="32" cy="31" r="3" fill="#253047"/>
+  <circle cx="40" cy="31" r="3" fill="#F97316"/>
+</svg>

--- a/assets/icons/mirror.svg
+++ b/assets/icons/mirror.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#DDD6FE"/>
+  <ellipse cx="32" cy="29" rx="16" ry="19" fill="#7C3AED"/>
+  <ellipse cx="32" cy="29" rx="11" ry="14" fill="#FFFFFF"/>
+  <path d="M32 48v7M24 56h16" stroke="#253047" stroke-width="4" stroke-linecap="round"/>
+  <path d="M24 20c3-4 8-6 12-5" stroke="#BAE6FD" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/people.svg
+++ b/assets/icons/people.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#FDE68A"/>
+  <circle cx="24" cy="26" r="8" fill="#F59E0B"/>
+  <circle cx="42" cy="25" r="7" fill="#253047"/>
+  <path d="M11 49c1-9 7-14 13-14s12 5 13 14" fill="#F59E0B"/>
+  <path d="M32 48c1-8 5-13 11-13 5 0 10 5 11 13" fill="#253047"/>
+</svg>

--- a/assets/icons/phone.svg
+++ b/assets/icons/phone.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#BFDBFE"/>
+  <rect x="21" y="9" width="22" height="46" rx="7" fill="#253047"/>
+  <rect x="24" y="15" width="16" height="31" rx="2" fill="#FFFFFF"/>
+  <rect x="28" y="18" width="8" height="10" rx="2" fill="#3B82F6"/>
+  <circle cx="32" cy="51" r="2" fill="#3B82F6"/>
+</svg>

--- a/assets/icons/pin.svg
+++ b/assets/icons/pin.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#C4B5FD"/>
+  <path d="m23 13 18 0-2 14 8 7v4H17v-4l8-7-2-14Z" fill="#8B5CF6"/>
+  <path d="M32 38v16" stroke="#253047" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/ruler.svg
+++ b/assets/icons/ruler.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#A7F3D0"/>
+  <path d="m15 42 27-27 8 8-27 27-8-8Z" fill="#10B981"/>
+  <path d="m36 21 7 7M30 27l5 5M24 33l7 7M19 38l5 5" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/sheet.svg
+++ b/assets/icons/sheet.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#FBCFE8"/>
+  <rect x="14" y="12" width="36" height="40" rx="5" fill="#FFFFFF"/>
+  <path d="M14 24h36M26 24v28M38 24v28M14 36h36M14 44h36" stroke="#EC4899" stroke-width="2.5"/>
+  <rect x="18" y="17" width="14" height="3" rx="1.5" fill="#253047"/>
+</svg>

--- a/assets/icons/skills.svg
+++ b/assets/icons/skills.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#FED7AA"/>
+  <path d="M16 20h32v29H16z" fill="#FFFFFF"/>
+  <path d="M22 20v-5h20v5" stroke="#253047" stroke-width="4" stroke-linecap="round"/>
+  <path d="M22 30h20M22 38h14M22 46h8" stroke="#F97316" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="44" cy="44" r="7" fill="#253047"/>
+  <path d="m41 44 2 2 4-5" stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/icons/sprout.svg
+++ b/assets/icons/sprout.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#BAE6FD"/>
+  <path d="M32 52V31" stroke="#253047" stroke-width="5" stroke-linecap="round"/>
+  <path d="M31 34C19 34 14 27 14 17c11 0 18 5 17 17Z" fill="#0EA5E9"/>
+  <path d="M33 32c12 0 17-7 17-17-11 0-18 5-17 17Z" fill="#22C55E"/>
+  <path d="M21 52h22" stroke="#253047" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/swords.svg
+++ b/assets/icons/swords.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#DDD6FE"/>
+  <path d="m16 14 25 25" stroke="#253047" stroke-width="6" stroke-linecap="round"/>
+  <path d="m48 14-25 25" stroke="#7C3AED" stroke-width="6" stroke-linecap="round"/>
+  <path d="m14 45 8-8M50 45l-8-8" stroke="#253047" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="13" cy="50" r="4" fill="#7C3AED"/>
+  <circle cx="51" cy="50" r="4" fill="#253047"/>
+</svg>

--- a/assets/icons/test.svg
+++ b/assets/icons/test.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#FDE68A"/>
+  <path d="M25 11h14v9l10 27c1 3-1 6-5 6H20c-4 0-6-3-5-6l10-27v-9Z" fill="#FFFFFF"/>
+  <path d="M23 37h18l7 12H16l7-12Z" fill="#F59E0B"/>
+  <path d="M25 20h14" stroke="#253047" stroke-width="4"/>
+  <circle cx="29" cy="42" r="3" fill="#253047"/>
+  <circle cx="37" cy="46" r="2" fill="#FFFFFF"/>
+</svg>

--- a/assets/icons/undo.svg
+++ b/assets/icons/undo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#BFDBFE"/>
+  <path d="M26 18 14 29l12 11V18Z" fill="#3B82F6"/>
+  <path d="M23 29h13c10 0 16 6 16 15" stroke="#253047" stroke-width="5" stroke-linecap="round"/>
+  <path d="M49 44c0 3-1 5-3 7" stroke="#3B82F6" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/user-round.svg
+++ b/assets/icons/user-round.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#C4B5FD"/>
+  <circle cx="32" cy="23" r="11" fill="#8B5CF6"/>
+  <path d="M13 52c2-13 10-20 19-20s17 7 19 20" fill="#253047"/>
+  <circle cx="32" cy="32" r="22" stroke="#FFFFFF" stroke-width="3" opacity=".7"/>
+</svg>

--- a/assets/icons/volume.svg
+++ b/assets/icons/volume.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#A7F3D0"/>
+  <path d="M13 27h10l11-10v30L23 37H13V27Z" fill="#10B981"/>
+  <path d="M40 25c5 4 5 10 0 14M45 19c9 7 9 19 0 26" stroke="#253047" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/wish.svg
+++ b/assets/icons/wish.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#FBCFE8"/>
+  <path d="m32 10 5 14 15 1-12 9 4 15-12-8-12 8 4-15-12-9 15-1 5-14Z" fill="#EC4899"/>
+  <circle cx="18" cy="16" r="3" fill="#FFFFFF"/>
+  <circle cx="49" cy="15" r="2" fill="#253047"/>
+  <path d="m16 42 2 4 4 2-4 2-2 4-2-4-4-2 4-2 2-4Z" fill="#253047"/>
+</svg>

--- a/assets/icons/x-circle.svg
+++ b/assets/icons/x-circle.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#FED7AA"/>
+  <circle cx="32" cy="32" r="20" fill="#F97316"/>
+  <path d="m24 24 16 16M40 24 24 40" stroke="#FFFFFF" stroke-width="5" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Root cause
The new global `audit:icons` check correctly found 38 literal `kind-icon:*` references whose corresponding SVG files did not exist under `assets/icons/`. Those references silently render blank in the browser.

## What changed
- Added exactly the 38 missing SVG filenames under `assets/icons/`.
- Kept every existing reference unchanged.
- Used the repo's colorful 64×64 rounded asset language so these don't become a monochrome grab-bag.
- No component, store, route, audit, or test behavior was weakened.

## Verification before PR
- Confirmed the failing main run reports exactly 38 missing icons.
- Branch diff is exactly 38 added SVG files, one commit, no unrelated edits.
- All generated SVG payloads were XML-parse validated before commit.

## Expected CI
`Art Prompt + Icon Safety` should now pass `npm run audit:icons` with zero missing referenced icons.