### PR TITLE
Redesign Storybook setup as an art-first story spread

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,25 @@ MariaDB. Production is served at `https://kindrobots.org` through the current co
 - When returning code in chat, return complete copy-paste-ready files or sections — never
   placeholders or ellipses. In-repo, normal targeted edits are fine.
 
+## Art-first interface standard
+
+Kind Robots is an **art-focused website**. Outside settings, administration, diagnostics,
+and similarly utilitarian screens, a feature is not finished merely because every field,
+button, or data object is technically reachable.
+
+- Prefer image-led cards, galleries, canvases, stages, decks, maps, timelines, and other
+  visual interaction surfaces over text-and-button control panels.
+- When a user chooses a Character, Dream, Scenario, Facet, Reward, artwork, or other entity
+  that has art, the art is a primary part of the choice. Do not reduce it to a tiny thumbnail
+  beside a form row unless dense utility UI genuinely requires that treatment.
+- Creative setup flows should feel open and compositional. Avoid wizard/tab proliferation
+  when the choices can coexist coherently on one visual surface.
+- Empty art is a product problem, not permission to design a permanently text-first card.
+  Use the shared art fallback while preserving an image-shaped slot, and wire real entity art
+  whenever the model provides it.
+- Settings-style UI is appropriate for settings. A creative product surface should look and
+  feel designed before it is sent to Silas for visual acceptance.
+
 ## Database — standing rules from Silas (2026-07-02)
 
 The database holds real data.

--- a/components/narrative/narrative-ingredient-card.vue
+++ b/components/narrative/narrative-ingredient-card.vue
@@ -2,11 +2,11 @@
 <template>
   <button
     type="button"
-    class="group relative flex min-h-32 w-full overflow-hidden rounded-2xl border text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transform-none motion-reduce:transition-none"
+    class="group relative flex aspect-[2/3] min-h-56 w-full flex-col overflow-hidden rounded-[1.5rem] border text-left shadow-md transition hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transform-none motion-reduce:transition-none"
     :class="
       selected
-        ? 'border-secondary bg-secondary/10 ring-1 ring-secondary/40'
-        : 'border-base-300 bg-base-100 hover:border-secondary/40'
+        ? 'border-secondary ring-2 ring-secondary/45'
+        : 'border-base-300 bg-base-100 hover:border-secondary/45'
     "
     :aria-pressed="selected"
     :aria-label="`${selected ? 'Selected' : 'Select'} ${item.title}`"
@@ -14,50 +14,57 @@
     :disabled="disabled"
     @click="emit('select', item.slug)"
   >
-    <span
-      class="relative flex w-28 shrink-0 items-center justify-center overflow-hidden bg-base-200 sm:w-32"
-      aria-hidden="true"
-    >
+    <span class="absolute inset-0 bg-base-200" aria-hidden="true">
       <img
         v-if="artwork"
         :src="artwork"
         alt=""
-        class="absolute inset-0 size-full object-cover transition duration-300 group-hover:scale-105 motion-reduce:transform-none motion-reduce:transition-none"
-      />
-      <Icon
-        v-else
-        :name="item.icon || 'kind-icon:tag'"
-        class="size-8 text-base-content/35"
+        class="size-full object-cover transition duration-300 group-hover:scale-105 motion-reduce:transform-none motion-reduce:transition-none"
       />
       <span
-        v-if="item.badge"
-        class="badge badge-sm absolute left-2 top-2 max-w-[calc(100%_-_1rem)] truncate rounded-xl border-base-100/60 bg-base-100/90 text-[0.65rem] font-bold shadow-sm"
+        v-else
+        class="flex size-full items-center justify-center bg-linear-to-br from-base-200 to-base-300"
       >
-        {{ item.badge }}
+        <Icon
+          :name="item.icon || 'kind-icon:tag'"
+          class="size-12 text-base-content/30"
+        />
       </span>
     </span>
 
-    <span class="flex min-w-0 flex-1 flex-col justify-center gap-1.5 p-3">
-      <span class="flex items-start gap-2">
-        <span class="min-w-0 flex-1 truncate text-sm font-black">
-          {{ item.title }}
-        </span>
-        <Icon
-          v-if="selected"
-          name="kind-icon:check"
-          class="mt-0.5 size-4 shrink-0 text-secondary"
-          aria-hidden="true"
-        />
+    <span
+      class="absolute inset-0 bg-linear-to-t from-black/90 via-black/15 to-transparent"
+      aria-hidden="true"
+    />
+
+    <span
+      v-if="item.badge"
+      class="badge badge-sm absolute left-2 top-2 z-10 max-w-[calc(100%_-_3.25rem)] truncate rounded-xl border-white/30 bg-black/55 text-[0.62rem] font-bold text-white shadow backdrop-blur"
+    >
+      {{ item.badge }}
+    </span>
+
+    <span
+      v-if="selected"
+      class="absolute right-2 top-2 z-10 flex size-8 items-center justify-center rounded-full bg-secondary text-secondary-content shadow-lg"
+      aria-hidden="true"
+    >
+      <Icon name="kind-icon:check" class="size-4" />
+    </span>
+
+    <span class="relative z-10 mt-auto flex min-w-0 flex-col gap-1.5 p-3 text-white">
+      <span class="text-sm font-black leading-tight sm:text-base">
+        {{ item.title }}
       </span>
       <span
         v-if="summary"
         :id="descriptionId"
-        class="line-clamp-3 text-xs leading-relaxed text-base-content/60"
+        class="line-clamp-3 text-[0.7rem] leading-relaxed text-white/75"
       >
         {{ summary }}
       </span>
-      <span v-else :id="descriptionId" class="text-xs text-base-content/35">
-        Add this ingredient to the narrative.
+      <span v-else :id="descriptionId" class="text-[0.7rem] text-white/60">
+        Add this ingredient to the story.
       </span>
     </span>
   </button>

--- a/components/narrative/narrative-ingredient-multi-picker.vue
+++ b/components/narrative/narrative-ingredient-multi-picker.vue
@@ -101,7 +101,7 @@
 
     <div
       v-else
-      class="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6"
+      class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,10rem),1fr))] gap-3"
     >
       <NarrativeIngredientCard
         v-for="item in visibleItems"
@@ -119,7 +119,7 @@
     <div v-if="showToggle" class="flex justify-center">
       <button
         type="button"
-        class="btn btn-ghost btn-sm rounded-xl border border-base-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70"
+        class="btn btn-ghost btn-sm rounded-xl border border-base-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 motion-reduce:transition-none"
         :disabled="disabled"
         :aria-expanded="expanded"
         @click="expanded = !expanded"

--- a/components/narrative/narrative-ingredient-multi-picker.vue
+++ b/components/narrative/narrative-ingredient-multi-picker.vue
@@ -1,7 +1,7 @@
 <!-- /components/narrative/narrative-ingredient-multi-picker.vue -->
 <template>
   <section
-    class="kr-panel-flat space-y-3 p-3"
+    class="space-y-3 rounded-[1.75rem] border border-base-300 bg-base-100/85 p-4 shadow-sm"
     role="group"
     :aria-labelledby="headingId"
     :aria-describedby="describedBy"
@@ -9,16 +9,13 @@
   >
     <div class="flex flex-wrap items-start gap-2">
       <div class="min-w-0 flex-1">
-        <h3
-          :id="headingId"
-          class="text-xs font-bold uppercase tracking-wide text-base-content/55"
-        >
+        <h3 :id="headingId" class="text-lg font-black">
           {{ label }}
         </h3>
         <p
           v-if="helper"
           :id="helperId"
-          class="mt-1 text-xs leading-relaxed text-base-content/45"
+          class="mt-1 max-w-3xl text-xs leading-relaxed text-base-content/50"
         >
           {{ helper }}
         </p>
@@ -44,7 +41,7 @@
 
     <label
       v-if="searchVisible"
-      class="kr-input-sm flex w-full items-center gap-2 bg-base-100"
+      class="kr-input-sm flex w-full max-w-xl items-center gap-2 bg-base-100"
     >
       <Icon
         name="kind-icon:search"
@@ -77,7 +74,7 @@
     <div
       v-else-if="loading"
       role="status"
-      class="flex min-h-32 items-center justify-center kr-panel-flat border-dashed bg-base-100/60"
+      class="flex min-h-56 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100/60"
     >
       <span
         class="loading loading-dots loading-md text-secondary motion-reduce:hidden"
@@ -89,7 +86,7 @@
     <div
       v-else-if="!items.length"
       role="status"
-      class="kr-panel-flat border-dashed bg-base-100/60 p-4 text-center text-xs text-base-content/50"
+      class="rounded-2xl border border-dashed border-base-300 bg-base-100/60 p-5 text-center text-xs text-base-content/50"
     >
       {{ emptyState }}
     </div>
@@ -97,12 +94,15 @@
     <p
       v-else-if="query.trim() && !filteredItems.length"
       role="status"
-      class="kr-panel-flat border-dashed rounded-xl bg-base-100/60 px-3 py-2 text-xs text-base-content/45"
+      class="rounded-xl border border-dashed border-base-300 bg-base-100/60 px-3 py-2 text-xs text-base-content/45"
     >
       No matching {{ label.toLowerCase() }}.
     </p>
 
-    <div v-else class="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+    <div
+      v-else
+      class="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6"
+    >
       <NarrativeIngredientCard
         v-for="item in visibleItems"
         :key="item.id ?? item.slug"
@@ -119,7 +119,7 @@
     <div v-if="showToggle" class="flex justify-center">
       <button
         type="button"
-        class="btn btn-ghost btn-sm rounded-xl border border-base-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 motion-reduce:transform-none motion-reduce:transition-none"
+        class="btn btn-ghost btn-sm rounded-xl border border-base-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70"
         :disabled="disabled"
         :aria-expanded="expanded"
         @click="expanded = !expanded"
@@ -175,18 +175,12 @@ const query = ref('')
 const expanded = ref(false)
 
 const atLimit = computed(() => props.modelValue.length >= props.maxSelections)
-/* The count badge is v-else to the loading spinner, so while loading its id
-   does not exist in the DOM; pointing aria-describedby at it then is a
-   dangling reference for screen readers. */
 const describedBy = computed(() =>
   [props.helper ? helperId : '', props.loading ? '' : countId]
     .filter(Boolean)
     .join(' '),
 )
 
-/* See narrative-ingredient-picker.vue: the search box only renders while the
-   list is longer than the initial limit, and the store-derived lists can
-   shrink after a query has been typed. Drop the query when its input goes. */
 const searchVisible = computed(
   () => props.items.length > Math.max(1, props.initialLimit),
 )
@@ -219,10 +213,6 @@ watch(
   },
 )
 
-/* Same hidden-selection case as narrative-ingredient-picker.vue, extended to
-   multiple selections: expand if ANY selected slug sorts beyond the initial
-   collapsed slice, so a restored setupDraft never shows selected Facets or
-   Rewards as if nothing were picked. Only ever turns expanded on. */
 watch(
   () => [props.items, props.modelValue] as const,
   ([items, values]) => {

--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -93,12 +93,12 @@
 
     <div
       v-else
-      class="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6"
+      class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,10rem),1fr))] gap-3"
     >
       <button
         v-if="allowEmpty"
         type="button"
-        class="group relative aspect-[2/3] min-h-56 overflow-hidden rounded-[1.5rem] border text-left shadow-md transition hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transform-none"
+        class="group relative aspect-[2/3] min-h-56 overflow-hidden rounded-[1.5rem] border text-left shadow-md transition hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transform-none motion-reduce:transition-none"
         :class="
           modelValue === null
             ? 'border-secondary ring-2 ring-secondary/45'
@@ -153,7 +153,7 @@
     <div v-if="showToggle" class="flex justify-center">
       <button
         type="button"
-        class="btn btn-ghost btn-sm rounded-xl border border-base-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70"
+        class="btn btn-ghost btn-sm rounded-xl border border-base-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 motion-reduce:transition-none"
         :disabled="disabled"
         :aria-expanded="expanded"
         @click="expanded = !expanded"

--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -1,7 +1,7 @@
 <!-- /components/narrative/narrative-ingredient-picker.vue -->
 <template>
   <section
-    class="kr-panel-flat space-y-3 p-3"
+    class="space-y-3 rounded-[1.75rem] border border-base-300 bg-base-100/85 p-4 shadow-sm"
     role="group"
     :aria-labelledby="headingId"
     :aria-describedby="helper ? helperId : undefined"
@@ -9,16 +9,13 @@
   >
     <div class="flex flex-wrap items-start gap-2">
       <div class="min-w-0 flex-1">
-        <h3
-          :id="headingId"
-          class="text-xs font-bold uppercase tracking-wide text-base-content/55"
-        >
+        <h3 :id="headingId" class="text-lg font-black">
           {{ label }}
         </h3>
         <p
           v-if="helper"
           :id="helperId"
-          class="mt-1 text-xs leading-relaxed text-base-content/45"
+          class="mt-1 max-w-3xl text-xs leading-relaxed text-base-content/50"
         >
           {{ helper }}
         </p>
@@ -28,18 +25,14 @@
         class="loading loading-spinner loading-sm motion-reduce:hidden"
         aria-hidden="true"
       />
-      <span
-        v-else
-        class="kr-badge-ghost-sm rounded-xl"
-        aria-live="polite"
-      >
+      <span v-else class="kr-badge-ghost-sm rounded-xl" aria-live="polite">
         {{ items.length }} options
       </span>
     </div>
 
     <label
       v-if="searchVisible"
-      class="kr-input-sm flex w-full items-center gap-2 bg-base-100"
+      class="kr-input-sm flex w-full max-w-xl items-center gap-2 bg-base-100"
     >
       <Icon
         name="kind-icon:search"
@@ -59,7 +52,7 @@
     <p
       v-if="query.trim() && !filteredItems.length"
       role="status"
-      class="kr-panel-flat border-dashed rounded-xl bg-base-100/60 px-3 py-2 text-xs text-base-content/45"
+      class="rounded-xl border border-dashed border-base-300 bg-base-100/60 px-3 py-2 text-xs text-base-content/45"
     >
       No matching {{ label.toLowerCase() }}. Clear the search or leave the
       narrator free to choose.
@@ -81,7 +74,7 @@
     <div
       v-else-if="loading"
       role="status"
-      class="flex min-h-32 items-center justify-center kr-panel-flat border-dashed bg-base-100/60"
+      class="flex min-h-56 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-100/60"
     >
       <span
         class="loading loading-dots loading-md text-secondary motion-reduce:hidden"
@@ -93,23 +86,23 @@
     <div
       v-else-if="!items.length"
       role="status"
-      class="kr-panel-flat border-dashed bg-base-100/60 p-4 text-center text-xs text-base-content/50"
+      class="rounded-2xl border border-dashed border-base-300 bg-base-100/60 p-5 text-center text-xs text-base-content/50"
     >
       {{ emptyState }}
     </div>
 
     <div
       v-else
-      class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,20rem),1fr))] gap-2"
+      class="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6"
     >
       <button
         v-if="allowEmpty"
         type="button"
-        class="flex min-h-32 w-full overflow-hidden rounded-2xl border text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transform-none motion-reduce:transition-none"
+        class="group relative aspect-[2/3] min-h-56 overflow-hidden rounded-[1.5rem] border text-left shadow-md transition hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transform-none"
         :class="
           modelValue === null
-            ? 'border-secondary bg-secondary/10 ring-1 ring-secondary/40'
-            : 'border-base-300 bg-base-100 hover:border-secondary/40'
+            ? 'border-secondary ring-2 ring-secondary/45'
+            : 'border-base-300 bg-base-200'
         "
         :aria-pressed="modelValue === null"
         :aria-label="`${modelValue === null ? 'Selected' : 'Select'} ${emptyLabel}`"
@@ -118,26 +111,29 @@
         @click="select(null)"
       >
         <span
-          class="flex w-28 shrink-0 items-center justify-center bg-base-200 sm:w-32"
+          class="absolute inset-0 flex items-center justify-center bg-linear-to-br from-base-200 via-base-300 to-primary/20"
           aria-hidden="true"
         >
-          <Icon :name="emptyIcon" class="size-8 text-base-content/35" />
+          <Icon :name="emptyIcon" class="size-14 text-base-content/25" />
         </span>
-        <span class="flex min-w-0 flex-1 flex-col justify-center gap-1.5 p-3">
-          <span class="flex items-start gap-2">
-            <span class="min-w-0 flex-1 truncate text-sm font-black">
-              {{ emptyLabel }}
-            </span>
-            <Icon
-              v-if="modelValue === null"
-              name="kind-icon:check"
-              class="mt-0.5 size-4 shrink-0 text-secondary"
-              aria-hidden="true"
-            />
+        <span
+          class="absolute inset-0 bg-linear-to-t from-black/85 via-black/10 to-transparent"
+          aria-hidden="true"
+        />
+        <span
+          v-if="modelValue === null"
+          class="absolute right-2 top-2 flex size-8 items-center justify-center rounded-full bg-secondary text-secondary-content shadow"
+          aria-hidden="true"
+        >
+          <Icon name="kind-icon:check" class="size-4" />
+        </span>
+        <span class="absolute inset-x-0 bottom-0 p-3 text-white">
+          <span class="block text-sm font-black sm:text-base">
+            {{ emptyLabel }}
           </span>
           <span
             :id="emptyDescriptionId"
-            class="text-xs leading-relaxed text-base-content/55"
+            class="mt-1 block text-[0.7rem] leading-relaxed text-white/70"
           >
             {{ emptyDescription }}
           </span>
@@ -157,7 +153,7 @@
     <div v-if="showToggle" class="flex justify-center">
       <button
         type="button"
-        class="btn btn-ghost btn-sm rounded-xl border border-base-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70 motion-reduce:transform-none motion-reduce:transition-none"
+        class="btn btn-ghost btn-sm rounded-xl border border-base-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary/70"
         :disabled="disabled"
         :aria-expanded="expanded"
         @click="expanded = !expanded"
@@ -243,12 +239,6 @@ const showToggle = computed(
     filteredItems.value.length > Math.max(1, props.initialLimit),
 )
 
-/* The search box only renders while the list is longer than the initial
-   limit. The option lists are store-derived (browseCharacters, the Dream and
-   Reward stores' active filters) and can shrink after a query has been typed
-   -- when that happens the box disappears but the query kept filtering, so
-   the reader was left staring at "No matching characters. Clear the search"
-   with no search left to clear. Drop the query the moment its input goes. */
 const searchVisible = computed(
   () => props.items.length > Math.max(1, props.initialLimit),
 )
@@ -260,13 +250,6 @@ watch(
   },
 )
 
-/* modelValue can arrive already set to a pick from an earlier session --
-   Storybook's setupDraft persists to localStorage and restores it. If that
-   pick sorts beyond the initial collapsed slice, the picker would render
-   collapsed with no card showing as selected at all, and nothing on screen
-   would say a choice was already made. Auto-expand to reveal it; this only
-   ever turns expanded on, never off, so it never fights a manual toggle or
-   the reset above. */
 watch(
   () => [props.items, props.modelValue] as const,
   ([items, value]) => {

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -205,7 +205,10 @@
     </section>
 
     <div class="min-h-0 flex-1 overflow-hidden">
-      <StorybookPage />
+      <StorybookVisualSetup v-if="!storyStore.session" />
+      <div v-show="storyStore.session" class="size-full">
+        <StorybookPage />
+      </div>
     </div>
   </section>
 </template>
@@ -223,21 +226,6 @@ const libraryOpen = ref(false)
 const restartArmed = ref(false)
 const newStoryArmed = ref(false)
 
-// storybook-page.vue's seedFromQuery() (child, mounted first) treats these as
-// one-shot: it consumes them into the setup draft, then strips them with its
-// own router.replace() so a reload, bookmark, or share never silently re-adds
-// the ingredient. That replace() races this component's own onMounted
-// (parent, mounted second, same synchronous tick) whenever it also calls
-// updateStoryQuery() -- e.g. arriving at `/storybook?character=<slug>` while
-// a previous session is still active in localStorage, exactly the case
-// seedFromQuery's own comment describes ("a link never destroys a story
-// someone was already assembling"). Neither router.replace() has resolved
-// when the second one is built, so updateStoryQuery()'s `{ ...route.query }`
-// still carries the stale, not-yet-stripped ingredient key, and its
-// navigation -- issued after seedFromQuery's -- wins: the ingredient key
-// resurfaces in the URL alongside `story=`, undoing the one-shot consumption
-// seedFromQuery just performed. Stripping these keys here too, on every query
-// rewrite this component makes, closes the race regardless of ordering.
 const SEED_QUERY_KEYS = new Set([
   'scenario',
   'location',
@@ -309,15 +297,6 @@ function downloadStory(
   if (payload) triggerDownload(payload)
 }
 
-// The Export menu used to be a native <details>/<summary> dropdown, the only
-// one in the codebase built that way -- every sibling dropdown (channel-select
-// .vue, tab-select.vue, watchlist-browse.vue) is the focus-based
-// `.dropdown`/`.dropdown-content` pair instead, which channel-select.vue
-// explicitly closes on selection via its own closeDropdown() (blurring
-// document.activeElement). <details> has no such behavior: clicking an item
-// inside it does not close the menu, so after switching to the same
-// focus-based pattern here, closing on click still needs to be wired up by
-// hand -- this mirrors that one closeDropdown() helper.
 function closeExportMenu(): void {
   if (typeof document === 'undefined') return
   const element = document.activeElement as HTMLElement | null
@@ -350,15 +329,6 @@ function formatStoryDate(value: string): string {
 watch(
   () => storyStore.session?.id ?? null,
   (sessionId) => {
-    // A "Restart from the beginning?" / "Discard this tale?" arm is a
-    // confirmation for THIS session, not a standing state. Opening a
-    // different story, duplicating, restarting, or starting a new one all
-    // swap the active session out from under an armed-but-unconfirmed
-    // button -- without this reset, the next session renders straight into
-    // the armed, warning-colored button (never the plain "Restart"/"New
-    // story" one), so a single click that looks like a first press instead
-    // fires the destructive action immediately, with no confirmation ever
-    // given for the story actually on screen.
     restartArmed.value = false
     newStoryArmed.value = false
     if (sessionId !== queryStoryId()) updateStoryQuery(sessionId)
@@ -377,21 +347,6 @@ onMounted(() => {
   storyStore.restoreFromLocalStorage()
   storyStore.initializeLibrary()
   const directId = queryStoryId()
-  // Only call openStory() when it would actually SWITCH sessions. On a plain
-  // reload mid-story, restoreFromLocalStorage() above already restored the
-  // live session, and updateStoryQuery() keeps ?story= in sync with it while
-  // playing -- so directId equals storyStore.session.id on every ordinary
-  // refresh, not just some rare cross-story navigation. Calling openStory()
-  // anyway re-clones the just-restored session and, critically, invokes
-  // resumeNarrativeArtJobs() a SECOND time on top of the one
-  // restoreFromLocalStorage() already performed. For any beat whose art job
-  // enqueue never reached the server before the reload (status still
-  // 'queueing', no jobId yet -- a real window between the optimistic status
-  // update and the resolved POST), both resume() calls independently find no
-  // existing job and independently submit one, generating and billing two
-  // illustrations for a single beat. The watcher below already guards the
-  // same call this way (`value === storyStore.session?.id`); mount just
-  // never matched it.
   if (directId && directId !== storyStore.session?.id) {
     storyStore.openStory(directId)
   }

--- a/components/storybook/storybook-visual-setup.vue
+++ b/components/storybook/storybook-visual-setup.vue
@@ -1,0 +1,625 @@
+<template>
+  <section
+    class="relative min-h-0 overflow-y-auto rounded-[2rem] border border-base-300 bg-base-100 shadow-xl"
+  >
+    <div class="pointer-events-none absolute inset-x-0 top-0 h-[34rem] overflow-hidden rounded-t-[2rem]">
+      <img
+        :src="heroImage"
+        alt=""
+        class="size-full object-cover opacity-35"
+        aria-hidden="true"
+      />
+      <div
+        class="absolute inset-0 bg-linear-to-b from-base-100/10 via-base-100/75 to-base-100"
+      />
+    </div>
+
+    <div class="relative space-y-7 p-4 sm:p-6 lg:p-8">
+      <header class="mx-auto max-w-5xl text-center">
+        <p
+          class="text-xs font-black uppercase tracking-[0.28em] text-primary/75"
+        >
+          Storybook
+        </p>
+        <h1 class="mt-2 text-3xl font-black sm:text-4xl lg:text-5xl">
+          Lay out your story
+        </h1>
+        <p
+          class="mx-auto mt-3 max-w-2xl text-sm leading-relaxed text-base-content/65 sm:text-base"
+        >
+          Put the pieces on the table. Pick the people, place, plot, mood, and
+          treasures that belong in this tale, then let Storybook weave them
+          together.
+        </p>
+      </header>
+
+      <div class="mx-auto grid max-w-7xl gap-4 xl:grid-cols-[minmax(0,1.6fr)_minmax(18rem,0.65fr)]">
+        <section
+          class="rounded-[1.75rem] border border-primary/20 bg-base-100/90 p-4 shadow-lg backdrop-blur sm:p-5"
+        >
+          <div class="flex items-center gap-3">
+            <div
+              class="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary"
+            >
+              <Icon name="kind-icon:sparkles" class="size-5" />
+            </div>
+            <div>
+              <h2 class="text-lg font-black">The spark</h2>
+              <p class="text-xs text-base-content/50">
+                One premise is enough. Everything else can stay loose.
+              </p>
+            </div>
+          </div>
+
+          <div class="mt-4 grid gap-3 sm:grid-cols-[minmax(12rem,0.55fr)_minmax(0,1fr)]">
+            <label class="form-control">
+              <span
+                class="mb-1 text-[0.68rem] font-black uppercase tracking-wider text-base-content/50"
+              >
+                Working title
+              </span>
+              <input
+                v-model="store.setupDraft.title"
+                type="text"
+                class="kr-input rounded-2xl bg-base-100/90"
+                placeholder="The Clockwork Orchard"
+              />
+            </label>
+
+            <label class="form-control">
+              <span
+                class="mb-1 text-[0.68rem] font-black uppercase tracking-wider text-base-content/50"
+              >
+                Premise
+              </span>
+              <textarea
+                v-model="store.setupDraft.premise"
+                rows="4"
+                class="kr-textarea rounded-2xl bg-base-100/90 text-sm leading-relaxed"
+                placeholder="Every midnight, the abandoned observatory receives a letter from a star that should not exist…"
+              />
+            </label>
+          </div>
+        </section>
+
+        <aside
+          class="rounded-[1.75rem] border border-secondary/20 bg-base-100/90 p-4 shadow-lg backdrop-blur sm:p-5"
+        >
+          <p
+            class="text-[0.68rem] font-black uppercase tracking-[0.2em] text-secondary/75"
+          >
+            Your spread
+          </p>
+          <div class="mt-3 grid grid-cols-3 gap-2 text-center">
+            <div class="rounded-2xl bg-base-200/70 p-2">
+              <p class="text-xl font-black">{{ selectedCast.length }}</p>
+              <p class="text-[0.65rem] text-base-content/50">cast</p>
+            </div>
+            <div class="rounded-2xl bg-base-200/70 p-2">
+              <p class="text-xl font-black">{{ selectedFacets.length }}</p>
+              <p class="text-[0.65rem] text-base-content/50">facets</p>
+            </div>
+            <div class="rounded-2xl bg-base-200/70 p-2">
+              <p class="text-xl font-black">{{ selectedRewards.length }}</p>
+              <p class="text-[0.65rem] text-base-content/50">rewards</p>
+            </div>
+          </div>
+
+          <div class="mt-4 flex flex-wrap gap-1.5 text-xs">
+            <span class="kr-badge-ghost-sm rounded-xl capitalize">
+              {{ store.setupDraft.narratorStyle }} voice
+            </span>
+            <span class="kr-badge-ghost-sm rounded-xl">
+              {{ structureLabel }}
+            </span>
+            <span v-if="selectedScenario" class="kr-badge-ghost-sm rounded-xl">
+              {{ selectedScenario.title }}
+            </span>
+            <span v-if="selectedLocation" class="kr-badge-ghost-sm rounded-xl">
+              {{ selectedLocation.title }}
+            </span>
+          </div>
+
+          <button
+            type="button"
+            class="kr-btn-primary mt-5 w-full justify-center rounded-2xl"
+            :disabled="!canBegin || store.isWeaving"
+            @click="beginStory"
+          >
+            <span
+              v-if="store.isWeaving"
+              class="loading loading-spinner loading-sm"
+            />
+            <Icon v-else name="kind-icon:book-open" class="size-4" />
+            {{ store.isWeaving ? 'Opening the story…' : 'Open this story' }}
+          </button>
+          <p class="mt-2 text-center text-[0.68rem] text-base-content/45">
+            {{ canBegin ? 'You can always start with fewer cards.' : 'Give the story a premise first.' }}
+          </p>
+        </aside>
+      </div>
+
+      <section class="mx-auto max-w-7xl space-y-3">
+        <div>
+          <p
+            class="text-[0.68rem] font-black uppercase tracking-[0.2em] text-base-content/45"
+          >
+            How it feels
+          </p>
+          <h2 class="text-xl font-black">Choose a narrator voice</h2>
+        </div>
+        <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+          <button
+            v-for="option in narratorCards"
+            :key="option.value"
+            type="button"
+            class="group relative aspect-[2/3] overflow-hidden rounded-[1.5rem] border text-left shadow-md transition hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 motion-reduce:transform-none"
+            :class="
+              store.setupDraft.narratorStyle === option.value
+                ? 'border-primary ring-2 ring-primary/45'
+                : 'border-base-300'
+            "
+            :aria-pressed="store.setupDraft.narratorStyle === option.value"
+            @click="store.setupDraft.narratorStyle = option.value"
+          >
+            <img
+              :src="option.image"
+              alt=""
+              class="absolute inset-0 size-full object-cover transition duration-300 group-hover:scale-105"
+              aria-hidden="true"
+            />
+            <span
+              class="absolute inset-0 bg-linear-to-t from-black/85 via-black/15 to-transparent"
+            />
+            <span
+              v-if="store.setupDraft.narratorStyle === option.value"
+              class="absolute right-2 top-2 flex size-7 items-center justify-center rounded-full bg-primary text-primary-content shadow"
+            >
+              <Icon name="kind-icon:check" class="size-4" />
+            </span>
+            <span class="absolute inset-x-0 bottom-0 p-3 text-white">
+              <span class="block text-sm font-black sm:text-base">
+                {{ option.label }}
+              </span>
+              <span class="mt-1 block text-[0.68rem] leading-snug text-white/75">
+                {{ option.description }}
+              </span>
+            </span>
+          </button>
+        </div>
+      </section>
+
+      <section class="mx-auto max-w-7xl space-y-3">
+        <div>
+          <p
+            class="text-[0.68rem] font-black uppercase tracking-[0.2em] text-base-content/45"
+          >
+            How it unfolds
+          </p>
+          <h2 class="text-xl font-black">Choose the shape of the tale</h2>
+        </div>
+        <div class="grid gap-3 sm:grid-cols-3">
+          <button
+            v-for="option in structureCards"
+            :key="option.value"
+            type="button"
+            class="group relative min-h-48 overflow-hidden rounded-[1.5rem] border text-left shadow-md transition hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 motion-reduce:transform-none"
+            :class="
+              store.setupDraft.structure === option.value
+                ? 'border-primary ring-2 ring-primary/45'
+                : 'border-base-300'
+            "
+            :aria-pressed="store.setupDraft.structure === option.value"
+            @click="store.setupDraft.structure = option.value"
+          >
+            <img
+              :src="option.image"
+              alt=""
+              class="absolute inset-0 size-full object-cover transition duration-300 group-hover:scale-105"
+              aria-hidden="true"
+            />
+            <span
+              class="absolute inset-0 bg-linear-to-t from-black/85 via-black/20 to-transparent"
+            />
+            <span class="absolute inset-x-0 bottom-0 p-4 text-white">
+              <span class="block text-lg font-black">{{ option.label }}</span>
+              <span class="mt-1 block text-xs leading-relaxed text-white/80">
+                {{ option.description }}
+              </span>
+            </span>
+            <span
+              v-if="store.setupDraft.structure === option.value"
+              class="absolute right-3 top-3 flex size-8 items-center justify-center rounded-full bg-primary text-primary-content shadow"
+            >
+              <Icon name="kind-icon:check" class="size-4" />
+            </span>
+          </button>
+        </div>
+      </section>
+
+      <div class="mx-auto max-w-7xl space-y-6">
+        <NarrativeIngredientMultiPicker
+          v-model="store.setupDraft.castSlugs"
+          :items="characterOptions"
+          label="Cast"
+          helper="Choose up to five existing characters. Their artwork and identity travel into the story."
+          empty-state="No characters are available yet. Storybook can still invent a cast from the premise."
+          :loading="characterStore.loading || characterStore.isInitializing"
+          :error="characterStore.error"
+          :initial-limit="10"
+          :max-selections="MAX_CAST_SELECTIONS"
+        />
+
+        <NarrativeRoleAssigner
+          v-if="selectedCast.length"
+          v-model="store.setupDraft.castRoles"
+          :members="selectedCast"
+        />
+
+        <NarrativeIngredientPicker
+          v-model="store.setupDraft.scenarioSlug"
+          :items="scenarioOptions"
+          label="Plot thread"
+          helper="Choose an existing Scenario as the spine of the story, or leave the premise free to lead."
+          empty-label="Premise-led story"
+          empty-description="No fixed plot thread. Storybook follows the ingredients you place on the table."
+          empty-icon="kind-icon:wand"
+          empty-state="No Scenarios are available yet."
+          :allow-empty="true"
+          :loading="scenarioStore.loading"
+          :initial-limit="8"
+        />
+
+        <NarrativeIngredientPicker
+          v-model="store.setupDraft.locationSlug"
+          :items="locationOptions"
+          label="Primary setting"
+          helper="Choose one reusable LOCATION Dream, or let Storybook invent the place."
+          empty-label="Invent a new place"
+          empty-description="The setting will grow from your premise and selected Facets."
+          empty-icon="kind-icon:moon"
+          empty-state="No LOCATION Dreams are available yet."
+          :loading="dreamStore.loading"
+          :error="dreamStore.error"
+          :initial-limit="8"
+        />
+
+        <NarrativeIngredientMultiPicker
+          v-model="store.setupDraft.facetSlugs"
+          :items="facetOptions"
+          label="Creative Facets"
+          helper="Mix genre, mood, theme, style, and art direction. Pick the cards that make this story feel like itself."
+          empty-state="No active creative Facets are available yet."
+          :loading="facetStore.loading"
+          :error="facetStore.error"
+          :initial-limit="10"
+          :max-selections="MAX_FACET_SELECTIONS"
+        />
+
+        <NarrativeIngredientMultiPicker
+          v-model="store.setupDraft.rewardSlugs"
+          :items="rewardOptions"
+          label="Possible treasures"
+          helper="Choose up to three Rewards the fiction may discover, grant, spend, or lose."
+          empty-state="No active Rewards are available yet. The story can continue without inventory."
+          :loading="rewardStore.isLoading || rewardStore.isInitializing"
+          :error="rewardStore.error"
+          :initial-limit="10"
+          :max-selections="MAX_REWARD_SELECTIONS"
+        />
+      </div>
+
+      <section
+        class="mx-auto max-w-7xl rounded-[1.75rem] border border-base-300 bg-base-100/85 p-4 shadow-sm sm:p-5"
+      >
+        <label class="form-control">
+          <span class="font-black">One last note, if you want one</span>
+          <span class="mt-1 text-xs text-base-content/50">
+            A boundary, relationship, running gag, or bit of direction the
+            narrator should remember.
+          </span>
+          <textarea
+            v-model="store.setupDraft.notes"
+            rows="3"
+            class="kr-textarea mt-3 rounded-2xl"
+            placeholder="Keep the rivalry affectionate. Let every machine feel slightly alive. Avoid a chosen-one prophecy."
+          />
+        </label>
+      </section>
+
+      <footer
+        class="sticky bottom-3 z-10 mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300 bg-base-100/95 p-3 shadow-xl backdrop-blur"
+      >
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm rounded-xl"
+          :disabled="store.isWeaving"
+          @click="store.resetSetup()"
+        >
+          Clear the table
+        </button>
+        <div class="flex items-center gap-3">
+          <p class="hidden text-xs text-base-content/50 sm:block">
+            {{ canBegin ? 'Ready when you are.' : 'A premise unlocks the story.' }}
+          </p>
+          <button
+            type="button"
+            class="kr-btn-primary rounded-xl"
+            :disabled="!canBegin || store.isWeaving"
+            @click="beginStory"
+          >
+            <span
+              v-if="store.isWeaving"
+              class="loading loading-spinner loading-sm"
+            />
+            <Icon v-else name="kind-icon:book-open" class="size-4" />
+            {{ store.isWeaving ? 'Opening…' : 'Open this story' }}
+          </button>
+        </div>
+      </footer>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useCharacterStore } from '@/stores/characterStore'
+import { useDreamStore } from '@/stores/dreamStore'
+import { useFacetStore } from '@/stores/facetStore'
+import { useRewardStore } from '@/stores/rewardStore'
+import { useScenarioStore } from '@/stores/scenarioStore'
+import {
+  STORYBOOK_STRUCTURES,
+  useStorybookStore,
+  type StorybookIngredient,
+  type StorybookNarratorStyle,
+  type StorybookStructure,
+} from '@/stores/storybookStore'
+import type { NarrativeIngredientOption } from '@/utils/narrativeIngredients'
+import { isNarrativeRoleKey } from '@/utils/narrativeRoles'
+import {
+  getTutorialHeroPath,
+  getTutorialImagePath,
+} from '@/stores/helpers/tutorialCards'
+
+const store = useStorybookStore()
+const characterStore = useCharacterStore()
+const dreamStore = useDreamStore()
+const facetStore = useFacetStore()
+const rewardStore = useRewardStore()
+const scenarioStore = useScenarioStore()
+
+const MAX_CAST_SELECTIONS = 5
+const MAX_FACET_SELECTIONS = 5
+const MAX_REWARD_SELECTIONS = 3
+
+const heroImage = computed(() => getTutorialImagePath('scenario', 'storybook'))
+
+const narratorCards: {
+  value: StorybookNarratorStyle
+  label: string
+  description: string
+  image: string
+}[] = [
+  {
+    value: 'cinematic',
+    label: 'Cinematic',
+    description: 'Big images, clean momentum, dramatic turns.',
+    image: getTutorialHeroPath('scenario'),
+  },
+  {
+    value: 'playful',
+    label: 'Playful',
+    description: 'Bouncy, curious, delighted by strange possibilities.',
+    image: getTutorialHeroPath('character'),
+  },
+  {
+    value: 'storybook',
+    label: 'Storybook',
+    description: 'Warm, lyrical, and made to be read aloud.',
+    image: getTutorialHeroPath('dream'),
+  },
+  {
+    value: 'mysterious',
+    label: 'Mysterious',
+    description: 'Shadows, clues, restraint, and unanswered questions.',
+    image: getTutorialHeroPath('bot'),
+  },
+  {
+    value: 'intimate',
+    label: 'Intimate',
+    description: 'Close to the characters and what they notice.',
+    image: getTutorialHeroPath('reward'),
+  },
+]
+
+const structureArt: Record<StorybookStructure, string> = {
+  'short-story': getTutorialHeroPath('reward'),
+  chaptered: getTutorialHeroPath('dream'),
+  episodic: getTutorialHeroPath('scenario'),
+}
+
+const structureCards = STORYBOOK_STRUCTURES.map((structure) => ({
+  ...structure,
+  image: structureArt[structure.value],
+}))
+
+const characterOptions = computed<NarrativeIngredientOption[]>(() =>
+  characterStore.browseCharacters.map((character) => ({
+    id: character.id,
+    slug: character.slug || `character-${character.id}`,
+    title: character.name || `Character ${character.id}`,
+    description: character.presentation || character.role || character.class,
+    flavorText: [character.species, character.class, character.genre]
+      .filter(Boolean)
+      .join(' · '),
+    imagePath: character.imagePath,
+    icon: 'kind-icon:mask',
+    badge: character.isPublic ? 'Public character' : 'Private character',
+  })),
+)
+
+const scenarioOptions = computed<NarrativeIngredientOption[]>(() =>
+  scenarioStore.scenarios
+    .filter((scenario) => scenario.slug)
+    .map((scenario) => ({
+      id: scenario.id,
+      slug: scenario.slug || String(scenario.id),
+      title: scenario.title || 'Untitled scenario',
+      description: scenario.description,
+      imagePath: scenario.imagePath,
+      icon: 'kind-icon:map',
+      badge: scenario.genres || undefined,
+    })),
+)
+
+const locationOptions = computed<NarrativeIngredientOption[]>(() =>
+  dreamStore.dreams
+    .filter(
+      (dream) => dream.dreamType === 'LOCATION' && dream.isActive && dream.slug,
+    )
+    .map((dream) => ({
+      id: dream.id,
+      slug: dream.slug || String(dream.id),
+      title: dream.title || 'Untitled location',
+      description: dream.description,
+      flavorText: dream.flavorText,
+      imagePath:
+        dream.imagePath ||
+        dream.highlightImage ||
+        dream.ArtImage?.imagePath ||
+        null,
+      icon: 'kind-icon:moon',
+      badge: 'Location',
+    })),
+)
+
+const creativeFacetTaxonomies = new Set([
+  'GENRE',
+  'CORE',
+  'THEME',
+  'MOOD',
+  'STYLE',
+  'ART_DIRECTION',
+])
+
+const facetOptions = computed<NarrativeIngredientOption[]>(() =>
+  facetStore.activeFacets
+    .filter(
+      (facet) => creativeFacetTaxonomies.has(facet.taxonomy) && facet.slug,
+    )
+    .map((facet) => ({
+      id: facet.id,
+      slug: facet.slug || String(facet.id),
+      title: facet.title,
+      description: facet.description,
+      flavorText: facet.flavorText,
+      imagePath: facet.imagePath,
+      icon: facet.icon,
+      badge: taxonomyLabel(facet.taxonomy),
+    })),
+)
+
+const rewardOptions = computed<NarrativeIngredientOption[]>(() =>
+  rewardStore.rewards
+    .filter((reward) => reward.isActive && reward.slug)
+    .map((reward) => ({
+      id: reward.id,
+      slug: reward.slug || String(reward.id),
+      title: reward.name || `Reward ${reward.id}`,
+      description: reward.description || reward.effect,
+      flavorText: reward.flavorText,
+      imagePath: reward.imagePath,
+      icon: reward.icon || 'kind-icon:gift',
+      badge: `${rarityLabel(reward.rarity)} ${reward.rewardType.toLowerCase()}`,
+    })),
+)
+
+const selectedCast = computed(() =>
+  characterOptions.value.filter((item) =>
+    store.setupDraft.castSlugs.includes(item.slug),
+  ),
+)
+const selectedScenario = computed(() =>
+  scenarioOptions.value.find(
+    (item) => item.slug === store.setupDraft.scenarioSlug,
+  ),
+)
+const selectedLocation = computed(() =>
+  locationOptions.value.find(
+    (item) => item.slug === store.setupDraft.locationSlug,
+  ),
+)
+const selectedFacets = computed(() =>
+  facetOptions.value.filter((item) =>
+    store.setupDraft.facetSlugs.includes(item.slug),
+  ),
+)
+const selectedRewards = computed(() =>
+  rewardOptions.value.filter((item) =>
+    store.setupDraft.rewardSlugs.includes(item.slug),
+  ),
+)
+
+const canBegin = computed(() => store.setupDraft.premise.trim().length >= 10)
+const structureLabel = computed(
+  () =>
+    STORYBOOK_STRUCTURES.find(
+      (structure) => structure.value === store.setupDraft.structure,
+    )?.label || store.setupDraft.structure,
+)
+
+function taxonomyLabel(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function rarityLabel(value: string): string {
+  return value.toLowerCase().replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function assignedRole(slug: string): string | null {
+  const key = store.setupDraft.castRoles?.[slug]
+  return key && isNarrativeRoleKey(key) ? key : null
+}
+
+function toIngredient(option: NarrativeIngredientOption): StorybookIngredient {
+  const reward = rewardStore.rewards.find((item) => item.slug === option.slug)
+  return {
+    id: option.id,
+    slug: option.slug,
+    title: option.title,
+    description: option.description,
+    flavorText: option.flavorText,
+    imagePath: option.cardPath || option.imagePath || option.heroPath || null,
+    icon: option.icon,
+    rarity: reward?.rarity || null,
+    effect: reward?.effect || null,
+  }
+}
+
+async function beginStory(): Promise<void> {
+  if (!canBegin.value || store.isWeaving) return
+  await store.beginStory({
+    title: store.setupDraft.title,
+    premise: store.setupDraft.premise,
+    narratorStyle: store.setupDraft.narratorStyle,
+    structure: store.setupDraft.structure,
+    cast: selectedCast.value.map((member) => ({
+      ...toIngredient(member),
+      roleKey: assignedRole(member.slug),
+    })),
+    location: selectedLocation.value
+      ? toIngredient(selectedLocation.value)
+      : undefined,
+    facets: selectedFacets.value.map(toIngredient),
+    rewards: selectedRewards.value.map(toIngredient),
+    scenario: selectedScenario.value
+      ? toIngredient(selectedScenario.value)
+      : undefined,
+    notes: store.setupDraft.notes,
+  })
+}
+</script>

--- a/components/storybook/storybook-visual-setup.vue
+++ b/components/storybook/storybook-visual-setup.vue
@@ -33,7 +33,9 @@
         </p>
       </header>
 
-      <div class="mx-auto grid max-w-7xl gap-4 xl:grid-cols-[minmax(0,1.6fr)_minmax(18rem,0.65fr)]">
+      <div
+        class="mx-auto grid max-w-7xl grid-cols-[repeat(auto-fit,minmax(min(100%,24rem),1fr))] gap-4"
+      >
         <section
           class="rounded-[1.75rem] border border-primary/20 bg-base-100/90 p-4 shadow-lg backdrop-blur sm:p-5"
         >
@@ -51,7 +53,9 @@
             </div>
           </div>
 
-          <div class="mt-4 grid gap-3 sm:grid-cols-[minmax(12rem,0.55fr)_minmax(0,1fr)]">
+          <div
+            class="mt-4 grid grid-cols-[repeat(auto-fit,minmax(min(100%,14rem),1fr))] gap-3"
+          >
             <label class="form-control">
               <span
                 class="mb-1 text-[0.68rem] font-black uppercase tracking-wider text-base-content/50"
@@ -122,7 +126,7 @@
 
           <button
             type="button"
-            class="kr-btn-primary mt-5 w-full justify-center rounded-2xl"
+            class="kr-btn-primary mt-5 w-full justify-center rounded-2xl motion-reduce:transition-none"
             :disabled="!canBegin || store.isWeaving"
             @click="beginStory"
           >
@@ -148,12 +152,14 @@
           </p>
           <h2 class="text-xl font-black">Choose a narrator voice</h2>
         </div>
-        <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        <div
+          class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,10rem),1fr))] gap-3"
+        >
           <button
             v-for="option in narratorCards"
             :key="option.value"
             type="button"
-            class="group relative aspect-[2/3] overflow-hidden rounded-[1.5rem] border text-left shadow-md transition hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 motion-reduce:transform-none"
+            class="group relative aspect-[2/3] overflow-hidden rounded-[1.5rem] border text-left shadow-md transition hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 motion-reduce:transform-none motion-reduce:transition-none"
             :class="
               store.setupDraft.narratorStyle === option.value
                 ? 'border-primary ring-2 ring-primary/45'
@@ -165,7 +171,7 @@
             <img
               :src="option.image"
               alt=""
-              class="absolute inset-0 size-full object-cover transition duration-300 group-hover:scale-105"
+              class="absolute inset-0 size-full object-cover transition duration-300 group-hover:scale-105 motion-reduce:transition-none"
               aria-hidden="true"
             />
             <span
@@ -198,12 +204,14 @@
           </p>
           <h2 class="text-xl font-black">Choose the shape of the tale</h2>
         </div>
-        <div class="grid gap-3 sm:grid-cols-3">
+        <div
+          class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,15rem),1fr))] gap-3"
+        >
           <button
             v-for="option in structureCards"
             :key="option.value"
             type="button"
-            class="group relative min-h-48 overflow-hidden rounded-[1.5rem] border text-left shadow-md transition hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 motion-reduce:transform-none"
+            class="group relative min-h-48 overflow-hidden rounded-[1.5rem] border text-left shadow-md transition hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 motion-reduce:transform-none motion-reduce:transition-none"
             :class="
               store.setupDraft.structure === option.value
                 ? 'border-primary ring-2 ring-primary/45'
@@ -215,7 +223,7 @@
             <img
               :src="option.image"
               alt=""
-              class="absolute inset-0 size-full object-cover transition duration-300 group-hover:scale-105"
+              class="absolute inset-0 size-full object-cover transition duration-300 group-hover:scale-105 motion-reduce:transition-none"
               aria-hidden="true"
             />
             <span
@@ -332,7 +340,7 @@
       >
         <button
           type="button"
-          class="btn btn-ghost btn-sm rounded-xl"
+          class="btn btn-ghost btn-sm rounded-xl motion-reduce:transition-none"
           :disabled="store.isWeaving"
           @click="store.resetSetup()"
         >
@@ -344,7 +352,7 @@
           </p>
           <button
             type="button"
-            class="kr-btn-primary rounded-xl"
+            class="kr-btn-primary rounded-xl motion-reduce:transition-none"
             :disabled="!canBegin || store.isWeaving"
             @click="beginStory"
           >

--- a/utils/scripts/verifyStorybookSessionLibrary.mjs
+++ b/utils/scripts/verifyStorybookSessionLibrary.mjs
@@ -16,7 +16,6 @@ const storePath = 'stores/storybookStore.ts'
 
 const helper = source(helperPath)
 const shell = source(shellPath)
-const store = source(storePath)
 
 includesAll(helperPath, [
   "const LIBRARY_STORAGE_KEY = 'storybook-session-library-v1'",

--- a/utils/scripts/verifyStorybookStudio.mjs
+++ b/utils/scripts/verifyStorybookStudio.mjs
@@ -15,13 +15,72 @@ function includesAll(path, values) {
 }
 
 const pagePath = 'components/conductor/storybook-page.vue'
+const shellPath = 'components/pages/storybook-library-page.vue'
+const setupPath = 'components/storybook/storybook-visual-setup.vue'
+const ingredientCardPath = 'components/narrative/narrative-ingredient-card.vue'
 const storePath = 'stores/storybookStore.ts'
-const page = source(pagePath)
-const store = source(storePath)
+const agentsPath = 'AGENTS.md'
 
-includesAll(pagePath, [
+const page = source(pagePath)
+const shell = source(shellPath)
+const setup = source(setupPath)
+const ingredientCard = source(ingredientCardPath)
+const store = source(storePath)
+const agents = source(agentsPath)
+
+includesAll(shellPath, [
+  '<StorybookVisualSetup v-if="!storyStore.session"',
+  'v-show="storyStore.session"',
+  '<StorybookPage />',
+])
+
+includesAll(setupPath, [
+  'Lay out your story',
+  'The spark',
+  'Choose a narrator voice',
+  'Choose the shape of the tale',
   '<NarrativeIngredientMultiPicker',
   '<NarrativeIngredientPicker',
+  '<NarrativeRoleAssigner',
+  'characterOptions',
+  'scenarioOptions',
+  'locationOptions',
+  'facetOptions',
+  'rewardOptions',
+  'store.beginStory',
+])
+
+assert.ok(
+  !setup.includes('setupStep'),
+  'The primary Storybook setup must be one visual surface, not a step/tab wizard',
+)
+assert.ok(
+  !setup.includes('setupSteps'),
+  'The primary Storybook setup must not recreate the four-step progress nav',
+)
+
+includesAll(ingredientCardPath, [
+  'aspect-[2/3]',
+  'object-cover',
+  'bg-linear-to-t from-black/90',
+])
+assert.ok(
+  !ingredientCard.includes('w-28 shrink-0'),
+  'Narrative entity art must not be reduced to the old left-thumbnail form row',
+)
+
+assert.match(
+  agents,
+  /Kind Robots is an \*\*art-focused website\*\*/,
+  'The standing agent contract must preserve the art-first product rule',
+)
+assert.match(
+  agents,
+  /Avoid wizard\/tab proliferation/,
+  'Creative setup flows must prefer open visual composition over wizard tabs',
+)
+
+includesAll(pagePath, [
   '<KrChatWindow',
   '<NarrativeResponseComposer',
   'Story bible',
@@ -68,9 +127,6 @@ assert.ok(
   'Storybook store must not treat roadmap tasks as story state',
 )
 
-// Opening generation is the only beat created before the reader has any
-// recovery control. A failed first weave must return to the saved setup draft
-// instead of leaving an active zero-beat session that cannot continue.
 const beginStoryBlock = store.slice(
   store.indexOf('async function beginStory'),
   store.indexOf('async function answerCurrentBeat'),
@@ -89,7 +145,7 @@ includesAll('components/narrative/narrative-ingredient-multi-picker.vue', [
 ])
 
 console.log(
-  'Storybook studio contract passed: dedicated progressive setup, reusable ' +
-    'creative entities, story-bible review, persistent independent sessions, ' +
+  'Storybook studio contract passed: art-first single-screen story spread, ' +
+    'image-led reusable entity choices, independent persistent sessions, ' +
     'shared narrative presentation, and no Taskmaster/task-write boundary leak.',
 )

--- a/utils/scripts/verifyStorybookStudio.mjs
+++ b/utils/scripts/verifyStorybookStudio.mjs
@@ -22,7 +22,6 @@ const storePath = 'stores/storybookStore.ts'
 const agentsPath = 'AGENTS.md'
 
 const page = source(pagePath)
-const shell = source(shellPath)
 const setup = source(setupPath)
 const ingredientCard = source(ingredientCardPath)
 const store = source(storePath)


### PR DESCRIPTION
Silas rejected the current Storybook setup in visual acceptance. The four-step form reads like settings UI, not an art-focused creative product.

This redesign keeps the existing Storybook engine/persistence and replaces the primary setup surface:

- one continuous, open setup screen instead of the visible four-step wizard
- large illustrated narrator and story-shape cards
- Character, Scenario, Dream, Facet, and Reward choices presented as 2:3 art-first cards rather than text rows with a thumbnail
- real entity artwork remains the primary selection surface when available; fallback art keeps the same image-shaped card geometry
- existing casting/role board is preserved inside the single story spread
- a visible “Your spread” summary and sticky “Open this story” action replace the separate review step
- the legacy StorybookPage stays mounted but hidden during setup so its mature restore/query-seeding/data-init lifecycle is preserved; it becomes visible once a story session exists
- the root AGENTS contract now codifies Silas’s standing rule that Kind Robots is an art-focused site and non-settings creative surfaces must be visual, not merely technically complete

The Storybook studio contract now guards the new one-screen/art-first architecture so a future cleanup cannot quietly turn it back into a form wizard.

Conductor storybook/t-016 has been sent back from human acceptance and should not be re-presented to Silas until this redesign is merged and deployed.