### PR TITLE
style: add kr-toggle-row-compact/-xs/-plain primitives, migrate 7 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -762,6 +762,36 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply label cursor-pointer justify-between rounded-2xl border border-base-300 bg-base-200 px-3 py-2;
   }
 
+  /* .kr-toggle-row-sm's own bg-base-200/px-3-py-2 shape at .kr-panel-
+   * compact's tighter rounded-xl radius instead of rounded-2xl, with a
+   * `gap-2` label layout instead of `justify-between` (interface-vision
+   * t-104 slice 145) -- these three checkbox toggles sit close to their own
+   * label text rather than spread to the row's far edge. Previously
+   * hand-rolled identically across 3 occurrences in image-upload.vue
+   * (CFG + 0.5 / Public / Mature flag toggles). */
+  .kr-toggle-row-compact {
+    @apply label cursor-pointer gap-2 rounded-xl border border-base-300 bg-base-200 px-3 py-2;
+  }
+
+  /* .kr-toggle-row-compact's own shape one radius/padding step tighter still
+   * (interface-vision t-104 slice 145) -- `rounded-lg`/`px-2 py-1.5` instead
+   * of `rounded-xl`/`px-3 py-2`, otherwise identical (bg-base-200, `gap-2`
+   * label layout). Previously hand-rolled identically across 2 occurrences
+   * in art-styler.vue (inherit-negative-prompt / public toggles). */
+  .kr-toggle-row-xs {
+    @apply label cursor-pointer gap-2 rounded-lg border border-base-300 bg-base-200 px-2 py-1.5;
+  }
+
+  /* .kr-toggle-row-compact's own rounded-xl/px-3-py-2 shape on the "plain"
+   * base-100 background instead of base-200, with the `justify-between`
+   * label layout .kr-toggle-row/-sm use (interface-vision t-104 slice 145)
+   * -- the base-100 counterpart these two rounded-2xl variants never covered.
+   * Previously hand-rolled identically across 2 occurrences in
+   * art-interact.vue (Public / Mature toggles). */
+  .kr-toggle-row-plain {
+    @apply label cursor-pointer justify-between rounded-xl border border-base-300 bg-base-100 px-3 py-2;
+  }
+
   /* Larger-radius page-section surface: coloring-book studio panels and
    * conductor-app project pages. Approved by Silas (interface-vision/t-123)
    * as the named primitive for the previously hand-rolled

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -297,9 +297,7 @@
                 />
               </label>
 
-              <label
-                class="label cursor-pointer justify-between rounded-xl border border-base-300 bg-base-100 px-3 py-2"
-              >
+              <label class="kr-toggle-row-plain">
                 <span class="label-text text-xs font-bold">Public</span>
                 <input
                   v-model="editForm.isPublic"
@@ -308,9 +306,7 @@
                 />
               </label>
 
-              <label
-                class="label cursor-pointer justify-between rounded-xl border border-base-300 bg-base-100 px-3 py-2"
-              >
+              <label class="kr-toggle-row-plain">
                 <span class="label-text text-xs font-bold">Mature</span>
                 <input
                   v-model="editForm.isMature"

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -506,9 +506,7 @@
         />
 
         <div class="flex items-center gap-2">
-          <label
-            class="label cursor-pointer gap-2 rounded-lg border border-base-300 bg-base-200 px-2 py-1.5"
-          >
+          <label class="kr-toggle-row-xs">
             <input
               v-model="useNegative"
               type="checkbox"
@@ -519,9 +517,7 @@
               Inherit negative prompt
             </span>
           </label>
-          <label
-            class="label cursor-pointer gap-2 rounded-lg border border-base-300 bg-base-200 px-2 py-1.5"
-          >
+          <label class="kr-toggle-row-xs">
             <input
               v-model="isPublic"
               type="checkbox"

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -296,9 +296,7 @@
 
           <!-- Flag toggles -->
           <div class="mt-3 flex flex-wrap gap-2">
-            <label
-              class="label cursor-pointer gap-2 rounded-xl border border-base-300 bg-base-200 px-3 py-2"
-            >
+            <label class="kr-toggle-row-compact">
               <input
                 v-model="imageForm.cfgHalf"
                 type="checkbox"
@@ -307,9 +305,7 @@
               />
               <span class="label-text text-xs font-semibold">CFG + 0.5</span>
             </label>
-            <label
-              class="label cursor-pointer gap-2 rounded-xl border border-base-300 bg-base-200 px-3 py-2"
-            >
+            <label class="kr-toggle-row-compact">
               <input
                 v-model="imageForm.isPublic"
                 type="checkbox"
@@ -318,9 +314,7 @@
               />
               <span class="label-text text-xs font-semibold">Public</span>
             </label>
-            <label
-              class="label cursor-pointer gap-2 rounded-xl border border-base-300 bg-base-200 px-3 py-2"
-            >
+            <label class="kr-toggle-row-compact">
               <input
                 v-model="imageForm.isMature"
                 type="checkbox"


### PR DESCRIPTION
### Task
interface-vision/t-104: slice 145 of the recurring kr-* front-end consistency sweep (kind: software)

### What changed / what I produced
- Added three new members to the `.kr-toggle-row` shape family in `assets/css/tailwind.css` (a bordered/backed box wrapping a DaisyUI toggle checkbox + label), previously only covered at rounded-2xl/px-4-py-3 (`.kr-toggle-row`) and rounded-2xl/px-3-py-2 (`.kr-toggle-row-sm`):
  - `.kr-toggle-row-compact`: `rounded-xl border border-base-300 bg-base-200 px-3 py-2` + `gap-2` label layout — migrated `components/art/image-upload.vue`'s CFG+0.5/Public/Mature flag toggles (3 occurrences)
  - `.kr-toggle-row-xs`: `rounded-lg border border-base-300 bg-base-200 px-2 py-1.5` + `gap-2` label layout — migrated `components/art/art-styler.vue`'s inherit-negative-prompt/public toggles (2 occurrences)
  - `.kr-toggle-row-plain`: `rounded-xl border border-base-300 bg-base-100 px-3 py-2` + `justify-between` label layout — migrated `components/art/art-interact.vue`'s Public/Mature toggles (2 occurrences)
- These 7 occurrences were previously surveyed and explicitly skipped by `kr_panel_codemod.py`'s dry-run report as "unsafe extra tokens, needs manual review" (the `label` root class isn't in that codemod's safe-extras allowlist) — confirmed by inspection that all 7 are genuine toggle-row shapes (checkbox + `toggle` input inside a `label`), just at three previously-uncovered radius/background/padding/label-layout combinations.
- No geometry or behavior change: each new class's `@apply` rule reproduces its prior hand-rolled utility sequence exactly.

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint` on all 3 changed `.vue` files: clean (0 errors)
- `npm run test:layout-contract`: holds at the existing 207-violation baseline (unchanged bucket, `viewport-grid` only — this slice didn't touch that rule)
- `npm run test:lint-ratchet`: holds at 334 problems/-58 (no rule got worse)
- `prettier --check`: flagged the 3 changed `.vue` files after the substitution (shortened `class` attribute reflowing onto one line); ran `prettier --write` on just those 3 files and re-verified clean — pure formatting, no visual change. `assets/css/tailwind.css`'s own prettier warning was confirmed pre-existing via `git stash` before this change.

### Stakes
reversible

### Flags for Reviewer
None — small, mechanical, fully verified.

### Kaizen suggestion
None new this slice — all known codemods (`kr_panel_codemod.py`, `kr_badge_codemod.py`, `kr_checkbox_codemod.py`, `kr_input_codemod.py`, `kr_input_select_codemod.py`, `kr_panel_section_codemod.py`, `kr_textarea_codemod.py`, `kr_btn_order_variant_codemod.py`, `kr_btn_xs_codemod.py`) are at 0 remaining candidates as of this session. The next bounded family will need a fresh survey of the codebase for a not-yet-named hand-rolled pattern.

### Notes for reviewer
`kindrobots.org` production is down (site-wide 502, already tracked as `kindrobots-unraid/t-015`) during this session, so no live/deployed verification was possible or attempted beyond local `vue-tsc`/`eslint`/contract checks — unrelated to this PR's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Usur9wfFGWCXwmcX27gEa5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Usur9wfFGWCXwmcX27gEa5)_