### PR TITLE
Rainbow profiles: use ArtImage-backed avatars

### DIFF
--- a/server/api/rainbow/directory/profile.get.ts
+++ b/server/api/rainbow/directory/profile.get.ts
@@ -2,6 +2,7 @@ import { defineEventHandler } from 'h3'
 import { requireHumanOrRainbowApiUser } from '@/server/utils/authGuard'
 import { errorHandler } from '@/server/utils/error'
 import prisma from '@/server/utils/prisma'
+import { resolveRainbowAvatar } from '@/server/utils/rainbowDirectory'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -12,6 +13,7 @@ export default defineEventHandler(async (event) => {
         id: true,
         username: true,
         avatarImage: true,
+        artImageId: true,
         bio: true,
         designerName: true,
       },
@@ -20,7 +22,13 @@ export default defineEventHandler(async (event) => {
       event.node.res.statusCode = 404
       return { success: false, message: 'User not found.' }
     }
-    return { success: true, user }
+    return {
+      success: true,
+      user: {
+        ...user,
+        avatarImage: resolveRainbowAvatar(user),
+      },
+    }
   } catch (error) {
     const { message, statusCode } = errorHandler(error)
     event.node.res.statusCode = statusCode || 500

--- a/server/api/rainbow/directory/profile.patch.ts
+++ b/server/api/rainbow/directory/profile.patch.ts
@@ -2,9 +2,11 @@ import { createError, defineEventHandler, readBody } from 'h3'
 import { requireHumanOrRainbowApiUser } from '@/server/utils/authGuard'
 import { errorHandler } from '@/server/utils/error'
 import prisma from '@/server/utils/prisma'
+import { resolveRainbowAvatar } from '@/server/utils/rainbowDirectory'
 
 type ProfileBody = {
   avatarImage?: unknown
+  artImageId?: unknown
   bio?: unknown
   designerName?: unknown
 }
@@ -22,21 +24,68 @@ function optionalText(value: unknown, label: string, max: number): string | null
   return trimmed || null
 }
 
+function optionalArtImageId(value: unknown): number | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null || value === '') return null
+  const id = Number(value)
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError({ statusCode: 400, message: 'artImageId must be a positive image id.' })
+  }
+  return id
+}
+
 export default defineEventHandler(async (event) => {
   try {
     const auth = await requireHumanOrRainbowApiUser(event)
     const body = (await readBody<ProfileBody>(event)) ?? {}
     const avatarImage = optionalText(body.avatarImage, 'avatarImage', 764)
+    const artImageId = optionalArtImageId(body.artImageId)
     const bio = optionalText(body.bio, 'bio', 5000)
     const designerName = optionalText(body.designerName, 'designerName', 120)
 
-    const data: { avatarImage?: string | null; bio?: string | null; designerName?: string | null } = {}
+    const data: {
+      avatarImage?: string | null
+      artImageId?: number | null
+      bio?: string | null
+      designerName?: string | null
+    } = {}
     if (avatarImage !== undefined) data.avatarImage = avatarImage
+    if (artImageId !== undefined) data.artImageId = artImageId
     if (bio !== undefined) data.bio = bio
     if (designerName !== undefined) data.designerName = designerName
+
     if (!Object.keys(data).length) {
       throw createError({ statusCode: 400, message: 'No supported profile fields were provided.' })
     }
+
+    if (artImageId !== undefined && artImageId !== null) {
+      const image = await prisma.artImage.findFirst({
+        where: {
+          id: artImageId,
+          userId: auth.user.id,
+          isActive: true,
+          isMature: false,
+        },
+        select: { id: true },
+      })
+      if (!image) {
+        throw createError({
+          statusCode: 400,
+          message: 'Avatar must be one of your active non-mature images.',
+        })
+      }
+
+      // A Rainbow directory avatar is a public profile asset. Publish only the
+      // selected image, then link it by ArtImage id just like Kind Robots' own
+      // avatar picker. Never copy base64 into User.avatarImage.
+      await prisma.artImage.update({
+        where: { id: image.id },
+        data: { isPublic: true, isMature: false },
+      })
+      data.avatarImage = null
+    }
+
+    if (artImageId === null) data.avatarImage = avatarImage ?? null
 
     const user = await prisma.user.update({
       where: { id: auth.user.id },
@@ -45,11 +94,18 @@ export default defineEventHandler(async (event) => {
         id: true,
         username: true,
         avatarImage: true,
+        artImageId: true,
         bio: true,
         designerName: true,
       },
     })
-    return { success: true, user }
+    return {
+      success: true,
+      user: {
+        ...user,
+        avatarImage: resolveRainbowAvatar(user),
+      },
+    }
   } catch (error) {
     const { message, statusCode } = errorHandler(error)
     event.node.res.statusCode = statusCode || 500

--- a/server/utils/rainbowDirectory.ts
+++ b/server/utils/rainbowDirectory.ts
@@ -28,6 +28,44 @@ export type RainbowDirectoryHuman = {
   allowMessages: boolean
 }
 
+function kindRobotsPublicOrigin(): string {
+  const configured = String(process.env.APP_BASE_URL || 'https://kindrobots.org').trim()
+  try {
+    return new URL(configured).origin
+  } catch {
+    return 'https://kindrobots.org'
+  }
+}
+
+/**
+ * Rainbow is a separate origin from Kind Robots, so a legacy avatar such as
+ * `/images/avatars/foo.webp` must not be handed to Rainbow as a bare relative
+ * path. Uploaded user avatars use artImageId as their durable source of truth,
+ * matching Kind Robots' own avatar picker.
+ */
+export function resolveRainbowAvatar(input: {
+  avatarImage?: string | null
+  artImageId?: number | null
+}): string | null {
+  const origin = kindRobotsPublicOrigin()
+  const artImageId = Number(input.artImageId)
+  if (Number.isInteger(artImageId) && artImageId > 0) {
+    return `${origin}/api/art/images/${artImageId}/file`
+  }
+
+  const raw = input.avatarImage?.trim()
+  if (!raw) return null
+
+  try {
+    const parsed = new URL(raw)
+    if (parsed.protocol === 'https:' || parsed.protocol === 'http:') return parsed.toString()
+  } catch {
+    // Relative Kind Robots media path. Resolve it against the canonical origin.
+  }
+
+  return new URL(raw.replace(/^\.?\//, ''), `${origin}/`).toString()
+}
+
 export async function getRainbowDirectoryPreference(
   userId: number,
 ): Promise<RainbowDirectoryPreference> {
@@ -76,6 +114,7 @@ export async function listPublicRainbowHumans(): Promise<RainbowDirectoryHuman[]
       id: number
       username: string
       avatarImage: string | null
+      artImageId: number | null
       bio: string | null
       designerName: string | null
       allowMessages: boolean | number
@@ -85,6 +124,7 @@ export async function listPublicRainbowHumans(): Promise<RainbowDirectoryHuman[]
       u.id,
       u.username,
       u.avatarImage,
+      u.artImageId,
       u.bio,
       u.designerName,
       rdp.allowMessages
@@ -97,11 +137,18 @@ export async function listPublicRainbowHumans(): Promise<RainbowDirectoryHuman[]
     LIMIT 500
   `)
 
-  return rows.map((row) => ({ ...row, allowMessages: Boolean(row.allowMessages) }))
+  return rows.map((row) => ({
+    id: row.id,
+    username: row.username,
+    avatarImage: resolveRainbowAvatar(row),
+    bio: row.bio,
+    designerName: row.designerName,
+    allowMessages: Boolean(row.allowMessages),
+  }))
 }
 
 export async function listPublicRainbowAgents(): Promise<RainbowDirectoryAgent[]> {
-  return prisma.agentProfile.findMany({
+  const agents = await prisma.agentProfile.findMany({
     where: { isPublic: true, isActive: true },
     orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
     take: 500,
@@ -115,6 +162,11 @@ export async function listPublicRainbowAgents(): Promise<RainbowDirectoryAgent[]
       createdAt: true,
     },
   })
+
+  return agents.map((agent) => ({
+    ...agent,
+    avatarImage: resolveRainbowAvatar({ avatarImage: agent.avatarImage }),
+  }))
 }
 
 export async function getPublicRainbowHuman(
@@ -125,6 +177,7 @@ export async function getPublicRainbowHuman(
       id: number
       username: string
       avatarImage: string | null
+      artImageId: number | null
       bio: string | null
       designerName: string | null
       allowMessages: boolean | number
@@ -134,6 +187,7 @@ export async function getPublicRainbowHuman(
       u.id,
       u.username,
       u.avatarImage,
+      u.artImageId,
       u.bio,
       u.designerName,
       rdp.allowMessages
@@ -147,13 +201,22 @@ export async function getPublicRainbowHuman(
   `)
 
   const row = humans[0]
-  return row ? { ...row, allowMessages: Boolean(row.allowMessages) } : null
+  return row
+    ? {
+        id: row.id,
+        username: row.username,
+        avatarImage: resolveRainbowAvatar(row),
+        bio: row.bio,
+        designerName: row.designerName,
+        allowMessages: Boolean(row.allowMessages),
+      }
+    : null
 }
 
 export async function getPublicRainbowAgent(
   agentProfileId: number,
 ): Promise<RainbowDirectoryAgent | null> {
-  return prisma.agentProfile.findFirst({
+  const agent = await prisma.agentProfile.findFirst({
     where: { id: agentProfileId, isPublic: true, isActive: true },
     select: {
       id: true,
@@ -165,12 +228,16 @@ export async function getPublicRainbowAgent(
       createdAt: true,
     },
   })
+
+  return agent
+    ? { ...agent, avatarImage: resolveRainbowAvatar({ avatarImage: agent.avatarImage }) }
+    : null
 }
 
 export async function getPublicAgentsForHuman(
   userId: number,
 ): Promise<RainbowDirectoryAgent[]> {
-  return prisma.agentProfile.findMany({
+  const agents = await prisma.agentProfile.findMany({
     where: { userId, isPublic: true, isActive: true },
     orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
     select: {
@@ -183,6 +250,11 @@ export async function getPublicAgentsForHuman(
       createdAt: true,
     },
   })
+
+  return agents.map((agent) => ({
+    ...agent,
+    avatarImage: resolveRainbowAvatar({ avatarImage: agent.avatarImage }),
+  }))
 }
 
 export function parsePositiveDirectoryId(value: unknown, label = 'id'): number {

--- a/tests/contracts/verifyRainbowDirectory.ts
+++ b/tests/contracts/verifyRainbowDirectory.ts
@@ -29,6 +29,16 @@ assert.match(helper, /isPublic: true, isActive: true/)
 assert.match(listing, /listPublicRainbowHumans/)
 assert.match(listing, /listPublicRainbowAgents/)
 
+// Directory avatars are cross-origin-safe. User ArtImages are the durable
+// source of truth and old relative Kind Robots media paths are made absolute
+// before Rainbow receives them.
+assert.match(helper, /u\.artImageId/)
+assert.match(helper, /resolveRainbowAvatar/)
+assert.match(helper, /\/api\/art\/images\/\$\{artImageId\}\/file/)
+assert.match(helper, /kindrobots\.org/)
+assert.match(profileGet, /artImageId/)
+assert.match(profileGet, /resolveRainbowAvatar/)
+
 // A public AgentProfile may remain visible while its human liaison is private;
 // the public response omits the canonical owner scalar and only emits a
 // liaison object when the human independently opted in.
@@ -57,5 +67,15 @@ for (const source of [profileGet, profilePatch]) {
   assert.match(source, /designerName/)
   assert.doesNotMatch(source, /email|password|apiKey|tokens|mana/)
 }
+
+// Rainbow may link only one of the signed-in human's active, non-mature
+// ArtImages. Selecting it publishes only that avatar asset and clears the
+// legacy URL field so base64/string avatar state cannot drift in parallel.
+assert.match(profilePatch, /artImageId/)
+assert.match(profilePatch, /userId: auth\.user\.id/)
+assert.match(profilePatch, /isActive: true/)
+assert.match(profilePatch, /isMature: false/)
+assert.match(profilePatch, /data: \{ isPublic: true, isMature: false \}/)
+assert.match(profilePatch, /data\.avatarImage = null/)
 
 console.log('Rainbow community directory contract OK')


### PR DESCRIPTION
## What
- allow the trusted Rainbow first-party profile surface to link an owned `ArtImage` by `artImageId`
- verify the selected image belongs to the signed-in user, is active, and is non-mature
- use the same `artImageId` avatar source-of-truth already used by Kind Robots' avatar picker
- resolve ArtImage avatars to the public `/api/art/images/:id/file` route
- normalize legacy relative avatar paths such as `/images/avatars/...` to the canonical Kind Robots origin
- apply the same relative-path normalization to public agent avatars
- extend the Rainbow directory contract coverage

## Why
Rainbow Butterflies currently exposes `User.avatarImage` as a literal URL field. Besides being poor UX, relative Kind Robots image paths are then interpreted as Rainbow paths and break. The Kind Robots app already solved uploaded avatars properly by storing them as ArtImages and linking `User.artImageId`; Rainbow should reuse that contract rather than inventing a second avatar system.

The selected avatar ArtImage is made public/non-mature because it becomes a public directory profile asset. No arbitrary ArtImage IDs or cross-user images can be linked.