### PR TITLE
style: add kr-btn-ghost-*-outline primitives, migrate 5 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1056,6 +1056,44 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-ghost rounded-2xl;
   }
 
+  /* A ghost button styled to also read as an outlined surface — the same
+   * `border border-base-300 bg-base-100` outline .kr-panel-flat gives a
+   * container, layered on top of the `sm`/`rounded-xl` ghost-button shape
+   * (interface-vision t-104 slice 147). `btn btn-ghost btn-sm rounded-xl
+   * border border-base-300 bg-base-100`, previously hand-rolled in
+   * workspace-header.vue. Named `-outline` (not a size/radius suffix) since
+   * it adds a border+background layer on top of an existing shape rather
+   * than changing the shape itself — mirrors `badge-outline`'s modifier
+   * role on the badge family. */
+  .kr-btn-ghost-outline {
+    @apply btn btn-ghost btn-sm rounded-xl border border-base-300 bg-base-100;
+  }
+
+  /* The `.kr-btn-ghost-md` (DaisyUI default size) counterpart to
+   * .kr-btn-ghost-outline (interface-vision t-104 slice 147): `btn btn-ghost
+   * rounded-xl border border-base-300 bg-base-100`, previously hand-rolled
+   * in taskmaster-page.vue. */
+  .kr-btn-ghost-md-outline {
+    @apply btn btn-ghost rounded-xl border border-base-300 bg-base-100;
+  }
+
+  /* The `.kr-btn-ghost-2xl` (wider corner radius) counterpart to
+   * .kr-btn-ghost-outline (interface-vision t-104 slice 147): `btn btn-ghost
+   * btn-sm rounded-2xl border border-base-300 bg-base-100`, previously
+   * hand-rolled in chat-gallery.vue. */
+  .kr-btn-ghost-2xl-outline {
+    @apply btn btn-ghost btn-sm rounded-2xl border border-base-300 bg-base-100;
+  }
+
+  /* The `.kr-btn-ghost-md-2xl` counterpart to .kr-btn-ghost-outline
+   * (interface-vision t-104 slice 147): `btn btn-ghost rounded-2xl border
+   * border-base-300 bg-base-100`, previously hand-rolled in
+   * chat-gallery.vue (a second, distinct call site from the -2xl-outline
+   * shape above). */
+  .kr-btn-ghost-md-2xl-outline {
+    @apply btn btn-ghost rounded-2xl border border-base-300 bg-base-100;
+  }
+
   /* The most-repeated *filled* (non-ghost) button shape in the app
    * (interface-vision t-104 slice 51): the primary-color small action
    * button used for form submits and gallery/manager primary actions —

--- a/components/navigation/server-selector.vue
+++ b/components/navigation/server-selector.vue
@@ -2,7 +2,7 @@
 <template>
   <div class="relative inline-flex shrink-0">
     <button
-      class="btn btn-sm btn-ghost flex h-9 min-h-9 w-9 min-w-9 shrink-0 items-center justify-center rounded-xl border border-base-300 bg-base-100 p-0 sm:h-full sm:w-full sm:min-w-0"
+      class="kr-btn-ghost-outline flex h-9 min-h-9 w-9 min-w-9 shrink-0 items-center justify-center p-0 sm:h-full sm:w-full sm:min-w-0"
       type="button"
       title="Server settings"
       aria-label="Server settings"

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -51,7 +51,7 @@
       <button
         v-if="showBackButton"
         type="button"
-        class="btn btn-ghost btn-sm btn-square shrink-0 rounded-xl border border-base-300 bg-base-100"
+        class="kr-btn-ghost-outline btn-square shrink-0"
         aria-label="Go back"
         title="Go back"
         @click="goBack"

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -385,7 +385,7 @@
           </p>
           <button
             type="button"
-            class="btn btn-ghost flex-1 rounded-xl border border-base-300 bg-base-100 sm:flex-none"
+            class="kr-btn-ghost-md-outline flex-1 sm:flex-none"
             :disabled="store.isWeaving || !canBegin"
             @click="begin(true)"
           >

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -18,7 +18,7 @@
 
         <button
           v-if="activeThread"
-          class="btn btn-ghost btn-sm shrink-0 rounded-2xl border border-base-300 bg-base-100"
+          class="kr-btn-ghost-2xl-outline shrink-0"
           type="button"
           @click="closeThread"
         >
@@ -45,7 +45,7 @@
         </label>
 
         <button
-          class="btn btn-ghost rounded-2xl border border-base-300 bg-base-100"
+          class="kr-btn-ghost-md-2xl-outline"
           type="button"
           :disabled="isLoading"
           @click="refreshChats"

--- a/utils/scripts/codemods/kr_btn_ghost_outline_codemod.py
+++ b/utils/scripts/codemods/kr_btn_ghost_outline_codemod.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled kr-btn-ghost-{outline,md-outline,2xl-outline,
+md-2xl-outline} buttons — one of the four existing ghost-button base shapes
+(`.kr-btn-ghost`, `.kr-btn-ghost-md`, `.kr-btn-ghost-2xl`, `.kr-btn-ghost-md-2xl`)
+with a trailing `border border-base-300 bg-base-100` outline appended, the
+same border+background combo `.kr-panel-flat` gives a container
+(interface-vision t-104 slice 147).
+
+Dry-run is the default. Pass --write to update matching Vue files in place.
+Only static `class="..."` attributes are touched — never `:class`/
+`v-bind:class` bindings — regardless of the base tokens' order in the
+source. A source that already carries the target primitive, or is missing
+any one of the base tokens, is left untouched. Extra tokens beyond the base
+set (shrink-0, btn-square, flex-1, sm:flex-none, ...) are preserved verbatim
+after the primitive class, matching the kr-badge-*/kr-toggle-row-*
+codemods' subset-match convention — they're plain Tailwind utilities layered
+on top, not another component-root class.
+
+FAMILIES is ordered most-specific-first: each entry's base token set differs
+only in size (`btn-sm` vs bare) and radius (`rounded-xl` vs `rounded-2xl`),
+so no entry's base set is a subset of another's — order among them doesn't
+affect correctness, but keeping the four together (rather than interleaved
+with unrelated families) mirrors how the badge codemod groups its own
+same-shape variants.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+FAMILIES = [
+    (
+        "kr-btn-ghost-outline",
+        {"btn", "btn-ghost", "btn-sm", "rounded-xl", "border", "border-base-300", "bg-base-100"},
+    ),
+    (
+        "kr-btn-ghost-md-outline",
+        {"btn", "btn-ghost", "rounded-xl", "border", "border-base-300", "bg-base-100"},
+    ),
+    (
+        "kr-btn-ghost-2xl-outline",
+        {"btn", "btn-ghost", "btn-sm", "rounded-2xl", "border", "border-base-300", "bg-base-100"},
+    ),
+    (
+        "kr-btn-ghost-md-2xl-outline",
+        {"btn", "btn-ghost", "rounded-2xl", "border", "border-base-300", "bg-base-100"},
+    ),
+]
+
+
+def migrate_classes(classes: str) -> str | None:
+    tokens = classes.split()
+    for primitive, base_tokens in FAMILIES:
+        if primitive in tokens or not base_tokens.issubset(tokens):
+            continue
+        remaining = [token for token in tokens if token not in base_tokens]
+        return " ".join([primitive, *remaining])
+    return None
+
+
+def migrate_text(text: str) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1))
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim, same
+        # rationale as the badge/toggle-row codemods (interface-vision t-104
+        # slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-btn-ghost-*-outline {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules — slice 147 (kind: software, recurring)

### What changed / what I produced
- Added four new ghost-button primitives to `assets/css/tailwind.css`, each layering the same `border border-base-300 bg-base-100` outline `.kr-panel-flat` gives a container onto one of the four existing ghost-button base shapes:
  - `.kr-btn-ghost-outline` (`btn btn-ghost btn-sm rounded-xl` + outline)
  - `.kr-btn-ghost-md-outline` (`btn btn-ghost rounded-xl` + outline)
  - `.kr-btn-ghost-2xl-outline` (`btn btn-ghost btn-sm rounded-2xl` + outline)
  - `.kr-btn-ghost-md-2xl-outline` (`btn btn-ghost rounded-2xl` + outline)
- Added `utils/scripts/codemods/kr_btn_ghost_outline_codemod.py` (dry-run by default, `--write` to apply) and ran it to migrate all 5 previously hand-rolled call sites: `components/navigation/server-selector.vue`, `components/navigation/workspace-header.vue`, `components/pages/taskmaster-page.vue`, and `components/user/chat-gallery.vue` (2 occurrences).
- Every substitution folds only the matched base tokens into the new primitive class and preserves every extra utility token verbatim (e.g. `shrink-0`, `btn-square`, `flex-1 sm:flex-none`, the icon-button sizing on `server-selector.vue`) — no geometry or behavior change.
- Confirmed all 9 pre-existing kr-* codemods (`kr_panel_codemod.py`, `kr_badge_codemod.py`, `kr_checkbox_codemod.py`, `kr_input_codemod.py`, `kr_input_select_codemod.py`, `kr_panel_section_codemod.py`, `kr_textarea_codemod.py`, `kr_btn_order_variant_codemod.py`, `kr_btn_xs_codemod.py`) are at 0 remaining candidates — this is a freshly-surveyed pattern, not a known one that had gone unmigrated.

### How I verified
- `npm run test:layout-contract` — holds, no new violations (all counts unchanged).
- `npm run test:lint-ratchet` — holds at 334 problems / 24 rules (-58), no rule got worse.
- `npx vue-tsc --noEmit` — clean, 0 errors.
- `npx eslint` on all changed `.vue` files — 0 errors, 0 warnings.
- `npx prettier --check` on all changed files — the 2 files it flags (`tailwind.css`, `server-selector.vue`) carry the identical pre-existing warning verified via `git stash` against the unmodified baseline; not introduced by this diff.
- Manually surveyed the whole repo for the base token set (`btn`, `btn-ghost`, `border`, `border-base-300`, `bg-base-100`) together in a static `class="..."` attribute to confirm 5 was the complete candidate set, not a partial pass.

### Stakes
reversible

### Flags for Reviewer
- `server-selector.vue`'s occurrence carries many extra sizing/responsive tokens (`h-9 min-h-9 w-9 min-w-9 sm:h-full sm:w-full sm:min-w-0`, etc.) alongside the matched base — preserved verbatim after the primitive class per the same unrestricted subset-match convention the badge/toggle-row codemods already use for plain utility extras, so no style change results.

### Kaizen suggestion
No further known hand-rolled pattern survives this slice's survey; the next slice needs its own fresh survey for a not-yet-named shape, same as this one was needed after slice 146 drained every existing codemod's candidate pool.

### Notes for reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMVfe5DyXMan6e9rShhoQU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMVfe5DyXMan6e9rShhoQU)_