### PR TITLE
feat(header): add a Memory Dungeon shortcut beside the account hub

### DIFF
--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -14,6 +14,15 @@
   (see account-hub.vue for the inventory) and the horizontal tab strip became a
   dropdown hanging off its own title (see tab-select.vue).
 
+  FIVE, as of 2026-09-08. Silas asked for a Memory Dungeon link "on the
+  dashboard next to the tutorial and account manager links", and this cluster is
+  the only place those two sit side by side. It is a deliberate exception to the
+  rule above, not an oversight: the game is one of his oldest projects and he
+  wants it one click from anywhere. It obeys the constraint that actually
+  matters here -- a fixed-width square icon that never grows -- so it costs the
+  row nothing. It sits BEFORE the workspace toggle, because that one is
+  documented below as the last icon in the row and stays that way.
+
   WHAT THIS DELETES, and why none of it is missed
   ----------------------------------------------
   The strip took a scrolling viewport, two chevron scrollers, a map-icon
@@ -216,6 +225,39 @@
       <account-hub class="header-account shrink-0" />
 
       <!--
+        MEMORY DUNGEON. Silas, 2026-09-08: "I'm really proud of my memory match
+        game, it was one of my first projects and still one that I occasionally
+        return to. I want a link for it on the dashboard next to the tutorial
+        and account manager links."
+
+        A NuxtLink rather than a button because it is navigation, so it gets
+        middle-click, cmd-click and a real href for free. Square and
+        fixed-width, matching the toggle beside it -- see the note at the top of
+        this file about nothing in this row being allowed to grow.
+
+        The icon is the one the page declares for itself
+        (content/play/memory.md, `icon: kind-icon:brain`), so the button and the
+        page it opens agree; the route is that file's own path. The same game
+        also has a nav card in the footer deck (dashboardHelper.ts, the `games`
+        tab, which uses kind-icon:castle); this is a shortcut to it, not a
+        replacement.
+      -->
+      <NuxtLink
+        to="/play/memory"
+        class="btn btn-ghost btn-sm btn-square shrink-0 rounded-xl border border-base-300"
+        :class="
+          memoryActive
+            ? 'border-primary bg-primary/15 text-primary'
+            : 'bg-base-100'
+        "
+        :aria-current="memoryActive ? 'page' : undefined"
+        aria-label="Memory Dungeon"
+        title="Memory Dungeon"
+      >
+        <Icon name="kind-icon:brain" class="h-5 w-5" />
+      </NuxtLink>
+
+      <!--
         FAR RIGHT, per Silas, and the last icon standing in this row.
 
         It is the WORKSPACE toggle -- the workspace sheet is what carries the
@@ -322,6 +364,11 @@ const workspaceSheetOpen = computed(() => navStore.workspaceSheetOpen)
 const workspaceToggleLabel = computed(() =>
   workspaceSheetOpen.value ? 'Close workspace' : 'Open workspace',
 )
+
+// Lit when you are already in the dungeon, matching how the workspace toggle
+// shows its own open state. startsWith rather than an equality check because
+// the game's deeper routes (a level, a run) should keep the button lit too.
+const memoryActive = computed(() => route.path.startsWith('/play/memory'))
 
 const activeTabKey = computed(() => {
   const channel = resolvedChannel.value


### PR DESCRIPTION
## What

A one-click link to the Memory Dungeon in the workspace header, between the account hub and the `?` workspace toggle.

> "I'm really proud of my memory match game, it was one of my first projects and still one that I occasionally return to. I want a link for it on the dashboard next to the tutorial and account manager links." — Silas, 2026-09-08

That cluster is the only place in the app where those two sit side by side: `<account-hub>` (the account manager), then the workspace toggle that opens the tutorial panel.

## About the "four things" rule

`workspace-header.vue` opens with a note that this row holds exactly four things and warns against re-adding controls to it. Worth being explicit about why this doesn't violate it:

That warning is about **width**. The tab strip it replaced needed ~300 lines of capacity arithmetic — scroll viewport, chevrons, per-breakpoint measurement, a ResizeObserver — precisely because a child's width was unbounded. A fixed-width square icon costs the row nothing, and the constraint the note actually cares about ("nothing in it grows") still holds. The note now records the exception rather than being quietly contradicted.

Placed **before** the workspace toggle, which is documented as "the last icon standing in this row" and stays that way.

## Details

- `NuxtLink`, not a button — it's navigation, so middle-click, cmd-click and a real href come free.
- Lights up on `/play/memory` the way the workspace toggle shows its open state, via a `memoryActive` computed. Uses `startsWith` so deeper routes under the game keep it lit, and sets `aria-current="page"` when active.
- Icon is the one the page declares for itself (`content/play/memory.md`, `icon: kind-icon:brain`), so button and destination agree. The footer nav deck's `games` card uses `kind-icon:castle` and is unchanged — this is a shortcut to the game, not a replacement for that card.

## Testing

`npx prettier --check` clean, and `audit:icons` passes (`kind-icon:brain` exists at `assets/icons/brain.svg`; 232 distinct references, all resolving).

`nuxi prepare` can't run in this container — `@nuxt/kit` fails to resolve — so ESLint and `vue-tsc` couldn't run locally and are left to CI. The change is a template addition plus one `computed` using the already-declared `route`, so there's nothing new to resolve, but the typecheck is the real confirmation.

Not visually verified — no browser here. Worth a glance at the header on a narrow viewport to confirm the extra square doesn't crowd the tab dropdown at `sm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGb4quwjzWKjbgxAC6pgDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGb4quwjzWKjbgxAC6pgDx)_