### PR TITLE
style: add kr-tile-sm/-md primitives, migrate 33 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -744,6 +744,25 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-6;
   }
 
+  /* A genuinely new family, not another kr-panel-* variant (interface-vision
+   * t-104 slice 148): every kr-panel-* surface above carries a `border
+   * border-base-300` outline, but this small stat/info tile never does --
+   * just a solid rounded-2xl bg-base-200 fill, nested inside a raised
+   * base-100 panel the same way .kr-panel-muted is, minus the border. Named
+   * `kr-tile` rather than folded into the panel family since the missing
+   * border is a structural difference, not a padding/opacity variant.
+   * `-md` (p-3) previously hand-rolled across 10 occurrences (character-
+   * chat.vue x3, character-flip-card.vue x3, coloring-book-studio.vue x4);
+   * `-sm` (p-2) across 11 occurrences (coloring-book-package-readiness.vue
+   * x3, coloring-book-studio.vue x4, coloring-book-readiness.vue x4) — all
+   * grid-of-stats or labeled-value tiles. */
+  .kr-tile-md {
+    @apply rounded-2xl bg-base-200 p-3;
+  }
+  .kr-tile-sm {
+    @apply rounded-2xl bg-base-200 p-2;
+  }
+
   /* The hand-rolled toggle-row label: a bordered muted strip pairing a
    * label with a DaisyUI `toggle` input (Public/Mature/Active-style
    * checkboxes) — same rounded-2xl/border-base-300/bg-base-200 surface as

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -138,7 +138,7 @@
         </button>
 
         <!-- result -->
-        <div class="flex min-h-48 items-center justify-center rounded-2xl bg-base-200 p-3">
+        <div class="kr-tile-md flex min-h-48 items-center justify-center">
           <div
             v-if="result(side).status === 'idle'"
             class="flex flex-col items-center gap-2 text-xs text-base-content/50"

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -376,7 +376,7 @@
         </div>
 
         <pre
-          class="max-h-80 overflow-auto whitespace-pre-wrap rounded-2xl bg-base-200 p-3 text-xs text-base-content/70"
+          class="kr-tile-md max-h-80 overflow-auto whitespace-pre-wrap text-xs text-base-content/70"
           >{{ promptPreview }}</pre>
       </section>
     </aside>

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -133,7 +133,7 @@
           </h2>
 
           <div class="mt-3 grid gap-2 text-sm">
-            <div class="rounded-2xl bg-base-200 p-3">
+            <div class="kr-tile-md">
               <p class="text-xs font-bold uppercase text-base-content/50">
                 Character
               </p>
@@ -143,7 +143,7 @@
               </p>
             </div>
 
-            <div class="rounded-2xl bg-base-200 p-3">
+            <div class="kr-tile-md">
               <p class="text-xs font-bold uppercase text-base-content/50">
                 Scenario
               </p>
@@ -153,7 +153,7 @@
               </p>
             </div>
 
-            <div class="rounded-2xl bg-base-200 p-3">
+            <div class="kr-tile-md">
               <p class="text-xs font-bold uppercase text-base-content/50">
                 Reward
               </p>
@@ -459,7 +459,7 @@
             </h2>
 
             <pre
-              class="max-h-96 overflow-auto rounded-2xl bg-base-200 p-3 text-xs text-base-content/70"
+              class="kr-tile-md max-h-96 overflow-auto text-xs text-base-content/70"
               >{{
                 JSON.stringify(characterStore.selectedCharacter, null, 2)
               }}</pre>

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -343,7 +343,7 @@
             </h2>
 
             <pre
-              class="max-h-96 overflow-auto rounded-2xl bg-base-200 p-3 text-xs text-base-content/70"
+              class="kr-tile-md max-h-96 overflow-auto text-xs text-base-content/70"
               >{{
                 JSON.stringify(characterStore.selectedCharacter, null, 2)
               }}</pre>
@@ -357,7 +357,7 @@
             </h2>
 
             <div class="mt-3 grid gap-2 text-sm">
-              <div class="rounded-2xl bg-base-200 p-3">
+              <div class="kr-tile-md">
                 <p class="text-xs font-bold uppercase text-base-content/50">
                   Character
                 </p>
@@ -367,7 +367,7 @@
                 </p>
               </div>
 
-              <div class="rounded-2xl bg-base-200 p-3">
+              <div class="kr-tile-md">
                 <p class="text-xs font-bold uppercase text-base-content/50">
                   Scenario
                 </p>
@@ -377,7 +377,7 @@
                 </p>
               </div>
 
-              <div class="rounded-2xl bg-base-200 p-3">
+              <div class="kr-tile-md">
                 <p class="text-xs font-bold uppercase text-base-content/50">
                   Reward
                 </p>
@@ -452,7 +452,7 @@
             </h2>
 
             <pre
-              class="max-h-96 overflow-auto whitespace-pre-wrap rounded-2xl bg-base-200 p-3 text-sm text-base-content/75"
+              class="kr-tile-md max-h-96 overflow-auto whitespace-pre-wrap text-sm text-base-content/75"
               >{{ adventurePrompt }}</pre>
           </section>
         </aside>

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -66,19 +66,19 @@
         />
 
         <div class="grid grid-cols-3 gap-2 text-center text-xs">
-          <div class="rounded-2xl bg-base-200 p-2">
+          <div class="kr-tile-sm">
             <p class="font-black">
               {{ book.finalPairCount }}/{{ book.expectedInteriorCount }}
             </p>
             <p class="text-base-content/45">Final pairs</p>
           </div>
-          <div class="rounded-2xl bg-base-200 p-2">
+          <div class="kr-tile-sm">
             <p class="font-black" :class="book.coverStatus === 'final' ? 'text-success' : ''">
               {{ book.coverStatus }}
             </p>
             <p class="text-base-content/45">Cover</p>
           </div>
-          <div class="rounded-2xl bg-base-200 p-2">
+          <div class="kr-tile-sm">
             <p class="font-black">
               {{ book.missingLayoutFields.length + book.missingExportFields.length }}
             </p>

--- a/components/coloring/coloring-book-readiness.vue
+++ b/components/coloring/coloring-book-readiness.vue
@@ -51,21 +51,21 @@
         />
 
         <div class="grid grid-cols-4 gap-2 text-center text-xs">
-          <div class="rounded-2xl bg-base-200 p-2">
+          <div class="kr-tile-sm">
             <p class="font-black">{{ item.summary.final }}</p>
             <p class="text-base-content/45">Final</p>
           </div>
-          <div class="rounded-2xl bg-base-200 p-2">
+          <div class="kr-tile-sm">
             <p class="font-black">{{ item.summary.finalize }}</p>
             <p class="text-base-content/45">Finalize</p>
           </div>
-          <div class="rounded-2xl bg-base-200 p-2">
+          <div class="kr-tile-sm">
             <p class="font-black">
               {{ item.summary.acceptColor + item.summary.acceptBw }}
             </p>
             <p class="text-base-content/45">Accept</p>
           </div>
-          <div class="rounded-2xl bg-base-200 p-2">
+          <div class="kr-tile-sm">
             <p class="font-black text-error">{{ item.summary.blocked }}</p>
             <p class="text-base-content/45">Blocked</p>
           </div>

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -94,19 +94,19 @@
           />
 
           <div class="grid grid-cols-4 gap-2 text-center text-xs">
-            <div class="rounded-2xl bg-base-200 p-2">
+            <div class="kr-tile-sm">
               <strong class="block text-base">{{ book.counts.prompts }}</strong>
               Prompts
             </div>
-            <div class="rounded-2xl bg-base-200 p-2">
+            <div class="kr-tile-sm">
               <strong class="block text-base">{{ book.counts.rendered }}</strong>
               Rendered
             </div>
-            <div class="rounded-2xl bg-base-200 p-2">
+            <div class="kr-tile-sm">
               <strong class="block text-base">{{ book.counts.acceptedPairs }}</strong>
               Pairs
             </div>
-            <div class="rounded-2xl bg-base-200 p-2">
+            <div class="kr-tile-sm">
               <strong class="block text-base">{{ book.counts.finalPairs }}</strong>
               Final
             </div>
@@ -153,21 +153,21 @@
           </div>
 
           <dl class="grid grid-cols-2 gap-3 text-sm">
-            <div class="rounded-2xl bg-base-200 p-3">
+            <div class="kr-tile-md">
               <dt class="text-base-content/50">Pending color</dt>
               <dd class="text-lg font-black">{{ book.counts.pending }}</dd>
             </div>
-            <div class="rounded-2xl bg-base-200 p-3">
+            <div class="kr-tile-md">
               <dt class="text-base-content/50">Needs attention</dt>
               <dd class="text-lg font-black">
                 {{ book.counts.needsReview + book.counts.blocked }}
               </dd>
             </div>
-            <div class="rounded-2xl bg-base-200 p-3">
+            <div class="kr-tile-md">
               <dt class="text-base-content/50">Accepted color</dt>
               <dd class="text-lg font-black">{{ book.counts.acceptedColor }}</dd>
             </div>
-            <div class="rounded-2xl bg-base-200 p-3">
+            <div class="kr-tile-md">
               <dt class="text-base-content/50">Final pairs</dt>
               <dd class="text-lg font-black">{{ book.counts.finalPairs }}</dd>
             </div>
@@ -375,19 +375,19 @@
           </div>
 
           <div class="grid gap-3 sm:grid-cols-3">
-            <div class="rounded-2xl bg-base-200 p-3 text-sm">
+            <div class="kr-tile-md text-sm">
               <span class="block text-xs text-base-content/45">Semantic score</span>
               <strong>
                 {{ studio.selectedProposal.queue.semanticScore ?? '—' }}
               </strong>
             </div>
-            <div class="rounded-2xl bg-base-200 p-3 text-sm">
+            <div class="kr-tile-md text-sm">
               <span class="block text-xs text-base-content/45">Render engine</span>
               <strong>
                 {{ studio.selectedProposal.queue.renderEngine ?? '—' }}
               </strong>
             </div>
-            <div class="rounded-2xl bg-base-200 p-3 text-sm">
+            <div class="kr-tile-md text-sm">
               <span class="block text-xs text-base-content/45">
                 Archived revisions
               </span>

--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -108,7 +108,7 @@
     >
       <!-- 1. WHO YOU ARE, and the door to the account menu. The full width is
               its own now, so the name and role stop truncating. -->
-      <div class="flex flex-col gap-2 rounded-2xl bg-base-200 p-2">
+      <div class="kr-tile-sm flex flex-col gap-2">
         <button
           type="button"
           class="flex items-center gap-3 rounded-xl p-1 text-left transition hover:bg-base-300/60"

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -476,7 +476,7 @@
 
           <pre
             v-if="showPromptPreview"
-            class="mt-3 max-h-72 overflow-auto whitespace-pre-wrap rounded-2xl bg-base-200 p-3 text-xs text-base-content/70"
+            class="kr-tile-md mt-3 max-h-72 overflow-auto whitespace-pre-wrap text-xs text-base-content/70"
             >{{ rewardPromptPreview }}</pre>
         </section>
       </aside>

--- a/components/themes/theme-gallery.vue
+++ b/components/themes/theme-gallery.vue
@@ -346,7 +346,7 @@
           </div>
 
           <pre
-            class="max-h-72 overflow-auto rounded-2xl bg-base-200 p-3 text-xs text-base-content/75"
+            class="kr-tile-md max-h-72 overflow-auto text-xs text-base-content/75"
             >{{ inspectValues }}</pre>
         </section>
       </section>

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -1,6 +1,6 @@
 <!-- /components/content/user/user-dashboard.vue -->
 <template>
-  <section class="kr-surface gap-4 rounded-2xl bg-base-200 p-3 sm:p-4">
+  <section class="kr-tile-md kr-surface gap-4 sm:p-4">
     <header class="kr-toolbar kr-panel-flat px-4 py-3">
       <Icon name="kind-icon:sparkles" class="h-5 w-5 shrink-0 text-primary" />
 

--- a/utils/scripts/codemods/kr_tile_codemod.py
+++ b/utils/scripts/codemods/kr_tile_codemod.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled kr-tile-{sm,md} info/stat tiles -- a
+borderless rounded-2xl bg-base-200 box, distinct from every existing
+kr-panel-* surface (`.kr-panel`, `.kr-panel-muted`, `.kr-panel-flat`, ...),
+which all carry a `border border-base-300` outline. This shape never does
+(interface-vision t-104 slice 148).
+
+Dry-run is the default. Pass --write to update matching Vue files in place.
+Only static `class="..."` attributes are touched -- never `:class`/
+`v-bind:class` bindings -- regardless of the base tokens' order in the
+source. A source that already carries the target primitive, or is missing
+any one of the base tokens, is left untouched. Extra tokens beyond the base
+set are preserved verbatim after the primitive class, matching the
+kr-badge-*/kr-toggle-row-* codemods' subset-match convention -- they're
+plain Tailwind utilities layered on top, not another component-root class.
+
+FAMILIES is ordered most-specific-first (larger padding before smaller) so
+neither entry's base set can ever be mistaken for the other's -- `p-2` and
+`p-3` are disjoint tokens, so order doesn't actually affect correctness
+here, but keeping the convention matches the other multi-entry codemods
+in this directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+FAMILIES = [
+    (
+        "kr-tile-md",
+        {"rounded-2xl", "bg-base-200", "p-3"},
+    ),
+    (
+        "kr-tile-sm",
+        {"rounded-2xl", "bg-base-200", "p-2"},
+    ),
+]
+
+
+def migrate_classes(classes: str) -> str | None:
+    tokens = classes.split()
+    if "border" in tokens:
+        # A bordered rounded-2xl/bg-base-200 box is the existing
+        # .kr-panel-muted-sm/-md shape (or an as-yet-unnamed border+p-2
+        # variant) -- a structurally different surface from the borderless
+        # kr-tile family, not a superset of it. Leave it untouched rather
+        # than silently dropping its border.
+        return None
+    for primitive, base_tokens in FAMILIES:
+        if primitive in tokens or not base_tokens.issubset(tokens):
+            continue
+        remaining = [token for token in tokens if token not in base_tokens]
+        return " ".join([primitive, *remaining])
+    return None
+
+
+def migrate_text(text: str) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1))
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim, same
+        # rationale as the badge/toggle-row codemods (interface-vision t-104
+        # slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-tile-* {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104, slice 148 — the recurring "drive live front-end consistency onto shared kr-* components" umbrella task.

### What changed / what I produced
All 9 pre-existing kr-* codemods report 0 remaining candidates, so this slice needed a fresh survey for a not-yet-named hand-rolled pattern. Found a genuinely new family, not another `kr-panel-*` variant: a **borderless** `rounded-2xl bg-base-200` stat/info tile. Every existing `kr-panel-*` surface (`.kr-panel`, `.kr-panel-muted`, `.kr-panel-flat`, ...) carries a `border border-base-300` outline — this shape never does.

Added two new primitives to `assets/css/tailwind.css`:
- `.kr-tile-sm` — `rounded-2xl bg-base-200 p-2` (previously hand-rolled across 11 occurrences)
- `.kr-tile-md` — `rounded-2xl bg-base-200 p-3` (previously hand-rolled across 22 occurrences once the codemod's subset-match generalized past my initial literal grep)

Added `utils/scripts/codemods/kr_tile_codemod.py`, modeled on `kr_btn_ghost_outline_codemod.py`'s subset-match/extras-preserved convention, with one extra guard: it explicitly excludes any occurrence that also carries a `border` token, so two lookalike-but-different bordered occurrences (`stylist-manager.vue`, `checkpoint-card.vue` — an existing `kr-panel-muted`-shaped gap at `p-2`, out of scope for this slice) are left untouched rather than silently stripped of their border.

Migrated all 33 correctly-matched occurrences across 11 files: `build-bench.vue`, `bot-chat.vue`, `character-chat.vue` (×4), `character-flip-card.vue` (×5), `coloring-book-package-readiness.vue` (×3), `coloring-book-readiness.vue` (×4), `coloring-book-studio.vue` (×11), `account-hub.vue`, `reward-encounter.vue`, `theme-gallery.vue`, `user-dashboard.vue`. No geometry or behavior change — every extra utility token (`max-h-96`, `overflow-auto`, `text-xs`, `sm:p-4`, etc.) preserved verbatim after the primitive class.

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint` on touched files: 0 new errors (`character-flip-card.vue`'s pre-existing `no-unused-vars` on `userStore` confirmed via `git stash` against the unmodified baseline)
- `npm run test:layout-contract`: holds at 207, no new violations
- `npm run test:lint-ratchet`: holds at 334/-58, no rule regressed
- `prettier --check` on touched files: pre-existing warnings only (confirmed via `git stash`)
- Grepped `utils/scripts/*.mjs` for the literal class strings being replaced — no source-text contract hits (the slice 69 lesson)

### Stakes
Reversible, scoped, non-human-gated software change.

### Flags for Reviewer
None — straightforward CSS-primitive extraction, same shape as prior slices in this recurring task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4w9xYnvxV9LfimGCHxHjs)_