### PR TITLE
feat(header): add an admin-only ArtJob queue shortcut

### DIFF
--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -23,6 +23,15 @@
   row nothing. It sits BEFORE the workspace toggle, because that one is
   documented below as the last icon in the row and stays that way.
 
+  SIX FOR ADMINS, same day: an ArtJob queue shortcut, rendered only when
+  userStore.isAdmin. Everyone else still sees five. The row reads
+  account -> ops -> play -> help, and both additions are the same fixed-width
+  square, so the no-growth rule still holds.
+
+  If a seventh is ever proposed, weigh it against that rule rather than against
+  the count: what this row cannot afford is a child whose width is unbounded,
+  which is what the 300 lines of deleted measurement below were all for.
+
   WHAT THIS DELETES, and why none of it is missed
   ----------------------------------------------
   The strip took a scrolling viewport, two chevron scrollers, a map-icon
@@ -225,6 +234,41 @@
       <account-hub class="header-account shrink-0" />
 
       <!--
+        ARTJOB QUEUE, ADMINS ONLY. Silas, 2026-09-08: "if the user is an admin
+        (me) I want an artjob queue button as well, next to the others."
+
+        v-if rather than a disabled state: a control that only Silas can use is
+        noise in everyone else's header, and /artjob already refuses non-admins
+        (content/artjob.md carries `requiredRole: ADMIN`, so this is a shortcut
+        to a gated page, not the gate itself -- never treat a hidden button as
+        access control).
+
+        userStore.isAdmin and account-hub.vue's own `v-if="userStore.isLoggedIn"`
+        rows derive from the same user state, so this cluster already renders
+        conditionally on who is signed in and adding another such branch changes
+        nothing about the header's hydration behaviour.
+
+        Ordered account -> ops -> play -> help: this sits with the account hub
+        because it is an operations control, and the game stays next to the
+        tutorial toggle.
+      -->
+      <NuxtLink
+        v-if="userStore.isAdmin"
+        to="/artjob"
+        class="btn btn-ghost btn-sm btn-square shrink-0 rounded-xl border border-base-300"
+        :class="
+          artjobActive
+            ? 'border-primary bg-primary/15 text-primary'
+            : 'bg-base-100'
+        "
+        :aria-current="artjobActive ? 'page' : undefined"
+        aria-label="ArtJob queue"
+        title="ArtJob queue"
+      >
+        <Icon name="kind-icon:server" class="h-5 w-5" />
+      </NuxtLink>
+
+      <!--
         MEMORY DUNGEON. Silas, 2026-09-08: "I'm really proud of my memory match
         game, it was one of my first projects and still one that I occasionally
         return to. I want a link for it on the dashboard next to the tutorial
@@ -369,6 +413,11 @@ const workspaceToggleLabel = computed(() =>
 // shows its own open state. startsWith rather than an equality check because
 // the game's deeper routes (a level, a run) should keep the button lit too.
 const memoryActive = computed(() => route.path.startsWith('/play/memory'))
+
+// Exact match, unlike memoryActive: /artjob is a single page with no children,
+// and startsWith would light the button on any future sibling route that merely
+// shares the prefix.
+const artjobActive = computed(() => route.path === '/artjob')
 
 const activeTabKey = computed(() => {
   const channel = resolvedChannel.value


### PR DESCRIPTION
## What

An ArtJob queue button in the workspace header, visible only to admins.

> "if the user is an admin (me) I want an artjob queue button as well, next to the others." — Silas, 2026-09-08

Placed with the account hub, so the cluster reads **account → ops → play → help**: the ArtJob queue is an operations control, and the Memory Dungeon link ([#2515](https://github.com/silasfelinus/kind_robots/pull/2515)) stays beside the workspace toggle.

## Hidden, not disabled — and hiding is not the gate

`v-if="userStore.isAdmin"`, because a control only admins can use is noise in everyone else's header.

Worth being explicit that this is **not** access control: `content/artjob.md` carries `requiredRole: ADMIN`, so `/artjob` refuses non-admins on its own. The button is a shortcut to an already-protected page. A hidden button should never be the only thing standing between a user and a route.

## Details

- Route and icon come from the page's own frontmatter (`/artjob`, `kind-icon:server`), matching how the Memory Dungeon button was done.
- Active state is an **exact** path match, not `startsWith` like `memoryActive` — `/artjob` has no child routes, and a prefix test would light the button on any future sibling that happened to share it.
- The file's opening "four things" note now records six-for-admins / five for everyone else, and restates what that rule actually protects: not a count, but the absence of any child in this row whose width is unbounded. Both new buttons are the same fixed-width square, so the constraint holds.

## Testing

`npx prettier --check` clean; `audit:icons` passes (1746 references, 232 distinct, all resolving — `kind-icon:server` included).

`nuxi prepare` still can't run in this container (`@nuxt/kit` won't resolve), so ESLint and `vue-tsc` are left to CI, as with #2515.

Not visually verified — no browser here. Two things worth an eyeball once deployed: the header at `sm` now that admins see a sixth square, and that non-admin sessions show exactly five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGb4quwjzWKjbgxAC6pgDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGb4quwjzWKjbgxAC6pgDx)_