### PR TITLE
style: add kr-icon-tile primitive, migrate 8 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1552,6 +1552,17 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply input w-full bg-base-200;
   }
 
+  /* The page-header icon badge: a tinted `h-12 w-12` square housing a
+   * page-header `<Icon>`, sitting beside the page title (interface-vision
+   * t-104 slice 149) -- previously hand-rolled identically across 8
+   * occurrences (build-bench.vue, mission-accrual-page.vue,
+   * creator-earnings-page.vue, click-leaderboard.vue, privacy-page.vue,
+   * appmaker-page.vue, rebel-button.vue, wallet-page.vue), every one of
+   * them a page-header hero row's leading icon slot. */
+  .kr-icon-tile {
+    @apply grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -2,9 +2,7 @@
   <section class="kr-container flex flex-col gap-4 p-4 md:p-6">
     <header class="flex flex-wrap items-center justify-between gap-3">
       <div class="flex items-center gap-3">
-        <span
-          class="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary"
-        >
+        <span class="kr-icon-tile">
           <Icon name="kind-icon:server" class="h-7 w-7" />
         </span>
         <div>

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -5,9 +5,7 @@
   <section class="kr-unbound kr-container space-y-6 p-4">
     <header class="flex flex-wrap items-center justify-between gap-3">
       <div class="flex items-center gap-3">
-        <span
-          class="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary"
-        >
+        <span class="kr-icon-tile">
           <Icon name="kind-icon:toolbox" class="h-7 w-7" />
         </span>
         <div>

--- a/components/pages/click-leaderboard.vue
+++ b/components/pages/click-leaderboard.vue
@@ -3,9 +3,7 @@
   <div class="kr-surface">
     <div class="kr-scroll p-4">
       <header class="flex items-center gap-3 mb-4">
-        <span
-          class="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary"
-        >
+        <span class="kr-icon-tile">
           <Icon name="kind-icon:trophy" class="h-7 w-7" />
         </span>
         <div>

--- a/components/pages/creator-earnings-page.vue
+++ b/components/pages/creator-earnings-page.vue
@@ -1,9 +1,7 @@
 <template>
   <div class="kr-unbound kr-container max-w-3xl p-6 space-y-8">
     <header class="flex items-center gap-3">
-      <span
-        class="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary"
-      >
+      <span class="kr-icon-tile">
         <Icon name="kind-icon:coin" class="h-7 w-7" />
       </span>
       <div>

--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -1,9 +1,7 @@
 <template>
   <div class="kr-unbound kr-container max-w-3xl p-6 space-y-8">
     <header class="flex items-center gap-3">
-      <span
-        class="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary"
-      >
+      <span class="kr-icon-tile">
         <Icon name="kind-icon:hand-heart" class="h-7 w-7" />
       </span>
       <div>

--- a/components/pages/privacy-page.vue
+++ b/components/pages/privacy-page.vue
@@ -3,9 +3,7 @@
     class="kr-unbound privacy-page max-w-3xl mx-auto px-6 py-12 text-base leading-relaxed"
   >
     <header class="mb-10 flex items-center gap-3">
-      <span
-        class="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary"
-      >
+      <span class="kr-icon-tile">
         <Icon name="kind-icon:shield" class="h-7 w-7" />
       </span>
       <div>

--- a/components/pages/rebel-button.vue
+++ b/components/pages/rebel-button.vue
@@ -2,9 +2,7 @@
 <template>
   <main class="kr-unbound">
     <header class="flex items-center gap-3 m-2">
-      <span
-        class="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary"
-      >
+      <span class="kr-icon-tile">
         <Icon name="kind-icon:button" class="h-7 w-7" />
       </span>
       <div>

--- a/components/pages/wallet-page.vue
+++ b/components/pages/wallet-page.vue
@@ -1,9 +1,7 @@
 <template>
   <div class="kr-unbound kr-container max-w-3xl p-6 space-y-8">
     <header class="flex items-center gap-3">
-      <span
-        class="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary"
-      >
+      <span class="kr-icon-tile">
         <Icon name="kind-icon:money" class="h-7 w-7" />
       </span>
       <div>

--- a/utils/scripts/codemods/kr_icon_tile_codemod.py
+++ b/utils/scripts/codemods/kr_icon_tile_codemod.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled kr-icon-tile page-header icon badges: a
+tinted `h-12 w-12` square housing a page-header `<Icon>`, sitting beside
+the page title the same way every page-header component in
+`components/pages/*.vue` composes its hero row (interface-vision t-104
+slice 149).
+
+Dry-run is the default. Pass --write to update matching Vue files in place.
+Only static `class="..."` attributes are touched -- never `:class`/
+`v-bind:class` bindings -- regardless of the base tokens' order in the
+source. A source that already carries the target primitive, or is missing
+any one of the base tokens, is left untouched. Extra tokens beyond the base
+set are preserved verbatim after the primitive class, matching the
+kr-tile/kr-badge-*/kr-toggle-row-* codemods' subset-match convention.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-icon-tile"
+BASE_TOKENS = {
+    "grid",
+    "h-12",
+    "w-12",
+    "shrink-0",
+    "place-items-center",
+    "rounded-2xl",
+    "bg-primary/15",
+    "text-primary",
+}
+
+
+def migrate_classes(classes: str) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1))
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim, same
+        # rationale as the badge/toggle-row/tile codemods (interface-vision
+        # t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"{PRIMITIVE} {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104, slice 149 — the recurring "drive live front-end consistency onto shared kr-* components" umbrella task.

### What changed / what I produced
Fresh survey (icon/avatar-tint family) found the page-header icon badge: a tinted `h-12 w-12` square housing a page-header `<Icon>`, sitting beside the page title. Previously hand-rolled identically across 8 occurrences — every one of them a page-header hero row's leading icon slot: `build-bench.vue`, `mission-accrual-page.vue`, `creator-earnings-page.vue`, `click-leaderboard.vue`, `privacy-page.vue`, `appmaker-page.vue`, `rebel-button.vue`, `wallet-page.vue`.

Added `.kr-icon-tile` (`grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary`) to `assets/css/tailwind.css`, and `utils/scripts/codemods/kr_icon_tile_codemod.py` (same subset-match/extras-preserved convention as prior slices). Migrated all 8 occurrences.

No geometry or behavior change. The three files that already carried pre-existing (unrelated) prettier warnings had their now-short `<span>` collapsed onto one line by hand rather than run through whole-file `prettier --write`, which would have reformatted unrelated pre-existing code in those files and blown up the diff well beyond this slice's scope.

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint` on touched files: 0 new errors
- `npm run test:layout-contract`: holds at 207, no new violations
- `npm run test:lint-ratchet`: holds at 334/-58, no rule regressed
- `prettier --check` on touched files: matches baseline exactly, file-for-file (confirmed via `git stash`)
- Grepped `utils/scripts/*.mjs` for the literal class string being replaced — no source-text contract hits

### Stakes
Reversible, scoped, non-human-gated software change.

### Flags for Reviewer
None — straightforward CSS-primitive extraction, same shape as prior slices in this recurring task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4w9xYnvxV9LfimGCHxHjs)_