### PR TITLE
style: introduce kr-spinner-xs for the colorless busy-indicator spinner

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1563,6 +1563,21 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary;
   }
 
+  /* The colorless DaisyUI busy indicator: a bare tiny spinner dropped into
+   * a button or inline slot while an action is pending, no tint (the
+   * button/text color around it usually already carries the tone)
+   * (interface-vision t-104 slice 150) -- `loading loading-spinner
+   * loading-xs`, previously hand-rolled identically in 83 files (123
+   * occurrences), by far the largest single exact-duplicate class string
+   * found in a survey of the codebase's most-repeated static `class="..."`
+   * values. Named to mirror the `kr-badge-*`/`kr-tile-*` convention of
+   * wrapping DaisyUI's own component classes rather than only hand-rolled
+   * Tailwind utilities -- `.kr-badge-sm` already does the same for
+   * `badge badge-sm`. */
+  .kr-spinner-xs {
+    @apply loading loading-spinner loading-xs;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -122,7 +122,7 @@
             >
               <span
                 v-if="artRequests.requesting[facet.id]"
-                class="loading loading-spinner loading-xs"
+                class="kr-spinner-xs"
               />
               <Icon v-else name="kind-icon:image" class="size-3.5" />
               {{ artRequests.requested[facet.id] ? 'Requested' : 'Art' }}

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -75,7 +75,7 @@
             :disabled="isLoading"
             @click="refreshGallery"
           >
-            <span v-if="isLoading" class="loading loading-spinner loading-xs" />
+            <span v-if="isLoading" class="kr-spinner-xs" />
             <Icon v-else name="kind-icon:refresh" class="h-3.5 w-3.5" />
           </button>
 
@@ -370,7 +370,7 @@
             >
               <span
                 v-if="isBatchWorking"
-                class="loading loading-spinner loading-xs"
+                class="kr-spinner-xs"
               />
               <Icon v-else name="kind-icon:trash" class="h-3.5 w-3.5" />
               Delete

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -48,10 +48,7 @@
           "
           @click="setAsAvatar"
         >
-          <span
-            v-if="isSettingAvatar"
-            class="loading loading-spinner loading-xs"
-          />
+          <span v-if="isSettingAvatar" class="kr-spinner-xs" />
           <Icon v-else name="kind-icon:user" class="h-4 w-4" />
           {{ isCurrentAvatar ? 'Avatar' : 'Set avatar' }}
         </button>
@@ -87,10 +84,7 @@
             @click="confirmDelete"
             @blur="deleteArmed = false"
           >
-            <span
-              v-if="isDeleting"
-              class="loading loading-spinner loading-xs"
-            />
+            <span v-if="isDeleting" class="kr-spinner-xs" />
             <Icon v-else name="kind-icon:trash" class="h-4 w-4" />
             Confirm?
           </button>
@@ -212,10 +206,7 @@
                 :disabled="isSaving || !hasDirtyFields"
                 @click="saveImageEdits"
               >
-                <span
-                  v-if="isSaving"
-                  class="loading loading-spinner loading-xs"
-                />
+                <span v-if="isSaving" class="kr-spinner-xs" />
                 <Icon v-else name="kind-icon:save" class="h-4 w-4" />
                 Save
               </button>

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -533,7 +533,7 @@
     <Transition name="fade">
       <div v-if="isGenerating" class="flex flex-col gap-2">
         <div class="flex items-center gap-2 text-xs font-semibold text-primary">
-          <span class="loading loading-spinner loading-xs" />
+          <span class="kr-spinner-xs" />
           Applying {{ generatingStyleLabel }} via Kontext…
         </div>
         <progress class="progress progress-primary w-full" />

--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -337,7 +337,7 @@
             :disabled="saving"
             @click="save"
           >
-            <span v-if="saving" class="loading loading-spinner loading-xs" />
+            <span v-if="saving" class="kr-spinner-xs" />
             {{ actionLabel }}
           </button>
         </div>

--- a/components/art/artjob-failed-page-requeue.vue
+++ b/components/art/artjob-failed-page-requeue.vue
@@ -18,10 +18,7 @@
           :disabled="Boolean(submitting)"
           @click="cancelFailedOnPage"
         >
-          <span
-            v-if="submitting === 'cancel'"
-            class="loading loading-spinner loading-xs"
-          />
+          <span v-if="submitting === 'cancel'" class="kr-spinner-xs" />
           Clear failed on this page ({{ failedJobIds.length }})
         </button>
         <button
@@ -30,10 +27,7 @@
           :disabled="Boolean(submitting)"
           @click="requeueFailedOnPage"
         >
-          <span
-            v-if="submitting === 'requeue'"
-            class="loading loading-spinner loading-xs"
-          />
+          <span v-if="submitting === 'requeue'" class="kr-spinner-xs" />
           Requeue failed on this page ({{ failedJobIds.length }})
         </button>
       </div>

--- a/components/art/artjob-feedback-manager.vue
+++ b/components/art/artjob-feedback-manager.vue
@@ -25,7 +25,7 @@
         >
           <span
             v-if="artJobStore.loadingTrainerJobs"
-            class="loading loading-spinner loading-xs"
+            class="kr-spinner-xs"
           />
           Refresh
         </button>

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -42,7 +42,7 @@
             :disabled="isLoading"
             @click="refresh"
           >
-            <span v-if="isLoading" class="loading loading-spinner loading-xs" />
+            <span v-if="isLoading" class="kr-spinner-xs" />
             Refresh
           </button>
         </div>
@@ -123,7 +123,7 @@
                   >
                     <span
                       v-if="refreshingServerIds.includes(server.id)"
-                      class="loading loading-spinner loading-xs"
+                      class="kr-spinner-xs"
                     />
                     <span v-else>Refresh</span>
                   </button>
@@ -136,7 +136,7 @@
                   >
                     <span
                       v-if="removingServerIds.includes(server.id)"
-                      class="loading loading-spinner loading-xs"
+                      class="kr-spinner-xs"
                     />
                     <span v-else>Remove</span>
                   </button>

--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -50,10 +50,7 @@
           :disabled="isLoadingPreview"
           @click="loadProtectedPreview"
         >
-          <span
-            v-if="isLoadingPreview"
-            class="loading loading-spinner loading-xs"
-          />
+          <span v-if="isLoadingPreview" class="kr-spinner-xs" />
           {{ isLoadingPreview ? 'Loading preview' : 'Load protected preview' }}
         </button>
         <p
@@ -298,7 +295,7 @@
           >
             <span
               v-if="priorityStore.prioritizingJobIds.includes(job.id)"
-              class="loading loading-spinner loading-xs"
+              class="kr-spinner-xs"
             />
             {{ job.priority > 0 ? 'Normal priority' : 'Move to front' }}
           </button>

--- a/components/art/artjob-trainer-redo-controls.vue
+++ b/components/art/artjob-trainer-redo-controls.vue
@@ -77,7 +77,7 @@
         :disabled="submitting || promptString.trim().length < 3"
         @click="queueRevision"
       >
-        <span v-if="submitting" class="loading loading-spinner loading-xs" />
+        <span v-if="submitting" class="kr-spinner-xs" />
         {{ submitting ? 'Queuing revision…' : 'Revise + queue redo' }}
       </button>
     </div>

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -15,7 +15,7 @@
       </div>
       <div class="flex flex-wrap items-center gap-2">
         <button class="kr-btn-primary-plain" :disabled="running" @click="store.runBoth">
-          <span v-if="running" class="loading loading-spinner loading-xs" />
+          <span v-if="running" class="kr-spinner-xs" />
           Run both
         </button>
         <button class="kr-btn-ghost-plain" :disabled="running" @click="store.newMatchup">

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -121,7 +121,7 @@
               :disabled="removingHistoryId === item.id"
               @click="removeHistory(item.id)"
             >
-              <span v-if="removingHistoryId === item.id" class="loading loading-spinner loading-xs" />
+              <span v-if="removingHistoryId === item.id" class="kr-spinner-xs" />
               <Icon v-else name="kind-icon:trash" class="size-3" />
             </button>
             <p class="truncate px-2 py-1 text-[0.65rem] text-base-content/50">
@@ -390,7 +390,7 @@
           class="btn btn-secondary btn-sm ml-auto gap-1.5 rounded-xl"
           :disabled="prompt.trim().length < 3 || submitting || (generationMode === 'img2img' && !currentSrc)"
         >
-          <span v-if="submitting" class="loading loading-spinner loading-xs" />
+          <span v-if="submitting" class="kr-spinner-xs" />
           <Icon v-else name="kind-icon:sparkles" class="size-4" />
           {{ submitting ? 'Queuing…' : `Queue ${selectedSlot.label}` }}
         </button>
@@ -485,7 +485,7 @@
           class="btn btn-primary btn-sm ml-auto gap-1.5 rounded-xl"
           :disabled="!uploadFile || submitting"
         >
-          <span v-if="submitting" class="loading loading-spinner loading-xs" />
+          <span v-if="submitting" class="kr-spinner-xs" />
           <Icon v-else name="kind-icon:upload" class="size-4" />
           {{ submitting ? 'Uploading…' : 'Upload & replace' }}
         </button>

--- a/components/art/stylist-client-gallery.vue
+++ b/components/art/stylist-client-gallery.vue
@@ -59,7 +59,7 @@
         class="kr-btn-primary-plain"
         :class="{ 'btn-disabled': uploading }"
       >
-        <span v-if="uploading" class="loading loading-spinner loading-xs" />
+        <span v-if="uploading" class="kr-spinner-xs" />
         <Icon v-else name="kind-icon:upload" class="size-4" />
         Add photos
         <input

--- a/components/art/stylist-manager.vue
+++ b/components/art/stylist-manager.vue
@@ -25,7 +25,7 @@
         class="mr-1 flex items-center gap-1 text-xs font-semibold text-base-content/50"
         title="Syncing the service book"
       >
-        <span class="loading loading-spinner loading-xs" />
+        <span class="kr-spinner-xs" />
         syncing
       </span>
       <span

--- a/components/art/stylist-relay-status.vue
+++ b/components/art/stylist-relay-status.vue
@@ -35,7 +35,7 @@
           :disabled="loading"
           @click="refresh"
         >
-          <span v-if="loading" class="loading loading-spinner loading-xs" />
+          <span v-if="loading" class="kr-spinner-xs" />
           Refresh
         </button>
       </div>

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -22,7 +22,7 @@
         v-if="stylist.isBusy"
         class="flex items-center gap-1 text-xs font-semibold text-primary"
       >
-        <span class="loading loading-spinner loading-xs" />
+        <span class="kr-spinner-xs" />
         {{ stylist.pendingCount }} styling…
       </span>
     </header>
@@ -322,7 +322,7 @@
                   : 'Waiting for the studio engine to pick this up'
               "
             >
-              <span class="loading loading-spinner loading-xs" />
+              <span class="kr-spinner-xs" />
               {{ job.queueState === 'rendering' ? 'rendering' : 'queued' }}
             </span>
             <span v-else-if="job.status === 'failed'" class="kr-badge-error-xs">failed</span>

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -229,7 +229,7 @@
           >
             <span
               v-if="isGeneratingFields"
-              class="loading loading-spinner loading-xs"
+              class="kr-spinner-xs"
             />
             <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
             Update Selected

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -53,10 +53,7 @@
             :disabled="isLoading || botStore.loading"
             @click="refreshBots(true)"
           >
-            <span
-              v-if="isLoading || botStore.loading"
-              class="loading loading-spinner loading-xs"
-            />
+            <span v-if="isLoading || botStore.loading" class="kr-spinner-xs" />
             <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
             <span class="hidden sm:inline">Refresh</span>
           </button>

--- a/components/brainstorm/brainstorm-candidate-card.vue
+++ b/components/brainstorm/brainstorm-candidate-card.vue
@@ -52,7 +52,7 @@
             v-if="artBusy"
             class="flex items-center gap-1 rounded-full bg-secondary/10 px-2.5 py-1 text-[0.68rem] font-bold text-secondary"
           >
-            <span class="loading loading-spinner loading-xs" />
+            <span class="kr-spinner-xs" />
             Generating art…
           </span>
         </div>
@@ -341,7 +341,7 @@
         >
           <span
             v-if="busy && busyAction === 'regenerate'"
-            class="loading loading-spinner loading-xs"
+            class="kr-spinner-xs"
           />
           Regenerate
         </button>
@@ -351,10 +351,7 @@
           :disabled="disabled"
           @click="branch"
         >
-          <span
-            v-if="busy && busyAction === 'branch'"
-            class="loading loading-spinner loading-xs"
-          />
+          <span v-if="busy && busyAction === 'branch'" class="kr-spinner-xs" />
           More like this
         </button>
         <button
@@ -365,10 +362,7 @@
           :disabled="disabled"
           @click="promote"
         >
-          <span
-            v-if="busy && busyAction === 'promote'"
-            class="loading loading-spinner loading-xs"
-          />
+          <span v-if="busy && busyAction === 'promote'" class="kr-spinner-xs" />
           Promote to Character
         </button>
       </div>

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -381,7 +381,7 @@
             data-testid="brainstorm-source-search"
             @click="runSourceSearch"
           >
-            <span v-if="isSearchingSource" class="loading loading-spinner loading-xs" aria-hidden="true" />
+            <span v-if="isSearchingSource" class="kr-spinner-xs" aria-hidden="true" />
             Search
           </button>
         </div>
@@ -454,7 +454,7 @@
                 data-testid="brainstorm-save-session"
                 @click="saveSession"
               >
-                <span v-if="persistenceState === 'saving'" class="loading loading-spinner loading-xs" aria-hidden="true" />
+                <span v-if="persistenceState === 'saving'" class="kr-spinner-xs" aria-hidden="true" />
                 {{ savedSessionId ? 'Update saved session' : 'Save session' }}
               </button>
               <button
@@ -737,7 +737,7 @@
         >
           <span
             v-if="isGeneratingArt"
-            class="loading loading-spinner loading-xs"
+            class="kr-spinner-xs"
           />
           <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
           {{

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -343,7 +343,7 @@
           >
             <span
               v-if="isGeneratingFields"
-              class="loading loading-spinner loading-xs"
+              class="kr-spinner-xs"
             />
             <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
             Update selected

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -10,7 +10,7 @@
           this character independently of their name.
         </p>
       </div>
-      <span v-if="loading || saving" class="loading loading-spinner loading-xs" />
+      <span v-if="loading || saving" class="kr-spinner-xs" />
       <span class="kr-badge-ghost-sm">{{ selectedFacets.length }}</span>
     </div>
 

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -141,7 +141,7 @@
           >
             <span
               v-if="isExporting"
-              class="loading loading-spinner loading-xs"
+              class="kr-spinner-xs"
             />
             <Icon v-else name="kind-icon:image" class="h-4 w-4" />
             Save image

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -164,7 +164,7 @@
             >
               <span
                 v-if="stateFor(item.id).status === 'creating'"
-                class="loading loading-spinner loading-xs"
+                class="kr-spinner-xs"
               />
               Create record
             </button>
@@ -176,7 +176,7 @@
             >
               <span
                 v-if="stateFor(item.id).status === 'generating-art'"
-                class="loading loading-spinner loading-xs"
+                class="kr-spinner-xs"
               />
               Generate art
             </button>

--- a/components/conductor/packmaker-pack-editor.vue
+++ b/components/conductor/packmaker-pack-editor.vue
@@ -39,7 +39,7 @@
           :disabled="scaffolding"
           @click="onScaffold"
         >
-          <span v-if="scaffolding" class="loading loading-spinner loading-xs" />
+          <span v-if="scaffolding" class="kr-spinner-xs" />
           Generate scaffold
         </button>
         <span

--- a/components/conductor/project-deliverables-panel.vue
+++ b/components/conductor/project-deliverables-panel.vue
@@ -92,7 +92,7 @@
         :disabled="saving"
         @click="save"
       >
-        <span v-if="saving" class="loading loading-spinner loading-xs" />
+        <span v-if="saving" class="kr-spinner-xs" />
         Save
       </button>
     </div>

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -126,7 +126,7 @@
         title="Refresh project"
         @click="refreshProject"
       >
-        <span v-if="refreshing" class="loading loading-spinner loading-xs" />
+        <span v-if="refreshing" class="kr-spinner-xs" />
         <Icon v-else name="kind-icon:refresh" class="size-3.5" />
       </button>
     </div>
@@ -296,10 +296,7 @@
               class="kr-btn-primary"
               :disabled="!projectTaskText.trim() || projectTaskSubmitting"
             >
-              <span
-                v-if="projectTaskSubmitting"
-                class="loading loading-spinner loading-xs"
-              />
+              <span v-if="projectTaskSubmitting" class="kr-spinner-xs" />
               Add
             </button>
           </div>

--- a/components/curation/coloring-book-curation.vue
+++ b/components/curation/coloring-book-curation.vue
@@ -48,7 +48,7 @@
         :disabled="store.loading"
         @click="refresh"
       >
-        <span v-if="store.loading" class="loading loading-spinner loading-xs" />
+        <span v-if="store.loading" class="kr-spinner-xs" />
         Refresh
       </button>
     </div>

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -32,7 +32,7 @@
       </div>
 
       <button class="kr-btn" type="button" :disabled="loading" @click="load">
-        <span v-if="loading" class="loading loading-spinner loading-xs" />
+        <span v-if="loading" class="kr-spinner-xs" />
         Refresh
       </button>
     </div>
@@ -297,10 +297,7 @@
                 :disabled="isGenerating(fish.slug) || !canGenerate(fish)"
                 @click="generate(fish)"
               >
-                <span
-                  v-if="isGenerating(fish.slug)"
-                  class="loading loading-spinner loading-xs"
-                />
+                <span v-if="isGenerating(fish.slug)" class="kr-spinner-xs" />
                 {{
                   isGenerating(fish.slug)
                     ? generationLabel(fish.slug)
@@ -313,10 +310,7 @@
                 :disabled="isSaving(fish.slug)"
                 @click="save(fish)"
               >
-                <span
-                  v-if="isSaving(fish.slug)"
-                  class="loading loading-spinner loading-xs"
-                />
+                <span v-if="isSaving(fish.slug)" class="kr-spinner-xs" />
                 Save curation
               </button>
               <span v-if="draft.jobId" class="text-xs text-base-content/45">

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -16,7 +16,7 @@
           :disabled="loading"
           @click="store.load()"
         >
-          <span v-if="loading" class="loading loading-spinner loading-xs" />
+          <span v-if="loading" class="kr-spinner-xs" />
           Refresh
         </button>
       </div>
@@ -432,7 +432,7 @@
               :disabled="!canSave"
               @click="store.saveSelected()"
             >
-              <span v-if="saving" class="loading loading-spinner loading-xs" />
+              <span v-if="saving" class="kr-spinner-xs" />
               Save changes
             </button>
             <button

--- a/components/dreams/daily-digest-object-dialog.vue
+++ b/components/dreams/daily-digest-object-dialog.vue
@@ -164,7 +164,7 @@
                   class="btn btn-primary btn-sm gap-2 rounded-xl"
                   :disabled="saving || !hasChanges || missingRequiredField"
                 >
-                  <span v-if="saving" class="loading loading-spinner loading-xs" />
+                  <span v-if="saving" class="kr-spinner-xs" />
                   <Icon v-else name="kind-icon:save" class="size-4" />
                   {{ saving ? 'Saving…' : 'Save changes' }}
                 </button>

--- a/components/dreams/daily-dream-generator.vue
+++ b/components/dreams/daily-dream-generator.vue
@@ -62,7 +62,7 @@
           :disabled="loading"
           @click="createDailyDream"
         >
-          <span v-if="loading" class="loading loading-spinner loading-xs" />
+          <span v-if="loading" class="kr-spinner-xs" />
           <Icon v-else name="kind-icon:dream" class="size-4" />
           Build today’s Dream
         </button>

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -166,7 +166,7 @@
             :disabled="submitting || prompt.trim().length < 3 || (mode === 'img2img' && !currentSrc)"
             @click="queueArt"
           >
-            <span v-if="submitting" class="loading loading-spinner loading-xs" />
+            <span v-if="submitting" class="kr-spinner-xs" />
             <Icon v-else name="kind-icon:sparkles" class="size-4" />
             {{ submitting ? 'Queuing…' : `Queue ${selectedSlot.label}` }}
           </button>

--- a/components/dreams/dream-art-chooser.vue
+++ b/components/dreams/dream-art-chooser.vue
@@ -31,10 +31,7 @@
         aria-label="Refresh art collections"
         @click="loadAssets(true)"
       >
-        <span
-          v-if="isLoadingAssets"
-          class="loading loading-spinner loading-xs"
-        />
+        <span v-if="isLoadingAssets" class="kr-spinner-xs" />
         <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
       </button>
     </div>
@@ -77,10 +74,7 @@
         :disabled="!selectedCollectionId || isSaving"
         @click="attachSelectedCollection"
       >
-        <span
-          v-if="isSavingCollection"
-          class="loading loading-spinner loading-xs"
-        />
+        <span v-if="isSavingCollection" class="kr-spinner-xs" />
         <Icon v-else name="kind-icon:folder" class="h-4 w-4" />
         Attach Collection
       </button>
@@ -92,7 +86,7 @@
         data-tip="Pick a random image from a connected collection"
         @click="useRandomCollectionImage"
       >
-        <span v-if="isSavingImage" class="loading loading-spinner loading-xs" />
+        <span v-if="isSavingImage" class="kr-spinner-xs" />
         <Icon v-else name="kind-icon:dice" class="h-4 w-4" />
         Random from Collection
       </button>

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -28,7 +28,7 @@
           >
             <span
               v-if="dreamStore.loading"
-              class="loading loading-spinner loading-xs"
+              class="kr-spinner-xs"
             />
             <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
             Generate

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -177,7 +177,7 @@
         >
           <span
             v-if="isLoading || dreamStore.loading"
-            class="loading loading-spinner loading-xs"
+            class="kr-spinner-xs"
           />
           <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
         </button>

--- a/components/dreams/dream-inspire-button.vue
+++ b/components/dreams/dream-inspire-button.vue
@@ -62,7 +62,7 @@
       >
         <span
           v-if="s.status === 'generating'"
-          class="loading loading-spinner loading-xs"
+          class="kr-spinner-xs"
         />
         {{ s.label }}
       </div>

--- a/components/dreams/dream-list.vue
+++ b/components/dreams/dream-list.vue
@@ -16,7 +16,7 @@
         :disabled="isLoading"
         @click="refreshList"
       >
-        <span v-if="isLoading" class="loading loading-spinner loading-xs" />
+        <span v-if="isLoading" class="kr-spinner-xs" />
         <Icon v-else name="kind-icon:refresh" class="h-3 w-3" />
         {{ refreshLabel }}
       </button>

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -50,7 +50,7 @@
           >
             <span
               v-if="dreamStore.isSaving"
-              class="loading loading-spinner loading-xs"
+              class="kr-spinner-xs"
             />
             <Icon v-else name="kind-icon:save" class="h-4 w-4" />
             {{ saveLabel }}

--- a/components/facets/facet-editor.vue
+++ b/components/facets/facet-editor.vue
@@ -61,10 +61,7 @@
         :disabled="!editForm.title.trim() || facetStore.saving"
         @click="save"
       >
-        <span
-          v-if="facetStore.saving"
-          class="loading loading-spinner loading-xs"
-        />
+        <span v-if="facetStore.saving" class="kr-spinner-xs" />
         Save canonical profile
       </button>
 

--- a/components/facets/facet-manager.vue
+++ b/components/facets/facet-manager.vue
@@ -66,7 +66,7 @@
           >
             <span
               v-if="facetStore.saving"
-              class="loading loading-spinner loading-xs"
+              class="kr-spinner-xs"
             />
             <Icon v-else name="kind-icon:plus" class="size-3.5" />
             Create canonical Facet

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -12,7 +12,7 @@
       </div>
       <span
         v-if="saving || loadingAssignments"
-        class="loading loading-spinner loading-xs"
+        class="kr-spinner-xs"
       />
       <span class="kr-badge-ghost-sm">{{ selectedFacets.length }}</span>
     </div>
@@ -140,7 +140,7 @@
         >
           <span
             v-if="facetStore.saving"
-            class="loading loading-spinner loading-xs"
+            class="kr-spinner-xs"
           />
           <Icon v-else name="kind-icon:plus" class="size-3.5" />
           Create and attach

--- a/components/home/home-attention.vue
+++ b/components/home/home-attention.vue
@@ -179,10 +179,7 @@
               :disabled="isUpdating(gate) || !replyText(gate)"
               @click="act(gate, 'answer')"
             >
-              <span
-                v-if="isUpdating(gate)"
-                class="loading loading-spinner loading-xs"
-              />
+              <span v-if="isUpdating(gate)" class="kr-spinner-xs" />
               <Icon v-else name="kind-icon:send" class="size-3" />
               Send to agent
             </button>

--- a/components/home/home-object-sheet.vue
+++ b/components/home/home-object-sheet.vue
@@ -216,10 +216,7 @@
               :disabled="redoBusy || !redoPrompt.trim()"
               @click="submitRedo"
             >
-              <span
-                v-if="redoBusy"
-                class="loading loading-spinner loading-xs"
-              />
+              <span v-if="redoBusy" class="kr-spinner-xs" />
               <Icon v-else name="kind-icon:refresh" class="size-3.5" />
               Queue new art
             </button>

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -154,7 +154,7 @@
           >
             <span
               v-if="queuing === card.civitaiModelVersionId"
-              class="loading loading-spinner loading-xs"
+              class="kr-spinner-xs"
             />
             <Icon v-else :name="downloadButtonIcon(card)" class="h-4 w-4" />
             {{ downloadButtonLabel(card) }}

--- a/components/manager/kr-manager.vue
+++ b/components/manager/kr-manager.vue
@@ -86,7 +86,7 @@
         :disabled="loading"
         @click="emit('refresh')"
       >
-        <span v-if="loading" class="loading loading-spinner loading-xs" />
+        <span v-if="loading" class="kr-spinner-xs" />
         <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
         Refresh
       </button>

--- a/components/mandarin/mandarin-voice-coach.vue
+++ b/components/mandarin/mandarin-voice-coach.vue
@@ -36,7 +36,7 @@
           :disabled="recording || evaluating || Boolean(tutorStore.audioLoadingKey)"
           @click="tutorStore.speak(card)"
         >
-          <span v-if="tutorStore.audioLoadingKey === card.key" class="loading loading-spinner loading-xs" />
+          <span v-if="tutorStore.audioLoadingKey === card.key" class="kr-spinner-xs" />
           {{ tutorStore.audioLoadingKey === card.key ? 'Preparing reference…' : 'Hear reference' }}
         </button>
         <button
@@ -46,7 +46,7 @@
           :disabled="evaluating || !voiceSupported"
           @click="startRecording"
         >
-          <span v-if="evaluating" class="loading loading-spinner loading-xs" />
+          <span v-if="evaluating" class="kr-spinner-xs" />
           {{ evaluating ? 'Checking pronunciation…' : transcript ? 'Try again' : 'Say it' }}
         </button>
         <button

--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -109,7 +109,7 @@
           >
             <span
               v-if="cancellingRunId === run.id"
-              class="loading loading-spinner loading-xs"
+              class="kr-spinner-xs"
               aria-hidden="true"
             />
             <Icon

--- a/components/narrative/kr-narrator-stage.vue
+++ b/components/narrative/kr-narrator-stage.vue
@@ -94,7 +94,7 @@
         >
           <span
             v-if="isNarratorResponding"
-            class="loading loading-spinner loading-xs"
+            class="kr-spinner-xs"
           />
           <Icon v-else name="kind-icon:send" class="h-4 w-4" />
         </button>

--- a/components/navigation/maturity-toggle.vue
+++ b/components/navigation/maturity-toggle.vue
@@ -35,7 +35,7 @@
         </span>
 
         <span class="flex shrink-0 items-center gap-2">
-          <span v-if="isUpdating" class="loading loading-spinner loading-xs" />
+          <span v-if="isUpdating" class="kr-spinner-xs" />
           <input
             type="checkbox"
             class="toggle toggle-warning toggle-sm"
@@ -67,7 +67,7 @@
       :disabled="isUpdating"
       @click="setShowMature(!showMature)"
     >
-      <span v-if="isUpdating" class="loading loading-spinner loading-xs" />
+      <span v-if="isUpdating" class="kr-spinner-xs" />
       <Icon
         v-else
         :name="showMature ? 'kind-icon:eye' : 'kind-icon:eye-off'"

--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -23,7 +23,7 @@
         >
           <span
             v-if="channelContentStore.loading"
-            class="loading loading-spinner loading-xs"
+            class="kr-spinner-xs"
           />
           <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
           Reload content

--- a/components/navigation/workspace-narrator.vue
+++ b/components/navigation/workspace-narrator.vue
@@ -446,7 +446,7 @@
                   >
                     <span
                       v-if="isNarratorResponding"
-                      class="loading loading-spinner loading-xs"
+                      class="kr-spinner-xs"
                     />
                     <Icon v-else name="kind-icon:send" class="h-4 w-4" />
                     Ask

--- a/components/newsfeed/newsfeed-feed.vue
+++ b/components/newsfeed/newsfeed-feed.vue
@@ -158,7 +158,7 @@
           :aria-busy="isLoading"
           @click="loadFeed()"
         >
-          <span v-if="isLoading" class="loading loading-spinner loading-xs" />
+          <span v-if="isLoading" class="kr-spinner-xs" />
           <Icon v-else name="kind-icon:refresh" class="size-4" />
           <span v-if="!compact" class="hidden 2xl:inline">Refresh</span>
         </button>

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -106,7 +106,7 @@
           class="badge badge-warning badge-lg gap-2"
           :title="`Requested ${formatDate(item.requestedAt)} — waiting for the next Worker cycle`"
         >
-          <span class="loading loading-spinner loading-xs" />
+          <span class="kr-spinner-xs" />
           {{ item.slug }}
         </div>
       </div>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -153,7 +153,7 @@
         >
           <span
             v-if="syncingMissing"
-            class="loading loading-spinner loading-xs"
+            class="kr-spinner-xs"
           />
           <Icon v-else name="kind-icon:warning" class="size-3" />
           Sync {{ missingProjectSlugs.length }}
@@ -179,7 +179,7 @@
           :disabled="pending"
           @click="refreshWorkspace"
         >
-          <span v-if="pending" class="loading loading-spinner loading-xs" />
+          <span v-if="pending" class="kr-spinner-xs" />
           <Icon v-else name="kind-icon:refresh" class="size-3.5" />
         </button>
       </template>
@@ -657,7 +657,7 @@
                   >
                     <span
                       v-if="projectTaskSubmitting"
-                      class="loading loading-spinner loading-xs"
+                      class="kr-spinner-xs"
                     />
                     Add
                   </button>

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -42,7 +42,7 @@
             :disabled="isLoading"
             @click="refresh"
           >
-            <span v-if="isLoading" class="loading loading-spinner loading-xs" />
+            <span v-if="isLoading" class="kr-spinner-xs" />
             <Icon v-else name="kind-icon:refresh" class="size-4" />
             Refresh
           </button>
@@ -217,7 +217,7 @@
                   :disabled="isUpdating(pitch.slug)"
                   @click="setStatus(pitch, 'approved')"
                 >
-                  <span v-if="isUpdating(pitch.slug)" class="loading loading-spinner loading-xs" />
+                  <span v-if="isUpdating(pitch.slug)" class="kr-spinner-xs" />
                   <Icon v-else name="kind-icon:check" class="size-3.5" />
                   Approve
                 </button>
@@ -293,7 +293,7 @@
             :disabled="requestingPitches"
             @click="requestPitchRun"
           >
-            <span v-if="requestingPitches" class="loading loading-spinner loading-xs" />
+            <span v-if="requestingPitches" class="kr-spinner-xs" />
             <Icon v-else name="kind-icon:sparkles" class="size-4" />
             Queue a fresh pitch run
           </button>

--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -73,7 +73,7 @@
         >
           <span
             v-if="projects.saving"
-            class="loading loading-spinner loading-xs"
+            class="kr-spinner-xs"
           />
           <Icon v-else name="kind-icon:plus" class="size-3.5" />
           Create Project
@@ -210,7 +210,7 @@
               :disabled="loading"
               @click="refresh"
             >
-              <span v-if="loading" class="loading loading-spinner loading-xs" />
+              <span v-if="loading" class="kr-spinner-xs" />
               <Icon v-else name="kind-icon:refresh" class="size-3.5" />
               <span class="hidden sm:inline">Refresh</span>
             </button>

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -72,10 +72,7 @@
               :disabled="conductorStore.pending"
               @click="conductorStore.fetchProjects(true)"
             >
-              <span
-                v-if="conductorStore.pending"
-                class="loading loading-spinner loading-xs"
-              />
+              <span v-if="conductorStore.pending" class="kr-spinner-xs" />
               <Icon v-else name="kind-icon:refresh-cw" class="size-4" />
               Refresh
             </button>
@@ -225,7 +222,7 @@
                   >
                     <span
                       v-if="taskIsUpdating(gate.project.slug, gate.task.id)"
-                      class="loading loading-spinner loading-xs"
+                      class="kr-spinner-xs"
                     />
                     <Icon v-else name="kind-icon:check" class="size-4" />
                     Approve

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -732,7 +732,7 @@
                       >
                         <span
                           v-if="item.status === 'queued'"
-                          class="loading loading-spinner loading-xs"
+                          class="kr-spinner-xs"
                         />
                         <template v-else>Apply</template>
                       </button>

--- a/components/projects/project-placement-manager.vue
+++ b/components/projects/project-placement-manager.vue
@@ -88,10 +88,7 @@
               :disabled="busy"
               @click="loadProjects"
             >
-              <span
-                v-if="projectStore.loading"
-                class="loading loading-spinner loading-xs"
-              />
+              <span v-if="projectStore.loading" class="kr-spinner-xs" />
               <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
               Load projects
             </button>
@@ -102,10 +99,7 @@
               :disabled="busy || !projectStore.loaded"
               @click="applyPlacements"
             >
-              <span
-                v-if="applying"
-                class="loading loading-spinner loading-xs"
-              />
+              <span v-if="applying" class="kr-spinner-xs" />
               <Icon v-else name="kind-icon:wand" class="h-4 w-4" />
               Apply placements
             </button>

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -431,10 +431,7 @@ onMounted(async () => {
             :disabled="resourceGalleryStore.isLoading"
             @click="resourceGalleryStore.loadResources()"
           >
-            <span
-              v-if="resourceGalleryStore.isLoading"
-              class="loading loading-spinner loading-xs"
-            />
+            <span v-if="resourceGalleryStore.isLoading" class="kr-spinner-xs" />
             <icon v-else name="kind-icon:refresh" class="h-3.5 w-3.5" />
             Refresh
           </button>
@@ -530,7 +527,7 @@ onMounted(async () => {
             >
               <span
                 v-if="activePreviewResourceId === infoResource.id"
-                class="loading loading-spinner loading-xs"
+                class="kr-spinner-xs"
               />
               <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
               {{ infoResourceArt ? 'Regenerate art' : 'Generate art' }}

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -10,7 +10,7 @@
           object independently of its name.
         </p>
       </div>
-      <span v-if="loading || saving" class="loading loading-spinner loading-xs" />
+      <span v-if="loading || saving" class="kr-spinner-xs" />
       <span class="kr-badge-ghost-sm">{{ selectedFacets.length }}</span>
     </div>
 

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -64,7 +64,7 @@
             :disabled="isLoading"
             @click="refreshRewards(true)"
           >
-            <span v-if="isLoading" class="loading loading-spinner loading-xs" />
+            <span v-if="isLoading" class="kr-spinner-xs" />
             <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
             <span class="hidden sm:inline">Refresh</span>
           </button>

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -38,7 +38,7 @@
             :disabled="isLoading"
             @click="refreshScenarios(true)"
           >
-            <span v-if="isLoading" class="loading loading-spinner loading-xs" />
+            <span v-if="isLoading" class="kr-spinner-xs" />
             <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
           </button>
         </div>

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -156,7 +156,7 @@
               >
                 <span
                   v-if="llmLoading"
-                  class="loading loading-spinner loading-xs"
+                  class="kr-spinner-xs"
                 />
                 <Icon v-else name="mdi:sparkles" class="h-3.5 w-3.5" />
                 {{ form.prompt ? 'Regenerate' : 'Generate' }}

--- a/components/user/account-settings.vue
+++ b/components/user/account-settings.vue
@@ -67,10 +67,7 @@
               :disabled="account.isSaving"
               @click="onSendVerification"
             >
-              <span
-                v-if="account.isSaving"
-                class="loading loading-spinner loading-xs"
-              />
+              <span v-if="account.isSaving" class="kr-spinner-xs" />
               Send verification email
             </button>
           </div>
@@ -120,10 +117,7 @@
               class="kr-btn-primary"
               :disabled="account.isSaving || !canSubmitPassword"
             >
-              <span
-                v-if="account.isSaving"
-                class="loading loading-spinner loading-xs"
-              />
+              <span v-if="account.isSaving" class="kr-spinner-xs" />
               {{ hasPassword ? 'Update password' : 'Set password' }}
             </button>
             <span

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -217,7 +217,7 @@
         class="btn btn-primary btn-sm w-full rounded-xl"
         :disabled="isCreating || !newLabel.trim() || !newBotId || !newScopes.length"
       >
-        <span v-if="isCreating" class="loading loading-spinner loading-xs" />
+        <span v-if="isCreating" class="kr-spinner-xs" />
         {{ replacingCredentialId ? 'Create replacement key' : 'Create credential' }}
       </button>
     </form>

--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -133,7 +133,7 @@
               title="Refresh"
               @click="refreshGallery(true)"
             >
-              <span v-if="isLoadingGallery" class="loading loading-spinner loading-xs" />
+              <span v-if="isLoadingGallery" class="kr-spinner-xs" />
               <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
             </button>
           </div>

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -50,7 +50,7 @@
           :disabled="isLoading"
           @click="refreshChats"
         >
-          <span v-if="isLoading" class="loading loading-spinner loading-xs" />
+          <span v-if="isLoading" class="kr-spinner-xs" />
           <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
           Refresh
         </button>
@@ -232,10 +232,7 @@
             :disabled="isReplying || !canReply || !replyMessage.trim()"
             @click="sendReply"
           >
-            <span
-              v-if="isReplying"
-              class="loading loading-spinner loading-xs"
-            />
+            <span v-if="isReplying" class="kr-spinner-xs" />
             <Icon v-else name="kind-icon:send" class="h-4 w-4" />
             Send
           </button>

--- a/components/user/messenger.vue
+++ b/components/user/messenger.vue
@@ -119,10 +119,7 @@
             class="kr-btn-primary-md"
             :disabled="convo.isSending || !draft.trim()"
           >
-            <span
-              v-if="convo.isSending"
-              class="loading loading-spinner loading-xs"
-            />
+            <span v-if="convo.isSending" class="kr-spinner-xs" />
             <Icon v-else name="kind-icon:send" class="h-4 w-4" />
           </button>
         </form>

--- a/components/user/password-reset.vue
+++ b/components/user/password-reset.vue
@@ -39,10 +39,7 @@
         class="kr-btn-primary"
         :disabled="account.isSaving || !email"
       >
-        <span
-          v-if="account.isSaving"
-          class="loading loading-spinner loading-xs"
-        />
+        <span v-if="account.isSaving" class="kr-spinner-xs" />
         Send reset link
       </button>
     </form>
@@ -78,10 +75,7 @@
         class="kr-btn-primary"
         :disabled="account.isSaving || next.length < 8 || next !== confirm"
       >
-        <span
-          v-if="account.isSaving"
-          class="loading loading-spinner loading-xs"
-        />
+        <span v-if="account.isSaving" class="kr-spinner-xs" />
         Set new password
       </button>
     </form>

--- a/components/user/user-panel.vue
+++ b/components/user/user-panel.vue
@@ -32,7 +32,7 @@
         :disabled="isSaving || !hasProfile"
         @click="updateProfile"
       >
-        <span v-if="isSaving" class="loading loading-spinner loading-xs" />
+        <span v-if="isSaving" class="kr-spinner-xs" />
         <span>{{ isSaving ? 'Saving...' : 'Update Profile' }}</span>
       </button>
     </header>
@@ -88,7 +88,7 @@
           class="btn btn-primary w-full rounded-xl md:w-auto"
           :disabled="isSaving"
         >
-          <span v-if="isSaving" class="loading loading-spinner loading-xs" />
+          <span v-if="isSaving" class="kr-spinner-xs" />
           <span>{{ isSaving ? 'Saving Profile' : 'Save Changes' }}</span>
         </button>
       </div>

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -539,7 +539,7 @@
           :disabled="isLoading"
           @click="showMore"
         >
-          <span v-if="isLoading" class="loading loading-spinner loading-xs" />
+          <span v-if="isLoading" class="kr-spinner-xs" />
           Show more
         </button>
       </div>

--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -145,10 +145,7 @@
             :disabled="entry.reviewPublic || isPublishing || !draft.trim()"
             @click="publish"
           >
-            <span
-              v-if="isPublishing"
-              class="loading loading-spinner loading-xs"
-            />
+            <span v-if="isPublishing" class="kr-spinner-xs" />
             {{ entry.reviewPublic ? 'Published' : 'Publish' }}
           </button>
         </div>

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -47,10 +47,7 @@
             :disabled="isExporting || !pageDefinition"
             @click="saveImage"
           >
-            <span
-              v-if="isExporting"
-              class="loading loading-spinner loading-xs"
-            />
+            <span v-if="isExporting" class="kr-spinner-xs" />
             <Icon v-else name="kind-icon:image" class="h-4 w-4" />
             Save image
           </button>

--- a/pages/admin/achievement-art.vue
+++ b/pages/admin/achievement-art.vue
@@ -20,7 +20,7 @@
           :disabled="loading"
           @click="loadAchievements(true)"
         >
-          <span v-if="loading" class="loading loading-spinner loading-xs" />
+          <span v-if="loading" class="kr-spinner-xs" />
           Refresh
         </button>
       </header>

--- a/pages/admin/forum-moderation.vue
+++ b/pages/admin/forum-moderation.vue
@@ -21,7 +21,7 @@
           :disabled="loading"
           @click="moderationStore.fetchHiddenPosts()"
         >
-          <span v-if="loading" class="loading loading-spinner loading-xs" />
+          <span v-if="loading" class="kr-spinner-xs" />
           Refresh
         </button>
       </header>

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -23,7 +23,7 @@
             :disabled="triageStore.isSaving || loading"
             @click="refresh"
           >
-            <span v-if="loading" class="loading loading-spinner loading-xs" />
+            <span v-if="loading" class="kr-spinner-xs" />
             <Icon v-else name="kind-icon:refresh" class="size-4" />
             Refresh
           </button>
@@ -35,10 +35,7 @@
             "
             @click="triageStore.saveChanges()"
           >
-            <span
-              v-if="triageStore.isSaving"
-              class="loading loading-spinner loading-xs"
-            />
+            <span v-if="triageStore.isSaving" class="kr-spinner-xs" />
             <Icon v-else name="kind-icon:save" class="size-4" />
             Save {{ triageStore.pendingChanges.length }} change{{
               triageStore.pendingChanges.length === 1 ? '' : 's'

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -21,7 +21,7 @@
             :disabled="store.loading || store.queueing || !userStore.isAdmin"
             @click="store.load()"
           >
-            <span v-if="store.loading" class="loading loading-spinner loading-xs" />
+            <span v-if="store.loading" class="kr-spinner-xs" />
             Refresh
           </button>
         </div>
@@ -307,7 +307,7 @@
                     :disabled="store.queueing"
                     @click="store.retrySource(source.name)"
                   >
-                    <span v-if="store.retryingSource === source.name" class="loading loading-spinner loading-xs" />
+                    <span v-if="store.retryingSource === source.name" class="kr-spinner-xs" />
                     Retry this scene
                   </button>
                 </div>

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -22,7 +22,7 @@
           :disabled="loading"
           @click="draftsStore.populate()"
         >
-          <span v-if="loading" class="loading loading-spinner loading-xs" />
+          <span v-if="loading" class="kr-spinner-xs" />
           Scan daily dreams for new drafts
         </button>
       </header>
@@ -104,7 +104,7 @@
             :disabled="loading"
             @click="draftsStore.fetchDrafts()"
           >
-            <span v-if="loading" class="loading loading-spinner loading-xs" />
+            <span v-if="loading" class="kr-spinner-xs" />
             Refresh
           </button>
           <span class="text-xs text-base-content/50">

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -399,7 +399,7 @@
                           votingSubmissionId === submission.id &&
                           pendingReaction === reaction.value
                         "
-                        class="loading loading-spinner loading-xs"
+                        class="kr-spinner-xs"
                       />
                       <span v-else>{{ reaction.icon }}</span>
                       {{ reaction.label }}

--- a/pages/play/challenges/leaderboard.vue
+++ b/pages/play/challenges/leaderboard.vue
@@ -14,7 +14,7 @@
           :disabled="loading"
           @click="loadLeaderboard"
         >
-          <span v-if="loading" class="loading loading-spinner loading-xs" />
+          <span v-if="loading" class="kr-spinner-xs" />
           <Icon v-else name="kind-icon:refresh" class="size-4" />
           Refresh
         </button>

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -159,7 +159,7 @@
                   <p class="text-xs opacity-60">Create “{{ searchQuery.trim() }}” as a requested learning card.</p>
                 </div>
                 <button class="kr-btn-primary-plain" type="button" :disabled="requestingWord" @click="requestCurrentWord">
-                  <span v-if="requestingWord" class="loading loading-spinner loading-xs" />
+                  <span v-if="requestingWord" class="kr-spinner-xs" />
                   {{ requestingWord ? 'Creating…' : 'Create requested card' }}
                 </button>
               </div>

--- a/utils/scripts/codemods/kr_spinner_codemod.py
+++ b/utils/scripts/codemods/kr_spinner_codemod.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `loading loading-spinner loading-xs` busy
+indicators to `kr-spinner-xs`.
+
+Dry-run is the default. Pass --write to update matching Vue files in place.
+Only the exact, colorless `loading loading-spinner loading-xs` shape is
+touched, and only in static `class="..."` attributes -- never
+`:class`/`v-bind:class` bindings, and regardless of the base tokens' order
+in the source. A source that already carries `kr-spinner-xs`, or is missing
+any one of the base tokens, is left untouched. Extra tokens beyond the base
+set (shrink-0, self-end, motion-reduce:hidden, ...) are preserved verbatim
+after the primitive class, matching the kr-badge-*/kr-input-*/kr-checkbox-*
+codemods' subset-match convention -- pass --exact-only to restrict a slice
+to sources with no extra tokens at all, the safest and most literal pool.
+
+This deliberately does NOT touch the colored variants (`loading
+loading-spinner loading-xs text-primary`, `loading-sm`, `loading-lg
+text-primary`, `loading-dots ...`, etc.) surveyed alongside this one in
+interface-vision t-104 slice 150 -- each is its own bounded family for a
+future slice, not folded in here just because the grep that found them
+overlaps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-spinner-xs"
+BASE_TOKENS = {"loading", "loading-spinner", "loading-xs"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-spinner-xs {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
interface-vision t-104 slice 150. A broad survey of the codebase's most-repeated static `class="..."` values turned up `loading loading-spinner loading-xs` (DaisyUI's plain busy-indicator spinner, no color tint) as the single largest exact-duplicate class string in the app — hand-rolled identically in 83 files, 123 occurrences, almost all standalone `<span>` pending-state indicators inside buttons.

Added `.kr-spinner-xs` (`loading loading-spinner loading-xs`) to `assets/css/tailwind.css`, following the same convention as `.kr-badge-*` of wrapping DaisyUI's own component classes rather than only hand-rolled Tailwind utilities. Added `kr_spinner_codemod.py` (`--exact-only`, `--write`) mirroring `kr_badge_codemod.py`'s subset-match convention, and used it to migrate all 123 exact occurrences.

Left out of scope for this slice, each its own bounded family for later: the colored variants (`loading-xs text-primary`: 6/7 occurrences; `loading-sm`: 50; `loading-lg text-primary`: 28; `loading-dots`/`-ring` variants) surfaced by the same survey but not folded in here.

## Verification
- `vue-tsc --noEmit` clean
- `test:lint-ratchet` holds (333 problems, -59 vs. baseline)
- `test:layout-contract` holds (no new violations)
- `prettier --check` matches baseline file-for-file (confirmed via `git stash`; 21 files needed a follow-up `prettier --write` after the codemod, since shortening the class value let several multi-line `<span>` tags collapse to one line under prettier's print width — same failure mode noted in slice 149's TALKBACK entry)
- Grepped `utils/scripts/*.{mjs,ts}` for the literal class string being replaced — no source-text contract hits

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBDs83ZoXYPQ9tjbXy6F3H)_