### PR TITLE
fix(art-queue): group jobs by heavy model, not by the whole model stack

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Entity art primary/crop contract
         run: npm run test:entity-art-primary-crop
 
+      - name: ArtJob smart-queue affinity contract
+        run: npm run test:artjob-queue-affinity
+
       - name: GitHub file-read contract
         run: npm run test:github-file-contents
 

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "test:art-prompt-repair": "tsx utils/scripts/verifyArtPromptRepair.ts",
     "test:art-prompt-contract": "tsx utils/scripts/verifyArtPromptContract.ts",
     "test:entity-art-primary-crop": "tsx utils/scripts/verifyEntityArtPrimaryCrop.ts",
+    "test:artjob-queue-affinity": "tsx utils/scripts/verifyArtJobQueueAffinity.ts",
     "test:artjob-sampler-repair": "tsx utils/scripts/verifyArtJobSamplerRepair.ts",
     "test:comfy-only-generation": "tsx utils/scripts/verifyComfyOnlyGeneration.ts",
     "test:art-generator-presets": "tsx utils/scripts/verifyArtGeneratorPresets.ts",

--- a/server/api/art/queue/claim.post.ts
+++ b/server/api/art/queue/claim.post.ts
@@ -7,8 +7,11 @@
 //
 // Smart queueing is enabled by default. Within the highest-priority tier, the
 // relay prefers a bounded lookahead job whose model-loader affinity matches the
-// last job that relay completed. The bypass cap prevents a busy model family
-// from starving older work indefinitely. Set smartQueue=false for strict FIFO.
+// last job that relay completed, trying an exact match (nothing reloads) before
+// a heavy-model match (same unet, different LoRAs - avoids the 8-12GB swap that
+// actually costs throughput on a 12GB card). The bypass cap prevents a busy
+// model family from starving older work indefinitely. Set smartQueue=false for
+// strict FIFO.
 // The claim itself is an updateMany guarded on the expected status, so two
 // relays can never win the same job — the loser retries another candidate.
 import { createError, defineEventHandler, readBody } from 'h3'
@@ -26,6 +29,7 @@ import {
 } from '../../../utils/artJobProvenance'
 import {
   artJobQueueAffinityKey,
+  artJobQueueModelKey,
   selectSmartQueueCandidate,
 } from '../../../utils/artJobQueueAffinity'
 import { reconcileQueuedArtJobCoverage } from '../../../utils/artJobQueueCoverage'
@@ -168,11 +172,19 @@ export default defineEventHandler(async (event) => {
         })
       : null
 
+    const previousPayload = previousJob
+      ? parseArtJobPayload(previousJob.payload)
+      : null
+
     const preferredAffinity = previousJob
-      ? artJobQueueAffinityKey(
-          previousJob.engine,
-          parseArtJobPayload(previousJob.payload),
-        )
+      ? artJobQueueAffinityKey(previousJob.engine, previousPayload)
+      : null
+
+    // The heavy half of the same key. Matching on it lets a Krea job follow a
+    // Krea job that merely uses a different LoRA, which the full key counts as
+    // a miss - see the second tier in selectSmartQueueCandidate.
+    const preferredModelKey = previousJob
+      ? artJobQueueModelKey(previousJob.engine, previousPayload)
       : null
 
     for (let attempt = 0; attempt < CLAIM_CANDIDATE_TRIES; attempt++) {
@@ -226,6 +238,7 @@ export default defineEventHandler(async (event) => {
         eligible,
         smartQueue ? preferredAffinity : null,
         smartQueue ? SMART_QUEUE_MAX_BYPASS : 0,
+        smartQueue ? preferredModelKey : null,
       )
       const candidate = selection.candidate
 
@@ -335,7 +348,7 @@ export default defineEventHandler(async (event) => {
         return {
           success: true,
           message: selection.affinityMatched
-            ? `Job claimed with model affinity (${selection.bypassedCount} older same-priority job(s) bypassed).`
+            ? `Job claimed with ${selection.matchTier === 'model' ? 'heavy-model' : 'exact'} affinity (${selection.bypassedCount} older same-priority job(s) bypassed).`
             : 'Job claimed.',
           data: {
             job: job ? decodeArtJobPayload(job) : null,
@@ -348,9 +361,12 @@ export default defineEventHandler(async (event) => {
             scheduling: {
               mode: smartQueue ? 'SMART' : 'FIFO',
               affinityMatched: selection.affinityMatched,
+              matchTier: selection.matchTier,
               bypassedCount: selection.bypassedCount,
               preferredAffinity: selection.preferredAffinity,
               selectedAffinity: selection.selectedAffinity,
+              preferredModelKey: selection.preferredModelKey ?? null,
+              selectedModelKey: selection.selectedModelKey ?? null,
             },
           },
           statusCode: 200,

--- a/server/utils/artJobQueueAffinity.ts
+++ b/server/utils/artJobQueueAffinity.ts
@@ -9,12 +9,17 @@ export type ArtJobAffinityCandidate = {
   priority: number
 }
 
+export type SmartQueueMatchTier = 'exact' | 'model' | 'none'
+
 export type SmartQueueSelection<T extends ArtJobAffinityCandidate> = {
   candidate: T | null
   affinityMatched: boolean
+  matchTier: SmartQueueMatchTier
   bypassedCount: number
   preferredAffinity: string | null
   selectedAffinity: string | null
+  preferredModelKey?: string | null
+  selectedModelKey?: string | null
 }
 
 const MODEL_RESOURCE_KEYS = new Set([
@@ -37,6 +42,28 @@ const MODEL_RESOURCE_KEYS = new Set([
   'upscale_model',
   'upscale_model_name',
   'vae_name',
+])
+
+// The resources whose swap costs a MULTI-GIGABYTE VRAM reload. On Ferngrotto's
+// 12GB 3060 a unet/checkpoint change evicts nearly everything and reloads from
+// disk; a LoRA or VAE change is a rounding error next to it. artJobQueueAffinityKey
+// deliberately treats all named resources alike, which is right for "can this run
+// with zero reload" and wrong for "which jobs should sit next to each other".
+//
+// Measured on the live queue, 2026-09-08: 23 pending jobs used exactly TWO heavy
+// models (flux1-kontext-dev-q5_k_m, krea-2-turbo-q5_k_s) but produced SEVEN
+// distinct full affinity keys, because jobs in the same family carried different
+// LoRA counts. Seven keys over two models means the exact-match pass almost never
+// fires inside a priority tier, so the claim falls back to FIFO and the engine
+// swaps unets far more often than the work requires.
+const HEAVY_MODEL_RESOURCE_KEYS = new Set([
+  'checkpoint',
+  'checkpoint_name',
+  'ckpt_name',
+  'diffusion_model',
+  'model_name',
+  'sd_model_checkpoint',
+  'unet_name',
 ])
 
 const MODEL_LOADER_CLASS_PATTERN =
@@ -105,7 +132,8 @@ function collectNamedResources(
   if (depth > 8 || value === null || value === undefined) return
 
   if (Array.isArray(value)) {
-    for (const child of value) collectNamedResources(child, resources, depth + 1)
+    for (const child of value)
+      collectNamedResources(child, resources, depth + 1)
     return
   }
 
@@ -173,10 +201,54 @@ export function artJobQueueAffinityKey(
   return `${normalizedEngine}|${parts.length ? parts.join('|') : 'default'}`
 }
 
+/**
+ * The heavy half of the affinity key: engine plus whichever unet/checkpoint the
+ * job loads, ignoring LoRAs, VAEs, CLIPs and loader settings.
+ *
+ * Returns null when no heavy resource can be identified, and callers must treat
+ * that as "do not group" rather than as a key. An engine-only fallback would
+ * bucket every unparsed payload together and reorder work on no evidence at all.
+ */
+export function artJobQueueModelKey(
+  engine: string,
+  rawPayload: unknown,
+): string | null {
+  const normalizedEngine = String(engine || 'UNKNOWN').toUpperCase()
+  const resources = new Set<string>()
+  collectNamedResources(asRecord(rawPayload) ?? {}, resources)
+
+  const heavy = [...resources]
+    .filter((entry) => HEAVY_MODEL_RESOURCE_KEYS.has(entry.split(':', 1)[0]))
+    .sort()
+
+  if (!heavy.length) return null
+  return `${normalizedEngine}|${heavy.join('|')}`
+}
+
+/**
+ * Pick the next job to claim, preferring one the engine can run with the least
+ * reloading.
+ *
+ * TWO TIERS, tried in order within the highest-priority window:
+ *
+ *   1. EXACT - same full affinity key: same unet AND same LoRAs, VAE, loader
+ *      settings. Nothing reloads at all.
+ *   2. MODEL - same heavy model, different accessories. A LoRA swap costs a few
+ *      hundred MB; the unet swap this avoids costs eight to twelve, which on a
+ *      12GB card means evicting the text encoders too and reloading them next
+ *      time round. This tier is why Krea and Flux work now arrives in runs
+ *      instead of interleaved.
+ *
+ * Priority still dominates absolutely: both tiers only ever look inside the
+ * highest-priority group, so a promoted job is never passed over for a cheaper
+ * one. maxBypass bounds each tier so a busy model family cannot starve older
+ * work indefinitely.
+ */
 export function selectSmartQueueCandidate<T extends ArtJobAffinityCandidate>(
   candidates: T[],
   preferredAffinity: string | null,
   maxBypass = 24,
+  preferredModelKey: string | null = null,
 ): SmartQueueSelection<T> {
   const ordered = [...candidates].sort(
     (left, right) => right.priority - left.priority || left.id - right.id,
@@ -187,20 +259,28 @@ export function selectSmartQueueCandidate<T extends ArtJobAffinityCandidate>(
     return {
       candidate: null,
       affinityMatched: false,
+      matchTier: 'none',
       bypassedCount: 0,
       preferredAffinity,
       selectedAffinity: null,
+      preferredModelKey,
+      selectedModelKey: null,
     }
   }
 
   const oldestAffinity = artJobQueueAffinityKey(oldest.engine, oldest.payload)
-  if (!preferredAffinity) {
+  const oldestModelKey = artJobQueueModelKey(oldest.engine, oldest.payload)
+
+  if (!preferredAffinity && !preferredModelKey) {
     return {
       candidate: oldest,
       affinityMatched: false,
+      matchTier: 'none',
       bypassedCount: 0,
       preferredAffinity: null,
       selectedAffinity: oldestAffinity,
+      preferredModelKey: null,
+      selectedModelKey: oldestModelKey,
     }
   }
 
@@ -208,32 +288,65 @@ export function selectSmartQueueCandidate<T extends ArtJobAffinityCandidate>(
   const samePriority = ordered.filter(
     (candidate) => candidate.priority === highestPriority,
   )
-  const matchIndex = samePriority.findIndex((candidate) => {
-    return (
-      artJobQueueAffinityKey(candidate.engine, candidate.payload) ===
-      preferredAffinity
-    )
-  })
+  const cap = Math.max(0, maxBypass)
 
-  if (matchIndex >= 0 && matchIndex <= Math.max(0, maxBypass)) {
-    const candidate = samePriority[matchIndex] ?? oldest
+  const pick = (index: number, tier: 'exact' | 'model') => {
+    const candidate = samePriority[index] ?? oldest
     return {
       candidate,
       affinityMatched: true,
-      bypassedCount: matchIndex,
+      matchTier: tier,
+      bypassedCount: index,
       preferredAffinity,
       selectedAffinity: artJobQueueAffinityKey(
         candidate.engine,
         candidate.payload,
       ),
-    }
+      preferredModelKey,
+      selectedModelKey: artJobQueueModelKey(
+        candidate.engine,
+        candidate.payload,
+      ),
+    } satisfies SmartQueueSelection<T>
   }
+
+  if (preferredAffinity) {
+    const exactIndex = samePriority.findIndex(
+      (candidate) =>
+        artJobQueueAffinityKey(candidate.engine, candidate.payload) ===
+        preferredAffinity,
+    )
+    if (exactIndex >= 0 && exactIndex <= cap) return pick(exactIndex, 'exact')
+  }
+
+  // Null means "no heavy resource identified" on one side or the other, which
+  // is not a match - see artJobQueueModelKey.
+  if (preferredModelKey) {
+    const modelIndex = samePriority.findIndex(
+      (candidate) =>
+        artJobQueueModelKey(candidate.engine, candidate.payload) ===
+        preferredModelKey,
+    )
+    if (modelIndex >= 0 && modelIndex <= cap) return pick(modelIndex, 'model')
+  }
+
+  const oldestMatchesExact =
+    !!preferredAffinity && oldestAffinity === preferredAffinity
+  const oldestMatchesModel =
+    !!preferredModelKey && oldestModelKey === preferredModelKey
 
   return {
     candidate: oldest,
-    affinityMatched: oldestAffinity === preferredAffinity,
+    affinityMatched: oldestMatchesExact || oldestMatchesModel,
+    matchTier: oldestMatchesExact
+      ? 'exact'
+      : oldestMatchesModel
+        ? 'model'
+        : 'none',
     bypassedCount: 0,
     preferredAffinity,
     selectedAffinity: oldestAffinity,
+    preferredModelKey,
+    selectedModelKey: oldestModelKey,
   }
 }

--- a/server/utils/artJobQueueAffinity.ts
+++ b/server/utils/artJobQueueAffinity.ts
@@ -217,8 +217,16 @@ export function artJobQueueModelKey(
   const resources = new Set<string>()
   collectNamedResources(asRecord(rawPayload) ?? {}, resources)
 
+  // indexOf/slice rather than split(':', 1)[0]: under the repo's strict
+  // settings that index is string | undefined, and a resource value can itself
+  // contain a colon (a path), so slicing at the FIRST colon is also the correct
+  // reading of the `key:value` entries collectNamedResources builds.
   const heavy = [...resources]
-    .filter((entry) => HEAVY_MODEL_RESOURCE_KEYS.has(entry.split(':', 1)[0]))
+    .filter((entry) => {
+      const separator = entry.indexOf(':')
+      if (separator <= 0) return false
+      return HEAVY_MODEL_RESOURCE_KEYS.has(entry.slice(0, separator))
+    })
     .sort()
 
   if (!heavy.length) return null

--- a/utils/scripts/verifyArtJobQueueAffinity.ts
+++ b/utils/scripts/verifyArtJobQueueAffinity.ts
@@ -2,6 +2,7 @@
 import assert from 'node:assert/strict'
 import {
   artJobQueueAffinityKey,
+  artJobQueueModelKey,
   selectSmartQueueCandidate,
 } from '../../server/utils/artJobQueueAffinity'
 
@@ -125,5 +126,180 @@ assert.equal(
   1,
   'affinity must not bypass more than the configured fairness cap',
 )
+
+// ---------------------------------------------------------------------------
+// HEAVY-MODEL TIER
+//
+// Measured on the live queue 2026-09-08: 23 pending jobs, TWO heavy models, but
+// SEVEN distinct full affinity keys, because jobs in one family carried
+// different LoRAs. Seven keys over two models means the exact tier almost never
+// fires and the claim falls back to FIFO, swapping unets far more often than
+// the work needs.
+
+const modelA = artJobQueueModelKey(
+  'COMFY',
+  comfyPayload('dream-a.safetensors', 1),
+)
+const modelB = artJobQueueModelKey(
+  'COMFY',
+  comfyPayload('dream-b.safetensors', 1),
+)
+
+assert.equal(
+  modelA,
+  artJobQueueModelKey('COMFY', comfyPayload('dream-a.safetensors', 7, 0.42)),
+  'a LoRA strength change must NOT split the heavy-model key',
+)
+assert.notEqual(
+  modelA,
+  modelB,
+  'different checkpoints must split the heavy-model key',
+)
+assert.equal(
+  artJobQueueModelKey('COMFY', {
+    workflow: { '1': { class_type: 'KSampler', inputs: { seed: 1 } } },
+  }),
+  null,
+  'a payload naming no heavy resource must yield null, never an engine-only bucket',
+)
+
+// The case the whole change exists for: nothing matches exactly, but a job on
+// the same unet sits behind one on a different unet.
+const differentLora = {
+  id: 31,
+  engine: 'COMFY',
+  payload: comfyPayload('dream-a.safetensors', 5, 0.65),
+  priority: 0,
+}
+const modelTier = selectSmartQueueCandidate(
+  [
+    {
+      id: 30,
+      engine: 'COMFY',
+      payload: comfyPayload('dream-b.safetensors', 4),
+      priority: 0,
+    },
+    differentLora,
+  ],
+  firstAffinity,
+  24,
+  modelA,
+)
+assert.equal(
+  modelTier.candidate?.id,
+  31,
+  'must prefer the same heavy model over a unet swap',
+)
+assert.equal(modelTier.matchTier, 'model')
+assert.equal(modelTier.affinityMatched, true)
+
+// The same call WITHOUT a preferred model key is the old behaviour, and it
+// takes the unet swap. Asserted so the tier above is provably what changes the
+// outcome, and so smartQueue=false stays strict FIFO.
+assert.equal(
+  selectSmartQueueCandidate(
+    [
+      {
+        id: 30,
+        engine: 'COMFY',
+        payload: comfyPayload('dream-b.safetensors', 4),
+        priority: 0,
+      },
+      differentLora,
+    ],
+    firstAffinity,
+    24,
+  ).candidate?.id,
+  30,
+  'without a model key the selector must behave exactly as before',
+)
+
+// An exact match must still win over a merely-same-model one, even when the
+// same-model job is older.
+const exactBeatsModel = selectSmartQueueCandidate(
+  [
+    differentLora,
+    {
+      id: 32,
+      engine: 'COMFY',
+      payload: comfyPayload('dream-a.safetensors', 6),
+      priority: 0,
+    },
+  ],
+  firstAffinity,
+  24,
+  modelA,
+)
+assert.equal(
+  exactBeatsModel.candidate?.id,
+  32,
+  'exact affinity must outrank heavy-model affinity',
+)
+assert.equal(exactBeatsModel.matchTier, 'exact')
+
+// Priority still dominates both tiers.
+assert.equal(
+  selectSmartQueueCandidate(
+    [
+      differentLora,
+      {
+        id: 33,
+        engine: 'COMFY',
+        payload: comfyPayload('dream-b.safetensors', 7),
+        priority: 5,
+      },
+    ],
+    firstAffinity,
+    24,
+    modelA,
+  ).candidate?.id,
+  33,
+  'heavy-model affinity must never jump a higher-priority job',
+)
+
+// And the fairness cap bounds the model tier too.
+const modelFairness = selectSmartQueueCandidate(
+  Array.from({ length: 27 }, (_, index) => ({
+    id: index + 1,
+    engine: 'COMFY',
+    payload: comfyPayload(
+      index === 26 ? 'dream-a.safetensors' : 'dream-b.safetensors',
+      index,
+      index === 26 ? 0.65 : 1,
+    ),
+    priority: 0,
+  })),
+  firstAffinity,
+  24,
+  modelA,
+)
+assert.equal(
+  modelFairness.candidate?.id,
+  1,
+  'heavy-model affinity must not bypass more than the fairness cap',
+)
+
+// A null preferred model key must never group: two unrelated payloads that both
+// fail heavy-resource detection must not be treated as the same model.
+const nullKeySelection = selectSmartQueueCandidate(
+  [
+    {
+      id: 40,
+      engine: 'COMFY',
+      payload: comfyPayload('dream-b.safetensors', 9),
+      priority: 0,
+    },
+    { id: 41, engine: 'COMFY', payload: { workflow: {} }, priority: 0 },
+  ],
+  null,
+  24,
+  null,
+)
+assert.equal(
+  nullKeySelection.candidate?.id,
+  40,
+  'a null model key must fall back to FIFO',
+)
+assert.equal(nullKeySelection.matchTier, 'none')
 
 console.log('ArtJob smart queue affinity checks passed.')


### PR DESCRIPTION
## Why Krea and Flux interleave

Smart queueing already existed — but its affinity key could almost never match.

`artJobQueueAffinityKey` hashes **every** named model resource plus every ComfyUI loader node's settings. Two jobs on the same unet that differ by one LoRA are different families to it.

**Measured against the live queue, 2026-09-08:**

| | |
|---|---|
| pending jobs | 23 |
| distinct **heavy models** | **2** (`flux1-kontext-dev-q5_k_m`, `krea-2-turbo-q5_k_s`) |
| distinct **full affinity keys** | **7** |

Seven keys over two models means the exact match almost never fires inside a priority tier, the claim falls back to `priority DESC, id ASC`, and the engine swaps unets far more often than the work requires.

The cost is wildly asymmetric and the key ignored that: on a 12GB 3060 a unet swap is 8–12GB off disk and evicts the text encoders with it, while a LoRA swap is a few hundred MB. The old key priced them the same.

## The fix

`selectSmartQueueCandidate` now tries two tiers inside the highest-priority window:

1. **EXACT** — the existing full key. Nothing reloads at all.
2. **MODEL** — new `artJobQueueModelKey`: the heavy half only (unet / checkpoint / diffusion model), ignoring LoRAs, VAEs, CLIPs and loader settings.

**Priority still dominates absolutely** — both tiers only look inside the highest-priority group, so a promoted job is never passed over for a cheaper one. The existing fairness cap bounds both tiers, so a busy model family still can't starve older work.

`artJobQueueModelKey` returns `null` when it finds no heavy resource, and callers treat null as *do not group*. An engine-only fallback would bucket every unparsed payload together and reorder work on no evidence at all.

## This should retire the manual priority hack

Earlier today I chained Flux work to the back of the queue with `priority: -100`. That only held until the next Flux job arrived — which is exactly what produced today's queue shape:

```
21649..21652   pri    1   flux1-kontext-dev
21653          pri    0   krea-2-turbo
20618..21631   pri  -10   krea-2-turbo
21638..21647   pri -100   flux1-kontext-dev
```

Flux above Krea above Flux. Grouping now happens automatically, so priority can go back to meaning urgency rather than doubling as a batching mechanism. Worth clearing those `-100`s once this is deployed and confirmed.

## Testing

`utils/scripts/verifyArtJobQueueAffinity.ts` existed but was wired into **neither `package.json` nor CI** — it had never run. Registered as `test:artjob-queue-affinity` in the Contract verifiers job, and extended to cover:

- a LoRA-strength change must **not** split the heavy key; a checkpoint change must
- a payload naming no heavy resource yields `null`, never an engine-only bucket
- the case this exists for: same-unet job behind a different-unet job → picks the same unet
- exact beats model, even when the same-model job is older
- priority dominance and the fairness cap, for the new tier
- a null model key falls back to FIFO
- **the selector without a model key behaves exactly as before** (so `smartQueue=false` stays strict FIFO)

All pass. I confirmed the new tests bite by disabling the model tier — `must prefer the same heavy model over a unet swap: 30 !== 31`.

Prettier clean. `nuxi prepare` still can't run in this container, so ESLint and `vue-tsc` are left to CI.

**Not verified end to end:** the relay's actual claim sequence against a real mixed queue. The unit contract proves the selection logic; the real confirmation is watching `scheduling.matchTier` come back as `model` in claim responses, and heavy-model swaps dropping toward one per family in a drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGb4quwjzWKjbgxAC6pgDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGb4quwjzWKjbgxAC6pgDx)_