### PR TITLE
refactor(ui): migrate loading-spinner loading-sm to kr-spinner-sm

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1578,6 +1578,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply loading loading-spinner loading-xs;
   }
 
+  /* Same colorless busy indicator as `.kr-spinner-xs`, one size up: the
+   * `loading-sm` DaisyUI spinner dropped into a wider inline slot or a
+   * standalone loading block (interface-vision t-104 slice 151) --
+   * `loading loading-spinner loading-sm`, previously hand-rolled
+   * identically in 37 files (50 exact occurrences), the largest bounded
+   * family surfaced by slice 150's same frequency survey and named as a
+   * follow-up target in that slice's kaizen suggestion. The colored
+   * variants found alongside it (`text-primary`, `text-primary-content`,
+   * `motion-reduce:hidden`) are left for a future slice, same convention
+   * as `.kr-spinner-xs`. */
+  .kr-spinner-sm {
+    @apply loading loading-spinner loading-sm;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/add-collection.vue
+++ b/components/art/add-collection.vue
@@ -80,7 +80,7 @@
         type="submit"
         :disabled="isSaving || disabled || !label.trim()"
       >
-        <span v-if="isSaving" class="loading loading-spinner loading-sm" />
+        <span v-if="isSaving" class="kr-spinner-sm" />
         <Icon v-else name="kind-icon:plus" class="h-5 w-5" />
         Create Collection
       </button>

--- a/components/art/art-lora-picker.vue
+++ b/components/art/art-lora-picker.vue
@@ -140,7 +140,7 @@
         v-if="resourceStore.isLoading && !resourceStore.hasLoaded"
         class="flex min-h-24 items-center justify-center rounded-xl bg-base-200"
       >
-        <span class="loading loading-spinner loading-sm" />
+        <span class="kr-spinner-sm" />
       </div>
 
       <p

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -567,7 +567,7 @@
         :disabled="!canGenerate"
         @click="runStyleTransfer"
       >
-        <span v-if="isGenerating" class="loading loading-spinner loading-sm" />
+        <span v-if="isGenerating" class="kr-spinner-sm" />
         <Icon v-else name="kind-icon:magic" class="h-5 w-5" />
         {{
           isGenerating

--- a/components/art/forum-art-generation-context.vue
+++ b/components/art/forum-art-generation-context.vue
@@ -31,7 +31,7 @@
       v-if="store.loadingPost"
       class="mt-4 flex items-center gap-2 text-sm text-base-content/55"
     >
-      <span class="loading loading-spinner loading-sm" />
+      <span class="kr-spinner-sm" />
       Loading the source forum post…
     </div>
 
@@ -134,10 +134,7 @@
           "
           @click="store.queueArt()"
         >
-          <span
-            v-if="store.queueing"
-            class="loading loading-spinner loading-sm"
-          />
+          <span v-if="store.queueing" class="kr-spinner-sm" />
           {{
             store.queueing
               ? 'Queueing…'

--- a/components/art/hair-studio-manager.vue
+++ b/components/art/hair-studio-manager.vue
@@ -17,7 +17,7 @@
         v-if="stylist.isBusy"
         class="flex items-center gap-2 text-sm font-bold text-primary"
       >
-        <span class="loading loading-spinner loading-sm" />
+        <span class="kr-spinner-sm" />
         styling
       </span>
     </header>

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -456,10 +456,7 @@
         :disabled="isUploading || isFinalizingUpload"
         @click="handleBatchUpload"
       >
-        <span
-          v-if="isUploading || isFinalizingUpload"
-          class="loading loading-spinner loading-sm"
-        />
+        <span v-if="isUploading || isFinalizingUpload" class="kr-spinner-sm" />
         <Icon v-else name="kind-icon:camera" class="h-5 w-5" />
         {{
           isUploading || isFinalizingUpload

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -486,7 +486,7 @@
         >
           <span
             v-if="botStore.isSaving"
-            class="loading loading-spinner loading-sm"
+            class="kr-spinner-sm"
           />
           {{ saveLabel }}
         </button>

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -182,10 +182,7 @@
             :disabled="!canSend"
             @click="sendMessage"
           >
-            <span
-              v-if="isResponding"
-              class="loading loading-spinner loading-sm"
-            />
+            <span v-if="isResponding" class="kr-spinner-sm" />
             <span v-else>Send</span>
           </button>
         </div>

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -114,7 +114,7 @@
           :disabled="!canGenerate"
           data-testid="brainstorm-generate"
         >
-          <span v-if="isBatchGenerating" class="loading loading-spinner loading-sm" aria-hidden="true" />
+          <span v-if="isBatchGenerating" class="kr-spinner-sm" aria-hidden="true" />
           {{ isBatchGenerating ? 'Brainstorming…' : activeCandidates.length ? 'Fresh batch' : (isArtPromptDomain ? 'Generate art prompts' : 'Generate ideas') }}
         </button>
 

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -180,7 +180,7 @@
             >
               <span
                 v-if="characterStore.isGeneratingArt"
-                class="loading loading-spinner loading-sm"
+                class="kr-spinner-sm"
               />
               <Icon v-else name="kind-icon:magic" class="h-4 w-4" />
               Generate portrait
@@ -502,7 +502,7 @@
         >
           <span
             v-if="characterStore.isSaving"
-            class="loading loading-spinner loading-sm"
+            class="kr-spinner-sm"
           />
           {{ saveLabel }}
         </button>

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -104,7 +104,7 @@
           :disabled="!promptDirty || studio.savingCoverPrompt || promptDraft.trim().length < 40"
           @click="savePrompt"
         >
-          <span v-if="studio.savingCoverPrompt" class="loading loading-spinner loading-sm" />
+          <span v-if="studio.savingCoverPrompt" class="kr-spinner-sm" />
           <icon v-else name="kind-icon:save" class="size-5" />
           Save canonical cover prompt
         </button>
@@ -138,7 +138,7 @@
               :disabled="!canGenerate || studio.requestingAction || promptDirty"
               @click="requestCover(false)"
             >
-              <span v-if="studio.requestingAction" class="loading loading-spinner loading-sm" />
+              <span v-if="studio.requestingAction" class="kr-spinner-sm" />
               <icon v-else name="kind-icon:sparkles" class="size-5" />
               Generate cover candidate
             </button>

--- a/components/coloring/coloring-book-production-toolbar.vue
+++ b/components/coloring/coloring-book-production-toolbar.vue
@@ -141,7 +141,7 @@
           :disabled="!canRequestBw || studio.requestingAction"
           @click="requestBw(false)"
         >
-          <span v-if="studio.requestingAction" class="loading loading-spinner loading-sm" />
+          <span v-if="studio.requestingAction" class="kr-spinner-sm" />
           <icon v-else name="kind-icon:pencil" class="size-5" />
           Generate B&amp;W counterpart
         </button>

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -20,7 +20,7 @@
         :disabled="studio.loading"
         @click="studio.fetchStudio()"
       >
-        <span v-if="studio.loading" class="loading loading-spinner loading-sm" />
+        <span v-if="studio.loading" class="kr-spinner-sm" />
         <icon v-else name="kind-icon:refresh" class="size-5" />
         Refresh Conductor
       </button>
@@ -444,7 +444,7 @@
           >
             <span
               v-if="studio.savingPrompt"
-              class="loading loading-spinner loading-sm"
+              class="kr-spinner-sm"
             />
             <icon v-else name="kind-icon:save" class="size-5" />
             Save canonical prompt
@@ -470,7 +470,7 @@
           >
             <span
               v-if="studio.requestingRender"
-              class="loading loading-spinner loading-sm"
+              class="kr-spinner-sm"
             />
             <icon v-else name="kind-icon:sparkles" class="size-5" />
             {{

--- a/components/coloring/production-action-button.vue
+++ b/components/coloring/production-action-button.vue
@@ -6,7 +6,7 @@
     :disabled="!enabled || busy"
     @click="emit('click')"
   >
-    <span v-if="busy" class="loading loading-spinner loading-sm" />
+    <span v-if="busy" class="kr-spinner-sm" />
     <icon v-else :name="iconName" class="size-5" />
     {{ armed ? confirmLabel : label }}
   </button>

--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -58,7 +58,7 @@
               >
                 <span
                   v-if="loading"
-                  class="loading loading-spinner loading-sm"
+                  class="kr-spinner-sm"
                 />
                 <Icon v-else name="kind-icon:refresh" class="size-4" />
               </button>

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -115,10 +115,7 @@
               class="btn btn-primary btn-sm w-fit gap-1.5 rounded-xl"
               :disabled="submitting"
             >
-              <span
-                v-if="submitting"
-                class="loading loading-spinner loading-sm"
-              />
+              <span v-if="submitting" class="kr-spinner-sm" />
               <Icon v-else name="kind-icon:sparkles" class="size-4" />
               Begin a life
             </button>
@@ -362,10 +359,7 @@
                   :disabled="submitting"
                   @click="resolveLife"
                 >
-                  <span
-                    v-if="submitting"
-                    class="loading loading-spinner loading-sm"
-                  />
+                  <span v-if="submitting" class="kr-spinner-sm" />
                   <Icon v-else name="kind-icon:trophy" class="size-4" />
                   See your ending
                 </button>

--- a/components/dreams/dream-inspire-button.vue
+++ b/components/dreams/dream-inspire-button.vue
@@ -39,7 +39,7 @@
       :disabled="generating || pendingPrompts.length === 0"
       @click="handleClick"
     >
-      <span v-if="generating" class="loading loading-spinner loading-sm" />
+      <span v-if="generating" class="kr-spinner-sm" />
       <span v-else>Generate Inspiration</span>
       <span v-if="pendingPrompts.length > 0" class="badge badge-neutral">
         {{ pendingPrompts.length }}

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -11,7 +11,7 @@
       </div>
       <span
         v-if="catalog.loading"
-        class="loading loading-spinner loading-sm"
+        class="kr-spinner-sm"
         aria-label="Loading facets"
       />
       <span class="badge badge-ghost shrink-0">{{ visibleCount }} shown</span>

--- a/components/lora/add-lora.vue
+++ b/components/lora/add-lora.vue
@@ -214,7 +214,7 @@
         type="submit"
         :disabled="isSaving || !canSubmit"
       >
-        <span v-if="isSaving" class="loading loading-spinner loading-sm" />
+        <span v-if="isSaving" class="kr-spinner-sm" />
         <Icon v-else name="kind-icon:check" class="h-4 w-4" />
         {{ isEditing ? 'Save Changes' : 'Add LoRA' }}
       </button>

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -68,7 +68,7 @@
           type="submit"
           :disabled="loading"
         >
-          <span v-if="loading" class="loading loading-spinner loading-sm" />
+          <span v-if="loading" class="kr-spinner-sm" />
           <Icon v-else name="kind-icon:search" class="h-4 w-4" />
           {{ source === 'civarchive' ? 'Look up' : 'Search' }}
         </button>
@@ -180,7 +180,7 @@
         :disabled="loading"
         @click="runSearch(false)"
       >
-        <span v-if="loading" class="loading loading-spinner loading-sm" />
+        <span v-if="loading" class="kr-spinner-sm" />
         Load more
       </button>
     </footer>

--- a/components/model/add-model.vue
+++ b/components/model/add-model.vue
@@ -162,7 +162,7 @@
         type="submit"
         :disabled="isSaving || !canSubmit"
       >
-        <span v-if="isSaving" class="loading loading-spinner loading-sm" />
+        <span v-if="isSaving" class="kr-spinner-sm" />
         <Icon v-else name="kind-icon:check" class="h-4 w-4" />
         {{ isEditing ? 'Save Changes' : 'Add Model' }}
       </button>

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -253,7 +253,7 @@
             >
               <span
                 v-if="isGeneratingArt"
-                class="loading loading-spinner loading-sm"
+                class="kr-spinner-sm"
               />
               {{ isGeneratingArt ? 'Generating...' : 'Generate Art' }}
             </button>
@@ -296,7 +296,7 @@
         >
           <span
             v-if="rewardStore.isSaving"
-            class="loading loading-spinner loading-sm"
+            class="kr-spinner-sm"
           />
           {{ saveLabel }}
         </button>

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -204,10 +204,7 @@
                 :disabled="!canContinueCustom"
                 @click="continueWithCustomPath"
               >
-                <span
-                  v-if="isStarting"
-                  class="loading loading-spinner loading-sm"
-                />
+                <span v-if="isStarting" class="kr-spinner-sm" />
                 <Icon v-else name="kind-icon:wand" class="h-5 w-5" />
                 Continue Custom Path
               </button>
@@ -259,10 +256,7 @@
             :disabled="!canStartStory"
             @click="startRewardStory"
           >
-            <span
-              v-if="isStarting"
-              class="loading loading-spinner loading-sm"
-            />
+            <span v-if="isStarting" class="kr-spinner-sm" />
             <Icon v-else name="kind-icon:play" class="h-5 w-5" />
             Start Story
           </button>

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -265,10 +265,7 @@
               :disabled="isGeneratingArt"
               @click="generateArtImage"
             >
-              <span
-                v-if="isGeneratingArt"
-                class="loading loading-spinner loading-sm"
-              />
+              <span v-if="isGeneratingArt" class="kr-spinner-sm" />
               {{ isGeneratingArt ? 'Generating...' : 'Generate Art' }}
             </button>
           </div>
@@ -308,10 +305,7 @@
           :disabled="scenarioStore.isSaving"
           @click="saveScenario"
         >
-          <span
-            v-if="scenarioStore.isSaving"
-            class="loading loading-spinner loading-sm"
-          />
+          <span v-if="scenarioStore.isSaving" class="kr-spinner-sm" />
           {{ saveLabel }}
         </button>
       </footer>

--- a/components/scenarios/scenario-story.vue
+++ b/components/scenarios/scenario-story.vue
@@ -169,10 +169,7 @@
         :disabled="!canLaunchScenario"
         @click="storyStore.submitStoryTurn"
       >
-        <span
-          v-if="storyStore.isBusy"
-          class="loading loading-spinner loading-sm"
-        />
+        <span v-if="storyStore.isBusy" class="kr-spinner-sm" />
         <Icon v-else name="kind-icon:play" class="h-5 w-5" />
         {{ storyStore.isBusy ? 'Story goblin thinking...' : 'Start Story' }}
       </button>
@@ -330,10 +327,7 @@
           :disabled="!storyStore.canSubmitStory"
           @click="storyStore.submitStoryTurn"
         >
-          <span
-            v-if="storyStore.isBusy"
-            class="loading loading-spinner loading-sm"
-          />
+          <span v-if="storyStore.isBusy" class="kr-spinner-sm" />
           <Icon v-else name="kind-icon:play" class="h-5 w-5" />
           {{
             storyStore.isBusy ? 'Story goblin thinking...' : 'Send Next Turn'

--- a/components/servers/add-checkpoint.vue
+++ b/components/servers/add-checkpoint.vue
@@ -219,7 +219,7 @@
         type="submit"
         :disabled="isSaving || !canSubmit"
       >
-        <span v-if="isSaving" class="loading loading-spinner loading-sm" />
+        <span v-if="isSaving" class="kr-spinner-sm" />
         <Icon v-else name="kind-icon:plus" class="h-4 w-4" />
         Save Checkpoint
       </button>

--- a/components/servers/add-server.vue
+++ b/components/servers/add-server.vue
@@ -276,10 +276,7 @@
         type="submit"
         :disabled="serverStore.isSaving || !form.title || !form.baseUrl"
       >
-        <span
-          v-if="serverStore.isSaving"
-          class="loading loading-spinner loading-sm"
-        />
+        <span v-if="serverStore.isSaving" class="kr-spinner-sm" />
         Save Server
       </button>
     </footer>

--- a/components/storybook/storybook-visual-setup.vue
+++ b/components/storybook/storybook-visual-setup.vue
@@ -132,7 +132,7 @@
           >
             <span
               v-if="store.isWeaving"
-              class="loading loading-spinner loading-sm"
+              class="kr-spinner-sm"
             />
             <Icon v-else name="kind-icon:book-open" class="size-4" />
             {{ store.isWeaving ? 'Opening the story…' : 'Open this story' }}
@@ -358,7 +358,7 @@
           >
             <span
               v-if="store.isWeaving"
-              class="loading loading-spinner loading-sm"
+              class="kr-spinner-sm"
             />
             <Icon v-else name="kind-icon:book-open" class="size-4" />
             {{ store.isWeaving ? 'Opening…' : 'Open this story' }}

--- a/components/taskmaster/taskmaster-sample-tasks.vue
+++ b/components/taskmaster/taskmaster-sample-tasks.vue
@@ -54,7 +54,7 @@
             >
               <span
                 v-if="startingId === sample.id"
-                class="loading loading-spinner loading-sm"
+                class="kr-spinner-sm"
               />
               <Icon v-else :name="sample.icon" class="size-5" />
             </span>

--- a/components/ui/ui-gallery.vue
+++ b/components/ui/ui-gallery.vue
@@ -264,7 +264,7 @@
             <button class="btn btn-primary">md</button>
             <button class="btn btn-primary btn-lg">lg</button>
             <button class="btn btn-primary">
-              <span class="loading loading-spinner loading-sm" />
+              <span class="kr-spinner-sm" />
               Loading
             </button>
           </div>

--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -188,7 +188,7 @@
               :disabled="isApplying"
               @click="chooseFromGallery(selectedGalleryImage)"
             >
-              <span v-if="isApplying" class="loading loading-spinner loading-sm" />
+              <span v-if="isApplying" class="kr-spinner-sm" />
               <Icon v-else name="kind-icon:check" class="h-4 w-4" />
               Use this avatar
             </button>

--- a/components/user/user-manager.vue
+++ b/components/user/user-manager.vue
@@ -25,7 +25,7 @@
     </div>
 
     <div v-if="isLoadingManager" class="shrink-0 kr-panel-muted p-4">
-      <span class="loading loading-spinner loading-sm" />
+      <span class="kr-spinner-sm" />
       <span class="ml-2">Loading user account details...</span>
     </div>
 

--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -148,7 +148,7 @@
       v-if="resourceStore.isLoading && !resourceStore.hasLoaded"
       class="flex min-h-32 items-center justify-center rounded-lg bg-base-200"
     >
-      <span class="loading loading-spinner loading-sm" />
+      <span class="kr-spinner-sm" />
     </div>
 
     <div

--- a/components/wonderlab/reaction-card.vue
+++ b/components/wonderlab/reaction-card.vue
@@ -136,7 +136,7 @@
         >
           <span
             v-if="isSubmitting"
-            class="loading loading-spinner loading-sm"
+            class="kr-spinner-sm"
           />
 
           <Icon v-else name="kind-icon:check" class="h-4 w-4" />

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -150,7 +150,7 @@
                 :disabled="store.queueing || store.loading || !store.totalCount"
                 @click="store.enqueue(false)"
               >
-                <span v-if="store.queueing" class="loading loading-spinner loading-sm" />
+                <span v-if="store.queueing" class="kr-spinner-sm" />
                 {{ store.missingCount ? `Start / Resume ${store.missingCount} missing` : 'Resume / verify batch' }}
               </button>
               <button
@@ -275,7 +275,7 @@
                     </template>
                     <div v-else class="grid size-full place-items-center p-3 text-center text-xs text-base-content/40">
                       <template v-if="source.status === 'rendering' || source.status === 'queued'">
-                        <span class="loading loading-spinner loading-sm" />
+                        <span class="kr-spinner-sm" />
                         <span class="mt-1 block">{{ elapsedLabel(source) }}</span>
                       </template>
                       <span v-else>{{ statusLabel(source.status) }}</span>

--- a/pages/music-mentor.vue
+++ b/pages/music-mentor.vue
@@ -90,7 +90,7 @@
         >
           <span
             v-if="store.isBusy"
-            class="loading loading-spinner loading-sm"
+            class="kr-spinner-sm"
           />
           {{ analyzeLabel }}
         </button>

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -331,7 +331,7 @@
         >
           <span
             v-if="videoStore.isBusy"
-            class="loading loading-spinner loading-sm"
+            class="kr-spinner-sm"
           />
           {{ generateLabel }}
         </button>

--- a/utils/scripts/codemods/kr_spinner_sm_codemod.py
+++ b/utils/scripts/codemods/kr_spinner_sm_codemod.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `loading loading-spinner loading-sm` busy
+indicators to `kr-spinner-sm`.
+
+Sibling of kr_spinner_codemod.py (the `-xs` size), same conventions:
+dry-run by default, --write to update matching Vue files in place. Only
+the exact, colorless `loading loading-spinner loading-sm` shape is
+touched, and only in static `class="..."` attributes -- never
+`:class`/`v-bind:class` bindings, and regardless of the base tokens'
+order in the source. A source that already carries `kr-spinner-sm`, or is
+missing any one of the base tokens, is left untouched. Extra tokens
+beyond the base set are preserved verbatim after the primitive class,
+matching the kr-badge-*/kr-spinner-xs codemods' subset-match convention
+-- pass --exact-only to restrict a slice to sources with no extra tokens
+at all, the safest and most literal pool.
+
+This deliberately does NOT touch the colored variants (`loading
+loading-spinner loading-sm text-primary`, `text-primary-content`, etc.)
+surveyed alongside this one in interface-vision t-104 slice 151 -- each
+is its own bounded family for a future slice, not folded in here just
+because the grep that found them overlaps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-spinner-sm"
+BASE_TOKENS = {"loading", "loading-spinner", "loading-sm"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-spinner-sm {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 151: recurring front-end-consistency sweep (kind: software)

### What changed / what I produced
- Added `.kr-spinner-sm` to `assets/css/tailwind.css`, mirroring `.kr-spinner-xs`'s convention of wrapping DaisyUI's own component classes.
- Added `utils/scripts/codemods/kr_spinner_sm_codemod.py` (`--exact-only`, `--write`), a sibling of `kr_spinner_codemod.py` using the same subset-match convention.
- Migrated all 50 exact colorless `loading loading-spinner loading-sm` occurrences across 37 files to `.kr-spinner-sm`. Left the colored variants (`text-primary`, `text-primary-content`, `motion-reduce:hidden` extras — 11 occurrences) out of scope for a future slice, same as slice 150's precedent for `.kr-spinner-xs`.
- This target was named directly by slice 150's own kaizen suggestion (kind_robots#2520) as the largest remaining bounded spinner family after `loading-xs`.

### How I verified
- `vue-tsc`: clean
- `eslint` on all 37 changed `.vue` files: 0 new errors (2 pre-existing errors on `add-bot.vue`/`add-checkpoint.vue` confirmed present on baseline via `git stash`, unrelated to this change)
- `test:layout-contract`: holds, no new violations (an unrelated -2 viewport-grid baseline improvement on `narrative-ingredient-multi-picker.vue` is visible in the run but isn't this slice's to claim)
- `test:lint-ratchet`: holds at 333/-59
- `prettier --check`: matches the 21-file pre-existing baseline debt set exactly — 8 files whose now-shorter `<span>` collapsed onto one line under prettier's print width were fixed by hand via targeted `prettier --write` on just those files (confirmed via `git stash` that they carried no pre-existing prettier debt first), same fix pattern as slices 149/150
- Grepped `utils/scripts/*.{mjs,ts}` for the literal class string — no source-text contract hits

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
The same frequency survey that found this family also surfaced `label-text font-bold` (145 occurrences) and `flex items-center gap-2` (87 occurrences) as the next largest exact-duplicate class strings in the app — both much bigger than any family tackled so far, though `flex items-center gap-2` is generic enough it may not deserve its own primitive (worth a scoping look before committing a slice to it). `label-text font-bold` looks like the more promising next target: a DaisyUI form-label pattern, likely mechanically similar to the existing `kr-badge-*`/`kr-spinner-*` wrap-and-codemod approach.

### Notes for reviewer

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDXRmrFc2gEPUmQN23md3p

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDXRmrFc2gEPUmQN23md3p)_