### PR TITLE
refactor(ui): migrate label-text font-bold to kr-label-bold

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1592,6 +1592,21 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply loading loading-spinner loading-sm;
   }
 
+  /* A bolded DaisyUI form-label caption -- `label-text font-bold`, the
+   * label text of a form field's leading `<label class="label">` when the
+   * field name itself needs emphasis, no size/color override
+   * (interface-vision t-104 slice 152) -- previously hand-rolled
+   * identically 145 times across the app, the largest bounded family
+   * surfaced by slice 151's frequency survey and named as its own
+   * follow-up target in that slice's kaizen suggestion. The sized/tinted
+   * siblings found alongside it (`label-text text-xs font-bold`, `text-xs
+   * font-semibold`, `text-xs font-bold uppercase tracking-wide`, etc.) are
+   * left for future slices, same convention as `.kr-spinner-xs`/
+   * `.kr-spinner-sm`. */
+  .kr-label-bold {
+    @apply label-text font-bold;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1598,13 +1598,23 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
    * (interface-vision t-104 slice 152) -- previously hand-rolled
    * identically 145 times across the app, the largest bounded family
    * surfaced by slice 151's frequency survey and named as its own
-   * follow-up target in that slice's kaizen suggestion. The sized/tinted
-   * siblings found alongside it (`label-text text-xs font-bold`, `text-xs
-   * font-semibold`, `text-xs font-bold uppercase tracking-wide`, etc.) are
-   * left for future slices, same convention as `.kr-spinner-xs`/
-   * `.kr-spinner-sm`. */
+   * follow-up target in that slice's kaizen suggestion. Only `@apply
+   * font-bold` here: `label-text` is dead markup under daisyUI 5 (grepped
+   * daisyui's own dist CSS and this repo's assets/ -- no `.label-text`
+   * rule exists anywhere, a leftover token from a pre-5 daisyUI form
+   * convention), so `@apply label-text font-bold` fails the production
+   * build with "Cannot apply unknown utility class `label-text`"
+   * (Tailwind v4's @apply validates against real utilities, unlike a raw
+   * template class attribute, which it never validates) -- caught by CI's
+   * "Build production image" check, not by vue-tsc/eslint/layout-contract/
+   * lint-ratchet locally. Dropping the inert token is a pure no-op
+   * visually, confirmed by the absence of any `.label-text` rule to lose.
+   * The sized/tinted siblings found alongside it (`label-text text-xs
+   * font-bold`, `text-xs font-semibold`, `text-xs font-bold uppercase
+   * tracking-wide`, etc.) are left for future slices, same convention as
+   * `.kr-spinner-xs`/`.kr-spinner-sm`. */
   .kr-label-bold {
-    @apply label-text font-bold;
+    @apply font-bold;
   }
 
   .text-smart {

--- a/components/art/add-collection.vue
+++ b/components/art/add-collection.vue
@@ -22,7 +22,7 @@
     <form v-else class="grid gap-3" @submit.prevent="createCollection">
       <label class="form-control">
         <span class="label py-1">
-          <span class="label-text font-bold">New Collection</span>
+          <span class="kr-label-bold">New Collection</span>
 
           <button
             class="kr-btn-ghost-xs"
@@ -45,7 +45,7 @@
 
       <div v-if="showFlags" class="grid grid-cols-1 gap-2 sm:grid-cols-2">
         <label class="kr-toggle-row">
-          <span class="label-text font-bold">Public</span>
+          <span class="kr-label-bold">Public</span>
 
           <input
             v-model="isPublic"
@@ -56,7 +56,7 @@
         </label>
 
         <label class="kr-toggle-row">
-          <span class="label-text font-bold">Mature</span>
+          <span class="kr-label-bold">Mature</span>
 
           <input
             v-model="isMature"

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -250,7 +250,7 @@
             <template v-if="activeProfile.supports.checkpoint">
               <label class="form-control mt-2">
                 <span class="label py-1">
-                  <span class="label-text font-bold">Checkpoint</span>
+                  <span class="kr-label-bold">Checkpoint</span>
                   <span class="label-text-alt text-base-content/50">
                     {{ checkpointFamilyLabel }}
                   </span>
@@ -309,7 +309,7 @@
             >
               <label class="form-control">
                 <span class="label py-1">
-                  <span class="label-text font-bold">Steps</span>
+                  <span class="kr-label-bold">Steps</span>
                 </span>
                 <input
                   v-model.number="steps"
@@ -323,7 +323,7 @@
 
               <label class="form-control">
                 <span class="label py-1">
-                  <span class="label-text font-bold">
+                  <span class="kr-label-bold">
                     {{ activeProfile.supports.guidance ? 'Guidance' : 'CFG' }}
                   </span>
                 </span>
@@ -351,7 +351,7 @@
 
               <label v-if="activeProfile.supports.sampler" class="form-control">
                 <span class="label py-1">
-                  <span class="label-text font-bold">Sampler</span>
+                  <span class="kr-label-bold">Sampler</span>
                 </span>
                 <select
                   v-model="sampler"
@@ -373,7 +373,7 @@
                 class="form-control"
               >
                 <span class="label py-1">
-                  <span class="label-text font-bold">Scheduler</span>
+                  <span class="kr-label-bold">Scheduler</span>
                 </span>
                 <select
                   v-model="scheduler"
@@ -393,7 +393,7 @@
               <template v-if="activeProfile.supports.size">
                 <label class="form-control">
                   <span class="label py-1">
-                    <span class="label-text font-bold">Width</span>
+                    <span class="kr-label-bold">Width</span>
                   </span>
                   <input
                     v-model.number="width"
@@ -407,7 +407,7 @@
                 </label>
                 <label class="form-control">
                   <span class="label py-1">
-                    <span class="label-text font-bold">Height</span>
+                    <span class="kr-label-bold">Height</span>
                   </span>
                   <input
                     v-model.number="height"
@@ -423,7 +423,7 @@
 
               <label class="form-control col-span-full">
                 <span class="label py-1">
-                  <span class="label-text font-bold">Seed</span>
+                  <span class="kr-label-bold">Seed</span>
                   <span class="label-text-alt text-base-content/50">
                     blank = random
                   </span>
@@ -449,7 +449,7 @@
 
             <label class="form-control mt-2">
               <span class="label py-1">
-                <span class="label-text font-bold">Comfy server</span>
+                <span class="kr-label-bold">Comfy server</span>
               </span>
               <select
                 v-model="serverChoice"
@@ -475,7 +475,7 @@
 
             <label class="form-control mt-1">
               <span class="label py-1">
-                <span class="label-text font-bold"
+                <span class="kr-label-bold"
                   >Also save to collection</span
                 >
               </span>

--- a/components/art/forum-art-generation-context.vue
+++ b/components/art/forum-art-generation-context.vue
@@ -90,7 +90,7 @@
 
       <label class="form-control mt-4">
         <span class="label py-1">
-          <span class="label-text font-bold">Contribution prompt</span>
+          <span class="kr-label-bold">Contribution prompt</span>
           <span class="label-text-alt"
             >{{ store.promptDraft.length }} / 4000</span
           >

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -47,7 +47,7 @@
           <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">Name</span>
+                <span class="kr-label-bold">Name</span>
               </span>
 
               <input
@@ -61,7 +61,7 @@
 
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">Subtitle</span>
+                <span class="kr-label-bold">Subtitle</span>
               </span>
 
               <input
@@ -75,7 +75,7 @@
 
             <label class="form-control md:col-span-2">
               <span class="label">
-                <span class="label-text font-bold">Description</span>
+                <span class="kr-label-bold">Description</span>
               </span>
 
               <textarea
@@ -88,7 +88,7 @@
 
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">Tagline</span>
+                <span class="kr-label-bold">Tagline</span>
               </span>
 
               <input
@@ -102,7 +102,7 @@
 
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">Bot Type</span>
+                <span class="kr-label-bold">Bot Type</span>
               </span>
 
               <select
@@ -119,7 +119,7 @@
 
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">Designer</span>
+                <span class="kr-label-bold">Designer</span>
               </span>
 
               <input
@@ -132,7 +132,7 @@
 
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">Theme</span>
+                <span class="kr-label-bold">Theme</span>
               </span>
 
               <input
@@ -169,7 +169,7 @@
           <div class="mt-4 flex flex-col gap-3">
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">Avatar Image</span>
+                <span class="kr-label-bold">Avatar Image</span>
               </span>
 
               <input
@@ -296,7 +296,7 @@
           <div class="grid gap-4">
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">Personality</span>
+                <span class="kr-label-bold">Personality</span>
               </span>
 
               <textarea
@@ -309,7 +309,7 @@
 
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">System Prompt</span>
+                <span class="kr-label-bold">System Prompt</span>
               </span>
 
               <textarea
@@ -322,7 +322,7 @@
 
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">Sample Response</span>
+                <span class="kr-label-bold">Sample Response</span>
               </span>
 
               <textarea
@@ -343,7 +343,7 @@
           <div class="grid gap-4">
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">Bot Intro</span>
+                <span class="kr-label-bold">Bot Intro</span>
               </span>
 
               <textarea
@@ -356,7 +356,7 @@
 
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">User Intro</span>
+                <span class="kr-label-bold">User Intro</span>
               </span>
 
               <textarea
@@ -369,7 +369,7 @@
 
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">Modules</span>
+                <span class="kr-label-bold">Modules</span>
               </span>
 
               <textarea
@@ -405,7 +405,7 @@
 
         <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
           <label class="kr-toggle-row">
-            <span class="label-text font-bold">Public</span>
+            <span class="kr-label-bold">Public</span>
 
             <input
               v-model="botStore.botForm.isPublic"
@@ -415,7 +415,7 @@
           </label>
 
           <label class="kr-toggle-row">
-            <span class="label-text font-bold">Under Construction</span>
+            <span class="kr-label-bold">Under Construction</span>
 
             <input
               v-model="botStore.botForm.underConstruction"
@@ -425,7 +425,7 @@
           </label>
 
           <label class="kr-toggle-row">
-            <span class="label-text font-bold">Can Delete</span>
+            <span class="kr-label-bold">Can Delete</span>
 
             <input
               v-model="botStore.botForm.canDelete"

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -230,7 +230,7 @@
         <div class="grid gap-4">
           <label class="form-control">
             <div class="mb-1 flex items-center justify-between">
-              <span class="label-text font-bold">Temperature</span>
+              <span class="kr-label-bold">Temperature</span>
               <span class="font-mono text-sm font-bold text-primary">
                 {{ temperature.toFixed(1) }}
               </span>
@@ -254,7 +254,7 @@
 
           <label class="form-control">
             <span class="label">
-              <span class="label-text font-bold">Model</span>
+              <span class="kr-label-bold">Model</span>
             </span>
 
             <input
@@ -266,7 +266,7 @@
 
           <label class="form-control">
             <span class="label">
-              <span class="label-text font-bold">Max Tokens</span>
+              <span class="kr-label-bold">Max Tokens</span>
             </span>
 
             <input

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -46,7 +46,7 @@
 
           <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
             <label class="form-control">
-              <span class="label-text font-bold">Name</span>
+              <span class="kr-label-bold">Name</span>
               <input
                 v-model="characterStore.characterForm.name"
                 type="text"
@@ -57,7 +57,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text font-bold">Honorific</span>
+              <span class="kr-label-bold">Honorific</span>
               <input
                 v-model="characterStore.characterForm.honorific"
                 type="text"
@@ -68,7 +68,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text font-bold">Role</span>
+              <span class="kr-label-bold">Role</span>
               <input
                 v-model="characterStore.characterForm.role"
                 type="text"
@@ -78,7 +78,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text font-bold">Title</span>
+              <span class="kr-label-bold">Title</span>
               <input
                 v-model="characterStore.characterForm.title"
                 type="text"
@@ -88,7 +88,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text font-bold">Class</span>
+              <span class="kr-label-bold">Class</span>
               <input
                 v-model="characterStore.characterForm.class"
                 type="text"
@@ -99,7 +99,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text font-bold">Species</span>
+              <span class="kr-label-bold">Species</span>
               <input
                 v-model="characterStore.characterForm.species"
                 type="text"
@@ -110,7 +110,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text font-bold">Genre</span>
+              <span class="kr-label-bold">Genre</span>
               <input
                 v-model="characterStore.characterForm.genre"
                 type="text"
@@ -121,7 +121,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text font-bold">Gender</span>
+              <span class="kr-label-bold">Gender</span>
               <input
                 v-model="characterStore.characterForm.gender"
                 type="text"
@@ -131,7 +131,7 @@
             </label>
 
             <label class="form-control md:col-span-2">
-              <span class="label-text font-bold">Presentation</span>
+              <span class="kr-label-bold">Presentation</span>
               <input
                 v-model="characterStore.characterForm.presentation"
                 type="text"
@@ -162,7 +162,7 @@
           <image-upload class="mt-4" />
 
           <label class="form-control mt-4">
-            <span class="label-text font-bold">Art prompt</span>
+            <span class="kr-label-bold">Art prompt</span>
             <textarea
               v-model="characterStore.characterForm.artPrompt"
               class="kr-textarea-muted mt-1 min-h-28"
@@ -206,7 +206,7 @@
 
           <div class="grid gap-4">
             <label class="form-control">
-              <span class="label-text font-bold">Personality</span>
+              <span class="kr-label-bold">Personality</span>
               <textarea
                 v-model="characterStore.characterForm.personality"
                 class="kr-textarea-muted mt-1 min-h-32"
@@ -216,7 +216,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text font-bold">Voice</span>
+              <span class="kr-label-bold">Voice</span>
               <textarea
                 v-model="characterStore.characterForm.voice"
                 class="kr-textarea-muted mt-1 min-h-28"
@@ -226,7 +226,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text font-bold">Sample response</span>
+              <span class="kr-label-bold">Sample response</span>
               <textarea
                 v-model="characterStore.characterForm.sampleResponse"
                 class="kr-textarea-muted mt-1 min-h-28"
@@ -244,7 +244,7 @@
 
           <div class="grid gap-4">
             <label class="form-control">
-              <span class="label-text font-bold">Backstory</span>
+              <span class="kr-label-bold">Backstory</span>
               <textarea
                 v-model="characterStore.characterForm.backstory"
                 class="kr-textarea-muted mt-1 min-h-36"
@@ -254,7 +254,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text font-bold">Drive</span>
+              <span class="kr-label-bold">Drive</span>
               <input
                 v-model="characterStore.characterForm.drive"
                 type="text"
@@ -265,7 +265,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text font-bold">Quirks</span>
+              <span class="kr-label-bold">Quirks</span>
               <textarea
                 v-model="characterStore.characterForm.quirks"
                 class="kr-textarea-muted mt-1 min-h-28"
@@ -304,7 +304,7 @@
             :key="stat.key"
             class="form-control"
           >
-            <span class="label-text font-bold">{{ stat.label }}</span>
+            <span class="kr-label-bold">{{ stat.label }}</span>
             <select
               v-model="characterStore.characterForm[stat.key]"
               class="select select-bordered mt-1 w-full bg-base-200"
@@ -413,7 +413,7 @@
 
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-5">
           <label class="form-control">
-            <span class="label-text font-bold">Level</span>
+            <span class="kr-label-bold">Level</span>
             <input
               v-model.number="characterStore.characterForm.level"
               type="number"
@@ -423,7 +423,7 @@
           </label>
 
           <label class="form-control">
-            <span class="label-text font-bold">Experience</span>
+            <span class="kr-label-bold">Experience</span>
             <input
               v-model.number="characterStore.characterForm.experience"
               type="number"
@@ -433,7 +433,7 @@
           </label>
 
           <label class="form-control">
-            <span class="label-text font-bold">Designer</span>
+            <span class="kr-label-bold">Designer</span>
             <input
               v-model="characterStore.characterForm.designer"
               type="text"

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -216,7 +216,7 @@
             <div class="grid gap-3 md:grid-cols-3">
               <label class="form-control">
                 <span class="label py-1"
-                  ><span class="label-text font-bold">Icon</span></span
+                  ><span class="kr-label-bold">Icon</span></span
                 >
                 <input
                   v-model="dreamStore.dreamForm.icon"
@@ -228,7 +228,7 @@
 
               <label class="form-control">
                 <span class="label py-1"
-                  ><span class="label-text font-bold">Art Image ID</span></span
+                  ><span class="kr-label-bold">Art Image ID</span></span
                 >
                 <input
                   v-model.number="dreamStore.dreamForm.artImageId"
@@ -241,7 +241,7 @@
 
               <label class="form-control">
                 <span class="label py-1"
-                  ><span class="label-text font-bold"
+                  ><span class="kr-label-bold"
                     >Art Collection ID</span
                   ></span
                 >
@@ -258,7 +258,7 @@
             <div class="mt-3 grid gap-3 md:grid-cols-2">
               <label class="form-control">
                 <span class="label py-1"
-                  ><span class="label-text font-bold">Designer</span></span
+                  ><span class="kr-label-bold">Designer</span></span
                 >
                 <input
                   v-model="dreamStore.dreamForm.designer"
@@ -276,7 +276,7 @@
             <h2 class="text-lg font-black">Visibility</h2>
             <div class="mt-3 grid gap-2">
               <label class="kr-toggle-row-sm">
-                <span class="label-text font-bold">Public</span>
+                <span class="kr-label-bold">Public</span>
                 <input
                   v-model="dreamStore.dreamForm.isPublic"
                   type="checkbox"
@@ -285,7 +285,7 @@
               </label>
 
               <label class="kr-toggle-row-sm">
-                <span class="label-text font-bold">Mature</span>
+                <span class="kr-label-bold">Mature</span>
                 <input
                   v-model="dreamStore.dreamForm.isMature"
                   type="checkbox"
@@ -300,7 +300,7 @@
                 column from the UI at all.
               -->
               <label class="kr-toggle-row-sm">
-                <span class="label-text font-bold">Reviews</span>
+                <span class="kr-label-bold">Reviews</span>
                 <input
                   v-model="dreamStore.dreamForm.allowReviews"
                   type="checkbox"
@@ -309,7 +309,7 @@
               </label>
 
               <label class="kr-toggle-row-sm">
-                <span class="label-text font-bold">Active</span>
+                <span class="kr-label-bold">Active</span>
                 <input
                   v-model="dreamStore.dreamForm.isActive"
                   type="checkbox"

--- a/components/lora/add-lora.vue
+++ b/components/lora/add-lora.vue
@@ -41,7 +41,7 @@
     <div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Name (unique)</span>
+          <span class="kr-label-bold">Name (unique)</span>
         </span>
 
         <input
@@ -57,7 +57,7 @@
 
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Custom Label</span>
+          <span class="kr-label-bold">Custom Label</span>
         </span>
 
         <input
@@ -73,7 +73,7 @@
     <div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Type</span>
+          <span class="kr-label-bold">Type</span>
         </span>
 
         <select
@@ -87,7 +87,7 @@
 
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Base Model</span>
+          <span class="kr-label-bold">Base Model</span>
         </span>
 
         <select
@@ -107,7 +107,7 @@
 
     <label class="form-control">
       <span class="label">
-        <span class="label-text font-bold">Local Path</span>
+        <span class="kr-label-bold">Local Path</span>
         <span class="label-text-alt text-base-content/50">
           relative to the Lora root — becomes ComfyUI's lora_name
         </span>
@@ -125,7 +125,7 @@
     <div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Trigger Words</span>
+          <span class="kr-label-bold">Trigger Words</span>
           <span class="label-text-alt text-base-content/50">all, comma-separated</span>
         </span>
 
@@ -140,7 +140,7 @@
 
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Default Trigger</span>
+          <span class="kr-label-bold">Default Trigger</span>
           <span class="label-text-alt text-base-content/50">injected at gen time</span>
         </span>
 
@@ -157,7 +157,7 @@
     <div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Preview Image URL</span>
+          <span class="kr-label-bold">Preview Image URL</span>
         </span>
 
         <input
@@ -171,7 +171,7 @@
 
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Civitai URL</span>
+          <span class="kr-label-bold">Civitai URL</span>
         </span>
 
         <input
@@ -186,7 +186,7 @@
 
     <label class="form-control">
       <span class="label">
-        <span class="label-text font-bold">Description</span>
+        <span class="kr-label-bold">Description</span>
       </span>
 
       <textarea
@@ -206,7 +206,7 @@
           class="toggle toggle-warning"
         />
 
-        <span class="label-text font-bold">Mature (NSFW)</span>
+        <span class="kr-label-bold">Mature (NSFW)</span>
       </label>
 
       <button

--- a/components/model/add-model.vue
+++ b/components/model/add-model.vue
@@ -41,7 +41,7 @@
     <div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Name (unique)</span>
+          <span class="kr-label-bold">Name (unique)</span>
         </span>
 
         <input
@@ -57,7 +57,7 @@
 
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Custom Label</span>
+          <span class="kr-label-bold">Custom Label</span>
         </span>
 
         <input
@@ -72,7 +72,7 @@
 
     <label class="form-control">
       <span class="label">
-        <span class="label-text font-bold">Base Model</span>
+        <span class="kr-label-bold">Base Model</span>
       </span>
 
       <select
@@ -87,7 +87,7 @@
 
     <label class="form-control">
       <span class="label">
-        <span class="label-text font-bold">Local Path</span>
+        <span class="kr-label-bold">Local Path</span>
         <span class="label-text-alt text-base-content/50">
           subfolder-qualified — becomes ComfyUI's ckpt_name
         </span>
@@ -105,7 +105,7 @@
     <div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Preview Image URL</span>
+          <span class="kr-label-bold">Preview Image URL</span>
         </span>
 
         <input
@@ -119,7 +119,7 @@
 
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Civitai URL</span>
+          <span class="kr-label-bold">Civitai URL</span>
         </span>
 
         <input
@@ -134,7 +134,7 @@
 
     <label class="form-control">
       <span class="label">
-        <span class="label-text font-bold">Description</span>
+        <span class="kr-label-bold">Description</span>
       </span>
 
       <textarea
@@ -154,7 +154,7 @@
           class="toggle toggle-warning"
         />
 
-        <span class="label-text font-bold">Mature (NSFW)</span>
+        <span class="kr-label-bold">Mature (NSFW)</span>
       </label>
 
       <button

--- a/components/navigation/server-selector.vue
+++ b/components/navigation/server-selector.vue
@@ -48,7 +48,7 @@
 
           <section class="grid gap-3 md:grid-cols-2">
             <label class="form-control min-w-0">
-              <span class="label-text font-bold">Default Art</span>
+              <span class="kr-label-bold">Default Art</span>
               <select
                 v-model.number="selectedArtServerId"
                 class="select select-bordered w-full rounded-xl"
@@ -65,7 +65,7 @@
             </label>
 
             <label class="form-control min-w-0">
-              <span class="label-text font-bold">Default Text</span>
+              <span class="kr-label-bold">Default Text</span>
               <select
                 v-model.number="selectedTextServerId"
                 class="select select-bordered w-full rounded-xl"
@@ -257,7 +257,7 @@
 
             <div class="mt-3 grid gap-3 md:grid-cols-2">
               <label class="form-control min-w-0">
-                <span class="label-text font-bold">Server Type</span>
+                <span class="kr-label-bold">Server Type</span>
                 <select
                   v-model="newLocal.serverType"
                   class="select select-bordered w-full rounded-xl"
@@ -269,7 +269,7 @@
               </label>
 
               <label class="form-control min-w-0">
-                <span class="label-text font-bold">Connection Type</span>
+                <span class="kr-label-bold">Connection Type</span>
                 <select
                   v-model="newLocal.accessMode"
                   class="select select-bordered w-full rounded-xl"
@@ -283,7 +283,7 @@
               </label>
 
               <label class="form-control min-w-0">
-                <span class="label-text font-bold">Label</span>
+                <span class="kr-label-bold">Label</span>
                 <input
                   v-model.trim="newLocal.label"
                   class="input input-bordered w-full rounded-xl"
@@ -293,7 +293,7 @@
               </label>
 
               <label class="form-control min-w-0">
-                <span class="label-text font-bold">Base URL</span>
+                <span class="kr-label-bold">Base URL</span>
                 <input
                   v-model.trim="newLocal.baseUrl"
                   class="input input-bordered w-full rounded-xl"
@@ -347,7 +347,7 @@
 
             <div class="mt-3 grid gap-3 md:grid-cols-2">
               <label class="form-control min-w-0">
-                <span class="label-text font-bold">Label</span>
+                <span class="kr-label-bold">Label</span>
                 <input
                   v-model.trim="editForm.label"
                   class="input input-bordered w-full rounded-xl"
@@ -356,7 +356,7 @@
               </label>
 
               <label class="form-control min-w-0">
-                <span class="label-text font-bold">Connection Type</span>
+                <span class="kr-label-bold">Connection Type</span>
                 <select
                   v-model="editForm.accessMode"
                   class="select select-bordered w-full rounded-xl"
@@ -370,7 +370,7 @@
               </label>
 
               <label class="form-control min-w-0 md:col-span-2">
-                <span class="label-text font-bold">Base URL</span>
+                <span class="kr-label-bold">Base URL</span>
                 <input
                   v-model.trim="editForm.baseUrl"
                   class="input input-bordered w-full rounded-xl"
@@ -379,7 +379,7 @@
               </label>
 
               <label class="form-control min-w-0">
-                <span class="label-text font-bold">Endpoint Path</span>
+                <span class="kr-label-bold">Endpoint Path</span>
                 <input
                   v-model.trim="editForm.endpointPath"
                   class="input input-bordered w-full rounded-xl"
@@ -388,7 +388,7 @@
               </label>
 
               <label class="form-control min-w-0">
-                <span class="label-text font-bold">Health Path</span>
+                <span class="kr-label-bold">Health Path</span>
                 <input
                   v-model.trim="editForm.healthPath"
                   class="input input-bordered w-full rounded-xl"
@@ -397,7 +397,7 @@
               </label>
 
               <label class="form-control min-w-0 md:col-span-2">
-                <span class="label-text font-bold">Model</span>
+                <span class="kr-label-bold">Model</span>
                 <input
                   v-model.trim="editForm.model"
                   class="input input-bordered w-full rounded-xl"
@@ -407,7 +407,7 @@
               </label>
 
               <label class="form-control min-w-0 md:col-span-2">
-                <span class="label-text font-bold">Notes</span>
+                <span class="kr-label-bold">Notes</span>
                 <textarea
                   v-model.trim="editForm.notes"
                   class="textarea textarea-bordered w-full rounded-xl"

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -30,7 +30,7 @@
       <section class="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <label class="form-control">
           <span class="label">
-            <span class="label-text font-bold">Reward Name</span>
+            <span class="kr-label-bold">Reward Name</span>
           </span>
 
           <input
@@ -43,7 +43,7 @@
 
         <label class="form-control">
           <span class="label">
-            <span class="label-text font-bold">Collection</span>
+            <span class="kr-label-bold">Collection</span>
           </span>
 
           <input
@@ -56,7 +56,7 @@
 
         <label class="form-control lg:col-span-2">
           <span class="label">
-            <span class="label-text font-bold">Description</span>
+            <span class="kr-label-bold">Description</span>
             <span class="label-text-alt text-base-content/50">Optional</span>
           </span>
 
@@ -69,7 +69,7 @@
 
         <label class="form-control lg:col-span-2">
           <span class="label">
-            <span class="label-text font-bold">Flavor Text</span>
+            <span class="kr-label-bold">Flavor Text</span>
             <span class="label-text-alt text-base-content/50">Optional</span>
           </span>
 
@@ -83,7 +83,7 @@
 
         <label class="form-control lg:col-span-2">
           <span class="label">
-            <span class="label-text font-bold">Effect</span>
+            <span class="kr-label-bold">Effect</span>
           </span>
 
           <textarea
@@ -97,7 +97,7 @@
       <section class="grid grid-cols-1 gap-4 lg:grid-cols-3">
         <label class="form-control">
           <span class="label">
-            <span class="label-text font-bold">Icon</span>
+            <span class="kr-label-bold">Icon</span>
           </span>
 
           <input
@@ -110,7 +110,7 @@
 
         <label class="form-control">
           <span class="label">
-            <span class="label-text font-bold">Type</span>
+            <span class="kr-label-bold">Type</span>
           </span>
 
           <select
@@ -129,7 +129,7 @@
 
         <label class="form-control">
           <span class="label">
-            <span class="label-text font-bold">Rarity</span>
+            <span class="kr-label-bold">Rarity</span>
           </span>
 
           <select
@@ -157,7 +157,7 @@
 
         <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
           <label class="kr-toggle-row">
-            <span class="label-text font-bold">Public</span>
+            <span class="kr-label-bold">Public</span>
             <input
               v-model="rewardStore.rewardForm.isPublic"
               type="checkbox"
@@ -166,7 +166,7 @@
           </label>
 
           <label class="kr-toggle-row">
-            <span class="label-text font-bold">Mature</span>
+            <span class="kr-label-bold">Mature</span>
             <input
               v-model="rewardStore.rewardForm.isMature"
               type="checkbox"
@@ -234,7 +234,7 @@
           <div class="flex flex-col gap-3">
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">Image Prompt</span>
+                <span class="kr-label-bold">Image Prompt</span>
               </span>
 
               <textarea

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -307,7 +307,7 @@
           <div class="grid grid-cols-1 gap-4">
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">How do you find it?</span>
+                <span class="kr-label-bold">How do you find it?</span>
               </span>
 
               <select
@@ -331,7 +331,7 @@
 
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">Tone</span>
+                <span class="kr-label-bold">Tone</span>
               </span>
 
               <select
@@ -351,7 +351,7 @@
 
           <label class="form-control mt-4">
             <span class="label">
-              <span class="label-text font-bold">What do you do?</span>
+              <span class="kr-label-bold">What do you do?</span>
               <span class="label-text-alt text-base-content/50">Optional</span>
             </span>
 
@@ -374,7 +374,7 @@
 
           <label class="form-control">
             <span class="label">
-              <span class="label-text font-bold">Your background</span>
+              <span class="kr-label-bold">Your background</span>
               <span class="label-text-alt text-base-content/50">Optional</span>
             </span>
 

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -30,7 +30,7 @@
       <section class="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <label class="form-control">
           <span class="label">
-            <span class="label-text font-bold">Title</span>
+            <span class="kr-label-bold">Title</span>
           </span>
 
           <input
@@ -43,12 +43,12 @@
 
         <label class="form-control">
           <span class="label">
-            <span class="label-text font-bold">Locations</span>
+            <span class="kr-label-bold">Locations</span>
           </span>
 
           <div class="form-control">
             <span class="label">
-              <span class="label-text font-bold">Dream Location</span>
+              <span class="kr-label-bold">Dream Location</span>
             </span>
 
             <dream-gallery
@@ -66,7 +66,7 @@
 
         <label class="form-control lg:col-span-2">
           <span class="label">
-            <span class="label-text font-bold">Description</span>
+            <span class="kr-label-bold">Description</span>
           </span>
 
           <textarea
@@ -87,7 +87,7 @@
 
         <label class="form-control kr-panel-flat p-4">
           <span class="label">
-            <span class="label-text font-bold">Inspirations</span>
+            <span class="kr-label-bold">Inspirations</span>
           </span>
 
           <textarea
@@ -124,7 +124,7 @@
 
         <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
           <label class="kr-toggle-row">
-            <span class="label-text font-bold">Public</span>
+            <span class="kr-label-bold">Public</span>
             <input
               v-model="scenarioStore.scenarioForm.isPublic"
               type="checkbox"
@@ -133,7 +133,7 @@
           </label>
 
           <label class="kr-toggle-row">
-            <span class="label-text font-bold">Mature</span>
+            <span class="kr-label-bold">Mature</span>
             <input
               v-model="scenarioStore.scenarioForm.isMature"
               type="checkbox"
@@ -248,7 +248,7 @@
 
             <label class="form-control">
               <span class="label">
-                <span class="label-text font-bold">Art Prompt</span>
+                <span class="kr-label-bold">Art Prompt</span>
               </span>
 
               <textarea

--- a/components/servers/add-checkpoint.vue
+++ b/components/servers/add-checkpoint.vue
@@ -34,7 +34,7 @@
     <div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Name</span>
+          <span class="kr-label-bold">Name</span>
         </span>
 
         <input
@@ -49,7 +49,7 @@
 
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Custom Label</span>
+          <span class="kr-label-bold">Custom Label</span>
         </span>
 
         <input
@@ -65,7 +65,7 @@
     <div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Resource Type</span>
+          <span class="kr-label-bold">Resource Type</span>
         </span>
 
         <select
@@ -86,7 +86,7 @@
 
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Supported Server</span>
+          <span class="kr-label-bold">Supported Server</span>
         </span>
 
         <select
@@ -107,7 +107,7 @@
 
     <label class="form-control">
       <span class="label">
-        <span class="label-text font-bold">Local Path</span>
+        <span class="kr-label-bold">Local Path</span>
       </span>
 
       <input
@@ -122,7 +122,7 @@
     <div class="grid grid-cols-1 gap-3 lg:grid-cols-3">
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Civitai URL</span>
+          <span class="kr-label-bold">Civitai URL</span>
         </span>
 
         <input
@@ -136,7 +136,7 @@
 
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Hugging Face URL</span>
+          <span class="kr-label-bold">Hugging Face URL</span>
         </span>
 
         <input
@@ -150,7 +150,7 @@
 
       <label class="form-control">
         <span class="label">
-          <span class="label-text font-bold">Custom URL</span>
+          <span class="kr-label-bold">Custom URL</span>
         </span>
 
         <input
@@ -165,7 +165,7 @@
 
     <label class="form-control">
       <span class="label">
-        <span class="label-text font-bold">Media Path</span>
+        <span class="kr-label-bold">Media Path</span>
       </span>
 
       <input
@@ -179,7 +179,7 @@
 
     <label class="form-control">
       <span class="label">
-        <span class="label-text font-bold">Description</span>
+        <span class="kr-label-bold">Description</span>
       </span>
 
       <textarea
@@ -191,7 +191,7 @@
 
     <label class="form-control">
       <span class="label">
-        <span class="label-text font-bold">Generation Notes</span>
+        <span class="kr-label-bold">Generation Notes</span>
       </span>
 
       <textarea
@@ -211,7 +211,7 @@
           class="toggle toggle-warning"
         />
 
-        <span class="label-text font-bold">Mature resource</span>
+        <span class="kr-label-bold">Mature resource</span>
       </label>
 
       <button

--- a/components/servers/add-server.vue
+++ b/components/servers/add-server.vue
@@ -30,7 +30,7 @@
     <main class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
       <section class="grid gap-3 md:grid-cols-2">
         <label class="form-control">
-          <span class="label-text font-bold">Title</span>
+          <span class="kr-label-bold">Title</span>
           <input
             v-model="form.title"
             class="input input-bordered rounded-xl"
@@ -40,7 +40,7 @@
         </label>
 
         <label class="form-control">
-          <span class="label-text font-bold">Label</span>
+          <span class="kr-label-bold">Label</span>
           <input
             v-model="form.label"
             class="input input-bordered rounded-xl"
@@ -49,7 +49,7 @@
         </label>
 
         <label class="form-control">
-          <span class="label-text font-bold">Server Type</span>
+          <span class="kr-label-bold">Server Type</span>
           <select
             v-model="form.serverType"
             class="select select-bordered rounded-xl"
@@ -65,7 +65,7 @@
         </label>
 
         <label class="form-control">
-          <span class="label-text font-bold">Access Mode</span>
+          <span class="kr-label-bold">Access Mode</span>
           <select
             v-model="form.accessMode"
             class="select select-bordered rounded-xl"
@@ -79,7 +79,7 @@
         </label>
 
         <label class="form-control md:col-span-2">
-          <span class="label-text font-bold">Base URL</span>
+          <span class="kr-label-bold">Base URL</span>
           <input
             v-model="form.baseUrl"
             class="input input-bordered rounded-xl"
@@ -89,7 +89,7 @@
         </label>
 
         <label class="form-control">
-          <span class="label-text font-bold">Endpoint Path</span>
+          <span class="kr-label-bold">Endpoint Path</span>
           <input
             v-model="form.endpointPath"
             class="input input-bordered rounded-xl"
@@ -98,7 +98,7 @@
         </label>
 
         <label class="form-control">
-          <span class="label-text font-bold">Health Path</span>
+          <span class="kr-label-bold">Health Path</span>
           <input
             v-model="form.healthPath"
             class="input input-bordered rounded-xl"
@@ -107,7 +107,7 @@
         </label>
 
         <label class="form-control">
-          <span class="label-text font-bold">Category</span>
+          <span class="kr-label-bold">Category</span>
           <input
             v-model="form.category"
             class="input input-bordered rounded-xl"
@@ -116,7 +116,7 @@
         </label>
 
         <label class="form-control">
-          <span class="label-text font-bold">Model</span>
+          <span class="kr-label-bold">Model</span>
           <input
             v-model="form.model"
             class="input input-bordered rounded-xl"
@@ -134,7 +134,7 @@
 
         <div class="grid gap-3 md:grid-cols-2">
           <label class="form-control">
-            <span class="label-text font-bold">Auth Type</span>
+            <span class="kr-label-bold">Auth Type</span>
             <select
               v-model="form.authType"
               class="select select-bordered rounded-xl"
@@ -148,7 +148,7 @@
           </label>
 
           <label class="form-control">
-            <span class="label-text font-bold">API Key Header Name</span>
+            <span class="kr-label-bold">API Key Header Name</span>
             <input
               v-model="form.apiKeyName"
               class="input input-bordered rounded-xl"
@@ -157,7 +157,7 @@
           </label>
 
           <label class="form-control md:col-span-2">
-            <span class="label-text font-bold">API Key</span>
+            <span class="kr-label-bold">API Key</span>
             <input
               v-model="apiKey"
               :type="showApiKey ? 'text' : 'password'"
@@ -239,7 +239,7 @@
       </section>
 
       <label class="form-control">
-        <span class="label-text font-bold">Description</span>
+        <span class="kr-label-bold">Description</span>
         <textarea
           v-model="form.description"
           class="textarea textarea-bordered min-h-24 rounded-xl"
@@ -248,7 +248,7 @@
       </label>
 
       <label class="form-control">
-        <span class="label-text font-bold">Notes</span>
+        <span class="kr-label-bold">Notes</span>
         <textarea
           v-model="form.notes"
           class="textarea textarea-bordered min-h-24 rounded-xl"

--- a/components/wonderlab/reaction-card.vue
+++ b/components/wonderlab/reaction-card.vue
@@ -76,7 +76,7 @@
       >
         <label class="form-control">
           <span class="label">
-            <span class="label-text font-bold">Reaction Type</span>
+            <span class="kr-label-bold">Reaction Type</span>
           </span>
 
           <select
@@ -92,7 +92,7 @@
 
         <label v-if="showComment" class="form-control">
           <span class="label">
-            <span class="label-text font-bold">Comment</span>
+            <span class="kr-label-bold">Comment</span>
           </span>
 
           <input

--- a/utils/scripts/codemods/kr_label_bold_codemod.py
+++ b/utils/scripts/codemods/kr_label_bold_codemod.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `label-text font-bold` form-label captions to
+`kr-label-bold`.
+
+Sibling of kr_spinner_sm_codemod.py, same conventions: dry-run by default,
+--write to update matching Vue files in place. Only the exact `label-text
+font-bold` shape is touched, and only in static `class="..."` attributes --
+never `:class`/`v-bind:class` bindings, and regardless of the base tokens'
+order in the source. A source that already carries `kr-label-bold`, or is
+missing any one of the base tokens, is left untouched. Extra tokens beyond
+the base set are preserved verbatim after the primitive class, matching the
+kr-badge-*/kr-spinner-* codemods' subset-match convention -- pass
+--exact-only to restrict a slice to sources with no extra tokens at all, the
+safest and most literal pool.
+
+This deliberately does NOT touch the sized/tinted siblings (`label-text
+text-xs font-bold`, `label-text text-xs font-semibold`, `label-text text-xs
+font-bold uppercase tracking-wide`, etc.) surveyed alongside this one in
+interface-vision t-104 slice 151/152 -- each is its own bounded family for a
+future slice, not folded in here just because the grep that found them
+overlaps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-label-bold"
+BASE_TOKENS = {"label-text", "font-bold"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-label-bold {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (slice 152)  (kind: software)

### What changed / what I produced
- Added `.kr-label-bold` to `assets/css/tailwind.css` — a bolded DaisyUI form-label caption (`label-text font-bold`), previously hand-rolled identically 145 times across 16 files.
- Added `utils/scripts/codemods/kr_label_bold_codemod.py` (`--exact-only`, `--write`), a sibling of `kr_spinner_sm_codemod.py` using the same subset-match convention.
- Migrated all 145 exact occurrences of `class="label-text font-bold"` to `class="kr-label-bold"` across 16 files.
- Deliberately left the sized/tinted variants out of scope for future slices: `label-text text-xs font-bold` (23), `label-text text-xs font-semibold` (15), `label-text mb-1 text-xs font-semibold` (14), `label-text text-xs font-bold uppercase tracking-wide` (10), and smaller families.

### How I verified
- Frequency survey confirmed 145 exact occurrences match slice 151's kaizen suggestion exactly.
- `npm run test` (vue-tsc) — clean, no errors.
- `eslint` on all 16 changed `.vue` files — 3 pre-existing errors on `add-bot.vue`/`dream-maker.vue`/`add-checkpoint.vue`, confirmed present on baseline via `git stash` before this slice touched them; 0 new errors.
- `npx tsx utils/scripts/verifyLayoutContract.ts` — holds, no new violations (an unrelated -2 `viewport-grid` baseline improvement on `narrative-ingredient-multi-picker.vue` was visible but is not this slice's to claim).
- `npx tsx utils/scripts/verifyLintRatchet.ts` — holds at 333/-59.
- `prettier --check` on all 10 warned files (9 `.vue` + `tailwind.css`) — matches the pre-existing baseline debt set exactly, confirmed via `git stash`; no new prettier debt introduced.
- Grepped `utils/scripts/*.{mjs,ts}` for the literal class string `label-text font-bold` — no source-text contract hits (the retry_context lesson from slice 69).

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
`flex items-center gap-2` (87 occurrences) is the next largest exact-duplicate class string surfaced by the ongoing frequency survey, but is likely too generic for a single primitive without a closer scoping look first — worth checking whether it clusters into a few coherent sub-families (e.g. icon+label rows vs. form-row layouts) before committing to one wrapper class.

### Notes for reviewer
Conductor task `interface-vision/t-104` set to `status: review`; conductor PR incoming to close it out to `ready` (recurring re-arm) once this merges.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UskgioYfV54TJ2KpG67m5X

---
_Generated by [Claude Code](https://claude.ai/code/session_01UskgioYfV54TJ2KpG67m5X)_