### PR TITLE
refactor(ui): migrate text-sm text-base-content/60 to kr-text-dim-sm

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1617,6 +1617,29 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply font-bold;
   }
 
+  /* A muted secondary caption line at body-text size -- `text-sm
+   * text-base-content/60`, the small descriptive line under a title, form
+   * field, or list item that should read as secondary without dropping to
+   * the smaller `text-xs` scale (interface-vision t-104 slice 153) --
+   * previously hand-rolled identically in 38 files (51 exact occurrences),
+   * the largest single bounded family surfaced by slice 152's frequency
+   * survey once the still-unresolved `flex items-center gap-2` layout
+   * utility (87 occurrences, too generic and context-varied -- checkbox
+   * labels, icon rows, toolbars -- to name as one semantic primitive; see
+   * slice 153's own TALKBACK note) was set aside for a future slice with a
+   * narrower, more deliberate look at its sub-families. Named `kr-text-*`
+   * rather than reusing the existing `kr-*-muted` suffix (`.kr-panel-muted`,
+   * `.kr-input-muted`, `.kr-textarea-muted`) because that suffix already
+   * means "on the base-200 tinted background" elsewhere in this file --
+   * reusing it here for a text-opacity variant would read as the wrong kind
+   * of "muted". The sibling opacity/size variants surveyed alongside this
+   * one (`text-xs text-base-content/50`, `text-sm text-base-content/70`,
+   * `text-xs text-base-content/45`, etc.) are left for future slices, same
+   * convention as `.kr-spinner-xs`/`.kr-spinner-sm`. */
+  .kr-text-dim-sm {
+    @apply text-sm text-base-content/60;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -7,7 +7,7 @@
         </span>
         <div>
           <p class="text-2xl font-black tracking-tight">Build Bench</p>
-          <p class="text-sm text-base-content/60">
+          <p class="kr-text-dim-sm">
             Two builds enter, you decide. Clone one side, change a single knob,
             render both, pick the winner.
           </p>

--- a/components/art/hair-studio-manager.vue
+++ b/components/art/hair-studio-manager.vue
@@ -9,7 +9,7 @@
       </span>
       <div class="min-w-0 flex-1">
         <h2 class="text-lg font-black">Hair Studio</h2>
-        <p class="text-sm text-base-content/60">
+        <p class="kr-text-dim-sm">
           Preview a new color or cut on a private client photo.
         </p>
       </div>

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -219,9 +219,7 @@
               Session Controls
             </h2>
 
-            <p class="text-sm text-base-content/60">
-              Runtime options for this chat session.
-            </p>
+            <p class="kr-text-dim-sm">Runtime options for this chat session.</p>
           </div>
 
           <Icon name="kind-icon:sliders" class="h-6 w-6 text-primary" />

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -71,7 +71,7 @@
             {{ formTitle }}
           </h3>
 
-          <p class="text-sm text-base-content/60">
+          <p class="kr-text-dim-sm">
             {{ formSubtitle }}
           </p>
         </div>

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -204,7 +204,7 @@
               <div>
                 <h2 class="text-xl font-bold text-base-content">Chat</h2>
 
-                <p class="text-sm text-base-content/60">
+                <p class="kr-text-dim-sm">
                   Ask something sincere, weird, tactical, or suspiciously
                   therapeutic.
                 </p>

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -74,7 +74,7 @@
                   Selected Character
                 </h2>
 
-                <p class="text-sm text-base-content/60">
+                <p class="kr-text-dim-sm">
                   Choose who gets interrogated by destiny.
                 </p>
               </div>
@@ -102,7 +102,7 @@
               <div>
                 <h2 class="text-xl font-bold text-base-content">Chat</h2>
 
-                <p class="text-sm text-base-content/60">
+                <p class="kr-text-dim-sm">
                   Ask something sincere, weird, tactical, or suspiciously
                   therapeutic.
                 </p>

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -13,7 +13,7 @@
             {{ formTitle }}
           </h3>
 
-          <p class="text-sm text-base-content/60">
+          <p class="kr-text-dim-sm">
             {{ formSubtitle }}
           </p>
         </div>

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -191,7 +191,7 @@
             <div class="flex flex-wrap items-center justify-between gap-2">
               <div>
                 <h2 class="text-lg font-black">Art Prompt</h2>
-                <p class="text-sm text-base-content/60">
+                <p class="kr-text-dim-sm">
                   Used by Interact when generating art around this Dream.
                 </p>
               </div>

--- a/components/giftshop/giftshop-interact.vue
+++ b/components/giftshop/giftshop-interact.vue
@@ -180,7 +180,7 @@
 
       <div class="mt-4 grid gap-3">
         <div class="kr-panel-muted-md">
-          <div class="text-sm text-base-content/60">Items</div>
+          <div class="kr-text-dim-sm">Items</div>
 
           <div class="text-3xl font-black text-primary">
             {{ cartStore.totalItems }}
@@ -188,7 +188,7 @@
         </div>
 
         <div class="kr-panel-muted-md">
-          <div class="text-sm text-base-content/60">Total</div>
+          <div class="kr-text-dim-sm">Total</div>
 
           <div class="text-3xl font-black text-secondary">
             ${{ cartStore.formattedTotalPrice }}

--- a/components/giftshop/mana-wallet.vue
+++ b/components/giftshop/mana-wallet.vue
@@ -31,13 +31,13 @@
       >
         <div class="flex items-end justify-between">
           <div>
-            <div class="text-sm text-base-content/60">Current balance</div>
+            <div class="kr-text-dim-sm">Current balance</div>
             <div class="text-5xl font-extrabold text-primary tabular-nums">
               {{ manaStore.isFamily ? '∞' : manaStore.balance }}
             </div>
           </div>
           <div v-if="!manaStore.isFamily" class="text-right">
-            <div class="text-sm text-base-content/60">Daily cap</div>
+            <div class="kr-text-dim-sm">Daily cap</div>
             <div class="text-2xl font-bold">{{ manaStore.cap }}</div>
           </div>
         </div>
@@ -56,7 +56,7 @@
           </div>
         </div>
 
-        <p v-else class="text-sm text-base-content/60">
+        <p v-else class="kr-text-dim-sm">
           Family plan — unlimited generations on house tokens. 🏡
         </p>
 
@@ -83,7 +83,7 @@
       <div
         class="rounded-2xl border border-secondary/20 bg-base-100 shadow-lg p-6 space-y-1"
       >
-        <div class="text-sm text-base-content/60">Purchased tokens</div>
+        <div class="kr-text-dim-sm">Purchased tokens</div>
         <div class="text-3xl font-extrabold text-secondary tabular-nums">
           {{ manaStore.tokens }}
         </div>

--- a/components/lora/add-lora.vue
+++ b/components/lora/add-lora.vue
@@ -17,7 +17,7 @@
           {{ isEditing ? 'Edit LoRA' : 'Add LoRA' }}
         </h3>
 
-        <p class="text-sm text-base-content/60">
+        <p class="kr-text-dim-sm">
           Drops into <code>Lora/import</code> get catalogued automatically — use
           this to hand-add or fix a LoRA's label, base model, or triggers.
         </p>

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -17,7 +17,7 @@
         <h2 class="truncate text-lg font-bold text-base-content">
           Discover {{ discoverType === 'CHECKPOINT' ? 'Checkpoints' : 'LoRAs' }}
         </h2>
-        <p class="text-sm text-base-content/60">
+        <p class="kr-text-dim-sm">
           Search Civitai and download straight into your library.
         </p>
       </div>
@@ -168,7 +168,7 @@
       class="kr-panel-muted border-dashed text-center"
     >
       <p class="font-bold">No results.</p>
-      <p class="text-sm text-base-content/60">
+      <p class="kr-text-dim-sm">
         Try a different search or base model.
       </p>
     </div>

--- a/components/model/add-model.vue
+++ b/components/model/add-model.vue
@@ -18,7 +18,7 @@
           {{ isEditing ? 'Edit Model' : 'Add Model' }}
         </h3>
 
-        <p class="text-sm text-base-content/60">
+        <p class="kr-text-dim-sm">
           Hand-add or fix a checkpoint's label, base model, path, or preview.
         </p>
       </div>

--- a/components/navigation/card-picker.vue
+++ b/components/navigation/card-picker.vue
@@ -3,7 +3,7 @@
   <div class="flex h-full w-full flex-col gap-4 p-4">
     <header class="flex flex-col gap-1">
       <h2 class="text-lg font-black text-base-content">Card Back</h2>
-      <p class="text-sm text-base-content/60">
+      <p class="kr-text-dim-sm">
         Pick the design shown when your workspace cards flip.
       </p>
     </header>

--- a/components/navigation/navigation-trimmed.vue
+++ b/components/navigation/navigation-trimmed.vue
@@ -12,7 +12,7 @@
       <div class="flex flex-wrap items-end justify-between gap-3">
         <div class="flex min-w-0 flex-col">
           <h2 class="text-xl font-black sm:text-2xl">Explore Kind Robots</h2>
-          <p class="text-sm text-base-content/60">
+          <p class="kr-text-dim-sm">
             Every place you can go, grouped by channel.
           </p>
         </div>

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -10,7 +10,7 @@
         </span>
         <div>
           <p class="text-2xl font-black tracking-tight">AppMaker</p>
-          <p class="text-sm text-base-content/60">
+          <p class="kr-text-dim-sm">
             The app factory — every app is a workspace folder, a project
             roadmap, and a Dream sharing one slug.
           </p>

--- a/components/pages/click-leaderboard.vue
+++ b/components/pages/click-leaderboard.vue
@@ -8,7 +8,7 @@
         </span>
         <div>
           <p class="text-2xl font-black tracking-tight">Global Leaderboard</p>
-          <p class="text-sm text-base-content/60">
+          <p class="kr-text-dim-sm">
             The highest click records ever recorded, ranked best to worst.
           </p>
         </div>

--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -10,7 +10,7 @@
       </div>
       <div class="min-w-0 flex-1">
         <h2 class="text-2xl font-black tracking-tight">Projects</h2>
-        <p class="text-sm text-base-content/60">
+        <p class="kr-text-dim-sm">
           Browse every Conductor project, filter by status, or start a new
           one.
         </p>

--- a/components/pages/creator-earnings-page.vue
+++ b/components/pages/creator-earnings-page.vue
@@ -6,7 +6,7 @@
       </span>
       <div>
         <p class="text-2xl font-black tracking-tight">Creator Earnings</p>
-        <p class="text-sm text-base-content/60">
+        <p class="kr-text-dim-sm">
           What you've earned when someone spent tokens on something you made — a
           Bot, Character, Facet, Scenario, Pitch, Art, Pack, Reward, or Dream.
         </p>
@@ -63,7 +63,7 @@
         >
           <div class="flex flex-wrap items-end justify-between gap-3">
             <div>
-              <h2 class="text-sm text-base-content/60">Total earned</h2>
+              <h2 class="kr-text-dim-sm">Total earned</h2>
               <div class="text-5xl font-extrabold text-primary tabular-nums">
                 {{ formatUsdCents(summary.totalCents) }}
               </div>

--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -6,7 +6,7 @@
       </span>
       <div>
         <p class="text-2xl font-black tracking-tight">Mission Accrual</p>
-        <p class="text-sm text-base-content/60">
+        <p class="kr-text-dim-sm">
           How much mission share has accrued from the RevenueSplit ledger, how
           much has actually been remitted, and the outstanding balance still
           owed to the fundraiser.

--- a/components/pages/privacy-page.vue
+++ b/components/pages/privacy-page.vue
@@ -8,7 +8,7 @@
       </span>
       <div>
         <p class="text-2xl font-black tracking-tight">Privacy Policy</p>
-        <p class="text-sm text-base-content/60">Last updated: May 2026</p>
+        <p class="kr-text-dim-sm">Last updated: May 2026</p>
       </div>
     </header>
 

--- a/components/pages/rebel-button.vue
+++ b/components/pages/rebel-button.vue
@@ -7,7 +7,7 @@
       </span>
       <div>
         <p class="text-2xl font-black tracking-tight">Rebel Button</p>
-        <p class="text-sm text-base-content/60">
+        <p class="kr-text-dim-sm">
           Do not press this button. (You're going to press it.)
         </p>
       </div>

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -20,7 +20,7 @@
         </span>
         <div>
           <p class="text-2xl font-black tracking-tight">Serendipity</p>
-          <p class="text-sm text-base-content/60">
+          <p class="kr-text-dim-sm">
             Talk to Kind Robots through your Amazon Echo.
           </p>
         </div>

--- a/components/pages/wallet-page.vue
+++ b/components/pages/wallet-page.vue
@@ -6,7 +6,7 @@
       </span>
       <div>
         <p class="text-2xl font-black tracking-tight">Wallet</p>
-        <p class="text-sm text-base-content/60">
+        <p class="kr-text-dim-sm">
           Your karma and mana balance — earned by contributing, spent to
           create.
         </p>
@@ -32,7 +32,7 @@
       >
         <div class="flex items-end justify-between">
           <div>
-            <h2 class="text-sm text-base-content/60">Karma</h2>
+            <h2 class="kr-text-dim-sm">Karma</h2>
             <div class="text-5xl font-extrabold text-primary tabular-nums">
               {{ karmaStore.balance }}
             </div>
@@ -46,7 +46,7 @@
           </button>
         </div>
 
-        <p class="text-sm text-base-content/60">
+        <p class="kr-text-dim-sm">
           Earned by reacting, creating, sharing, and helping other Kind Robots
           users — a running score of your community contribution.
         </p>

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -82,7 +82,7 @@
             {{ formTitle }}
           </h3>
 
-          <p class="text-sm text-base-content/60">
+          <p class="kr-text-dim-sm">
             {{ formSubtitle }}
           </p>
         </div>

--- a/components/scenarios/choice-manager.vue
+++ b/components/scenarios/choice-manager.vue
@@ -26,7 +26,7 @@
         />
         <div class="p-2 text-center">
           <p class="font-semibold">{{ option.text }}</p>
-          <p class="text-sm text-base-content/60">{{ option.description }}</p>
+          <p class="kr-text-dim-sm">{{ option.description }}</p>
         </div>
       </div>
     </div>

--- a/components/servers/add-checkpoint.vue
+++ b/components/servers/add-checkpoint.vue
@@ -10,7 +10,7 @@
           {{ title }}
         </h3>
 
-        <p class="text-sm text-base-content/60">
+        <p class="kr-text-dim-sm">
           Add a custom checkpoint, LoRA, embedding, sampler, API, or URL
           resource.
         </p>

--- a/components/servers/add-server.vue
+++ b/components/servers/add-server.vue
@@ -11,7 +11,7 @@
         <h2 class="text-xl font-black text-primary">
           {{ form.id ? 'Edit Server' : 'Add Server' }}
         </h2>
-        <p class="text-sm text-base-content/60">
+        <p class="kr-text-dim-sm">
           Servers are now simple access cards: type, URL, endpoint, health path,
           and auth.
         </p>

--- a/components/servers/checkpoint-gallery.vue
+++ b/components/servers/checkpoint-gallery.vue
@@ -140,9 +140,7 @@
       <template #empty>
         <div class="kr-panel-muted border-dashed text-center">
           <p class="font-bold">No checkpoints found.</p>
-          <p class="text-sm text-base-content/60">
-            Try another filter or add a checkpoint.
-          </p>
+          <p class="kr-text-dim-sm">Try another filter or add a checkpoint.</p>
         </div>
       </template>
     </kr-gallery>

--- a/components/servers/server-gallery.vue
+++ b/components/servers/server-gallery.vue
@@ -103,7 +103,7 @@
             class="mx-auto mb-2 h-8 w-8 text-base-content/40"
           />
           <p class="font-bold">No matching servers.</p>
-          <p class="text-sm text-base-content/60">
+          <p class="kr-text-dim-sm">
             Add a configured A1111, Comfy, OpenAI, Anthropic, or Custom
             endpoint.
           </p>

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -229,7 +229,7 @@
 
         <!-- ── Species ────────────────────────────────────────────────── -->
         <div v-show="activeTab === 'species'" class="flex flex-col gap-3 p-5">
-          <p class="text-sm text-base-content/60">
+          <p class="kr-text-dim-sm">
             What is this entity? Choose from illustrated options or type your
             own.
           </p>
@@ -341,7 +341,7 @@
           v-show="activeTab === 'personality'"
           class="flex flex-col gap-3 p-5"
         >
-          <p class="text-sm text-base-content/60">
+          <p class="kr-text-dim-sm">
             How do they move through the world? Pick as many as apply. The
             combination is the character.
           </p>

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -224,7 +224,7 @@
         >
           <div class="flex flex-col gap-1">
             <h2 class="text-2xl font-black text-base-content">Pick a Stage</h2>
-            <p class="text-sm text-base-content/60">
+            <p class="kr-text-dim-sm">
               Choose the format. This determines the roles, rotation, and tone
               of the performance.
             </p>
@@ -281,7 +281,7 @@
               <h2 class="text-2xl font-black text-base-content">
                 Cast the Show
               </h2>
-              <p class="text-sm text-base-content/60">
+              <p class="kr-text-dim-sm">
                 Assign characters, bots, or preset performers to each role.
                 Required slots are shown first.
               </p>
@@ -504,7 +504,7 @@
             <h2 class="text-2xl font-black text-base-content">
               Configure the Show
             </h2>
-            <p class="text-sm text-base-content/60">
+            <p class="kr-text-dim-sm">
               Optional topic, custom opening, turn count, and server settings.
             </p>
           </div>

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -89,7 +89,7 @@
         <Icon name="kind-icon:chat" class="h-12 w-12 text-base-content/30" />
         <div>
           <p class="text-lg font-black text-base-content">No messages found.</p>
-          <p class="text-sm text-base-content/60">
+          <p class="kr-text-dim-sm">
             When a message arrives, human or otherwise, it will show up here.
           </p>
         </div>

--- a/components/user/forum-thread.vue
+++ b/components/user/forum-thread.vue
@@ -77,10 +77,7 @@
         </div>
       </div>
 
-      <div
-        v-if="!threadsByChannel(channel.slug).length"
-        class="text-sm text-base-content/60"
-      >
+      <div v-if="!threadsByChannel(channel.slug).length" class="kr-text-dim-sm">
         No posts yet. Be the first to say something.
       </div>
 
@@ -117,11 +114,7 @@
           v-if="expandedThreadId === thread.id"
           class="pl-4 border-l-2 border-base-300 space-y-3 mt-3"
         >
-          <div
-            v-if="repliesLoading"
-            class="text-sm text-base-content/60"
-            role="status"
-          >
+          <div v-if="repliesLoading" class="kr-text-dim-sm" role="status">
             Loading replies…
           </div>
 

--- a/components/user/friend-gallery.vue
+++ b/components/user/friend-gallery.vue
@@ -12,7 +12,7 @@
     <!-- Header -->
     <div class="flex items-center justify-between">
       <h2 class="text-xl font-bold">Community &amp; Friends</h2>
-      <span class="text-sm text-base-content/60">
+      <span class="kr-text-dim-sm">
         {{ visibleUsers.length }} public profile{{
           visibleUsers.length !== 1 ? 's' : ''
         }}

--- a/components/user/user-galleries.vue
+++ b/components/user/user-galleries.vue
@@ -5,7 +5,7 @@
   >
     <header class="shrink-0 kr-panel-flat p-4">
       <h2 class="text-xl font-black">User Galleries</h2>
-      <p class="text-sm text-base-content/60">
+      <p class="kr-text-dim-sm">
         Records where <span class="font-bold">userId</span> matches this
         profile. Each model gets one row.
       </p>

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -305,7 +305,7 @@
         <footer
           class="kr-panel flex flex-wrap items-center justify-between gap-3 p-3"
         >
-          <div class="text-sm text-base-content/60">
+          <div class="kr-text-dim-sm">
             Showing {{ pageStart }}–{{ pageEnd }} of
             {{ filteredResources.length }} matching LoRAs
           </div>

--- a/pages/music-mentor.vue
+++ b/pages/music-mentor.vue
@@ -9,7 +9,7 @@
         </div>
         <div class="min-w-0 flex-1 space-y-1">
           <p class="text-2xl font-black tracking-tight">Music Mentor</p>
-          <p class="text-sm text-base-content/60">
+          <p class="kr-text-dim-sm">
             Upload a recording of your sung medley and get honest, specific
             feedback on the singing and the arrangement. Everything is analyzed
             <strong>in your browser</strong> — the audio never leaves your

--- a/utils/scripts/codemods/kr_text_dim_sm_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_sm_codemod.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `text-sm text-base-content/60` muted caption
+text to `kr-text-dim-sm`.
+
+Sibling of kr_label_bold_codemod.py, same conventions: dry-run by default,
+--write to update matching Vue files in place. Only the exact `text-sm
+text-base-content/60` shape is touched, and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings, and regardless of the
+base tokens' order in the source. A source that already carries
+`kr-text-dim-sm`, or is missing either base token, is left untouched. Extra
+tokens beyond the base set are preserved verbatim after the primitive class,
+matching the kr-badge-*/kr-spinner-*/kr-label-bold codemods' subset-match
+convention -- pass --exact-only to restrict a slice to sources with no extra
+tokens at all, the safest and most literal pool.
+
+This deliberately does NOT touch the other opacity/size variants surveyed
+alongside this one in interface-vision t-104 slice 153 (`text-xs
+text-base-content/50`, `text-sm text-base-content/70`, `text-xs
+text-base-content/45`, etc.) -- each is its own bounded family for a future
+slice, not folded in here just because the grep that found them overlaps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-dim-sm"
+BASE_TOKENS = {"text-sm", "text-base-content/60"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-dim-sm {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: consistency umbrella, slice 153 (kind: software)

### What changed / what I produced
- Added `.kr-text-dim-sm` (`text-sm text-base-content/60`) to `assets/css/tailwind.css` — a muted secondary caption line at body-text size.
- Added `utils/scripts/codemods/kr_text_dim_sm_codemod.py`, sibling of `kr_label_bold_codemod.py` (dry-run by default, `--exact-only`/`--write`).
- Migrated all 51 exact hand-rolled occurrences of `text-sm text-base-content/60` across 38 files to `kr-text-dim-sm`. No geometry or behavior change.
- Fixed 3 files (`bot-chat.vue`, `checkpoint-gallery.vue`, `forum-thread.vue`) where the shortened class string let a previously multi-line tag collapse onto one line under prettier's print width — ran a scoped `prettier --write` after confirming via `git stash` that none of the three carried pre-existing prettier debt.

Named `kr-text-*` rather than the existing `kr-*-muted` suffix (`.kr-panel-muted`, `.kr-input-muted`, `.kr-textarea-muted`) since that suffix already means "on the base-200 tinted background" elsewhere in this file — reusing it for a text-opacity variant would read as the wrong kind of "muted".

Deliberately **not** touched this slice: `flex items-center gap-2` (87 occurrences, the largest family in the survey) — sampled its usage sites (mostly bare `<div>`s, some `<label>`/`<header>`/`<span>`) and found it's a generic layout utility spanning unrelated semantic roles (icon+text rows, checkbox labels, toolbar fragments), not a coherent component-shaped family the way `kr-spinner-*`/`kr-badge-*`/`kr-toggle-row` are. Left for a future slice with a narrower, more deliberate look at whether it splits into real sub-families. The other opacity/size variants surveyed alongside `text-sm text-base-content/60` (`text-xs text-base-content/50`, `text-sm text-base-content/70`, `text-xs text-base-content/45`, etc.) are each their own bounded family for a future slice.

### How I verified
- `vue-tsc --noEmit` — clean (exit 0)
- `eslint` on all changed files — 5 pre-existing errors confirmed unrelated to this diff (verified identical via `git stash`), 0 new errors/warnings on the 3 files touched by the prettier fix
- `npm run test:layout-contract` — holds, no new violations (an unrelated 2-entry viewport-grid baseline improvement in `narrative-ingredient-multi-picker.vue` from a prior merge was noticed and left alone, not this slice's to claim)
- `prettier --check` on all changed files — clean after the scoped 3-file fix
- `npm run test:lint-ratchet` — running in background at PR-open time; will confirm in a follow-up comment if it doesn't hold (expected clean — no eslint changes)
- Codemod dry-run (`--exact-only`, no `--write`) confirmed 51/51 candidates were exact-match with no leftover tokens before applying

### Stakes
reversible

### Flags for Reviewer
- None — first-pass clean, following the established slice 145-152 convention exactly.

### Kaizen suggestion
Next slice: take a deliberate second look at `flex items-center gap-2` (87 occurrences) — split by parent tag/context (icon+label div rows vs. checkbox `<label>` wrappers vs. `<header>` bars) to see if 2-3 narrower, semantically real primitives fall out, rather than treating it as one family or skipping it indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DcKUxxTWS7gfhEqzZaC3t

---
_Generated by [Claude Code](https://claude.ai/code/session_019DcKUxxTWS7gfhEqzZaC3t)_