### PR TITLE
refactor(ui): migrate text-xs text-base-content/50 to kr-text-dim-xs

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1640,6 +1640,23 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply text-sm text-base-content/60;
   }
 
+  /* The `text-xs` counterpart to `.kr-text-dim-sm` (interface-vision t-104
+   * slice 154): the same muted secondary caption concept at the smaller
+   * scale -- `text-xs text-base-content/50`, previously hand-rolled
+   * identically in 33 files (42 exact occurrences), the next largest
+   * bounded family surfaced by slice 152's original frequency survey and
+   * named as a follow-up target in slice 153's own kaizen suggestion. Not
+   * the same opacity as `.kr-text-dim-sm` (50 vs. 60) -- each size has its
+   * own established opacity in the wild, and this migration only
+   * consolidates what was already an exact duplicate, not what "should"
+   * match across sizes. The other opacity/size variants surveyed alongside
+   * this one (`text-sm text-base-content/70`, `text-xs
+   * text-base-content/45`, `text-xs text-base-content/55`, etc.) are left
+   * for future slices, same convention as `.kr-spinner-xs`/`.kr-spinner-sm`. */
+  .kr-text-dim-xs {
+    @apply text-xs text-base-content/50;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/achievements/achievement-gallery.vue
+++ b/components/achievements/achievement-gallery.vue
@@ -17,7 +17,7 @@
           <h1 class="text-lg font-black text-base-content">
             {{ userStore.username }}'s Achievements
           </h1>
-          <p class="text-xs text-base-content/50">
+          <p class="kr-text-dim-xs">
             {{ earnedAchievements.length }} earned ·
             {{ unearnedAchievements.length }} remaining
           </p>

--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -5,7 +5,7 @@
       <Icon name="kind-icon:tag" class="size-4 text-secondary" />
       <div class="min-w-0 flex-1">
         <h3 class="text-sm font-bold">{{ label }}</h3>
-        <p v-if="!compact" class="text-xs text-base-content/50">
+        <p v-if="!compact" class="kr-text-dim-xs">
           Canonical creative direction recorded on the ArtJob and finished
           image.
         </p>

--- a/components/art/art-lora-picker.vue
+++ b/components/art/art-lora-picker.vue
@@ -229,7 +229,7 @@
 
         <p
           v-if="search.trim() && !visibleLoras.length"
-          class="text-xs text-base-content/50"
+          class="kr-text-dim-xs"
         >
           No compatible LoRA matches “{{ search.trim() }}”.
         </p>

--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -318,7 +318,7 @@
       <footer
         class="flex flex-wrap items-center justify-between gap-3 border-t border-base-300 p-4"
       >
-        <p class="text-xs text-base-content/50">
+        <p class="kr-text-dim-xs">
           Blank seed creates a fresh random seed. Facets, visibility, and video
           settings are persisted as canonical ArtJob provenance.
         </p>

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -148,7 +148,7 @@
             </div>
             <p
               v-if="!privateArtServers.length"
-              class="text-xs text-base-content/50"
+              class="kr-text-dim-xs"
             >
               No private art servers registered.
             </p>
@@ -207,7 +207,7 @@
                 No samples in this window.
               </p>
             </div>
-            <p v-if="!uptime.length" class="text-xs text-base-content/50">
+            <p v-if="!uptime.length" class="kr-text-dim-xs">
               No uptime samples yet.
             </p>
           </div>

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -242,7 +242,7 @@
       <div class="flex items-start gap-2">
         <div class="min-w-0 flex-1">
           <p class="text-sm font-black">Generate {{ selectedSlot.label }} replacement</p>
-          <p class="text-xs text-base-content/50">
+          <p class="kr-text-dim-xs">
             Recreate starts fresh with Krea. Img2img uses the current image and defaults to SDXL.
           </p>
         </div>
@@ -405,7 +405,7 @@
       <div class="flex items-start gap-2">
         <div class="min-w-0 flex-1">
           <p class="text-sm font-black">Upload {{ selectedSlot.label }} replacement</p>
-          <p class="text-xs text-base-content/50">
+          <p class="kr-text-dim-xs">
             Upload a finished PNG, JPEG, or WebP, then choose whether the old image remains as inspiration.
           </p>
         </div>

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -135,7 +135,7 @@
             </option>
           </select>
 
-          <p class="text-xs text-base-content/50">
+          <p class="kr-text-dim-xs">
             Selected:
             <span class="font-semibold text-primary">
               {{ selectedCollectionLabel }}

--- a/components/art/stylist-history.vue
+++ b/components/art/stylist-history.vue
@@ -46,7 +46,7 @@
         <div class="flex flex-wrap items-center gap-2">
           <div class="flex min-w-0 flex-1 flex-col">
             <span class="truncate text-sm font-bold">{{ appointment.clientName }}</span>
-            <span class="text-xs text-base-content/50">
+            <span class="kr-text-dim-xs">
               {{ appointment.date }} · {{ formatCents(appointment.hourlyRateCents) }}/hr ×
               {{ formatMinutes(appointment.minutes) }} +
               {{ formatCents(appointment.productCostCents) }}

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -185,7 +185,7 @@
         <input v-model="enhanceImage" type="checkbox" class="kr-checkbox-primary-sm mt-1" />
         <div class="flex flex-1 flex-col gap-1">
           <span class="text-sm font-bold">Improve the overall image</span>
-          <span class="text-xs text-base-content/50">Cleaner lighting, sharper detail — face and identity kept.</span>
+          <span class="kr-text-dim-xs">Cleaner lighting, sharper detail — face and identity kept.</span>
         </div>
       </label>
 

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -642,7 +642,7 @@
           <Icon name="kind-icon:download" class="h-4 w-4" />
           Export .md
         </button>
-        <span v-if="keptExportMessage" class="text-xs text-base-content/50">{{
+        <span v-if="keptExportMessage" class="kr-text-dim-xs">{{
           keptExportMessage
         }}</span>
       </div>

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -5,7 +5,7 @@
       <Icon name="kind-icon:tag" class="size-4 text-secondary" />
       <div class="min-w-0 flex-1">
         <h3 class="text-sm font-bold">Character Facets</h3>
-        <p class="text-xs text-base-content/50">
+        <p class="kr-text-dim-xs">
           Species, archetype, quirks, and other reusable traits that shape
           this character independently of their name.
         </p>

--- a/components/conductor/conductor-app-page.vue
+++ b/components/conductor/conductor-app-page.vue
@@ -42,7 +42,7 @@
             {{ task.title }}
           </li>
         </ul>
-        <p class="text-xs text-base-content/50">
+        <p class="kr-text-dim-xs">
           Not on the App Store or Play Store yet — store readiness is its own
           tracked task before any submission.
         </p>

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -253,7 +253,7 @@
                 <p class="text-sm text-base-content/70">
                   The narrator is having trouble with this chapter.
                 </p>
-                <p class="text-xs text-base-content/50">{{ narrationError }}</p>
+                <p class="kr-text-dim-xs">{{ narrationError }}</p>
                 <div class="flex flex-wrap justify-center gap-2">
                   <button
                     type="button"

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -465,7 +465,7 @@
             <p class="break-words text-sm font-semibold leading-snug">
               {{ milestone.title }}
             </p>
-            <p class="text-xs text-base-content/50">
+            <p class="kr-text-dim-xs">
               <span v-if="milestoneTaskCounts.get(milestone.id)?.total">
                 {{ milestoneTaskCounts.get(milestone.id)?.done }}/{{
                   milestoneTaskCounts.get(milestone.id)?.total

--- a/components/conductor/sketchy-page.vue
+++ b/components/conductor/sketchy-page.vue
@@ -63,7 +63,7 @@
           </div>
         </div>
 
-        <p class="text-xs text-base-content/50">
+        <p class="kr-text-dim-xs">
           The full assignment engine and AI critique loop are in active
           development — this preview mirrors the real skill ladder and rubric.
         </p>

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -5,7 +5,7 @@
       <Icon name="kind-icon:tag" class="size-4 text-secondary" />
       <div class="min-w-0 flex-1">
         <h3 class="text-sm font-bold">{{ label }}</h3>
-        <p class="text-xs text-base-content/50">
+        <p class="kr-text-dim-xs">
           Reusable creative building blocks shared by Characters, Bots, Dreams,
           Rewards, Scenarios, and art. Aliases resolve to one canonical Facet.
         </p>

--- a/components/facets/facet-profile-editor.vue
+++ b/components/facets/facet-profile-editor.vue
@@ -113,7 +113,7 @@
         <Icon name="kind-icon:palette" class="size-4 text-accent" />
         <div>
           <h3 class="text-sm font-bold">Curated artwork</h3>
-          <p class="text-xs text-base-content/50">
+          <p class="kr-text-dim-xs">
             Preserve primary, portrait/card, and hero/wide roles separately.
           </p>
         </div>

--- a/components/giftshop/mana-wallet.vue
+++ b/components/giftshop/mana-wallet.vue
@@ -87,7 +87,7 @@
         <div class="text-3xl font-extrabold text-secondary tabular-nums">
           {{ manaStore.tokens }}
         </div>
-        <p class="text-xs text-base-content/50">
+        <p class="kr-text-dim-xs">
           Credited by top-ups. Generations spend tokens first, then fall back to
           free mana above. Not withdrawable — that's a Stripe refund, not a
           payout.
@@ -123,7 +123,7 @@
           >
             <div class="space-y-0.5">
               <div class="text-sm font-medium">{{ label(t.reason) }}</div>
-              <div class="text-xs text-base-content/50">
+              <div class="kr-text-dim-xs">
                 {{ when(t.createdAt) }}
               </div>
             </div>

--- a/components/giftshop/mermaids-pdf-purchase.vue
+++ b/components/giftshop/mermaids-pdf-purchase.vue
@@ -29,7 +29,7 @@
       </NuxtLink>
     </div>
 
-    <div v-else-if="checkingOwnership" class="text-xs text-base-content/50">
+    <div v-else-if="checkingOwnership" class="kr-text-dim-xs">
       Checking your library...
     </div>
 

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -139,7 +139,7 @@
           <h3 class="line-clamp-2 text-sm font-black" :title="card.name">
             {{ card.name }}
           </h3>
-          <p v-if="card.creator" class="text-xs text-base-content/50">
+          <p v-if="card.creator" class="kr-text-dim-xs">
             by {{ card.creator }}
           </p>
 

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -872,7 +872,7 @@
                     <p class="break-words text-sm font-semibold leading-snug">
                       {{ milestone.title }}
                     </p>
-                    <p class="text-xs text-base-content/50">
+                    <p class="kr-text-dim-xs">
                       weight {{ milestone.weight }}
                       <span v-if="milestoneTaskCounts.get(milestone.id)?.total"
                         >&middot;

--- a/components/pages/creator-earnings-page.vue
+++ b/components/pages/creator-earnings-page.vue
@@ -139,7 +139,7 @@
                     <p class="truncate text-sm font-black text-base-content">
                       {{ group.title }}
                     </p>
-                    <p class="text-xs text-base-content/50">
+                    <p class="kr-text-dim-xs">
                       {{ sourceTypeLabel(group.sourceType) }}
                     </p>
                   </div>
@@ -152,10 +152,7 @@
                 <p class="text-xl font-black text-primary tabular-nums">
                   {{ formatUsdCents(group.totalCents) }}
                 </p>
-                <p
-                  v-if="group.selfAttributedCents > 0"
-                  class="text-xs text-base-content/50"
-                >
+                <p v-if="group.selfAttributedCents > 0" class="kr-text-dim-xs">
                   +
                   {{ formatUsdCents(group.selfAttributedCents) }} self-generated
                   (not counted above)

--- a/components/pages/memory-dungeon.vue
+++ b/components/pages/memory-dungeon.vue
@@ -103,7 +103,7 @@
 
             <span
               v-if="gameStarted && !gameOver"
-              class="text-xs text-base-content/50"
+              class="kr-text-dim-xs"
             >
               Changes apply when you restart.
             </span>

--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -76,7 +76,7 @@
             <div class="text-3xl font-extrabold text-primary tabular-nums">
               {{ formatUsdCents(data.accrual.totalCents) }}
             </div>
-            <p class="text-xs text-base-content/50">
+            <p class="kr-text-dim-xs">
               {{ data.accrual.count }}
               {{ data.accrual.count === 1 ? 'spend' : 'spends' }} on record
             </p>
@@ -91,7 +91,7 @@
             <div class="text-3xl font-extrabold text-success tabular-nums">
               {{ formatUsdCents(data.remittedTotalCents) }}
             </div>
-            <p class="text-xs text-base-content/50">
+            <p class="kr-text-dim-xs">
               {{ data.remittances.length }}
               {{ data.remittances.length === 1 ? 'entry' : 'entries' }} logged
             </p>
@@ -111,7 +111,7 @@
             >
               {{ formatUsdCents(data.outstandingCents) }}
             </div>
-            <p class="text-xs text-base-content/50">accrued minus remitted</p>
+            <p class="kr-text-dim-xs">accrued minus remitted</p>
           </article>
         </section>
 
@@ -212,7 +212,7 @@
             >
               <div class="min-w-0 space-y-0.5 whitespace-normal">
                 <p class="text-sm font-medium">{{ entry.note }}</p>
-                <p class="text-xs text-base-content/50">
+                <p class="kr-text-dim-xs">
                   {{ formatWhen(entry.createdAt) }}
                   · logged by
                   {{ entry.remittedByUsername ?? `user#${entry.remittedById}` }}

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -67,7 +67,7 @@
           @change="saveRelay"
         />
       </label>
-      <p class="text-xs text-base-content/50">
+      <p class="kr-text-dim-xs">
         The serendipity-voice dev server (npm run dev:web).
       </p>
     </div>

--- a/components/pages/wallet-page.vue
+++ b/components/pages/wallet-page.vue
@@ -73,7 +73,7 @@
               <div class="text-sm font-medium">
                 {{ formatReason(txn.reason) }}
               </div>
-              <div class="text-xs text-base-content/50">
+              <div class="kr-text-dim-xs">
                 {{ formatWhen(txn.createdAt) }}
               </div>
             </div>

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -5,7 +5,7 @@
       <Icon name="kind-icon:tag" class="size-4 text-secondary" />
       <div class="min-w-0 flex-1">
         <h3 class="text-sm font-bold">Reward Facets</h3>
-        <p class="text-xs text-base-content/50">
+        <p class="kr-text-dim-xs">
           Materials, colors, themes, and other reusable traits that shape the
           object independently of its name.
         </p>

--- a/components/storybook/storybook-visual-setup.vue
+++ b/components/storybook/storybook-visual-setup.vue
@@ -47,7 +47,7 @@
             </div>
             <div>
               <h2 class="text-lg font-black">The spark</h2>
-              <p class="text-xs text-base-content/50">
+              <p class="kr-text-dim-xs">
                 One premise is enough. Everything else can stay loose.
               </p>
             </div>

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -132,7 +132,7 @@
                 </div>
 
                 <div class="flex shrink-0 flex-col items-end gap-1">
-                  <span class="text-xs text-base-content/50">
+                  <span class="kr-text-dim-xs">
                     {{ formatDate(thread.latest.createdAt) }}
                   </span>
                   <span

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -80,7 +80,7 @@
                 </div>
                 <div class="min-w-0">
                   <div class="truncate font-semibold">{{ u.username }}</div>
-                  <div class="text-xs text-base-content/50">#{{ u.id }}</div>
+                  <div class="kr-text-dim-xs">#{{ u.id }}</div>
                 </div>
               </div>
             </td>

--- a/pages/admin/forum-moderation.vue
+++ b/pages/admin/forum-moderation.vue
@@ -68,7 +68,7 @@
 
             <p class="whitespace-pre-line text-sm">{{ post.content }}</p>
 
-            <p class="text-xs text-base-content/50">
+            <p class="kr-text-dim-xs">
               By {{ post.botName || post.sender }} &middot; posted
               {{ formatDate(post.createdAt) }}
               <template v-if="post.updatedAt">

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -55,7 +55,7 @@
             <span class="text-sm font-black">
               {{ row.approvedToday }}/{{ row.ceiling }}
             </span>
-            <span class="text-xs text-base-content/50">approved today</span>
+            <span class="kr-text-dim-xs">approved today</span>
             <span
               v-if="row.approvedToday >= row.ceiling"
               class="kr-badge-warning-sm"
@@ -107,7 +107,7 @@
             <span v-if="loading" class="kr-spinner-xs" />
             Refresh
           </button>
-          <span class="text-xs text-base-content/50">
+          <span class="kr-text-dim-xs">
             {{ draftsStore.drafts.length }} draft(s) shown
           </span>
         </section>
@@ -158,7 +158,7 @@
               Disclosure: {{ draft.disclosureLabel }}
             </div>
 
-            <p class="text-xs text-base-content/50">
+            <p class="kr-text-dim-xs">
               Source: DREAM #{{ draft.sourceId }} &middot; queued
               {{ formatDate(draft.createdAt) }}
               <template v-if="draft.reviewedAt">

--- a/pages/music-mentor.vue
+++ b/pages/music-mentor.vue
@@ -15,7 +15,7 @@
             <strong>in your browser</strong> — the audio never leaves your
             device, and nothing is stored.
           </p>
-          <p class="text-xs text-base-content/50">
+          <p class="kr-text-dim-xs">
             Honest heads-up: this measures the objective stuff (pitch, timing,
             dynamics, structure) and reasons over your setlist. It can't judge
             tone, emotion, or "is this a good voice" — that still needs a human

--- a/utils/scripts/codemods/kr_text_dim_xs_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_xs_codemod.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `text-xs text-base-content/50` muted caption
+text to `kr-text-dim-xs`.
+
+Sibling of kr_text_dim_sm_codemod.py, same conventions: dry-run by default,
+--write to update matching Vue files in place. Only the exact `text-xs
+text-base-content/50` shape is touched, and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings, and regardless of the
+base tokens' order in the source. A source that already carries
+`kr-text-dim-xs`, or is missing either base token, is left untouched. Extra
+tokens beyond the base set are preserved verbatim after the primitive class,
+matching the kr-badge-*/kr-spinner-*/kr-label-bold/kr-text-dim-sm codemods'
+subset-match convention -- pass --exact-only to restrict a slice to sources
+with no extra tokens at all, the safest and most literal pool.
+
+This deliberately does NOT touch the other opacity/size variants surveyed
+alongside this one in interface-vision t-104 slices 153/154 (`text-sm
+text-base-content/70`, `text-xs text-base-content/45`, `text-xs
+text-base-content/55`, etc.) -- each is its own bounded family for a future
+slice, not folded in here just because the grep that found them overlaps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-dim-xs"
+BASE_TOKENS = {"text-xs", "text-base-content/50"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-dim-xs {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: consistency umbrella, slice 154 (kind: software)

### What changed / what I produced
- Added `.kr-text-dim-xs` (`text-xs text-base-content/50`) to `assets/css/tailwind.css` — the `text-xs` counterpart to slice 153's `.kr-text-dim-sm`.
- Added `utils/scripts/codemods/kr_text_dim_xs_codemod.py`, sibling of `kr_text_dim_sm_codemod.py` (dry-run by default, `--exact-only`/`--write`).
- Migrated all 42 exact hand-rolled occurrences of `text-xs text-base-content/50` across 33 files to `kr-text-dim-xs`. No geometry or behavior change.
- Fixed 1 file (`creator-earnings-page.vue`) where the shortened class string let a previously multi-line tag collapse onto one line under prettier's print width — ran a scoped `prettier --write` after confirming via `git stash` it was the only newly-affected file.

This was the next-largest bounded family surfaced by slice 152's original frequency survey, named as a follow-up target in slice 153's kaizen suggestion.

### How I verified
- `vue-tsc --noEmit` — clean (exit 0)
- `eslint` on all changed files — 6 pre-existing errors confirmed unrelated to this diff (verified identical via `git stash`), 0 new errors/warnings on the 1 file touched by the prettier fix
- `npm run test:layout-contract` — holds, no new violations (same unrelated 2-entry viewport-grid baseline improvement noticed in slice 153, still not this slice's to claim)
- `prettier --check` on all changed files — clean after the scoped 1-file fix
- `npm run test:lint-ratchet` — holds at 333/-59
- Codemod dry-run (`--exact-only`, no `--write`) confirmed 42/42 candidates were exact-match with no leftover tokens before applying

### Stakes
reversible

### Flags for Reviewer
- None — first-pass clean, following the established slice convention exactly.

### Kaizen suggestion
Next slice: `text-sm text-base-content/70` (35 occurrences) or `text-xs text-base-content/45` (17 occurrences) — the next opacity/size variants in the same survey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DcKUxxTWS7gfhEqzZaC3t

---
_Generated by [Claude Code](https://claude.ai/code/session_019DcKUxxTWS7gfhEqzZaC3t)_