### PR TITLE
refactor(ui): migrate text-sm text-base-content/70 to kr-text-dim-sm-70

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1657,6 +1657,26 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply text-xs text-base-content/50;
   }
 
+  /* A less-dimmed secondary caption at body-text size -- `text-sm
+   * text-base-content/70`, the same "secondary caption" role as
+   * `.kr-text-dim-sm` but at a lighter dim (70% vs. 60% opacity), used for
+   * descriptive paragraph text (project/page copy, card body text) rather
+   * than the more muted metadata-style line `.kr-text-dim-sm` targets
+   * (interface-vision t-104 slice 155) -- previously hand-rolled in 63
+   * files (118 occurrences, subset-match including extra tokens like
+   * `leading-relaxed`, `line-clamp-*`, `font-*`), the larger of the two
+   * candidates surveyed in slice 152's original frequency pass and named as
+   * slice 154's own follow-up target alongside `text-xs
+   * text-base-content/45`. Named `kr-text-dim-sm-70` rather than reusing
+   * `kr-text-dim-sm` because that name is already claimed by the 60%-opacity
+   * shape shipped in slice 153 -- both are real, independently-repeated
+   * exact shapes in the wild, not one "should normalize to" the other. The
+   * still-unresolved sibling (`text-xs text-base-content/45`) is left for a
+   * future slice, same convention as `.kr-spinner-xs`/`.kr-spinner-sm`. */
+  .kr-text-dim-sm-70 {
+    @apply text-sm text-base-content/70;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/academy/academy-manager.vue
+++ b/components/academy/academy-manager.vue
@@ -37,7 +37,7 @@
               class="loading loading-spinner loading-lg text-primary"
               aria-hidden="true"
             />
-            <p class="text-sm text-base-content/70">
+            <p class="kr-text-dim-sm-70">
               Dusting off the timeline, warming up the remix engine, and
               politely waking thirty-three centuries of dead masters...
             </p>

--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -11,7 +11,7 @@
           <Icon name="kind-icon:magic" class="h-5 w-5 text-primary" />
           Remix Studio
         </h2>
-        <p class="text-sm text-base-content/70">
+        <p class="kr-text-dim-sm-70">
           Pick a historical style, bring an image — yours or from the gallery —
           and let the Kontext engine repaint it the way the masters would have.
         </p>

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -21,7 +21,7 @@
         </div>
       </div>
       <div class="flex flex-col gap-3 p-4">
-        <p class="line-clamp-4 text-sm leading-relaxed text-base-content/70">
+        <p class="kr-text-dim-sm-70 line-clamp-4 leading-relaxed">
           {{ lesson.keyIdeas }}
         </p>
         <div class="flex flex-wrap gap-1.5">

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -15,7 +15,7 @@
           <h2 class="text-2xl font-black leading-tight text-base-content sm:text-3xl">
             The Art History Timeline
           </h2>
-          <p class="mt-2 text-sm leading-relaxed text-base-content/70 sm:text-base">
+          <p class="kr-text-dim-sm-70 mt-2 leading-relaxed sm:text-base">
             Start with the pictures. Move through thirty-three centuries of style,
             open whatever catches your eye, then turn what you learn into a remix.
           </p>
@@ -131,7 +131,7 @@
           </div>
 
           <div class="flex flex-1 flex-col gap-3 p-4">
-            <p class="line-clamp-2 text-sm leading-relaxed text-base-content/70">
+            <p class="kr-text-dim-sm-70 line-clamp-2 leading-relaxed">
               {{ style.recognitionCues[0] }}
             </p>
             <div class="mt-auto flex items-center justify-between gap-3 text-xs font-bold text-primary">

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -152,7 +152,7 @@
           <Icon :name="store.selectedItem.icon" class="h-12 w-12" />
         </div>
 
-        <p class="text-sm leading-relaxed text-base-content/70">
+        <p class="kr-text-dim-sm-70 leading-relaxed">
           {{ store.selectedItem.tooltip }}
         </p>
 

--- a/components/art/art-manager.vue
+++ b/components/art/art-manager.vue
@@ -7,7 +7,7 @@
     >
       <div class="flex flex-col items-center gap-3 text-center">
         <span class="loading loading-spinner loading-lg text-primary" />
-        <p class="text-sm text-base-content/70">
+        <p class="kr-text-dim-sm-70">
           {{ managerLoadMessage }}
         </p>
       </div>

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -315,7 +315,7 @@
           class="mt-3 flex min-h-40 flex-col items-center justify-center gap-3 kr-panel-dashed-plain text-center"
         >
           <span class="loading loading-spinner loading-md text-primary" />
-          <p class="text-sm text-base-content/70">{{ queueLoadMessage }}</p>
+          <p class="kr-text-dim-sm-70">{{ queueLoadMessage }}</p>
         </div>
 
         <div v-else class="mt-3 grid gap-3 xl:grid-cols-2">

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -38,7 +38,7 @@
         <Icon :name="icon" class="h-7 w-7" />
       </span>
       <div class="text-center">
-        <p class="text-sm font-semibold text-base-content/70">
+        <p class="kr-text-dim-sm-70 font-semibold">
           Drop images here or
           <span class="font-bold text-primary underline underline-offset-2"
             >browse</span

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -6,7 +6,7 @@
         {{ title }}
       </h1>
 
-      <p class="mt-2 text-sm text-base-content/70">
+      <p class="kr-text-dim-sm-70 mt-2">
         {{ subtitle }}
       </p>
     </header>
@@ -29,7 +29,7 @@
             <div>
               <h2 class="text-xl font-bold text-base-content">Identity</h2>
 
-              <p class="text-sm text-base-content/70">
+              <p class="kr-text-dim-sm-70">
                 Define the bot’s visible profile and general vibe.
               </p>
             </div>
@@ -150,7 +150,7 @@
             <div>
               <h2 class="text-xl font-bold text-base-content">Avatar</h2>
 
-              <p class="text-sm text-base-content/70">
+              <p class="kr-text-dim-sm-70">
                 Use a URL/path, upload an image, or borrow a gallery image.
               </p>
             </div>
@@ -215,7 +215,7 @@
               AI Update Controls
             </h2>
 
-            <p class="text-sm text-base-content/70">
+            <p class="kr-text-dim-sm-70">
               Select fields for AI to refresh. Fields marked “keep” are
               protected.
             </p>
@@ -389,7 +389,7 @@
           <div>
             <h2 class="text-xl font-bold text-base-content">Publishing</h2>
 
-            <p class="text-sm text-base-content/70">
+            <p class="kr-text-dim-sm-70">
               Control visibility and construction status. The text engine is
               chosen at chat time.
             </p>

--- a/components/bots/bot-card.vue
+++ b/components/bots/bot-card.vue
@@ -43,7 +43,7 @@
       >
         <p
           v-if="showDescription"
-          class="line-clamp-3 text-sm leading-relaxed text-base-content/70"
+          class="kr-text-dim-sm-70 line-clamp-3 leading-relaxed"
         >
           {{ bot.description || bot.personality || 'No bot description yet.' }}
         </p>

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -72,7 +72,7 @@
               {{ botStore.currentBot.subtitle }}
             </p>
 
-            <p class="mt-2 line-clamp-3 text-sm text-base-content/70">
+            <p class="kr-text-dim-sm-70 mt-2 line-clamp-3">
               {{ selectedBotSummary }}
             </p>
           </div>

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -13,10 +13,7 @@
             {{ title }}
           </h2>
 
-          <p
-            v-if="botStore.currentBot"
-            class="truncate text-sm text-base-content/70"
-          >
+          <p v-if="botStore.currentBot" class="kr-text-dim-sm-70 truncate">
             Selected:
             <span class="font-semibold text-primary">
               {{ selectedBotTitle }}

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -5,7 +5,7 @@
       <h1 class="text-3xl font-black text-primary md:text-4xl">
         {{ title }}
       </h1>
-      <p class="mt-2 text-sm text-base-content/70">
+      <p class="kr-text-dim-sm-70 mt-2">
         {{ subtitle }}
       </p>
     </header>
@@ -29,7 +29,7 @@
               <h2 class="text-xl font-bold text-base-content">
                 Character Identity
               </h2>
-              <p class="text-sm text-base-content/70">
+              <p class="kr-text-dim-sm-70">
                 Give this person a name, place in the world, and recognizable silhouette.
               </p>
             </div>
@@ -146,7 +146,7 @@
           <div class="mb-4 flex items-center justify-between gap-2">
             <div>
               <h2 class="text-xl font-bold text-base-content">Portrait</h2>
-              <p class="text-sm text-base-content/70">
+              <p class="kr-text-dim-sm-70">
                 Upload, borrow, or generate character art.
               </p>
             </div>
@@ -283,7 +283,7 @@
         >
           <div>
             <h2 class="text-xl font-bold text-base-content">Character Stats</h2>
-            <p class="text-sm text-base-content/70">
+            <p class="kr-text-dim-sm-70">
               Rarity-style strengths for adventures and rewards.
             </p>
           </div>
@@ -330,7 +330,7 @@
             <h2 class="text-xl font-bold text-base-content">
               AI Update Controls
             </h2>
-            <p class="text-sm text-base-content/70">
+            <p class="kr-text-dim-sm-70">
               Choose fields to refresh while protecting the parts already working.
             </p>
           </div>

--- a/components/characters/character-card.vue
+++ b/components/characters/character-card.vue
@@ -84,7 +84,7 @@
       >
         <p
           v-if="showDescription"
-          class="line-clamp-3 text-sm leading-relaxed text-base-content/70"
+          class="kr-text-dim-sm-70 line-clamp-3 leading-relaxed"
         >
           {{ descriptionText }}
         </p>

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -8,9 +8,7 @@
         Character Interact
       </h1>
 
-      <p
-        class="mx-auto mt-2 max-w-3xl text-sm text-base-content/70 md:text-base"
-      >
+      <p class="kr-text-dim-sm-70 mx-auto mt-2 max-w-3xl md:text-base">
         Chat with a character, drop them into a scenario, hand them a reward, or
         build a prompt for your next weird little adventure.
       </p>
@@ -161,7 +159,7 @@
               </div>
 
               <div v-if="isSendingChat" class="flex justify-start">
-                <div class="kr-panel p-3 text-sm text-base-content/70">
+                <div class="kr-text-dim-sm-70 kr-panel p-3">
                   <span class="loading loading-dots loading-sm text-primary" />
                   Thinking in character...
                 </div>

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -12,7 +12,7 @@
             <Icon name="kind-icon:paintbrush" class="h-5 w-5 text-primary" />
             Coloring Book
           </h2>
-          <p class="text-sm text-base-content/70">
+          <p class="kr-text-dim-sm-70">
             Pick a page and start coloring. Your work saves itself — walk away
             mid-masterpiece with total confidence.
           </p>

--- a/components/conductor/coat-dance-page.vue
+++ b/components/conductor/coat-dance-page.vue
@@ -5,13 +5,11 @@
       <section class="flex flex-col gap-3 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:sparkles" class="size-5 text-primary" />
-          <h3
-            class="text-sm font-black uppercase tracking-wide text-base-content/70"
-          >
+          <h3 class="kr-text-dim-sm-70 font-black uppercase tracking-wide">
             Behind the coat
           </h3>
         </div>
-        <p class="text-sm leading-relaxed text-base-content/70">
+        <p class="kr-text-dim-sm-70 leading-relaxed">
           The source is real: an experimental physical-theater duet with a black
           Goodwill trench coat, performed around 2006 while finishing a dance
           major at Humboldt State University — physical theater, object

--- a/components/conductor/conductor-app-page.vue
+++ b/components/conductor/conductor-app-page.vue
@@ -9,13 +9,11 @@
       <section class="flex flex-col items-start gap-3 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:server" class="size-5 text-primary" />
-          <h3
-            class="text-sm font-black uppercase tracking-wide text-base-content/70"
-          >
+          <h3 class="kr-text-dim-sm-70 font-black uppercase tracking-wide">
             Build progress
           </h3>
         </div>
-        <p class="text-sm text-base-content/70">
+        <p class="kr-text-dim-sm-70">
           The Flutter client is built in the open, one roadmap task at a time —
           the same conductor roadmap that steers every other project here.
         </p>
@@ -33,7 +31,7 @@
           <li
             v-for="task in nextTasks"
             :key="task.id"
-            class="text-sm text-base-content/70"
+            class="kr-text-dim-sm-70"
           >
             <Icon
               name="kind-icon:sparkles"

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -5,9 +5,7 @@
       <section class="flex flex-col gap-4 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:castle" class="size-5 text-primary" />
-          <h3
-            class="text-sm font-black uppercase tracking-wide text-base-content/70"
-          >
+          <h3 class="kr-text-dim-sm-70 font-black uppercase tracking-wide">
             Live a life
           </h3>
         </div>
@@ -80,7 +78,7 @@
             class="flex flex-col gap-3"
             @submit.prevent="startLife"
           >
-            <p class="text-sm text-base-content/70">
+            <p class="kr-text-dim-sm-70">
               Seed a fresh life. You'll move through a run of chapters, each
               choice nudging your legacy, wealth, love, wisdom, health, freedom,
               fame, creation, community, and mystery — then your story resolves
@@ -250,7 +248,7 @@
                 class="flex flex-col items-center gap-3 rounded-2xl border border-warning/40 bg-warning/10 p-6 text-center"
               >
                 <Icon name="kind-icon:warning" class="size-8 text-warning/70" />
-                <p class="text-sm text-base-content/70">
+                <p class="kr-text-dim-sm-70">
                   The narrator is having trouble with this chapter.
                 </p>
                 <p class="kr-text-dim-xs">{{ narrationError }}</p>
@@ -346,7 +344,7 @@
                 class="flex flex-col items-center gap-3 rounded-2xl border border-primary/30 bg-primary/5 p-6 text-center"
               >
                 <Icon name="kind-icon:trophy" class="size-8 text-primary/70" />
-                <p class="text-sm text-base-content/70">
+                <p class="kr-text-dim-sm-70">
                   {{
                     currentChapter
                       ? 'You can keep living, or draw the line here and see what it all added up to.'
@@ -386,7 +384,7 @@
               :label="`Illustration for how ${run?.protagonistName || 'this life'} ended`"
               @retry="retryEndingArt"
             />
-            <p class="max-w-md text-sm text-base-content/70">
+            <p class="kr-text-dim-sm-70 max-w-md">
               {{ endingData.summary }}
             </p>
             <p v-if="awardedNote" class="text-xs font-semibold text-success">
@@ -407,13 +405,11 @@
       <section class="flex flex-col items-start gap-3 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:trophy" class="size-5 text-primary" />
-          <h3
-            class="text-sm font-black uppercase tracking-wide text-base-content/70"
-          >
+          <h3 class="kr-text-dim-sm-70 font-black uppercase tracking-wide">
             Endings on record
           </h3>
         </div>
-        <p class="text-sm text-base-content/70">
+        <p class="kr-text-dim-sm-70">
           Each life resolves into one of the seeded endings below — reach it
           once and the matching achievement is yours for good.
         </p>

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -110,7 +110,7 @@
           <Icon name="kind-icon:pencil" class="size-3.5" />
           Edit / rename
         </button>
-        <p class="w-full text-sm leading-relaxed text-base-content/70">
+        <p class="kr-text-dim-sm-70 w-full leading-relaxed">
           {{ selectedPack.description }}
         </p>
       </div>

--- a/components/conductor/project-deliverables-panel.vue
+++ b/components/conductor/project-deliverables-panel.vue
@@ -8,9 +8,7 @@
   <section class="kr-panel-section">
     <div class="mb-3 flex items-center gap-2">
       <Icon name="kind-icon:check-circle" class="size-5 text-primary" />
-      <h3
-        class="text-sm font-black uppercase tracking-wide text-base-content/70"
-      >
+      <h3 class="kr-text-dim-sm-70 font-black uppercase tracking-wide">
         Deliverables &amp; status
       </h3>
       <button

--- a/components/conductor/project-front-page.vue
+++ b/components/conductor/project-front-page.vue
@@ -146,7 +146,7 @@
               {{ block.title }}
             </h3>
           </div>
-          <p class="text-sm leading-relaxed text-base-content/70">
+          <p class="kr-text-dim-sm-70 leading-relaxed">
             {{ block.body }}
           </p>
         </article>
@@ -173,7 +173,7 @@
         class="flex flex-col items-center gap-3 rounded-3xl border border-info/30 bg-info/5 p-6 text-center"
       >
         <Icon name="kind-icon:external-link" class="size-8 text-info/70" />
-        <p class="text-sm text-base-content/70">
+        <p class="kr-text-dim-sm-70">
           This experience lives in its own app. Launch it to dive in.
         </p>
         <a

--- a/components/conductor/project-gallery-strip.vue
+++ b/components/conductor/project-gallery-strip.vue
@@ -8,9 +8,7 @@
   <section v-if="images.length" class="kr-panel-section">
     <div class="mb-3 flex items-center gap-2">
       <Icon name="kind-icon:image" class="size-5 text-primary" />
-      <h3
-        class="text-sm font-black uppercase tracking-wide text-base-content/70"
-      >
+      <h3 class="kr-text-dim-sm-70 font-black uppercase tracking-wide">
         {{ title }}
       </h3>
       <span class="kr-badge-ghost-sm ml-auto rounded-lg">{{

--- a/components/conductor/sketchy-page.vue
+++ b/components/conductor/sketchy-page.vue
@@ -5,13 +5,11 @@
       <section class="flex flex-col items-start gap-3 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:pencil" class="size-5 text-primary" />
-          <h3
-            class="text-sm font-black uppercase tracking-wide text-base-content/70"
-          >
+          <h3 class="kr-text-dim-sm-70 font-black uppercase tracking-wide">
             Try today's assignment
           </h3>
         </div>
-        <p class="text-sm text-base-content/70">
+        <p class="kr-text-dim-sm-70">
           Sketchy hands you a tier-appropriate drawing prompt, then critiques
           the result on five dimensions and picks your next study. Preview a
           sample from each skill tier below.

--- a/components/conductor/voice-lab-page.vue
+++ b/components/conductor/voice-lab-page.vue
@@ -7,7 +7,7 @@
           <div class="flex items-center gap-2">
             <Icon name="kind-icon:server" class="size-5 text-primary" />
             <h3
-              class="text-sm font-black uppercase tracking-wide text-base-content/70"
+              class="kr-text-dim-sm-70 font-black uppercase tracking-wide"
             >
               Relay status
             </h3>
@@ -22,7 +22,7 @@
             {{ voice.connected ? 'Relay connected' : 'Relay offline' }}
           </span>
         </div>
-        <p class="text-sm text-base-content/70">
+        <p class="kr-text-dim-sm-70">
           The Serendipity voice runtime
           (<code>silasfelinus/serendipity-voice</code>) bridges an Alexa skill
           to Kind Robots through a local relay. Run
@@ -84,7 +84,7 @@
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:book" class="size-5 text-primary" />
           <h3
-            class="text-sm font-black uppercase tracking-wide text-base-content/70"
+            class="kr-text-dim-sm-70 font-black uppercase tracking-wide"
           >
             What you can say
           </h3>

--- a/components/dreams/dream-list.vue
+++ b/components/dreams/dream-list.vue
@@ -161,9 +161,7 @@
             <p v-if="entry.meta" class="mt-1 text-xs text-base-content/50">
               {{ entry.meta }}
             </p>
-            <p
-              class="mt-2 line-clamp-3 whitespace-pre-wrap text-sm text-base-content/70"
-            >
+            <p class="kr-text-dim-sm-70 mt-2 line-clamp-3 whitespace-pre-wrap">
               {{ entry.body }}
             </p>
           </div>

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -340,7 +340,7 @@
                   </p>
                 </div>
               </div>
-              <p class="mt-3 whitespace-pre-wrap text-sm text-base-content/70">
+              <p class="kr-text-dim-sm-70 mt-3 whitespace-pre-wrap">
                 {{
                   dreamStore.dreamForm.pitch ||
                   dreamStore.dreamForm.description ||

--- a/components/dreams/dream-sheet-toolbar.vue
+++ b/components/dreams/dream-sheet-toolbar.vue
@@ -8,7 +8,7 @@
           PitchSheets
         </p>
 
-        <p class="mt-1 text-sm text-base-content/70">
+        <p class="kr-text-dim-sm-70 mt-1">
           {{ statusText }}
         </p>
       </div>

--- a/components/facets/facet-manager.vue
+++ b/components/facets/facet-manager.vue
@@ -51,7 +51,7 @@
         :open="createOpen"
       >
         <summary
-          class="cursor-pointer px-4 py-3 text-sm font-bold text-base-content/70"
+          class="kr-text-dim-sm-70 cursor-pointer px-4 py-3 font-bold"
           @click.prevent="createOpen = !createOpen"
         >
           + Create a canonical Facet

--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -257,7 +257,7 @@
     </div>
 
     <div v-if="showDescription && !compact" class="px-0.5 pt-2.5">
-      <p class="line-clamp-3 text-sm leading-relaxed text-base-content/70">
+      <p class="kr-text-dim-sm-70 line-clamp-3 leading-relaxed">
         {{ description || descriptionFallback }}
       </p>
     </div>

--- a/components/giftshop/giftshop-interact.vue
+++ b/components/giftshop/giftshop-interact.vue
@@ -48,7 +48,7 @@
               {{ feature.title }}
             </h4>
 
-            <p class="mt-1 text-sm leading-relaxed text-base-content/70">
+            <p class="kr-text-dim-sm-70 mt-1 leading-relaxed">
               {{ feature.text }}
             </p>
           </article>
@@ -114,7 +114,7 @@
               />
 
               <div class="space-y-2 p-4">
-                <p class="line-clamp-2 text-sm text-base-content/70">
+                <p class="kr-text-dim-sm-70 line-clamp-2">
                   {{ art.promptString || 'Featured print' }}
                 </p>
 
@@ -143,7 +143,7 @@
                   {{ item.title }}
                 </h4>
 
-                <p class="text-sm text-base-content/70">
+                <p class="kr-text-dim-sm-70">
                   {{ item.text }}
                 </p>
               </div>
@@ -169,7 +169,7 @@
         <div>
           <h3 class="text-xl font-black text-primary">Cart Nest</h3>
 
-          <p class="text-sm text-base-content/70">
+          <p class="kr-text-dim-sm-70">
             Guarded by three butterflies and one emotionally available receipt
             printer.
           </p>

--- a/components/giftshop/giftshop-manager.vue
+++ b/components/giftshop/giftshop-manager.vue
@@ -89,7 +89,7 @@
                 Giftshop Forum
               </h2>
 
-              <p class="text-sm leading-relaxed text-base-content/70">
+              <p class="kr-text-dim-sm-70 leading-relaxed">
                 The butterflies are drafting community guidelines in glitter
                 ink. This tab is wired to the dashboard canon and ready for the
                 real forum component when it lands.

--- a/components/giftshop/mana-wallet.vue
+++ b/components/giftshop/mana-wallet.vue
@@ -95,7 +95,7 @@
       </div>
 
       <!-- BYO hint -->
-      <div class="rounded-xl bg-base-200 p-4 text-sm text-base-content/70">
+      <div class="kr-text-dim-sm-70 rounded-xl bg-base-200 p-4">
         💡 Using your own API key or local server? Those generations are free —
         and sharing what you make can earn you bonus mana.
       </div>

--- a/components/narrative/kr-choice-list.vue
+++ b/components/narrative/kr-choice-list.vue
@@ -27,7 +27,7 @@
     role="group"
     :aria-label="label"
   >
-    <p v-if="heading" class="w-full text-sm font-bold text-base-content/70">
+    <p v-if="heading" class="kr-text-dim-sm-70 w-full font-bold">
       {{ heading }}
     </p>
 

--- a/components/navigation/karma-widget.vue
+++ b/components/navigation/karma-widget.vue
@@ -16,7 +16,7 @@
         class="absolute right-0 z-50 mt-2 w-72 space-y-3 rounded-2xl border border-base-content/10 bg-base-100 p-4 shadow-xl"
       >
         <div class="flex items-baseline justify-between">
-          <span class="text-sm font-medium text-base-content/70">
+          <span class="kr-text-dim-sm-70 font-medium">
             {{ userStore.username }}'s Karma
           </span>
           <span class="text-2xl font-extrabold tabular-nums text-primary">

--- a/components/navigation/mana-widget.vue
+++ b/components/navigation/mana-widget.vue
@@ -19,7 +19,7 @@
         class="absolute right-0 z-50 mt-2 w-72 space-y-3 rounded-2xl border border-base-content/10 bg-base-100 p-4 shadow-xl"
       >
         <div class="flex items-baseline justify-between">
-          <span class="text-sm font-medium text-base-content/70">
+          <span class="kr-text-dim-sm-70 font-medium">
             {{ userStore.username }}'s Mana
           </span>
           <span class="text-2xl font-extrabold tabular-nums text-primary">

--- a/components/navigation/tutorial-flyer.vue
+++ b/components/navigation/tutorial-flyer.vue
@@ -63,7 +63,7 @@
         </div>
 
         <p
-          class="text-sm font-medium leading-relaxed text-base-content/70 md:text-base"
+          class="kr-text-dim-sm-70 font-medium leading-relaxed md:text-base"
         >
           {{ section.body }}
         </p>
@@ -222,7 +222,7 @@
                   </div>
 
                   <p
-                    class="mt-1.5 text-sm font-medium leading-relaxed text-base-content/70"
+                    class="kr-text-dim-sm-70 mt-1.5 font-medium leading-relaxed"
                   >
                     {{ section.body }}
                   </p>

--- a/components/navigation/workspace-sheet.vue
+++ b/components/navigation/workspace-sheet.vue
@@ -72,7 +72,7 @@
         <span class="flex items-center gap-2">
           <Icon name="kind-icon:info" class="h-5 w-5 text-primary" />
           <span
-            class="text-sm font-black uppercase tracking-widest text-base-content/70"
+            class="kr-text-dim-sm-70 font-black uppercase tracking-widest"
           >
             {{ showTutorial ? 'Hide tutorial' : 'Show tutorial' }}
           </span>
@@ -254,7 +254,7 @@
 
                   <div
                     v-if="isFieldOpen(card.key, field.key)"
-                    class="mt-3 rounded-2xl border border-base-300/60 bg-base-100/90 p-3 text-sm font-semibold leading-relaxed text-base-content/70 shadow-sm backdrop-blur"
+                    class="kr-text-dim-sm-70 mt-3 rounded-2xl border border-base-300/60 bg-base-100/90 p-3 font-semibold leading-relaxed shadow-sm backdrop-blur"
                   >
                     {{ fieldDetails(field) }}
                   </div>

--- a/components/pages/about-page.vue
+++ b/components/pages/about-page.vue
@@ -31,7 +31,7 @@
               {{ card.title }}
             </h2>
           </div>
-          <p class="text-sm leading-relaxed text-base-content/70">
+          <p class="kr-text-dim-sm-70 leading-relaxed">
             {{ card.content }}
           </p>
         </div>
@@ -49,7 +49,7 @@
           </h2>
         </div>
 
-        <p class="text-sm leading-relaxed text-base-content/70">
+        <p class="kr-text-dim-sm-70 leading-relaxed">
           Kind Robots grew alongside creative people and projects that share its
           optimistic, community-minded spirit. Our anti-malaria work points
           donations directly to the Against Malaria Foundation, while our

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -363,7 +363,7 @@
 
                 <p
                   v-if="pitch.idea"
-                  class="mt-3 line-clamp-5 text-sm leading-relaxed text-base-content/70"
+                  class="kr-text-dim-sm-70 mt-3 line-clamp-5 leading-relaxed"
                 >
                   {{ pitch.idea }}
                 </p>

--- a/components/pages/giving-page.vue
+++ b/components/pages/giving-page.vue
@@ -42,7 +42,7 @@
 
         <h2 class="mt-2 text-lg font-black text-base-content">Why AMF?</h2>
 
-        <p class="mt-1 text-sm leading-relaxed text-base-content/70">
+        <p class="kr-text-dim-sm-70 mt-1 leading-relaxed">
           {{ trivia }}
         </p>
       </div>
@@ -54,7 +54,7 @@
           Prefer It On Your Receipt?
         </h2>
 
-        <p class="mt-1 text-sm leading-relaxed text-base-content/70">
+        <p class="kr-text-dim-sm-70 mt-1 leading-relaxed">
           You can add a $1 AMF-designated donation to a Kind Robots purchase.
           Stripe collects it with the rest of the cart, and Kind Robots records
           it separately for AMF remittance. Use the direct link above when you
@@ -101,7 +101,7 @@
         <h2 class="mt-2 text-2xl font-black text-base-content">
           Support Kind Robots Monthly
         </h2>
-        <p class="mx-auto mt-2 max-w-2xl text-sm text-base-content/70">
+        <p class="kr-text-dim-sm-70 mx-auto mt-2 max-w-2xl">
           Monthly plans support Kind Robots itself: servers, art, stories, and
           continued development. This is separate from donations to AMF.
         </p>

--- a/components/pages/mermaids-page.vue
+++ b/components/pages/mermaids-page.vue
@@ -113,7 +113,7 @@
             aria-label="Book description"
             class="textarea textarea-bordered min-h-36 w-full text-sm leading-relaxed"
           />
-          <p v-else class="whitespace-pre-line text-sm leading-relaxed text-base-content/70">
+          <p v-else class="kr-text-dim-sm-70 whitespace-pre-line leading-relaxed">
             {{ draft.bookDescription }}
           </p>
 
@@ -179,7 +179,7 @@
           class="textarea textarea-bordered min-h-64 w-full text-sm leading-relaxed"
           placeholder="Write your note here."
         />
-        <p v-else class="whitespace-pre-line text-sm leading-relaxed text-base-content/70">
+        <p v-else class="kr-text-dim-sm-70 whitespace-pre-line leading-relaxed">
           {{ draft.personalNote }}
         </p>
       </section>
@@ -211,7 +211,7 @@
           aria-label="AI disclosure"
           class="textarea textarea-bordered min-h-56 w-full text-sm leading-relaxed"
         />
-        <p v-else class="whitespace-pre-line text-sm leading-relaxed text-base-content/70">
+        <p v-else class="kr-text-dim-sm-70 whitespace-pre-line leading-relaxed">
           {{ draft.aiNote }}
         </p>
       </section>

--- a/components/pages/portos-page.vue
+++ b/components/pages/portos-page.vue
@@ -8,7 +8,7 @@
         <div class="min-w-0 flex-1">
           <p class="text-xs font-bold uppercase tracking-wide text-accent/70">Portos</p>
           <h2 class="text-2xl font-black leading-tight">Portos Server Setup</h2>
-          <p class="mt-1 text-sm leading-relaxed text-base-content/70">
+          <p class="kr-text-dim-sm-70 mt-1 leading-relaxed">
             This tab is reserved for connecting a Porto server address and saving the user/server pairing cleanly once the server entry flow is wired in.
           </p>
         </div>
@@ -17,13 +17,13 @@
       <div class="grid gap-3 md:grid-cols-2">
         <article class="kr-panel-muted-md">
           <h3 class="font-bold">Planned flow</h3>
-          <p class="mt-2 text-sm leading-relaxed text-base-content/70">
+          <p class="kr-text-dim-sm-70 mt-2 leading-relaxed">
             Let the user add a Porto server address, validate that the endpoint responds, then save the server metadata through the normal server records instead of hiding it in component state.
           </p>
         </article>
         <article class="kr-panel-muted-md">
           <h3 class="font-bold">Not built yet</h3>
-          <p class="mt-2 text-sm leading-relaxed text-base-content/70">
+          <p class="kr-text-dim-sm-70 mt-2 leading-relaxed">
             The UI here is intentionally a placeholder so the Conductor tab split can land without inventing the Porto persistence contract too early. Tiny robot bureaucracy, but make it safe.
           </p>
         </article>

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -48,7 +48,7 @@
               Turn the next real thing into a quest
             </h2>
             <p
-              class="mt-3 max-w-lg text-sm font-semibold leading-relaxed text-base-content/70 sm:text-base"
+              class="kr-text-dim-sm-70 mt-3 max-w-lg font-semibold leading-relaxed sm:text-base"
             >
               Name what matters. Shape the adventure. Review the practical plan
               before the story begins.

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -6,7 +6,7 @@
         {{ heading }}
       </h1>
 
-      <p class="mt-2 text-sm text-base-content/70">
+      <p class="kr-text-dim-sm-70 mt-2">
         {{ subtitle }}
       </p>
     </header>
@@ -150,7 +150,7 @@
       <section class="kr-panel-flat p-4">
         <div class="mb-4">
           <h2 class="text-xl font-bold text-base-content">Publishing</h2>
-          <p class="text-sm text-base-content/70">
+          <p class="kr-text-dim-sm-70">
             Control who can discover this reward and whether mature-content filtering applies.
           </p>
         </div>
@@ -183,7 +183,7 @@
           <div>
             <h2 class="text-xl font-bold text-base-content">Reward Essence</h2>
 
-            <p class="text-sm text-base-content/70">
+            <p class="kr-text-dim-sm-70">
               Use reusable choices to shape what kind of story prompt this
               reward becomes.
             </p>
@@ -205,7 +205,7 @@
           <div>
             <h2 class="text-xl font-bold text-base-content">Reward Art</h2>
 
-            <p class="text-sm text-base-content/70">
+            <p class="kr-text-dim-sm-70">
               Upload, generate, or attach an image for the reward.
             </p>
           </div>

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -17,7 +17,7 @@
             v-if="rewardStore.selectedReward"
             class="flex min-w-0 items-center gap-2"
           >
-            <p class="truncate text-sm text-base-content/70">
+            <p class="kr-text-dim-sm-70 truncate">
               Selected:
               <span class="font-semibold text-primary">
                 {{ selectedRewardTitle }}

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -6,7 +6,7 @@
         {{ heading }}
       </h1>
 
-      <p class="mt-2 text-sm text-base-content/70">
+      <p class="kr-text-dim-sm-70 mt-2">
         {{ subtitle }}
       </p>
     </header>
@@ -116,7 +116,7 @@
       <section class="kr-panel-flat p-4">
         <div class="mb-4">
           <h2 class="text-xl font-bold text-base-content">Publishing</h2>
-          <p class="text-sm text-base-content/70">
+          <p class="kr-text-dim-sm-70">
             Control who can discover this scenario and whether mature-content
             filtering applies.
           </p>
@@ -148,7 +148,7 @@
           <div>
             <h2 class="text-xl font-bold text-base-content">Opening Choices</h2>
 
-            <p class="text-sm text-base-content/70">
+            <p class="kr-text-dim-sm-70">
               These become the starting choices players can click when the
               scenario begins.
             </p>
@@ -209,7 +209,7 @@
           <div>
             <h2 class="text-xl font-bold text-base-content">Scenario Art</h2>
 
-            <p class="text-sm text-base-content/70">
+            <p class="kr-text-dim-sm-70">
               Upload, randomize, or generate a visual anchor.
             </p>
           </div>

--- a/components/scenarios/scenario-relationship-gallery.vue
+++ b/components/scenarios/scenario-relationship-gallery.vue
@@ -93,7 +93,7 @@
       >
         <div class="kr-panel-flat p-3">
           <h3 class="font-black text-warning">Choose a Dream first</h3>
-          <p class="mt-1 text-sm text-base-content/70">
+          <p class="kr-text-dim-sm-70 mt-1">
             This Scenario view needs a Dream anchor before it can show useful
             relationships.
           </p>

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -291,7 +291,7 @@
             <div class="kr-panel-muted-sm">
               <button
                 type="button"
-                class="flex items-center gap-2 text-sm font-semibold text-base-content/70 hover:text-base-content"
+                class="kr-text-dim-sm-70 flex items-center gap-2 font-semibold hover:text-base-content"
                 @click="showPerformerGallery = !showPerformerGallery"
               >
                 <Icon

--- a/components/user/account-settings.vue
+++ b/components/user/account-settings.vue
@@ -8,7 +8,7 @@
   <section class="kr-container max-w-3xl flex flex-col gap-6 p-4 sm:p-6">
     <header class="flex flex-col gap-1">
       <h1 class="text-2xl font-black">Account &amp; Privacy</h1>
-      <p class="text-sm text-base-content/70">
+      <p class="kr-text-dim-sm-70">
         You're in control. Change what you share, who can reach you, and what
         lands in your inbox.
       </p>
@@ -34,7 +34,7 @@
       <!-- ── Security ─────────────────────────────────────────────── -->
       <div class="kr-panel-flat p-5">
         <h2 class="mb-1 text-lg font-black">Security</h2>
-        <p class="mb-4 text-sm text-base-content/70">
+        <p class="kr-text-dim-sm-70 mb-4">
           Update your password and verify your email address.
         </p>
 
@@ -79,9 +79,7 @@
           @submit.prevent="onChangePassword"
         >
           <label v-if="hasPassword" class="flex flex-col gap-1 sm:col-span-2">
-            <span class="text-sm font-bold text-base-content/70"
-              >Current password</span
-            >
+            <span class="kr-text-dim-sm-70 font-bold">Current password</span>
             <input
               v-model="pw.current"
               type="password"
@@ -90,9 +88,7 @@
             />
           </label>
           <label class="flex flex-col gap-1">
-            <span class="text-sm font-bold text-base-content/70"
-              >New password</span
-            >
+            <span class="kr-text-dim-sm-70 font-bold">New password</span>
             <input
               v-model="pw.next"
               type="password"
@@ -101,7 +97,7 @@
             />
           </label>
           <label class="flex flex-col gap-1">
-            <span class="text-sm font-bold text-base-content/70"
+            <span class="kr-text-dim-sm-70 font-bold"
               >Confirm new password</span
             >
             <input
@@ -134,7 +130,7 @@
       <!-- ── Privacy & Consent ────────────────────────────────────── -->
       <div class="kr-panel-flat p-5">
         <h2 class="mb-1 text-lg font-black">Privacy &amp; Consent</h2>
-        <p class="mb-4 text-sm text-base-content/70">
+        <p class="kr-text-dim-sm-70 mb-4">
           Consent is the default here. Choose what you see and what others can
           do.
         </p>
@@ -239,7 +235,7 @@
       <!-- ── Newsletter ───────────────────────────────────────────── -->
       <div class="kr-panel-flat p-5">
         <h2 class="mb-1 text-lg font-black">Updates &amp; Promotions</h2>
-        <p class="mb-4 text-sm text-base-content/70">
+        <p class="kr-text-dim-sm-70 mb-4">
           Can we email you updates? Pick a rhythm — we only send what you ask
           for, and we'll email you once to confirm.
         </p>

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -10,7 +10,7 @@
             Message Timeline
           </p>
           <h2 class="text-2xl font-black text-base-content">Chats</h2>
-          <p class="text-sm text-base-content/70">
+          <p class="kr-text-dim-sm-70">
             Human, system, welcome, bot, and beautifully suspicious robot
             conversations.
           </p>
@@ -144,7 +144,7 @@
                 </div>
               </div>
 
-              <p class="mt-2 line-clamp-2 text-sm text-base-content/70">
+              <p class="kr-text-dim-sm-70 mt-2 line-clamp-2">
                 <span class="font-semibold">
                   {{ previewPrefix(thread.latest) }}
                 </span>

--- a/components/user/friends-panel.vue
+++ b/components/user/friends-panel.vue
@@ -8,7 +8,7 @@
   <section class="kr-container max-w-3xl flex flex-col gap-6 p-4">
     <header>
       <h1 class="text-2xl font-black">Friends</h1>
-      <p class="text-sm text-base-content/70">
+      <p class="kr-text-dim-sm-70">
         Connect with people, manage requests, and control who can reach you.
       </p>
     </header>

--- a/components/user/login-page.vue
+++ b/components/user/login-page.vue
@@ -61,7 +61,7 @@
             Welcome back, friend 💜
           </p>
 
-          <p class="mt-1 text-sm font-medium text-base-content/70 sm:text-base">
+          <p class="kr-text-dim-sm-70 mt-1 font-medium sm:text-base">
             Sign in and let the tiny robots resume being suspiciously helpful.
           </p>
         </div>
@@ -160,7 +160,7 @@
           </button>
 
           <div
-            class="flex flex-col items-center justify-center gap-2 text-sm font-semibold text-base-content/70 sm:flex-row"
+            class="kr-text-dim-sm-70 flex flex-col items-center justify-center gap-2 font-semibold sm:flex-row"
           >
             <span>New here?</span>
             <NuxtLink
@@ -182,7 +182,7 @@
             You are already signed in.
           </p>
 
-          <p class="text-sm font-semibold text-base-content/70">
+          <p class="kr-text-dim-sm-70 font-semibold">
             The gate robot recognizes you. Slightly alarming, but convenient.
           </p>
 

--- a/components/user/password-reset.vue
+++ b/components/user/password-reset.vue
@@ -10,7 +10,7 @@
       <h1 class="text-2xl font-black">
         {{ hasToken ? 'Choose a new password' : 'Reset your password' }}
       </h1>
-      <p class="text-sm text-base-content/70">
+      <p class="kr-text-dim-sm-70">
         {{
           hasToken
             ? 'Pick a new password for your account.'
@@ -26,7 +26,7 @@
       @submit.prevent="onRequest"
     >
       <label class="flex flex-col gap-1">
-        <span class="text-sm font-bold text-base-content/70">Email</span>
+        <span class="kr-text-dim-sm-70 font-bold">Email</span>
         <input
           v-model="email"
           type="email"
@@ -51,7 +51,7 @@
       @submit.prevent="onReset"
     >
       <label class="flex flex-col gap-1">
-        <span class="text-sm font-bold text-base-content/70">New password</span>
+        <span class="kr-text-dim-sm-70 font-bold">New password</span>
         <input
           v-model="next"
           type="password"
@@ -60,9 +60,7 @@
         />
       </label>
       <label class="flex flex-col gap-1">
-        <span class="text-sm font-bold text-base-content/70"
-          >Confirm password</span
-        >
+        <span class="kr-text-dim-sm-70 font-bold">Confirm password</span>
         <input
           v-model="confirm"
           type="password"

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -253,7 +253,7 @@
                     <span class="text-sm font-black">Theme</span>
                   </div>
 
-                  <p class="truncate text-sm text-base-content/70">
+                  <p class="kr-text-dim-sm-70 truncate">
                     {{ themeStore.currentTheme }}
                   </p>
 

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -13,7 +13,7 @@
     >
       <div>
         <h1 class="text-2xl font-black">User Admin</h1>
-        <p class="text-sm text-base-content/70">
+        <p class="kr-text-dim-sm-70">
           {{ store.roster.length }} users · manage roles, maturity, access, and
           logins.
         </p>
@@ -221,7 +221,7 @@
     <dialog ref="passwordDialog" class="modal">
       <div class="modal-box rounded-2xl">
         <h3 class="mb-1 text-lg font-black">Reset password</h3>
-        <p class="mb-3 text-sm text-base-content/70">
+        <p class="kr-text-dim-sm-70 mb-3">
           Set a new password for <strong>{{ pwTarget?.username }}</strong
           >.
         </p>

--- a/components/user/user-panel.vue
+++ b/components/user/user-panel.vue
@@ -53,7 +53,7 @@
           class="flex min-w-0 flex-col gap-1"
           :class="{ 'md:col-span-2': field.type === 'textarea' }"
         >
-          <span class="text-sm font-bold text-base-content/70">
+          <span class="kr-text-dim-sm-70 font-bold">
             {{ field.label }}
           </span>
 

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -47,7 +47,7 @@
       <!-- Most active month (BROWSE-UX.md §1) -->
       <p
         v-if="mostActiveMonth"
-        class="kr-panel-flat px-4 py-2 text-center text-sm font-semibold text-base-content/70"
+        class="kr-text-dim-sm-70 kr-panel-flat px-4 py-2 text-center font-semibold"
       >
         You consumed the most in {{ mostActiveMonth.label }}:
         {{ mostActiveMonth.count }} entries

--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -33,7 +33,7 @@
       </div>
     </div>
 
-    <dl class="grid grid-cols-2 gap-x-4 gap-y-1 text-sm text-base-content/70">
+    <dl class="kr-text-dim-sm-70 grid grid-cols-2 gap-x-4 gap-y-1">
       <div>
         <dt class="text-xs font-semibold uppercase text-base-content/45">
           Consumed

--- a/components/wonderlab/reaction-card.vue
+++ b/components/wonderlab/reaction-card.vue
@@ -37,7 +37,7 @@
         <div
           class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >
-          <label class="text-sm font-bold text-base-content/70"> Rate </label>
+          <label class="kr-text-dim-sm-70 font-bold"> Rate </label>
 
           <button
             v-if="rating"

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -32,7 +32,7 @@
 
       <p class="text-base font-bold text-error">Content query failed</p>
 
-      <p class="max-w-xl text-sm text-base-content/70">
+      <p class="kr-text-dim-sm-70 max-w-xl">
         Nuxt Content could not load {{ contentPath }}.
       </p>
     </div>

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -255,7 +255,7 @@
                     {{ entityTitle(submission.Character, 'Unnamed character') }}
                   </h3>
                   <p
-                    class="mt-3 whitespace-pre-line text-sm leading-relaxed text-base-content/70"
+                    class="kr-text-dim-sm-70 mt-3 whitespace-pre-line leading-relaxed"
                   >
                     {{ entityDescription(submission.Character) }}
                   </p>
@@ -274,7 +274,7 @@
                     {{ entityTitle(submission.Scenario, 'Untitled scenario') }}
                   </h3>
                   <p
-                    class="mt-3 whitespace-pre-line text-sm leading-relaxed text-base-content/70"
+                    class="kr-text-dim-sm-70 mt-3 whitespace-pre-line leading-relaxed"
                   >
                     {{ entityDescription(submission.Scenario) }}
                   </p>

--- a/pages/users/[id].vue
+++ b/pages/users/[id].vue
@@ -57,7 +57,7 @@
           </div>
 
           <p
-            class="mt-5 rounded-2xl bg-base-200/70 p-4 text-sm leading-relaxed text-base-content/70"
+            class="kr-text-dim-sm-70 mt-5 rounded-2xl bg-base-200/70 p-4 leading-relaxed"
           >
             This member has chosen to make their Kind Robots profile public.
           </p>

--- a/utils/scripts/codemods/kr_text_dim_sm_70_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_sm_70_codemod.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `text-sm text-base-content/70` secondary
+caption text to `kr-text-dim-sm-70`.
+
+Sibling of kr_text_dim_sm_codemod.py / kr_text_dim_xs_codemod.py, same
+conventions: dry-run by default, --write to update matching Vue files in
+place. Only the exact `text-sm text-base-content/70` shape is touched, and
+only in static `class="..."` attributes -- never `:class`/`v-bind:class`
+bindings, and regardless of the base tokens' order in the source. A source
+that already carries `kr-text-dim-sm-70`, or is missing either base token, is
+left untouched. Extra tokens beyond the base set are preserved verbatim after
+the primitive class, matching the kr-badge-*/kr-spinner-*/kr-label-bold/
+kr-text-dim-sm/kr-text-dim-xs codemods' subset-match convention -- pass
+--exact-only to restrict a slice to sources with no extra tokens at all, the
+safest and most literal pool.
+
+This deliberately does NOT touch the other opacity/size variants surveyed
+alongside this one in interface-vision t-104 slices 152-154 (`text-xs
+text-base-content/45`, `text-xs text-base-content/55`, etc.) -- each is its
+own bounded family for a future slice, not folded in here just because the
+grep that found them overlaps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-dim-sm-70"
+BASE_TOKENS = {"text-sm", "text-base-content/70"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-dim-sm-70 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, slice 155)

### What changed / what I produced
- Added `.kr-text-dim-sm-70` (`text-sm text-base-content/70`) to `assets/css/tailwind.css`, the lighter-dim sibling of `.kr-text-dim-sm` (60% opacity) for descriptive paragraph/body-copy text.
- Added `utils/scripts/codemods/kr_text_dim_sm_70_codemod.py`, sibling of `kr_text_dim_sm_codemod.py` / `kr_text_dim_xs_codemod.py` (dry-run by default, `--write` to migrate, `--exact-only` to restrict to sources with no extra tokens).
- Migrated all 118 subset-match occurrences across 63 files — extra utility tokens (`leading-relaxed`, `line-clamp-*`, `font-*`, `mt-*`, etc.) preserved verbatim after the primitive class, matching the established `kr-badge-*`/`kr-spinner-*`/`kr-text-dim-*` subset-match convention. No geometry or behavior change.
- Fixed a scoped prettier collapse in 11 files where the shortened class string let a multi-line tag fit prettier's print width on one line (same recurring pattern as slices 153/154).

### How I verified
- `vue-tsc --noEmit` clean
- `npm run test:lint-ratchet` holds at 333/-59 (no new errors)
- `npm run test:layout-contract` holds (0 new violations; an unrelated pre-existing 2-entry `viewport-grid` baseline improvement was noticed and left alone, not this slice's to claim)
- `npx prettier --check` clean on all touched files — confirmed via `git stash` that the 29 other flagged files already carried pre-existing prettier debt unrelated to this change, and left those untouched (scope discipline)
- `verifyDaVinciNarrationErrorRoleGuard.ts` / `verifyDaVinciNarrationErrorToneGuard.ts` both pass against the real file — their `.test.ts` fixtures reference the same literal class string as unrelated synthetic test data, confirmed unaffected by this migration

### Stakes
reversible

### Kaizen suggestion
Next slice target: `text-xs text-base-content/45` (the sibling candidate surveyed alongside this one in slices 152-154, ~83 subset-match occurrences across 35 files).

### Notes for reviewer
Recurring consistency umbrella (interface-vision/t-104) — conductor task set to `status: review`, will re-arm to `ready` after merge for the next bounded slice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T69YFie73Wwg1QJCzpeXcF)_