### PR TITLE
refactor(ui): migrate text-xs text-base-content/45 to kr-text-dim-xs-45

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1677,6 +1677,24 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply text-sm text-base-content/70;
   }
 
+  /* A more-dimmed metadata line at caption size -- `text-xs
+   * text-base-content/45`, one step quieter than `.kr-text-dim-xs`'s 50%
+   * opacity, used for the least-emphasized annotation on a card or list row
+   * (timestamps, counts, secondary metadata beside a primary label)
+   * (interface-vision t-104 slice 156) -- previously hand-rolled in 35 files
+   * (83 occurrences, subset-match including extra tokens like `flex
+   * items-center gap-*`, `mt-*`, `truncate`), the sibling candidate surveyed
+   * alongside `text-sm text-base-content/70` in slice 152's original
+   * frequency pass and named as slice 154/155's own follow-up target. Named
+   * `kr-text-dim-xs-45` rather than reusing `kr-text-dim-xs` because that
+   * name is already claimed by the 50%-opacity shape shipped in slice 154 --
+   * both are real, independently-repeated exact shapes in the wild, not one
+   * "should normalize to" the other, same reasoning as
+   * `kr-text-dim-sm-70`/`kr-text-dim-sm`. */
+  .kr-text-dim-xs-45 {
+    @apply text-xs text-base-content/45;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -222,7 +222,7 @@
               </p>
               <h4 class="mt-2 text-xl font-black text-base-content">People behind the movement</h4>
             </div>
-            <span class="text-xs text-base-content/45">
+            <span class="kr-text-dim-xs-45">
               {{ lesson.artists.length }} featured {{ lesson.artists.length === 1 ? 'artist' : 'artists' }}
             </span>
           </div>
@@ -287,7 +287,7 @@
 
           <div class="flex flex-col gap-4 p-5">
             <div>
-              <p class="text-xs font-black uppercase tracking-wide text-base-content/45">Remix instruction</p>
+              <p class="kr-text-dim-xs-45 font-black uppercase tracking-wide">Remix instruction</p>
               <p class="mt-1 text-sm leading-relaxed text-base-content/80">
                 {{ lesson.remix.template }}
               </p>
@@ -326,7 +326,7 @@
         </section>
 
         <section class="kr-panel-section">
-          <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-base-content/45">
+          <p class="kr-text-dim-xs-45 flex items-center gap-1.5 font-black uppercase tracking-[0.16em]">
             <Icon name="kind-icon:chat" class="h-4 w-4" />
             Reflect
           </p>

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -62,14 +62,14 @@
 
     <div class="flex flex-wrap items-end justify-between gap-3 px-1">
       <div>
-        <p class="text-xs font-black uppercase tracking-[0.16em] text-base-content/45">
+        <p class="kr-text-dim-xs-45 font-black uppercase tracking-[0.16em]">
           Chronological gallery
         </p>
         <p class="mt-1 text-sm text-base-content/65">
           Each image opens into a lesson, gallery wall, and remix path.
         </p>
       </div>
-      <p class="text-xs font-semibold text-base-content/45">Earliest → latest</p>
+      <p class="kr-text-dim-xs-45 font-semibold">Earliest → latest</p>
     </div>
 
     <ol

--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -138,7 +138,7 @@
             </button>
           </div>
         </template>
-        <p v-if="!hasResults" class="px-3 py-3 text-xs text-base-content/45">
+        <p v-if="!hasResults" class="kr-text-dim-xs-45 px-3 py-3">
           {{
             search.trim()
               ? 'No matching canonical Facet.'

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -348,7 +348,7 @@
             />
             <span>
               <span class="block text-sm font-semibold">Keep as inspiration</span>
-              <span class="block text-xs text-base-content/45">
+              <span class="kr-text-dim-xs-45 block">
                 Save the current version in this {{ entityLabel }} artwork history.
               </span>
             </span>
@@ -363,7 +363,7 @@
             />
             <span>
               <span class="block text-sm font-semibold">Do not retain it</span>
-              <span class="block text-xs text-base-content/45">
+              <span class="kr-text-dim-xs-45 block">
                 Replace the entity reference without adding the old version to history.
               </span>
             </span>
@@ -453,7 +453,7 @@
             />
             <span>
               <span class="block text-sm font-semibold">Keep as inspiration</span>
-              <span class="block text-xs text-base-content/45">Retain the previous version in artwork history.</span>
+              <span class="kr-text-dim-xs-45 block">Retain the previous version in artwork history.</span>
             </span>
           </label>
           <label class="flex cursor-pointer items-start gap-2 rounded-lg px-2 py-1.5 hover:bg-base-100/60">
@@ -466,7 +466,7 @@
             />
             <span>
               <span class="block text-sm font-semibold">Do not retain it</span>
-              <span class="block text-xs text-base-content/45">Replace the entity reference without adding history.</span>
+              <span class="kr-text-dim-xs-45 block">Replace the entity reference without adding history.</span>
             </span>
           </label>
         </div>

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -243,7 +243,7 @@
               class="range range-primary range-sm"
             />
 
-            <div class="mt-1 flex justify-between text-xs text-base-content/45">
+            <div class="kr-text-dim-xs-45 mt-1 flex justify-between">
               <span>precise</span>
               <span>balanced</span>
               <span>wild</span>

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -35,7 +35,7 @@
           </p>
           <p
             v-if="persona?.tagline"
-            class="mt-1 text-xs italic text-base-content/45"
+            class="kr-text-dim-xs-45 mt-1 italic"
             data-testid="brainstorm-persona-tagline"
           >
             {{ persona.tagline }}
@@ -128,7 +128,7 @@
           <p class="text-xs font-black uppercase tracking-[0.12em] text-base-content/55">
             Push the batch
           </p>
-          <p class="text-xs text-base-content/45">Creative moves, not model knobs.</p>
+          <p class="kr-text-dim-xs-45">Creative moves, not model knobs.</p>
         </div>
         <div class="mt-2 flex flex-wrap gap-2" role="group" aria-label="Creative direction">
           <button
@@ -240,7 +240,7 @@
                 :disabled="isGenerating"
                 @input="updateReturnTypeCount(option.id, $event)"
               />
-              <span class="text-xs text-base-content/45">
+              <span class="kr-text-dim-xs-45">
                 {{ returnTypeCount(option.id) ? 'pinned' : 'Auto' }}
               </span>
             </div>
@@ -249,7 +249,7 @@
 
         <p
           v-if="batchShape === 'assortment' && returnTypes.length"
-          class="mt-3 text-xs leading-5 text-base-content/45"
+          class="kr-text-dim-xs-45 mt-3 leading-5"
         >
           Pinned quotas plus one slot for each Auto lens require at least {{ minimumMixResults }} ideas. Extra slots stay flexible.
         </p>
@@ -404,7 +404,7 @@
         </ul>
         <p
           v-else-if="!isSearchingSource && sourceQuery"
-          class="mt-3 text-xs text-base-content/45"
+          class="kr-text-dim-xs-45 mt-3"
         >
           No {{ sourceModelType }} matched "{{ sourceQuery }}".
         </p>
@@ -469,7 +469,7 @@
               </button>
             </div>
 
-            <p v-if="lastSavedAt" class="mt-2 text-xs text-base-content/45">
+            <p v-if="lastSavedAt" class="kr-text-dim-xs-45 mt-2">
               Last saved {{ formatSavedTime(lastSavedAt) }}.
             </p>
           </div>
@@ -492,7 +492,7 @@
 
             <p
               v-if="!savedSessions.length"
-              class="mt-2 text-xs leading-5 text-base-content/45"
+              class="kr-text-dim-xs-45 mt-2 leading-5"
             >
               No saved sessions loaded yet.
             </p>
@@ -653,7 +653,7 @@
       class="kr-panel-flat flex flex-wrap items-center gap-2 border border-base-content/10 bg-base-100/85 p-3"
       aria-label="Brainstorm batch history"
     >
-      <span class="mr-1 text-xs font-black uppercase tracking-[0.12em] text-base-content/45">Batches</span>
+      <span class="kr-text-dim-xs-45 mr-1 font-black uppercase tracking-[0.12em]">Batches</span>
       <button
         v-for="(batch, index) in batches"
         :key="batch.id"
@@ -672,7 +672,7 @@
       class="flex flex-wrap items-center justify-between gap-3 px-1"
     >
       <div>
-        <p class="text-xs font-black uppercase tracking-[0.14em] text-base-content/45">Current batch</p>
+        <p class="kr-text-dim-xs-45 font-black uppercase tracking-[0.14em]">Current batch</p>
         <p class="mt-1 text-sm text-base-content/65">
           {{ activeCandidates.length }} candidate{{ activeCandidates.length === 1 ? '' : 's' }} ·
           {{ keptCandidates.length }} kept · {{ rejectedCandidates.length }} rejected

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -93,7 +93,7 @@
       </div>
     </div>
 
-    <p v-if="!characterId" class="text-xs text-base-content/45">
+    <p v-if="!characterId" class="kr-text-dim-xs-45">
       These choices will attach when the new Character is saved.
     </p>
     <p v-if="errorMessage" class="text-xs text-error">{{ errorMessage }}</p>

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -55,7 +55,7 @@
           </span>
         </div>
 
-        <p class="break-all text-xs text-base-content/45">
+        <p class="kr-text-dim-xs-45 break-all">
           {{ displayPath || cover.imagePath }}
         </p>
 
@@ -78,7 +78,7 @@
       <article class="flex flex-col gap-4 kr-panel-section-flat">
         <div>
           <h4 class="text-xl font-black">Cover art prompt</h4>
-          <p v-if="cover.sourceRef" class="mt-1 break-all text-xs text-base-content/45">
+          <p v-if="cover.sourceRef" class="kr-text-dim-xs-45 mt-1 break-all">
             Historical source: {{ cover.sourceRef }}
           </p>
         </div>
@@ -90,7 +90,7 @@
           placeholder="Describe a coherent ensemble front-cover illustration with a quiet title area..."
         />
 
-        <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-base-content/45">
+        <div class="kr-text-dim-xs-45 flex flex-wrap items-center justify-between gap-2">
           <span>{{ promptDraft.length }} characters</span>
           <span v-if="promptDirty" class="kr-badge-warning-sm rounded-2xl">
             Unsaved changes
@@ -200,7 +200,7 @@
                 </button>
               </div>
             </label>
-            <p class="mt-2 text-xs text-base-content/45">
+            <p class="kr-text-dim-xs-45 mt-2">
               The file must already exist inside this book’s Conductor set. Missing ArtJob metadata is preserved as missing, not creatively hallucinated.
             </p>
           </div>
@@ -234,7 +234,7 @@
             class="aspect-[2/3] w-full rounded-xl bg-base-100 object-contain"
           />
           <p class="text-xs font-black">{{ revision.previousStatus || 'Archived revision' }}</p>
-          <p class="text-xs text-base-content/45">
+          <p class="kr-text-dim-xs-45">
             {{ formatDate(revision.requestedAt) }}
           </p>
           <p v-if="revision.semanticScore !== null" class="text-xs text-base-content/55">

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -193,7 +193,7 @@
 
           <p
             v-if="selectedPackage.orderedInteriorManifest"
-            class="mt-4 break-all text-xs text-base-content/45"
+            class="kr-text-dim-xs-45 mt-4 break-all"
           >
             Ordered manifest: {{ selectedPackage.orderedInteriorManifest }}
           </p>

--- a/components/coloring/coloring-book-production-history.vue
+++ b/components/coloring/coloring-book-production-history.vue
@@ -82,12 +82,12 @@
             <p class="text-sm font-black">
               {{ item.status || item.verdict || historyLabel(item.kind) }}
             </p>
-            <p v-if="item.createdAt" class="text-xs text-base-content/45">
+            <p v-if="item.createdAt" class="kr-text-dim-xs-45">
               {{ formatDate(item.createdAt) }}
             </p>
           </div>
 
-          <p v-if="item.path" class="break-all text-xs text-base-content/45">
+          <p v-if="item.path" class="kr-text-dim-xs-45 break-all">
             {{ item.path }}
           </p>
 

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -376,19 +376,19 @@
 
           <div class="grid gap-3 sm:grid-cols-3">
             <div class="kr-tile-md text-sm">
-              <span class="block text-xs text-base-content/45">Semantic score</span>
+              <span class="kr-text-dim-xs-45 block">Semantic score</span>
               <strong>
                 {{ studio.selectedProposal.queue.semanticScore ?? '—' }}
               </strong>
             </div>
             <div class="kr-tile-md text-sm">
-              <span class="block text-xs text-base-content/45">Render engine</span>
+              <span class="kr-text-dim-xs-45 block">Render engine</span>
               <strong>
                 {{ studio.selectedProposal.queue.renderEngine ?? '—' }}
               </strong>
             </div>
             <div class="kr-tile-md text-sm">
-              <span class="block text-xs text-base-content/45">
+              <span class="kr-text-dim-xs-45 block">
                 Archived revisions
               </span>
               <strong>{{ studio.selectedProposal.queue.revisionCount }}</strong>
@@ -401,7 +401,7 @@
         >
           <div>
             <h4 class="text-xl font-black">Canonical production prompt</h4>
-            <p class="mt-1 break-all text-xs text-base-content/45">
+            <p class="kr-text-dim-xs-45 mt-1 break-all">
               {{ studio.selectedProposal.promptSourcePath }}
             </p>
             <p
@@ -420,7 +420,7 @@
           />
 
           <div
-            class="flex flex-wrap items-center justify-between gap-2 text-xs text-base-content/45"
+            class="kr-text-dim-xs-45 flex flex-wrap items-center justify-between gap-2"
           >
             <span>{{ promptDraft.length }} characters</span>
             <span
@@ -530,7 +530,7 @@
         >
           <div>
             <p
-              class="text-xs font-black uppercase tracking-widest text-base-content/45"
+              class="kr-text-dim-xs-45 font-black uppercase tracking-widest"
             >
               {{ problem.bookTitle }} · {{ problem.proposal.id }}
             </p>

--- a/components/curation/coloring-book-curation.vue
+++ b/components/curation/coloring-book-curation.vue
@@ -277,10 +277,7 @@
             </button>
           </div>
 
-          <div
-            v-else
-            class="flex items-center gap-2 text-xs text-base-content/45"
-          >
+          <div v-else class="kr-text-dim-xs-45 flex items-center gap-2">
             <Icon name="kind-icon:lock" class="size-4" />
             Production edits are admin-only.
           </div>

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -313,16 +313,14 @@
                 <span v-if="isSaving(fish.slug)" class="kr-spinner-xs" />
                 Save curation
               </button>
-              <span v-if="draft.jobId" class="text-xs text-base-content/45">
+              <span v-if="draft.jobId" class="kr-text-dim-xs-45">
                 ArtJob #{{ draft.jobId }}
               </span>
             </div>
           </div>
 
           <div v-if="fish.curation.candidateImageIds.length" class="space-y-2">
-            <p
-              class="text-xs font-black uppercase tracking-wider text-base-content/45"
-            >
+            <p class="kr-text-dim-xs-45 font-black uppercase tracking-wider">
               Candidates
             </p>
             <div class="flex flex-wrap gap-2">

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -150,7 +150,7 @@
           class="flex flex-wrap items-center justify-between gap-2 border-b border-base-300 bg-base-200/60 px-4 py-3"
         >
           <p class="font-black">{{ visibleRows.length }} words shown</p>
-          <p class="text-xs text-base-content/45">
+          <p class="kr-text-dim-xs-45">
             Source identity is immutable. Select a row to edit its effective
             learner-facing values.
           </p>
@@ -185,7 +185,7 @@
                     }}</span>
                     <span
                       v-if="row.effective.traditional"
-                      class="text-xs text-base-content/45"
+                      class="kr-text-dim-xs-45"
                     >
                       {{ row.effective.traditional }}
                     </span>

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -141,7 +141,7 @@
           />
           <span>
             <span class="block text-sm font-bold">Keep the current version as inspiration</span>
-            <span class="block text-xs leading-relaxed text-base-content/45">
+            <span class="kr-text-dim-xs-45 block leading-relaxed">
               Preserve the previous image in object history before the replacement attaches.
             </span>
           </span>

--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -122,7 +122,7 @@
                 </p>
                 <p
                   v-if="item.meta"
-                  class="mt-1.5 text-xs text-base-content/45"
+                  class="kr-text-dim-xs-45 mt-1.5"
                 >
                   {{ item.meta }}
                 </p>
@@ -202,7 +202,7 @@
 
               <p
                 v-if="item.meta"
-                class="mt-1.5 text-xs text-base-content/45"
+                class="kr-text-dim-xs-45 mt-1.5"
               >
                 {{ item.meta }}
               </p>
@@ -293,7 +293,7 @@
                 </div>
                 <slot name="item-trailing" :item="item" />
               </div>
-              <p v-if="item.meta" class="mt-2 text-xs text-base-content/45">
+              <p v-if="item.meta" class="kr-text-dim-xs-45 mt-2">
                 {{ item.meta }}
               </p>
               <div

--- a/components/narrative/narrative-ingredient-multi-picker.vue
+++ b/components/narrative/narrative-ingredient-multi-picker.vue
@@ -94,7 +94,7 @@
     <p
       v-else-if="query.trim() && !filteredItems.length"
       role="status"
-      class="rounded-xl border border-dashed border-base-300 bg-base-100/60 px-3 py-2 text-xs text-base-content/45"
+      class="kr-text-dim-xs-45 rounded-xl border border-dashed border-base-300 bg-base-100/60 px-3 py-2"
     >
       No matching {{ label.toLowerCase() }}.
     </p>

--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -52,7 +52,7 @@
     <p
       v-if="query.trim() && !filteredItems.length"
       role="status"
-      class="rounded-xl border border-dashed border-base-300 bg-base-100/60 px-3 py-2 text-xs text-base-content/45"
+      class="kr-text-dim-xs-45 rounded-xl border border-dashed border-base-300 bg-base-100/60 px-3 py-2"
     >
       No matching {{ label.toLowerCase() }}. Clear the search or leave the
       narrator free to choose.

--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -141,7 +141,7 @@
               </span>
               <div class="min-w-0">
                 <h2 class="truncate text-lg font-black">{{ channel.label }}</h2>
-                <p class="truncate text-xs font-bold text-base-content/45">
+                <p class="kr-text-dim-xs-45 truncate font-bold">
                   {{ channel.channelKey }} · {{ channel.route }}
                 </p>
                 <p class="mt-1 line-clamp-2 text-sm text-base-content/65">
@@ -203,7 +203,7 @@
                   {{ tab.requiredRole }}
                 </span>
               </div>
-              <p class="mt-0.5 truncate text-xs font-semibold text-base-content/45">
+              <p class="kr-text-dim-xs-45 mt-0.5 truncate font-semibold">
                 {{ tab.tabKey }} · {{ tab.route }}
               </p>
               <p class="mt-1 line-clamp-2 text-xs text-base-content/65">

--- a/components/navigation/workspace-sheet.vue
+++ b/components/navigation/workspace-sheet.vue
@@ -54,7 +54,7 @@
 
         <p
           v-if="showDebugPath"
-          class="break-all rounded-xl bg-base-200 px-3 py-2 text-xs font-semibold text-base-content/45"
+          class="kr-text-dim-xs-45 break-all rounded-xl bg-base-200 px-3 py-2 font-semibold"
         >
           {{ imagePath || 'No image path resolved' }}
         </p>

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -152,7 +152,7 @@
                     {{ statusLabel(pitch) }}
                   </span>
                 </div>
-                <div class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-base-content/45">
+                <div class="kr-text-dim-xs-45 mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
                   <span v-if="pitch.projectTarget" class="flex items-center gap-1">
                     <Icon name="kind-icon:folder" class="size-3" />
                     {{ pitch.projectTarget }}

--- a/components/pages/creator-earnings-page.vue
+++ b/components/pages/creator-earnings-page.vue
@@ -218,7 +218,7 @@
                 <span class="flex items-center gap-3">
                   <span
                     v-if="bucket.selfAttributedCents > 0"
-                    class="text-xs text-base-content/45"
+                    class="kr-text-dim-xs-45"
                   >
                     +
                     {{ formatUsdCents(bucket.selfAttributedCents) }}

--- a/components/reviews/review-list.vue
+++ b/components/reviews/review-list.vue
@@ -17,7 +17,7 @@
 <template>
   <section class="grid gap-3">
     <header v-if="showHeader" class="flex flex-wrap items-baseline justify-between gap-2">
-      <p class="text-xs font-black uppercase tracking-widest text-base-content/45">
+      <p class="kr-text-dim-xs-45 font-black uppercase tracking-widest">
         {{ headingLabel }}
       </p>
       <span v-if="averageRating" class="text-sm font-black text-warning">

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -93,7 +93,7 @@
       </div>
     </div>
 
-    <p v-if="!rewardId" class="text-xs text-base-content/45">
+    <p v-if="!rewardId" class="kr-text-dim-xs-45">
       These choices will attach when the new Reward is saved.
     </p>
     <p v-if="errorMessage" class="text-xs text-error">{{ errorMessage }}</p>

--- a/components/storybook/storybook-state-panel.vue
+++ b/components/storybook/storybook-state-panel.vue
@@ -51,7 +51,7 @@
             </span>
           </article>
         </div>
-        <p v-else class="mt-2 text-xs leading-relaxed text-base-content/45">
+        <p v-else class="kr-text-dim-xs-45 mt-2 leading-relaxed">
           The story has not placed a selected Reward in your hands yet.
         </p>
       </section>
@@ -78,7 +78,7 @@
             <span>{{ item.text }}</span>
           </li>
         </ol>
-        <p v-else class="mt-2 text-xs leading-relaxed text-base-content/45">
+        <p v-else class="kr-text-dim-xs-45 mt-2 leading-relaxed">
           Consequences will accumulate as choices alter the story.
         </p>
       </section>
@@ -99,7 +99,7 @@
             <p class="mt-0.5 text-base-content/75">{{ branch.answer }}</p>
           </li>
         </ol>
-        <p v-else class="mt-2 text-xs leading-relaxed text-base-content/45">
+        <p v-else class="kr-text-dim-xs-45 mt-2 leading-relaxed">
           Your first answer will begin this session’s branch history.
         </p>
       </section>

--- a/components/user/login-page.vue
+++ b/components/user/login-page.vue
@@ -194,7 +194,7 @@
         <div v-if="!returnTarget" class="my-5 flex items-center gap-3">
           <span class="h-px flex-1 bg-base-content/15" />
           <span
-            class="rounded-full border border-base-content/10 bg-base-100/80 px-3 py-1 text-xs font-black uppercase tracking-widest text-base-content/45"
+            class="kr-text-dim-xs-45 rounded-full border border-base-content/10 bg-base-100/80 px-3 py-1 font-black uppercase tracking-widest"
           >
             or
           </span>

--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -35,27 +35,19 @@
 
     <dl class="kr-text-dim-sm-70 grid grid-cols-2 gap-x-4 gap-y-1">
       <div>
-        <dt class="text-xs font-semibold uppercase text-base-content/45">
-          Consumed
-        </dt>
+        <dt class="kr-text-dim-xs-45 font-semibold uppercase">Consumed</dt>
         <dd>{{ consumedLabel }}</dd>
       </div>
       <div v-if="entry.year">
-        <dt class="text-xs font-semibold uppercase text-base-content/45">
-          Year
-        </dt>
+        <dt class="kr-text-dim-xs-45 font-semibold uppercase">Year</dt>
         <dd>{{ entry.year }}</dd>
       </div>
       <div v-if="rewatchLabel">
-        <dt class="text-xs font-semibold uppercase text-base-content/45">
-          Rewatch
-        </dt>
+        <dt class="kr-text-dim-xs-45 font-semibold uppercase">Rewatch</dt>
         <dd>{{ rewatchLabel }}</dd>
       </div>
       <div class="col-span-2">
-        <dt class="text-xs font-semibold uppercase text-base-content/45">
-          Rating
-        </dt>
+        <dt class="kr-text-dim-xs-45 font-semibold uppercase">Rating</dt>
         <dd class="mt-0.5 flex items-center gap-1.5">
           <button
             type="button"
@@ -109,10 +101,7 @@
           <Icon name="kind-icon:check" class="size-3" />
           Published
         </span>
-        <span
-          v-else-if="saveState !== 'idle'"
-          class="text-xs text-base-content/45"
-        >
+        <span v-else-if="saveState !== 'idle'" class="kr-text-dim-xs-45">
           {{ saveStateLabel }}
         </span>
       </div>
@@ -161,15 +150,8 @@
       >
         Related entries
       </h3>
-      <p v-if="isLoadingRelated" class="text-xs text-base-content/45">
-        Loading…
-      </p>
-      <p
-        v-else-if="!relatedEntries.length"
-        class="text-xs text-base-content/45"
-      >
-        None
-      </p>
+      <p v-if="isLoadingRelated" class="kr-text-dim-xs-45">Loading…</p>
+      <p v-else-if="!relatedEntries.length" class="kr-text-dim-xs-45">None</p>
       <ul v-else class="flex flex-col gap-1">
         <li
           v-for="related in relatedEntries"

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -182,9 +182,7 @@
 
         <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
           <div class="kr-panel-muted-md">
-            <p
-              class="text-xs font-bold uppercase tracking-wide text-base-content/45"
-            >
+            <p class="kr-text-dim-xs-45 font-bold uppercase tracking-wide">
               Sections
             </p>
             <p class="mt-1 text-3xl font-black text-primary">
@@ -193,9 +191,7 @@
           </div>
 
           <div class="kr-panel-muted-md">
-            <p
-              class="text-xs font-bold uppercase tracking-wide text-base-content/45"
-            >
+            <p class="kr-text-dim-xs-45 font-bold uppercase tracking-wide">
               Groups
             </p>
             <p class="mt-1 text-3xl font-black text-secondary">
@@ -204,9 +200,7 @@
           </div>
 
           <div class="kr-panel-muted-md">
-            <p
-              class="text-xs font-bold uppercase tracking-wide text-base-content/45"
-            >
+            <p class="kr-text-dim-xs-45 font-bold uppercase tracking-wide">
               Saved colors
             </p>
             <p class="mt-1 text-3xl font-black text-accent">

--- a/components/wonderlab/reactable-card.vue
+++ b/components/wonderlab/reactable-card.vue
@@ -56,7 +56,7 @@
       >
         <div class="mb-2 flex items-center justify-between gap-2">
           <p
-            class="truncate text-xs font-bold uppercase tracking-wide text-base-content/45"
+            class="kr-text-dim-xs-45 truncate font-bold uppercase tracking-wide"
           >
             React
           </p>

--- a/components/wonderlab/reaction-card.vue
+++ b/components/wonderlab/reaction-card.vue
@@ -10,7 +10,7 @@
     >
       <div class="min-w-0">
         <p
-          class="text-xs font-bold uppercase tracking-wide text-base-content/45"
+          class="kr-text-dim-xs-45 font-bold uppercase tracking-wide"
         >
           Reaction
         </p>

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -63,31 +63,25 @@
       <template v-else>
         <section class="grid grid-cols-2 gap-2 sm:grid-cols-4">
           <div class="kr-panel p-3">
-            <p class="text-xs font-black uppercase text-base-content/45">
-              LoRAs
-            </p>
+            <p class="kr-text-dim-xs-45 font-black uppercase">LoRAs</p>
             <p class="mt-1 text-2xl font-black">
               {{ triageStore.loras.length }}
             </p>
           </div>
           <div class="kr-panel p-3">
-            <p class="text-xs font-black uppercase text-base-content/45">
-              Confirmed
-            </p>
+            <p class="kr-text-dim-xs-45 font-black uppercase">Confirmed</p>
             <p class="mt-1 text-2xl font-black text-success">
               {{ triageStore.confirmedCount }}
             </p>
           </div>
           <div class="kr-panel p-3">
-            <p class="text-xs font-black uppercase text-base-content/45">
-              Remaining
-            </p>
+            <p class="kr-text-dim-xs-45 font-black uppercase">Remaining</p>
             <p class="mt-1 text-2xl font-black">
               {{ triageStore.remainingCount }}
             </p>
           </div>
           <div class="kr-panel p-3">
-            <p class="text-xs font-black uppercase text-base-content/45">
+            <p class="kr-text-dim-xs-45 font-black uppercase">
               Unsaved changes
             </p>
             <p class="mt-1 text-2xl font-black text-warning">

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -288,7 +288,7 @@
                   <div class="flex items-start justify-between gap-2">
                     <div class="min-w-0">
                       <p class="truncate text-sm font-black" :title="source.name">{{ source.name }}</p>
-                      <p class="text-xs text-base-content/45">
+                      <p class="kr-text-dim-xs-45">
                         {{ formatBytes(source.bytes) }}
                         <template v-if="source.jobId"> · ArtJob #{{ source.jobId }}</template>
                       </p>

--- a/pages/play/aquarium/browse/[username]/[slug].vue
+++ b/pages/play/aquarium/browse/[username]/[slug].vue
@@ -39,7 +39,7 @@
         <Icon name="kind-icon:warning" class="mx-auto size-10 text-error" />
         <p class="mt-3 text-xl font-black">Tank unavailable</p>
         <p class="mt-2 text-sm text-base-content/65">{{ errorMessage }}</p>
-        <p class="mt-2 text-xs text-base-content/45">
+        <p class="kr-text-dim-xs-45 mt-2">
           Either this tank doesn't exist, or its owner has kept it private.
         </p>
       </div>
@@ -76,7 +76,7 @@
             </div>
           </div>
           <p
-            class="mt-4 text-xs font-bold uppercase tracking-wide text-base-content/45"
+            class="kr-text-dim-xs-45 mt-4 font-bold uppercase tracking-wide"
           >
             Read-only -- visiting doesn't feed, clean, or change anything here.
           </p>

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -109,7 +109,7 @@
               class="grid min-w-40 place-items-center rounded-3xl border border-primary/20 bg-base-100/75 p-5 text-center shadow-lg backdrop-blur"
             >
               <span
-                class="text-xs font-black uppercase tracking-[0.2em] text-base-content/45"
+                class="kr-text-dim-xs-45 font-black uppercase tracking-[0.2em]"
               >
                 Difficulty
               </span>
@@ -213,7 +213,7 @@
                   <h2 class="mt-2 truncate text-xl font-black uppercase">
                     {{ submission.Contender?.name || 'Mystery contender' }}
                   </h2>
-                  <p class="truncate text-xs font-bold text-base-content/45">
+                  <p class="kr-text-dim-xs-45 truncate font-bold">
                     {{ contenderSubtitle(submission) }}
                   </p>
                 </div>
@@ -464,14 +464,14 @@
               </span>
               <div class="min-w-0">
                 <p class="truncate font-black">{{ entry.name }}</p>
-                <p class="text-xs text-base-content/45">
+                <p class="kr-text-dim-xs-45">
                   {{ entry.submissions }}
                   {{ entry.submissions === 1 ? 'entry' : 'entries' }} ·
                   {{ entry.score.votes }} votes
                 </p>
               </div>
               <span
-                class="hidden text-xs font-bold text-base-content/45 sm:inline"
+                class="kr-text-dim-xs-45 hidden font-bold sm:inline"
               >
                 ♥ {{ entry.score.loved }} · 👏 {{ entry.score.clapped }} · 👎
                 {{ entry.score.booed }} · ✕ {{ entry.score.hated }}

--- a/pages/play/challenges/leaderboard.vue
+++ b/pages/play/challenges/leaderboard.vue
@@ -89,7 +89,7 @@
               </button>
             </div>
           </fieldset>
-          <p class="text-xs font-bold text-base-content/45">
+          <p class="kr-text-dim-xs-45 font-bold">
             {{ leaderboard.length }} ranked
             {{
               facetFilter === 'contender'
@@ -169,7 +169,7 @@
               #{{ entry.rank }}
             </span>
             <h2 class="mt-3 text-xl font-black uppercase">{{ entry.name }}</h2>
-            <p class="mt-1 text-xs font-bold text-base-content/45">
+            <p class="kr-text-dim-xs-45 mt-1 font-bold">
               {{ entry.subtitle }}
             </p>
             <p
@@ -248,7 +248,7 @@
                       </div>
                       <div>
                         <p class="font-black">{{ entry.name }}</p>
-                        <p class="text-xs text-base-content/45">
+                        <p class="kr-text-dim-xs-45">
                           {{ entry.subtitle }}
                         </p>
                       </div>

--- a/utils/scripts/codemods/kr_text_dim_xs_45_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_xs_45_codemod.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `text-xs text-base-content/45` metadata
+caption text to `kr-text-dim-xs-45`.
+
+Sibling of kr_text_dim_sm_codemod.py / kr_text_dim_xs_codemod.py /
+kr_text_dim_sm_70_codemod.py, same conventions: dry-run by default, --write
+to update matching Vue files in place. Only the exact `text-xs
+text-base-content/45` shape is touched, and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings, and regardless of the
+base tokens' order in the source. A source that already carries
+`kr-text-dim-xs-45`, or is missing either base token, is left untouched.
+Extra tokens beyond the base set are preserved verbatim after the primitive
+class, matching the kr-badge-*/kr-spinner-*/kr-label-bold/kr-text-dim-*
+codemods' subset-match convention -- pass --exact-only to restrict a slice to
+sources with no extra tokens at all, the safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-dim-xs-45"
+BASE_TOKENS = {"text-xs", "text-base-content/45"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-dim-xs-45 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, slice 156)

### What changed / what I produced
- Added `.kr-text-dim-xs-45` (`text-xs text-base-content/45`) to `assets/css/tailwind.css`, one step quieter than `.kr-text-dim-xs`'s 50% opacity, for the least-emphasized metadata annotation on a card/list row.
- Added `utils/scripts/codemods/kr_text_dim_xs_45_codemod.py`, sibling of the other `kr_text_dim_*_codemod.py` scripts (dry-run by default, `--write` to migrate, `--exact-only` to restrict to sources with no extra tokens).
- Migrated all 83 subset-match occurrences across 36 files — extra utility tokens (`flex items-center gap-*`, `mt-*`, `truncate`, `font-*`, etc.) preserved verbatim per the established convention. No geometry or behavior change.
- Fixed a scoped prettier collapse in 5 files where the shortened class string let a multi-line tag fit prettier's print width on one line (same recurring pattern as prior slices).

### How I verified
- `vue-tsc --noEmit` clean
- `npm run test:lint-ratchet` holds at 333/-59 (no new errors)
- `npm run test:layout-contract` holds (0 new violations; an unrelated pre-existing 2-entry `viewport-grid` baseline improvement was noticed and left alone, not this slice's to claim)
- `npx prettier --check` clean on all touched files — confirmed via `git stash` that the 26 other flagged files already carried pre-existing prettier debt unrelated to this change, and left those untouched (scope discipline)
- No source-text contract scripts reference this literal class string

### Stakes
reversible

### Kaizen suggestion
This closes out both candidates surveyed in slice 152's original frequency pass (`text-sm text-base-content/70` in slice 155, `text-xs text-base-content/45` here). A fresh frequency survey of the codebase's most-repeated static `class="..."` values would be worth running again before the next slice to find the next bounded family.

### Notes for reviewer
Recurring consistency umbrella (interface-vision/t-104) — conductor task set to `status: review`, will re-arm to `ready` after merge for the next bounded slice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T69YFie73Wwg1QJCzpeXcF)_