### PR TITLE
refactor(ui): migrate text-xs text-base-content/55 to kr-text-dim-xs-55 (slice 159)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1714,6 +1714,25 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply text-xs text-base-content/60;
   }
 
+  /* A caption-size metadata line one notch dimmer than `.kr-text-dim-xs-60`
+   * -- `text-xs text-base-content/55`, the middle opacity of the `text-xs
+   * text-base-content/NN` family sitting between `.kr-text-dim-xs`'s 50%
+   * and `.kr-text-dim-xs-60`'s 60% (interface-vision t-104 slice 159) --
+   * previously hand-rolled in 49 files (123 occurrences, subset-match
+   * including extra tokens like `mt-1`, `truncate`, `flex items-center
+   * gap-*`, `font-*`), the next-largest bounded family surfaced by
+   * re-running slice 152's original frequency survey against the sibling
+   * opacity variants left open in slice 158's own note (`/40`, `/55`,
+   * `/70`). Named `kr-text-dim-xs-55` for the same reason as its siblings --
+   * each size/opacity pairing is a real, independently-repeated exact shape
+   * in the wild, not one that "should normalize" to a neighboring opacity.
+   * The remaining `/40` (24 files, 38 occurrences) and `/70` (29
+   * occurrences) siblings are left for future slices, same convention as
+   * `.kr-spinner-xs`/`.kr-spinner-sm`. */
+  .kr-text-dim-xs-55 {
+    @apply text-xs text-base-content/55;
+  }
+
   /* A large, primary-colored busy indicator -- `loading loading-spinner
    * loading-lg text-primary`, the centered spinner shown while a gallery,
    * list, or manager view's main content is still loading (interface-vision

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -148,7 +148,7 @@
           </p>
           <h4 class="mt-1 text-xl font-black text-base-content">Look before you read</h4>
         </div>
-        <p class="max-w-xl text-xs leading-relaxed text-base-content/55">
+        <p class="kr-text-dim-xs-55 max-w-xl leading-relaxed">
           These are real historical works with provenance links. Open any image to visit its source collection.
         </p>
       </div>
@@ -308,7 +308,7 @@
               </p>
             </div>
 
-            <p class="flex items-start gap-2 text-xs leading-relaxed text-base-content/55">
+            <p class="kr-text-dim-xs-55 flex items-start gap-2 leading-relaxed">
               <Icon name="kind-icon:refresh" class="mt-0.5 h-4 w-4 shrink-0" />
               Not quite right? Try a different source image, tweak the instruction, or adjust the style strength and remix again.
             </p>

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -68,7 +68,7 @@
         <div class="flex items-center justify-between gap-3">
           <div>
             <p class="text-sm font-black text-base-content">{{ progressHeadline }}</p>
-            <p class="mt-0.5 text-xs text-base-content/55">{{ progressMessage }}</p>
+            <p class="kr-text-dim-xs-55 mt-0.5">{{ progressMessage }}</p>
           </div>
           <span class="text-sm font-black text-primary">{{ progressPercent }}%</span>
         </div>

--- a/components/achievements/achievement-popup.vue
+++ b/components/achievements/achievement-popup.vue
@@ -68,7 +68,7 @@
             <p class="text-lg font-black text-accent">
               +{{ achievement.karma ?? 0 }} karma
             </p>
-            <p class="text-xs text-base-content/55">
+            <p class="kr-text-dim-xs-55">
               You found 1 Jellybean (+1 mana)!
             </p>
           </div>

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -84,7 +84,7 @@
               <span class="block truncate font-black text-base-content">
                 {{ effect.label }}
               </span>
-              <span class="block truncate text-xs text-base-content/55">
+              <span class="kr-text-dim-xs-55 block truncate">
                 {{ effect.id }}
               </span>
             </span>

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -92,7 +92,7 @@
                   <Icon name="kind-icon:settings" class="h-4 w-4" />
                   Recipe
                 </h2>
-                <p class="mt-0.5 text-xs text-base-content/55">
+                <p class="kr-text-dim-xs-55 mt-0.5">
                   Picks the Comfy lane and its known-good numbers.
                 </p>
               </div>
@@ -188,7 +188,7 @@
             </label>
 
             <div class="mt-3 flex flex-wrap items-center gap-2">
-              <span class="text-xs font-bold text-base-content/55">
+              <span class="kr-text-dim-xs-55 font-bold">
                 🎲 Prompt seasoning
               </span>
               <button

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -145,7 +145,7 @@
               <span class="block text-sm font-black text-base-content"
                 >Generation Source</span
               >
-              <span class="block truncate text-xs text-base-content/55">
+              <span class="kr-text-dim-xs-55 block truncate">
                 {{ currentArtImage.checkpoint || 'No checkpoint recorded' }}
               </span>
             </span>
@@ -195,7 +195,7 @@
                 <h2 class="truncate text-base font-black text-base-content">
                   Quick Edit
                 </h2>
-                <p class="truncate text-xs text-base-content/55">
+                <p class="kr-text-dim-xs-55 truncate">
                   ArtImage metadata. Image bytes remain unbothered.
                 </p>
               </div>
@@ -354,7 +354,7 @@
                   <h2 class="truncate text-base font-black text-base-content">
                     Collections
                   </h2>
-                  <p class="truncate text-xs text-base-content/55">
+                  <p class="kr-text-dim-xs-55 truncate">
                     {{ selectedCollectionSummary }}
                   </p>
                 </div>
@@ -418,7 +418,7 @@
 
                 <div
                   v-if="visibleCollectionOptions.length === 0"
-                  class="rounded-xl border border-dashed border-base-300 bg-base-200 p-3 text-center text-xs text-base-content/55"
+                  class="kr-text-dim-xs-55 rounded-xl border border-dashed border-base-300 bg-base-200 p-3 text-center"
                 >
                   No collections match that search.
                 </div>

--- a/components/art/art-lora-picker.vue
+++ b/components/art/art-lora-picker.vue
@@ -7,7 +7,7 @@
           <Icon name="kind-icon:sparkles" class="size-4 text-secondary" />
           LoRAs <span class="font-normal opacity-50">(optional)</span>
         </h3>
-        <p class="mt-0.5 text-xs text-base-content/55">
+        <p class="kr-text-dim-xs-55 mt-0.5">
           Stack up to {{ MAX_LORAS_PER_JOB }} compatible LoRAs. They apply in
           order, and trigger words are added to the render prompt automatically.
         </p>

--- a/components/art/art-studio.vue
+++ b/components/art/art-studio.vue
@@ -26,7 +26,7 @@
         Gallery
       </button>
 
-      <p class="ml-1 hidden text-xs text-base-content/55 md:block">
+      <p class="kr-text-dim-xs-55 ml-1 hidden md:block">
         Make something new, or browse what you already made.
       </p>
     </nav>

--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -110,7 +110,7 @@
               <div class="flex flex-wrap items-start justify-between gap-2">
                 <div>
                   <h4 class="text-sm font-semibold">Video options</h4>
-                  <p class="mt-1 text-xs text-base-content/55">
+                  <p class="kr-text-dim-xs-55 mt-1">
                     These values update both the ArtJob metadata and the Comfy
                     workflow used by the relay.
                   </p>

--- a/components/art/artjob-trainer-redo-controls.vue
+++ b/components/art/artjob-trainer-redo-controls.vue
@@ -44,7 +44,7 @@
 
         <div
           v-else
-          class="kr-panel-compact-70-row text-xs text-base-content/55"
+          class="kr-text-dim-xs-55 kr-panel-compact-70-row"
         >
           <span class="font-semibold">Model:</span> SDXL · prompt only
         </div>

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -97,7 +97,7 @@
       <aside v-if="history.length" class="kr-panel-tint-compact-50">
         <div class="mb-2 flex items-center gap-2">
           <Icon name="kind-icon:history" class="size-3.5 text-base-content/50" />
-          <h4 class="text-xs font-black uppercase tracking-wide text-base-content/55">
+          <h4 class="kr-text-dim-xs-55 font-black uppercase tracking-wide">
             Inspiration history
           </h4>
           <span class="kr-badge-ghost-xs ml-auto">{{ filteredHistory.length }}</span>
@@ -371,7 +371,7 @@
         </div>
       </fieldset>
 
-      <div class="rounded-lg bg-base-100/60 px-3 py-2 text-xs text-base-content/55">
+      <div class="kr-text-dim-xs-55 rounded-lg bg-base-100/60 px-3 py-2">
         <strong>{{ generationMode === 'recreate' ? 'Recreate' : 'Img2img' }}:</strong>
         {{ engineLabel }} · {{ selectedSlot.width }}×{{ selectedSlot.height }}
         <template v-if="selectedPreset.description"> · {{ selectedPreset.description }}</template>

--- a/components/art/forum-art-generation-context.vue
+++ b/components/art/forum-art-generation-context.vue
@@ -44,9 +44,7 @@
 
     <template v-else-if="store.sourcePost">
       <article class="mt-4 rounded-2xl bg-base-200/60 p-3">
-        <div
-          class="flex flex-wrap items-center gap-2 text-xs text-base-content/55"
-        >
+        <div class="kr-text-dim-xs-55 flex flex-wrap items-center gap-2">
           <span class="kr-badge-outline-sm rounded-xl">
             {{
               store.sourcePost.author.kind === 'AI_AGENT'

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -67,7 +67,7 @@
 
       <div class="mt-4" data-testid="brainstorm-output-domain">
         <div class="flex flex-wrap items-baseline justify-between gap-2">
-          <p class="text-xs font-black uppercase tracking-[0.12em] text-base-content/55">
+          <p class="kr-text-dim-xs-55 font-black uppercase tracking-[0.12em]">
             Output
           </p>
         </div>
@@ -86,14 +86,14 @@
             {{ domain.label }}
           </button>
         </div>
-        <p class="mt-2 max-w-3xl text-xs leading-5 text-base-content/55">
+        <p class="kr-text-dim-xs-55 mt-2 max-w-3xl leading-5">
           {{ BRAINSTORM_OUTPUT_DOMAINS.find((domain) => domain.id === outputDomain)?.description }}
         </p>
       </div>
 
       <div class="mt-4 flex flex-wrap items-end gap-3">
         <div>
-          <label for="brainstorm-count" class="text-xs font-black uppercase tracking-[0.12em] text-base-content/55">
+          <label for="brainstorm-count" class="kr-text-dim-xs-55 font-black uppercase tracking-[0.12em]">
             {{ isArtPromptDomain ? 'Prompts' : 'Ideas' }}
           </label>
           <input
@@ -125,7 +125,7 @@
 
       <div class="mt-4" data-testid="brainstorm-creative-directions">
         <div class="flex flex-wrap items-baseline justify-between gap-2">
-          <p class="text-xs font-black uppercase tracking-[0.12em] text-base-content/55">
+          <p class="kr-text-dim-xs-55 font-black uppercase tracking-[0.12em]">
             Push the batch
           </p>
           <p class="kr-text-dim-xs-45">Creative moves, not model knobs.</p>
@@ -145,7 +145,7 @@
             {{ direction.label }}
           </button>
         </div>
-        <p class="mt-2 max-w-3xl text-xs leading-5 text-base-content/55">
+        <p class="kr-text-dim-xs-55 mt-2 max-w-3xl leading-5">
           {{ activeCreativeDirection.description }}
         </p>
       </div>
@@ -184,7 +184,7 @@
           </button>
         </div>
 
-        <p class="mt-2 max-w-3xl text-xs leading-5 text-base-content/55">
+        <p class="kr-text-dim-xs-55 mt-2 max-w-3xl leading-5">
           <template v-if="batchShape === 'focused'">
             Keep one coherent response family while the ideas themselves diverge.
           </template>
@@ -218,7 +218,7 @@
               />
               <span class="min-w-0">
                 <span class="block text-sm font-black text-base-content">{{ option.label }}</span>
-                <span class="mt-1 block text-xs leading-5 text-base-content/55">{{ option.description }}</span>
+                <span class="kr-text-dim-xs-55 mt-1 block leading-5">{{ option.description }}</span>
               </span>
             </label>
 
@@ -226,7 +226,7 @@
               v-if="returnTypeSelected(option.id)"
               class="mt-3 flex flex-wrap items-center gap-2 border-t border-base-content/8 pt-3"
             >
-              <label :for="`brainstorm-return-count-${option.id}`" class="text-xs font-bold text-base-content/55">
+              <label :for="`brainstorm-return-count-${option.id}`" class="kr-text-dim-xs-55 font-bold">
                 How many?
               </label>
               <input
@@ -261,7 +261,7 @@
         </summary>
         <div class="mt-4 grid grid-cols-[repeat(auto-fit,minmax(min(100%,18rem),1fr))] gap-4">
           <div>
-            <label for="brainstorm-constraints" class="text-xs font-black uppercase tracking-[0.12em] text-base-content/55">
+            <label for="brainstorm-constraints" class="kr-text-dim-xs-55 font-black uppercase tracking-[0.12em]">
               Constraints
             </label>
             <textarea
@@ -274,7 +274,7 @@
             />
           </div>
           <div>
-            <label for="brainstorm-examples" class="text-xs font-black uppercase tracking-[0.12em] text-base-content/55">
+            <label for="brainstorm-examples" class="kr-text-dim-xs-55 font-black uppercase tracking-[0.12em]">
               Your examples
             </label>
             <textarea
@@ -298,7 +298,7 @@
           <span v-if="source" class="ml-2 font-normal text-success">linked</span>
         </summary>
 
-        <p class="mt-3 max-w-3xl text-xs leading-5 text-base-content/55">
+        <p class="kr-text-dim-xs-55 mt-3 max-w-3xl leading-5">
           Pick a Character or Dream to brainstorm around. It rides along with the session and every candidate, but never changes what the model can see beyond what you'd normally share.
         </p>
 
@@ -324,7 +324,7 @@
             <p class="truncate text-sm font-black text-base-content">
               {{ resolvedSource.title }}
             </p>
-            <p class="truncate text-xs text-base-content/55">
+            <p class="kr-text-dim-xs-55 truncate">
               {{ resolvedSource.subtitle || resolvedSource.modelType }}
             </p>
           </div>
@@ -345,7 +345,7 @@
         <div class="mt-4 grid grid-cols-[auto_minmax(0,1fr)_auto] items-end gap-2">
           <label class="form-control">
             <span class="label py-1"
-              ><span class="label-text text-xs font-bold uppercase tracking-[0.12em] text-base-content/55"
+              ><span class="kr-text-dim-xs-55 label-text font-bold uppercase tracking-[0.12em]"
                 >Type</span
               ></span
             >
@@ -361,7 +361,7 @@
           </label>
           <label class="form-control">
             <span class="label py-1"
-              ><span class="label-text text-xs font-bold uppercase tracking-[0.12em] text-base-content/55"
+              ><span class="kr-text-dim-xs-55 label-text font-bold uppercase tracking-[0.12em]"
                 >Search</span
               ></span
             >
@@ -419,13 +419,13 @@
           <span v-if="savedSessionId" class="ml-2 font-normal text-success">linked</span>
         </summary>
 
-        <p class="mt-3 max-w-3xl text-xs leading-5 text-base-content/55">
+        <p class="kr-text-dim-xs-55 mt-3 max-w-3xl leading-5">
           Unsaved work stays private in this browser. Signed-in saves are private to your account and preserve batches, candidate IDs, curation, revisions, and branch lineage.
         </p>
 
         <div class="mt-4 grid grid-cols-[repeat(auto-fit,minmax(min(100%,18rem),1fr))] gap-4">
           <div class="rounded-2xl border border-base-content/10 bg-base-100/75 p-3">
-            <label for="brainstorm-session-name" class="text-xs font-black uppercase tracking-[0.12em] text-base-content/55">
+            <label for="brainstorm-session-name" class="kr-text-dim-xs-55 font-black uppercase tracking-[0.12em]">
               Session name
             </label>
             <input
@@ -476,7 +476,7 @@
 
           <div class="rounded-2xl border border-base-content/10 bg-base-100/75 p-3">
             <div class="flex flex-wrap items-center justify-between gap-2">
-              <p class="text-xs font-black uppercase tracking-[0.12em] text-base-content/55">
+              <p class="kr-text-dim-xs-55 font-black uppercase tracking-[0.12em]">
                 History
               </p>
               <button
@@ -614,7 +614,7 @@
             <span class="block truncate text-sm font-bold text-base-content">{{
               candidate.title
             }}</span>
-            <span class="line-clamp-2 text-xs leading-5 text-base-content/55">{{
+            <span class="kr-text-dim-xs-55 line-clamp-2 leading-5">{{
               candidate.text
             }}</span>
           </span>

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -237,7 +237,7 @@
           <p class="kr-text-dim-xs-45">
             {{ formatDate(revision.requestedAt) }}
           </p>
-          <p v-if="revision.semanticScore !== null" class="text-xs text-base-content/55">
+          <p v-if="revision.semanticScore !== null" class="kr-text-dim-xs-55">
             Semantic score {{ revision.semanticScore }}
           </p>
         </a>

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -86,7 +86,7 @@
           </div>
         </div>
 
-        <p class="mt-3 text-xs leading-relaxed text-base-content/55">
+        <p class="kr-text-dim-xs-55 mt-3 leading-relaxed">
           {{ book.nextAction }}
         </p>
       </button>

--- a/components/coloring/coloring-book-readiness.vue
+++ b/components/coloring/coloring-book-readiness.vue
@@ -124,7 +124,7 @@
             </span>
           </div>
 
-          <p class="line-clamp-3 text-xs leading-relaxed text-base-content/55">
+          <p class="kr-text-dim-xs-55 line-clamp-3 leading-relaxed">
             {{ entry.readiness.detail }}
           </p>
 

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -283,7 +283,7 @@
                 </span>
               </div>
               <p
-                class="line-clamp-2 text-xs leading-relaxed text-base-content/55"
+                class="kr-text-dim-xs-55 line-clamp-2 leading-relaxed"
               >
                 {{ proposal.prompt || 'No production prompt yet.' }}
               </p>

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -125,7 +125,7 @@
         >
           <div>
             <h2 class="text-lg font-black">The spark</h2>
-            <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+            <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
               Begin with the promise of the story. A sentence is enough; a
               strange paragraph is welcome.
             </p>
@@ -170,9 +170,7 @@
           </div>
 
           <div class="kr-panel-flat space-y-2 p-3">
-            <h3
-              class="text-xs font-bold uppercase tracking-wide text-base-content/55"
-            >
+            <h3 class="kr-text-dim-xs-55 font-bold uppercase tracking-wide">
               Narrator voice
             </h3>
             <div class="flex flex-wrap gap-2">
@@ -195,9 +193,7 @@
           </div>
 
           <div class="kr-panel-flat space-y-2 p-3">
-            <h3
-              class="text-xs font-bold uppercase tracking-wide text-base-content/55"
-            >
+            <h3 class="kr-text-dim-xs-55 font-bold uppercase tracking-wide">
               Shape of the tale
             </h3>
             <div class="grid gap-2 md:grid-cols-3">
@@ -215,9 +211,7 @@
                 @click="store.setupDraft.structure = structure.value"
               >
                 <span class="text-sm font-black">{{ structure.label }}</span>
-                <span
-                  class="mt-1 block text-xs leading-relaxed text-base-content/55"
-                >
+                <span class="kr-text-dim-xs-55 mt-1 block leading-relaxed">
                   {{ structure.description }}
                 </span>
               </button>
@@ -231,7 +225,7 @@
         >
           <div>
             <h2 class="text-lg font-black">The cast</h2>
-            <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+            <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
               Choose up to five existing characters. Leaving the cast empty lets
               Storybook invent whoever the premise requires.
             </p>
@@ -264,7 +258,7 @@
         >
           <div>
             <h2 class="text-lg font-black">The world and its flavor</h2>
-            <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+            <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
               Use canonical Dreams, Facets, and Rewards as ingredients. Their
               artwork becomes part of the setup surface while technical art
               direction remains automatic.
@@ -346,7 +340,7 @@
         >
           <div>
             <h2 class="text-lg font-black">Story bible</h2>
-            <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+            <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
               Review the creative contract before Storybook writes the opening
               scene.
             </p>
@@ -364,15 +358,13 @@
               </dd>
             </div>
             <div class="kr-panel-flat p-3">
-              <dt class="text-xs font-bold text-base-content/55">Narration</dt>
+              <dt class="kr-text-dim-xs-55 font-bold">Narration</dt>
               <dd class="mt-1 text-sm capitalize">
                 {{ store.setupDraft.narratorStyle }} · {{ structureLabel }}
               </dd>
             </div>
             <div class="kr-panel-flat p-3">
-              <dt class="text-xs font-bold text-base-content/55">
-                Plot thread
-              </dt>
+              <dt class="kr-text-dim-xs-55 font-bold">Plot thread</dt>
               <dd class="mt-2 flex items-center gap-3">
                 <div v-if="selectedScenario" class="w-16 shrink-0">
                   <KrArtPlate
@@ -390,7 +382,7 @@
               </dd>
             </div>
             <div class="kr-panel-flat p-3">
-              <dt class="text-xs font-bold text-base-content/55">Setting</dt>
+              <dt class="kr-text-dim-xs-55 font-bold">Setting</dt>
               <dd class="mt-2 flex items-center gap-3">
                 <div v-if="selectedLocation" class="w-16 shrink-0">
                   <KrArtPlate
@@ -408,7 +400,7 @@
               </dd>
             </div>
             <div class="kr-panel-flat p-3">
-              <dt class="text-xs font-bold text-base-content/55">Cast</dt>
+              <dt class="kr-text-dim-xs-55 font-bold">Cast</dt>
               <dd class="mt-2">
                 <ul v-if="selectedCast.length" class="flex flex-wrap gap-2">
                   <li
@@ -433,7 +425,7 @@
               </dd>
             </div>
             <div class="kr-panel-flat p-3">
-              <dt class="text-xs font-bold text-base-content/55">Facets</dt>
+              <dt class="kr-text-dim-xs-55 font-bold">Facets</dt>
               <dd class="mt-2">
                 <ul v-if="selectedFacets.length" class="flex flex-wrap gap-2">
                   <li
@@ -458,9 +450,7 @@
               </dd>
             </div>
             <div class="kr-panel-flat p-3 md:col-span-2">
-              <dt class="text-xs font-bold text-base-content/55">
-                Possible Rewards
-              </dt>
+              <dt class="kr-text-dim-xs-55 font-bold">Possible Rewards</dt>
               <dd class="mt-2">
                 <ul v-if="selectedRewards.length" class="flex flex-wrap gap-2">
                   <li
@@ -488,9 +478,7 @@
               v-if="store.setupDraft.notes.trim()"
               class="kr-panel-flat p-3 md:col-span-2"
             >
-              <dt class="text-xs font-bold text-base-content/55">
-                Additional direction
-              </dt>
+              <dt class="kr-text-dim-xs-55 font-bold">Additional direction</dt>
               <dd class="mt-1 whitespace-pre-line text-sm leading-relaxed">
                 {{ store.setupDraft.notes }}
               </dd>
@@ -645,7 +633,7 @@
             class="rounded-2xl border border-success/30 bg-success/5 p-4 text-center"
           >
             <p class="font-black text-success">The tale rests here</p>
-            <p class="mt-1 text-xs text-base-content/55">
+            <p class="kr-text-dim-xs-55 mt-1">
               The completed session remains saved in this browser until you
               begin another.
             </p>

--- a/components/content-visibility-controls.vue
+++ b/components/content-visibility-controls.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-wrap items-start justify-between gap-2">
       <div>
         <h3 class="text-sm font-bold">Content visibility</h3>
-        <p class="mt-0.5 text-xs text-base-content/55">
+        <p class="kr-text-dim-xs-55 mt-0.5">
           Mature work defaults private; general-audience work defaults public.
           You can override privacy after choosing maturity.
         </p>

--- a/components/curation/coloring-book-curation.vue
+++ b/components/curation/coloring-book-curation.vue
@@ -2,7 +2,7 @@
   <section class="space-y-4">
     <div class="kr-panel flex flex-wrap items-end gap-3 p-4">
       <label class="form-control min-w-60 gap-1">
-        <span class="text-xs font-bold text-base-content/55">Book</span>
+        <span class="kr-text-dim-xs-55 font-bold">Book</span>
         <select
           :value="store.selectedBookSlug"
           class="kr-select-sm"
@@ -22,7 +22,7 @@
       </label>
 
       <label class="form-control min-w-56 flex-1 gap-1">
-        <span class="text-xs font-bold text-base-content/55">Find a page</span>
+        <span class="kr-text-dim-xs-55 font-bold">Find a page</span>
         <input
           v-model="search"
           type="search"
@@ -176,7 +176,7 @@
             </h2>
             <p
               v-if="proposal.notes.length"
-              class="mt-2 line-clamp-2 text-xs leading-5 text-base-content/55"
+              class="kr-text-dim-xs-55 mt-2 line-clamp-2 leading-5"
             >
               {{ proposal.notes.join(' · ') }}
             </p>

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -2,9 +2,7 @@
   <section class="space-y-4">
     <div class="kr-panel flex flex-wrap items-end gap-3 p-4">
       <label class="form-control min-w-56 flex-1 gap-1">
-        <span class="text-xs font-bold text-base-content/55"
-          >Find a monster</span
-        >
+        <span class="kr-text-dim-xs-55 font-bold">Find a monster</span>
         <input
           v-model="search"
           type="search"

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -4,7 +4,7 @@
       <div class="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h1 class="text-xl font-black">Mandarin catalog</h1>
-          <p class="mt-1 max-w-3xl text-xs leading-5 text-base-content/55">
+          <p class="kr-text-dim-xs-55 mt-1 max-w-3xl leading-5">
             Curate one canonical learner-facing entry while the pinned source
             data stays untouched. Changes are global overrides with an
             append-only audit trail, not parallel editions.
@@ -57,9 +57,7 @@
         "
       >
         <label class="form-control gap-1">
-          <span class="text-xs font-black text-base-content/55"
-            >Search catalog</span
-          >
+          <span class="kr-text-dim-xs-55 font-black">Search catalog</span>
           <input
             v-model="search"
             type="search"
@@ -69,7 +67,7 @@
         </label>
 
         <label class="form-control gap-1">
-          <span class="text-xs font-black text-base-content/55">Category</span>
+          <span class="kr-text-dim-xs-55 font-black">Category</span>
           <select v-model="categoryFilter" class="kr-select-sm">
             <option value="all">All categories</option>
             <option
@@ -83,7 +81,7 @@
         </label>
 
         <label class="form-control gap-1">
-          <span class="text-xs font-black text-base-content/55">HSK</span>
+          <span class="kr-text-dim-xs-55 font-black">HSK</span>
           <select v-model="hskFilter" class="kr-select-sm">
             <option value="all">All levels</option>
             <option value="1">HSK 1</option>
@@ -92,7 +90,7 @@
         </label>
 
         <label class="form-control gap-1">
-          <span class="text-xs font-black text-base-content/55">Sort</span>
+          <span class="kr-text-dim-xs-55 font-black">Sort</span>
           <select v-model="sortKey" class="kr-select-sm">
             <option value="hsk">HSK / frequency</option>
             <option value="hanzi">Hanzi</option>

--- a/components/dreams/daily-dream-generator.vue
+++ b/components/dreams/daily-dream-generator.vue
@@ -13,7 +13,7 @@
       </span>
       <span class="min-w-0 flex-1">
         <span class="block font-black">Today’s Facet Dream</span>
-        <span class="block truncate text-xs text-base-content/55">
+        <span class="kr-text-dim-xs-55 block truncate">
           A complete Dream graph: world, cast, and material-driven objects.
         </span>
       </span>
@@ -52,7 +52,7 @@
             <option :value="4">4</option>
           </select>
         </label>
-        <p class="text-xs leading-relaxed text-base-content/55">
+        <p class="kr-text-dim-xs-55 leading-relaxed">
           The date supplies a stable seed. Reopening today returns the same Dream
           rather than creating duplicates.
         </p>
@@ -86,7 +86,7 @@
             Dream
           </p>
           <p class="mt-1 font-bold">{{ blueprint.title }}</p>
-          <p class="mt-1 line-clamp-3 text-xs text-base-content/55">
+          <p class="kr-text-dim-xs-55 mt-1 line-clamp-3">
             {{ blueprint.pitch }}
           </p>
         </div>

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -62,7 +62,7 @@
             <h3 class="mt-1 text-lg font-black">
               Rebuild or modify {{ selectedSlot.label.toLowerCase() }} art
             </h3>
-            <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+            <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
               Recreate starts from the prompt. Modify uses the current image as visual guidance.
             </p>
           </div>
@@ -147,7 +147,7 @@
           </span>
         </label>
 
-        <div class="rounded-xl bg-base-100/70 px-3 py-2 text-xs text-base-content/55">
+        <div class="kr-text-dim-xs-55 rounded-xl bg-base-100/70 px-3 py-2">
           <strong>{{ mode === 'recreate' ? 'Recreate' : 'Modify' }}:</strong>
           {{ engineLabel }} · {{ selectedPreset.description }}
         </div>

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -5,7 +5,7 @@
       <Icon name="kind-icon:tag" class="size-5 text-secondary" />
       <div class="min-w-0 flex-1">
         <p class="font-black">{{ title }}</p>
-        <p v-if="subtitle" class="text-xs text-base-content/55">
+        <p v-if="subtitle" class="kr-text-dim-xs-55">
           {{ subtitle }}
         </p>
       </div>

--- a/components/facets/facet-profile.vue
+++ b/components/facets/facet-profile.vue
@@ -22,7 +22,7 @@
 
       <div class="min-w-0 flex-1">
         <p class="truncate font-black">{{ selectedFacet.title }}</p>
-        <p class="truncate text-xs text-base-content/55">
+        <p class="kr-text-dim-xs-55 truncate">
           {{ taxonomyLabel(selectedFacet.taxonomy) }}
           <template v-if="selectedFacet.groupLabel">
             · {{ selectedFacet.groupLabel }}

--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -116,7 +116,7 @@
                 </h2>
                 <p
                   v-if="item.description"
-                  class="mt-0.5 line-clamp-2 text-xs text-base-content/55"
+                  class="kr-text-dim-xs-55 mt-0.5 line-clamp-2"
                 >
                   {{ item.description }}
                 </p>
@@ -192,7 +192,7 @@
                   </h2>
                   <p
                     v-if="item.description"
-                    class="mt-0.5 line-clamp-2 text-xs text-base-content/55"
+                    class="kr-text-dim-xs-55 mt-0.5 line-clamp-2"
                   >
                     {{ item.description }}
                   </p>
@@ -286,7 +286,7 @@
                   </h2>
                   <p
                     v-if="item.description"
-                    class="line-clamp-2 text-xs text-base-content/55"
+                    class="kr-text-dim-xs-55 line-clamp-2"
                   >
                     {{ item.description }}
                   </p>

--- a/components/giftshop/shopping-cart.vue
+++ b/components/giftshop/shopping-cart.vue
@@ -75,7 +75,7 @@
               </p>
               <p
                 v-else-if="item.artImageId > 0"
-                class="text-xs text-base-content/55"
+                class="kr-text-dim-xs-55"
               >
                 Artwork #{{ item.artImageId }}
               </p>
@@ -123,7 +123,7 @@
             <div class="text-4xl font-black text-primary">
               ${{ cartStore.formattedTotalPrice }}
             </div>
-            <p class="mt-1 text-xs text-base-content/55">
+            <p class="kr-text-dim-xs-55 mt-1">
               Prices are validated again on the server. The browser cannot set
               its own Stripe price.
             </p>

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -247,7 +247,7 @@
 
       <div
         v-if="item.generation !== 'image'"
-        class="rounded-lg bg-base-200 px-2 py-1.5 text-xs text-base-content/55"
+        class="kr-text-dim-xs-55 rounded-lg bg-base-200 px-2 py-1.5"
       >
         {{ item.generation }} generation is defined in the recipe but not yet
         wired into this front-end slice — image outputs run through the live art

--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -80,7 +80,7 @@
                 run.sourceType
               }}</span>
             </div>
-            <div class="flex items-center gap-2 text-xs text-base-content/55">
+            <div class="kr-text-dim-xs-55 flex items-center gap-2">
               <span>{{ recipeLabel(run) }}</span>
               <span class="text-base-content/30">·</span>
               <span>{{ progress(run) }} committed</span>

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -188,7 +188,7 @@
             </span>
             <span
               v-if="subtitle(record)"
-              class="line-clamp-2 text-xs text-base-content/55"
+              class="kr-text-dim-xs-55 line-clamp-2"
             >
               {{ subtitle(record) }}
             </span>

--- a/components/narrative/narrative-art-status.vue
+++ b/components/narrative/narrative-art-status.vue
@@ -41,7 +41,7 @@
         <p class="text-sm font-bold text-error">
           {{ art.status === 'cancelled' ? 'Illustration cancelled' : 'Illustration paused' }}
         </p>
-        <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+        <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
           {{ art.error || 'The story continues without blocking. You can retry this image.' }}
         </p>
       </div>

--- a/components/narrative/narrative-role-assigner.vue
+++ b/components/narrative/narrative-role-assigner.vue
@@ -18,7 +18,7 @@
     <div class="flex flex-wrap items-baseline justify-between gap-2">
       <div>
         <p class="text-sm font-black">The casting board</p>
-        <p class="mt-0.5 text-xs leading-relaxed text-base-content/55">
+        <p class="kr-text-dim-xs-55 mt-0.5 leading-relaxed">
           Drag a card onto a part, or use its buttons. Leave a card blank and
           the story decides.
         </p>

--- a/components/navigation/maturity-toggle.vue
+++ b/components/navigation/maturity-toggle.vue
@@ -28,7 +28,7 @@
             <span class="block text-sm font-bold text-base-content">
               {{ label }}
             </span>
-            <span class="block text-xs text-base-content/55">
+            <span class="kr-text-dim-xs-55 block">
               {{ showMature ? visibleText : hiddenText }}
             </span>
           </span>

--- a/components/navigation/navigation-trimmed.vue
+++ b/components/navigation/navigation-trimmed.vue
@@ -55,7 +55,7 @@
           <h3 class="truncate text-base font-black">{{ channel.label }}</h3>
           <p
             v-if="channel.summary || channel.description"
-            class="line-clamp-1 text-xs text-base-content/55"
+            class="kr-text-dim-xs-55 line-clamp-1"
           >
             {{ channel.summary || channel.description }}
           </p>

--- a/components/newsfeed/newsfeed-filters.vue
+++ b/components/newsfeed/newsfeed-filters.vue
@@ -12,7 +12,7 @@
     <div class="flex items-center justify-between gap-3">
       <div>
         <h3 class="font-black">Filters</h3>
-        <p class="text-xs text-base-content/55">
+        <p class="kr-text-dim-xs-55">
           Program what shows up -- keywords, sources, categories, and sort.
         </p>
       </div>
@@ -154,7 +154,7 @@
 
     <div class="flex flex-col gap-1.5">
       <span class="text-xs font-bold">Perspective balance</span>
-      <p class="text-xs text-base-content/55">
+      <p class="kr-text-dim-xs-55">
         Only reshapes feeds that carry political coverage (e.g. Activism) —
         other feeds are never affected.
       </p>

--- a/components/newsfeed/newsfeed-preferences.vue
+++ b/components/newsfeed/newsfeed-preferences.vue
@@ -10,7 +10,7 @@
     <div class="mb-3 flex items-center justify-between gap-3">
       <div>
         <h3 class="font-black">Manage feeds</h3>
-        <p class="text-xs text-base-content/55">
+        <p class="kr-text-dim-xs-55">
           Choose which feeds appear and the order they're shown in.
         </p>
       </div>
@@ -33,7 +33,7 @@
           <Icon :name="feed.icon" class="size-4 shrink-0 text-primary" />
           <div class="min-w-0">
             <span class="block truncate font-semibold">{{ feed.title }}</span>
-            <span class="block truncate text-xs text-base-content/55">
+            <span class="kr-text-dim-xs-55 block truncate">
               {{ feed.description }}
             </span>
           </div>
@@ -77,7 +77,7 @@
           <Icon :name="feed.icon" class="size-4 shrink-0" />
           <div class="min-w-0">
             <span class="block truncate font-semibold">{{ feed.title }}</span>
-            <span class="block truncate text-xs text-base-content/55">
+            <span class="kr-text-dim-xs-55 block truncate">
               {{ feed.description }}
             </span>
           </div>
@@ -92,10 +92,7 @@
       </li>
     </ul>
 
-    <p
-      v-if="!enabledFeeds.length"
-      class="pt-2 text-center text-xs text-base-content/55"
-    >
+    <p v-if="!enabledFeeds.length" class="kr-text-dim-xs-55 pt-2 text-center">
       No feeds enabled — turn one on above to see it here.
     </p>
   </div>

--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -139,7 +139,7 @@
             {{ task.projectTitle }} · {{ task.id }}
           </p>
           <p class="text-sm font-semibold">{{ task.title }}</p>
-          <p v-if="task.note" class="line-clamp-2 text-xs text-base-content/55">
+          <p v-if="task.note" class="kr-text-dim-xs-55 line-clamp-2">
             {{ task.note }}
           </p>
         </button>

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -121,7 +121,7 @@
       <div class="flex flex-wrap items-start justify-between gap-2">
         <div>
           <h2 class="text-lg font-black">Recent stories</h2>
-          <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+          <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
             Open an existing branch, duplicate it safely, or export a portable
             copy.
           </p>
@@ -155,7 +155,7 @@
               </span>
             </div>
             <p
-              class="mt-1 line-clamp-2 text-xs leading-relaxed text-base-content/55"
+              class="kr-text-dim-xs-55 mt-1 line-clamp-2 leading-relaxed"
             >
               {{ story.bible.premise }}
             </p>

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -120,7 +120,7 @@
                 <h3 class="mt-1 text-lg font-black sm:text-xl">
                   What needs to move?
                 </h3>
-                <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+                <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
                   Be plain and specific. Serendipity can make it magical after it
                   is honest.
                 </p>
@@ -190,7 +190,7 @@
                   Quest recipe
                 </p>
                 <h3 class="mt-1 text-lg font-black">Shape the journey</h3>
-                <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+                <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
                   Choose story ingredients, never model machinery.
                 </p>
               </div>
@@ -379,7 +379,7 @@
           class="taskmaster-action-rail sticky bottom-2 z-30 mx-3 mb-3 flex flex-wrap items-center gap-2 rounded-2xl border border-base-300/80 bg-base-100/90 p-2.5 shadow-2xl backdrop-blur-xl sm:mx-5 sm:p-3 lg:mx-8"
         >
           <p
-            class="hidden min-w-48 flex-1 text-xs font-medium leading-relaxed text-base-content/55 lg:block"
+            class="kr-text-dim-xs-55 hidden min-w-48 flex-1 font-medium leading-relaxed lg:block"
           >
             Next: review a practical checkpoint plan before the story begins.
           </p>
@@ -459,7 +459,7 @@
                 <h3 class="mt-1 text-xl font-black">
                   The quest starts with real checkpoints
                 </h3>
-                <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+                <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
                   Taskmaster weaves these actions into the fiction in order.
                   Nothing is written back without a separate Apply action.
                 </p>
@@ -484,7 +484,7 @@
                   <p class="font-black">{{ checkpoint.title }}</p>
                   <p
                     v-if="checkpoint.detail"
-                    class="mt-1 text-xs leading-relaxed text-base-content/55"
+                    class="kr-text-dim-xs-55 mt-1 leading-relaxed"
                   >
                     {{ checkpoint.detail }}
                   </p>
@@ -752,7 +752,7 @@
                 >
                   What happened in the real world?
                 </p>
-                <p class="mt-1 text-xs text-base-content/55">
+                <p class="kr-text-dim-xs-55 mt-1">
                   Choose the honest checkpoint outcome, then describe what happened
                   below.
                 </p>
@@ -814,7 +814,7 @@
                   <p v-if="store.currentCheckpoint" class="mt-1 text-sm font-black">
                     Current action: {{ store.currentCheckpoint.title }}
                   </p>
-                  <p v-else class="mt-1 text-xs text-base-content/55">
+                  <p v-else class="kr-text-dim-xs-55 mt-1">
                     Every planned checkpoint has an outcome.
                   </p>
                 </div>
@@ -892,7 +892,7 @@
                 <p class="text-sm font-black text-success">
                   All checkpoints have an outcome
                 </p>
-                <p class="mt-0.5 text-xs text-base-content/55">
+                <p class="kr-text-dim-xs-55 mt-0.5">
                   Review any optional Apply actions, then finish for a practical
                   recap.
                 </p>

--- a/components/screenfx/animation-selector.vue
+++ b/components/screenfx/animation-selector.vue
@@ -15,7 +15,7 @@
           <h2 class="text-lg font-black text-base-content">
             Animation preferences
           </h2>
-          <p class="text-xs text-base-content/55">
+          <p class="kr-text-dim-xs-55">
             Startup effects and butterfly behavior for this browser only.
           </p>
         </div>
@@ -77,7 +77,7 @@
         <span class="block text-sm font-black text-base-content">
           Adaptive guardrails
         </span>
-        <span class="block text-xs text-base-content/55">
+        <span class="kr-text-dim-xs-55 block">
           Treat your values as maximums and step down only when frames repeatedly
           struggle.
         </span>

--- a/components/storybook/storybook-state-panel.vue
+++ b/components/storybook/storybook-state-panel.vue
@@ -13,7 +13,7 @@
 
     <div class="mt-3 grid gap-3 lg:grid-cols-3">
       <section class="kr-panel-flat p-3">
-        <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/55">
+        <h3 class="kr-text-dim-xs-55 font-bold uppercase tracking-wide">
           Inventory
         </h3>
         <div v-if="session.inventory.length" class="mt-2 space-y-2">
@@ -57,7 +57,7 @@
       </section>
 
       <section class="kr-panel-flat p-3">
-        <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/55">
+        <h3 class="kr-text-dim-xs-55 font-bold uppercase tracking-wide">
           Consequences
         </h3>
         <ol v-if="recentConsequences.length" class="mt-2 space-y-2">
@@ -84,7 +84,7 @@
       </section>
 
       <section class="kr-panel-flat p-3">
-        <h3 class="text-xs font-bold uppercase tracking-wide text-base-content/55">
+        <h3 class="kr-text-dim-xs-55 font-bold uppercase tracking-wide">
           Branch path
         </h3>
         <ol v-if="recentBranches.length" class="mt-2 space-y-2">

--- a/components/taskmaster/taskmaster-sample-tasks.vue
+++ b/components/taskmaster/taskmaster-sample-tasks.vue
@@ -15,7 +15,7 @@
         <h3 id="taskmaster-samples-heading" class="mt-1 text-base font-black">
           Borrow a beginning
         </h3>
-        <p class="mt-1 text-xs leading-relaxed text-base-content/55">
+        <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
           Each spark builds a reviewable plan. Nothing is applied automatically.
         </p>
       </div>

--- a/components/themes/theme-gallery.vue
+++ b/components/themes/theme-gallery.vue
@@ -108,7 +108,7 @@
           -->
           <h2
             v-if="showBothGroups"
-            class="mb-2 truncate text-xs font-black uppercase tracking-wide text-base-content/55"
+            class="kr-text-dim-xs-55 mb-2 truncate font-black uppercase tracking-wide"
           >
             Default
           </h2>
@@ -201,7 +201,7 @@
           <!-- Same separator rule as Default above. -->
           <h2
             v-if="showBothGroups"
-            class="mb-2 truncate text-xs font-black uppercase tracking-wide text-base-content/55"
+            class="kr-text-dim-xs-55 mb-2 truncate font-black uppercase tracking-wide"
           >
             Shared
           </h2>

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -5,7 +5,7 @@
       <span class="text-sm font-black">Agent credentials</span>
     </div>
 
-    <p class="mb-3 text-xs text-base-content/55">
+    <p class="kr-text-dim-xs-55 mb-3">
       Give one owned Bot a narrow token instead of sharing your whole account.
       Forum agents normally need only profile:read, forum:read, and forum:write.
     </p>
@@ -71,7 +71,7 @@
         <div class="flex items-start justify-between gap-3">
           <div class="min-w-0">
             <p class="truncate text-sm font-bold">{{ credential.label }}</p>
-            <p class="truncate text-xs text-base-content/55">
+            <p class="kr-text-dim-xs-55 truncate">
               {{ botLabel(credential.botId) }} · {{ credential.keyPrefix }}…
             </p>
           </div>

--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -24,7 +24,7 @@
         <h1 class="text-lg font-black leading-tight text-base-content">
           Choose your avatar
         </h1>
-        <p class="truncate text-xs text-base-content/55">
+        <p class="kr-text-dim-xs-55 truncate">
           Pick from a collection, upload your own, or conjure something new.
         </p>
       </div>
@@ -177,7 +177,7 @@
 
             <p
               v-if="selectedGalleryImage.promptString"
-              class="line-clamp-2 max-w-xs text-center text-xs text-base-content/55"
+              class="kr-text-dim-xs-55 line-clamp-2 max-w-xs text-center"
             >
               {{ selectedGalleryImage.promptString }}
             </p>

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -8,7 +8,7 @@
         <p class="truncate text-base font-black text-base-content">
           {{ welcomeMessage }}
         </p>
-        <p class="text-xs text-base-content/55">
+        <p class="kr-text-dim-xs-55">
           Karma, mana, achievements, and everything you've made — all in one
           place.
         </p>
@@ -124,7 +124,7 @@
                     <span class="block font-black text-base-content">
                       Dashboard maturity toggle
                     </span>
-                    <span class="block text-xs text-base-content/55">
+                    <span class="kr-text-dim-xs-55 block">
                       Show a quick 18+ visibility control in the workspace
                       header. This preference stays in this browser.
                     </span>
@@ -154,7 +154,7 @@
                     {{ karmaStore.balance }}
                   </p>
 
-                  <p class="mt-1 text-xs text-base-content/55">
+                  <p class="kr-text-dim-xs-55 mt-1">
                     {{ karmaStore.transactions.length }} recent
                     {{
                       karmaStore.transactions.length === 1 ? 'entry' : 'entries'
@@ -191,7 +191,7 @@
                     max="100"
                   />
 
-                  <p class="mt-1 text-xs text-base-content/55">
+                  <p class="kr-text-dim-xs-55 mt-1">
                     {{
                       manaStore.refillReady
                         ? 'Refill ready'
@@ -213,7 +213,7 @@
                     {{ earnedAchievements.length }}
                   </p>
 
-                  <p class="mt-1 text-xs text-base-content/55">earned</p>
+                  <p class="kr-text-dim-xs-55 mt-1">earned</p>
 
                   <button
                     type="button"
@@ -272,7 +272,7 @@
                     <span class="text-sm font-black">Show mature content</span>
                   </label>
 
-                  <p class="text-xs text-base-content/55">
+                  <p class="kr-text-dim-xs-55">
                     Reveal content flagged mature while you browse.
                   </p>
 
@@ -298,7 +298,7 @@
                     <span class="text-sm font-black">Server preferences</span>
                   </div>
 
-                  <p class="text-xs text-base-content/55">
+                  <p class="kr-text-dim-xs-55">
                     Pick default art/text generation servers.
                   </p>
 

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -106,7 +106,7 @@
                   <span class="block truncate text-sm font-black">
                     {{ color.name }}
                   </span>
-                  <span class="block font-mono text-xs text-base-content/55">
+                  <span class="kr-text-dim-xs-55 block font-mono">
                     {{ color.value }}
                   </span>
                 </span>
@@ -254,7 +254,7 @@
               <div class="flex items-start justify-between gap-3">
                 <div>
                   <h3 class="font-black">{{ group.label }}</h3>
-                  <p class="mt-1 text-xs text-base-content/55">
+                  <p class="kr-text-dim-xs-55 mt-1">
                     {{ group.sections.length }} sections ·
                     {{ group.mixed ? 'mixed colors' : 'one color' }}
                   </p>

--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -91,7 +91,7 @@
               </div>
               <div class="min-w-0">
                 <p class="truncate text-sm font-black">{{ tank.title }}</p>
-                <p class="truncate text-xs text-base-content/55">
+                <p class="kr-text-dim-xs-55 truncate">
                   @{{ tank.User.username }}
                 </p>
               </div>

--- a/utils/scripts/codemods/kr_text_dim_xs_55_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_xs_55_codemod.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `text-xs text-base-content/55` metadata
+caption text to `kr-text-dim-xs-55`.
+
+Sibling of kr_text_dim_sm_codemod.py / kr_text_dim_xs_codemod.py /
+kr_text_dim_sm_70_codemod.py / kr_text_dim_xs_45_codemod.py /
+kr_text_dim_xs_60_codemod.py, same conventions: dry-run by default, --write
+to update matching Vue files in
+place. Only the exact `text-xs text-base-content/55` shape is touched, and
+only in static `class="..."` attributes -- never `:class`/`v-bind:class`
+bindings, and regardless of the base tokens' order in the source. A source
+that already carries `kr-text-dim-xs-55`, or is missing either base token,
+is left untouched. Extra tokens beyond the base set are preserved verbatim
+after the primitive class, matching the kr-badge-*/kr-spinner-*/
+kr-label-bold/kr-text-dim-* codemods' subset-match convention -- pass
+--exact-only to restrict a slice to sources with no extra tokens at all,
+the safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-dim-xs-55"
+BASE_TOKENS = {"text-xs", "text-base-content/55"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-dim-xs-55 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 159: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Added `.kr-text-dim-xs-55` to `assets/css/tailwind.css` (`text-xs text-base-content/55`) — the middle opacity of the `text-xs text-base-content/NN` family sitting between `.kr-text-dim-xs`'s 50% and `.kr-text-dim-xs-60`'s 60%, left open explicitly by slice 158's own note.
- Added `utils/scripts/codemods/kr_text_dim_xs_55_codemod.py`, mirroring the existing `kr_text_dim_xs_60_codemod.py` sibling's subset-match convention exactly (dry-run by default, `--write` to migrate, `--exact-only` to restrict to no-extra-token sources).
- Migrated all 123 occurrences (subset-match) across 49 `.vue` files.
- Targeted `prettier --write` on the 5 files newly flagged by the shortened class strings (the same collapsed-`<span>`-fits-print-width fallout prior slices documented).

### How I verified
- `vue-tsc --noEmit`: clean.
- `eslint` on all 49 changed `.vue` files: held at the same 5 pre-existing errors, confirmed unchanged before/after via `git stash`.
- `npx tsx utils/scripts/verifyLayoutContract.ts`: holds, no new violations (an unrelated pre-existing ratchet-shrink opportunity in `narrative-ingredient-multi-picker.vue` was left untouched — out of this slice's scope).
- `npx tsx utils/scripts/verifyLintRatchet.ts`: holds at 333 problems / -59.
- `prettier --check`: flagged 5 files needing a targeted `--write`; confirmed via `git stash` that none of the 5 carried pre-existing debt first, then the targeted write brought the full file set back to exactly the 34-file pre-existing baseline, file-for-file (verified with a diff of the before/after warning lists).

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
The remaining `text-xs text-base-content/NN` siblings (`/40`: 24 files / 38 occurrences, `/70`: 29 occurrences) are still open — worth a dedicated slice once picked up again, same cadence as this family's rundown.

### Notes for reviewer
Recurring umbrella task (interface-vision/t-104) — conductor roadmap task will be re-armed to `ready` after this merges.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01RL6qFDoDjbh1kNUZuuTcya

---
_Generated by [Claude Code](https://claude.ai/code/session_01RL6qFDoDjbh1kNUZuuTcya)_