### PR TITLE
refactor(ui): migrate text-xs text-base-content/50 to kr-text-dim-xs (slice 160)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1652,7 +1652,16 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
    * match across sizes. The other opacity/size variants surveyed alongside
    * this one (`text-sm text-base-content/70`, `text-xs
    * text-base-content/45`, `text-xs text-base-content/55`, etc.) are left
-   * for future slices, same convention as `.kr-spinner-xs`/`.kr-spinner-sm`. */
+   * for future slices, same convention as `.kr-spinner-xs`/`.kr-spinner-sm`.
+   * Slice 154 deliberately ran the codemod with `--exact-only`, bounding
+   * that first pass to sources with no extra tokens and leaving the fuller
+   * subset-match pool for later (the script's own `--exact-only` help text
+   * says as much). Slice 160 re-ran it without that flag: 74 further files
+   * (150 occurrences, token-order-independent -- `text-base-content/50
+   * text-xs` as well as `text-xs text-base-content/50`) carried the same
+   * pair alongside extra tokens (`ml-auto`, `mt-1`, `truncate`, `font-bold
+   * uppercase`, etc.). `.kr-text-dim-xs` now covers the family completely;
+   * 0 hand-rolled occurrences of this exact pair remain in `*.vue`. */
   .kr-text-dim-xs {
     @apply text-xs text-base-content/50;
   }

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -57,7 +57,7 @@
           </div>
         </div>
 
-        <p class="text-xs font-semibold text-base-content/50" aria-live="polite">
+        <p class="kr-text-dim-xs font-semibold" aria-live="polite">
           {{ resultSummary }}
         </p>
       </div>

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -180,7 +180,7 @@
           {{ store.isEffectActive(store.selectedItem.id) ? 'Stop effect' : 'Preview effect' }}
         </button>
 
-        <p class="text-xs leading-relaxed text-base-content/50">
+        <p class="kr-text-dim-xs leading-relaxed">
           Animation history now belongs in source control and Conductor. The retired
           Component museum is no longer used as a parallel build ledger.
         </p>

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -13,7 +13,7 @@
           {{ activeGroup ? activeGroup.title : 'Gallery' }}
         </h2>
         <p
-          class="hidden min-w-0 truncate text-xs text-base-content/50 sm:block"
+          class="kr-text-dim-xs hidden min-w-0 truncate sm:block"
         >
           {{ headerSummary }}
         </p>
@@ -120,7 +120,7 @@
         </label>
 
         <span
-          class="ml-auto hidden flex-wrap items-center gap-1.5 text-xs text-base-content/50 sm:flex"
+          class="kr-text-dim-xs ml-auto hidden flex-wrap items-center gap-1.5 sm:flex"
         >
           <span class="kr-badge-ghost-sm">
             {{ visibleGroups.length }} collections
@@ -504,7 +504,7 @@
     </section>
 
     <footer
-      class="shrink-0 flex items-center gap-3 rounded-xl border border-base-300 bg-base-200/80 px-3 py-2 text-xs text-base-content/50"
+      class="kr-text-dim-xs shrink-0 flex items-center gap-3 rounded-xl border border-base-300 bg-base-200/80 px-3 py-2"
     >
       <span>
         <span class="font-bold text-base-content">

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -42,7 +42,7 @@
               </span>
             </button>
 
-            <p class="text-center text-xs text-base-content/50">
+            <p class="kr-text-dim-xs text-center">
               {{ readinessSummary }}
             </p>
           </div>

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -312,7 +312,7 @@
                 class="flex cursor-pointer list-none items-center justify-between px-3 py-2 text-sm font-bold"
               >
                 <span>Prompt Text</span>
-                <span class="text-xs font-normal text-base-content/50"
+                <span class="kr-text-dim-xs font-normal"
                   >{{ editForm.promptString.length }} chars</span
                 >
               </summary>
@@ -433,10 +433,9 @@
                       <span class="block truncate text-sm font-semibold">{{
                         collection.label || `Collection ${collection.id}`
                       }}</span>
-                      <span
-                        class="block truncate text-xs text-base-content/50"
-                        >{{ getCollectionMeta(collection) }}</span
-                      >
+                      <span class="kr-text-dim-xs block truncate">{{
+                        getCollectionMeta(collection)
+                      }}</span>
                     </span>
                     <input
                       type="checkbox"

--- a/components/art/art-manager.vue
+++ b/components/art/art-manager.vue
@@ -137,7 +137,7 @@
               </button>
             </div>
 
-            <p class="hidden text-xs text-base-content/50 lg:block">
+            <p class="kr-text-dim-xs hidden lg:block">
               {{
                 artJobWorkspaceTab === 'queue'
                   ? 'Jobs refresh every 15s; health summaries refresh every minute'

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -139,7 +139,7 @@
         <div class="kr-tile-md flex min-h-48 items-center justify-center">
           <div
             v-if="result(side).status === 'idle'"
-            class="flex flex-col items-center gap-2 text-xs text-base-content/50"
+            class="kr-text-dim-xs flex flex-col items-center gap-2"
           >
             <Icon name="kind-icon:image" class="h-8 w-8 opacity-60" />
             No render yet

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -8,7 +8,7 @@
           <h3 class="text-sm font-black">Artwork</h3>
           <span class="kr-badge-ghost-xs">{{ entityLabel }}</span>
         </div>
-        <p class="mt-1 text-xs text-base-content/50">
+        <p class="kr-text-dim-xs mt-1">
           Recreate with Krea, edit the current image with SDXL or Kontext, or upload a finished replacement.
         </p>
       </div>
@@ -174,7 +174,7 @@
         >
           {{ collectionSlides.length }} collection
         </span>
-        <span class="ml-auto text-xs text-base-content/50">
+        <span class="kr-text-dim-xs ml-auto">
           {{ carouselIndex + 1 }} / {{ carouselSlides.length }}
         </span>
       </div>

--- a/components/art/forum-art-generation-context.vue
+++ b/components/art/forum-art-generation-context.vue
@@ -158,7 +158,7 @@
         </a>
       </div>
 
-      <p class="mt-2 text-xs text-base-content/50">
+      <p class="kr-text-dim-xs mt-2">
         The durable ArtJob survives this page. For an existing object or a
         contribution you do not own, completion creates a new Commons reply
         instead of mutating the source. Plain owned posts can still receive

--- a/components/art/image-card.vue
+++ b/components/art/image-card.vue
@@ -146,7 +146,7 @@
           v-if="
             showNegativePrompt && displayImage.negativePrompt && size === 'lg'
           "
-          class="mt-0.5 line-clamp-1 text-xs text-base-content/50"
+          class="kr-text-dim-xs mt-0.5 line-clamp-1"
         >
           ↓ {{ displayImage.negativePrompt }}
         </p>

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -46,7 +46,7 @@
 
           <div class="flex min-w-44 flex-1 flex-col">
             <span class="truncate text-sm font-bold">{{ customer.name }}</span>
-            <span class="truncate text-xs text-base-content/50">
+            <span class="kr-text-dim-xs truncate">
               {{ customer.email || 'no email' }} ·
               {{ superkate.appointmentsForCustomer(customer.id).length }} appointments ·
               {{ photoCounts[customer.id] || 0 }} photos

--- a/components/art/stylist-manager.vue
+++ b/components/art/stylist-manager.vue
@@ -22,7 +22,7 @@
       <div class="flex-1" />
       <span
         v-if="superkate.isSyncing"
-        class="mr-1 flex items-center gap-1 text-xs font-semibold text-base-content/50"
+        class="kr-text-dim-xs mr-1 flex items-center gap-1 font-semibold"
         title="Syncing the service book"
       >
         <span class="kr-spinner-xs" />

--- a/components/art/stylist-relay-status.vue
+++ b/components/art/stylist-relay-status.vue
@@ -46,7 +46,7 @@
 
       <div
         v-if="!loading && !error && !agents.length"
-        class="kr-panel-dashed-plain text-center text-xs text-base-content/50"
+        class="kr-text-dim-xs kr-panel-dashed-plain text-center"
       >
         No relay has polled since the server last restarted.
       </div>

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -275,7 +275,7 @@
       Style it
     </button>
 
-    <p class="text-center text-xs text-base-content/50">
+    <p class="kr-text-dim-xs text-center">
       Styling takes a minute or two — you can keep working or switch tabs; results land below when ready.
     </p>
 

--- a/components/bots/bot-card.vue
+++ b/components/bots/bot-card.vue
@@ -52,7 +52,7 @@
           v-if="showPersonality && bot.personality"
           class="kr-panel-flat p-3 text-sm"
         >
-          <p class="text-xs font-bold uppercase text-base-content/50">
+          <p class="kr-text-dim-xs font-bold uppercase">
             Personality
           </p>
 
@@ -65,7 +65,7 @@
           v-if="showPromptPreview && bot.prompt"
           class="kr-panel-flat p-3 text-sm"
         >
-          <p class="text-xs font-bold uppercase text-base-content/50">Prompt</p>
+          <p class="kr-text-dim-xs font-bold uppercase">Prompt</p>
 
           <p class="mt-1 line-clamp-4 text-base-content/70">
             {{ bot.prompt }}

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -162,7 +162,7 @@
             Clear
           </button>
 
-          <span class="ml-auto text-xs text-base-content/50">
+          <span class="kr-text-dim-xs ml-auto">
             {{ activeServerName }}
           </span>
         </div>
@@ -277,15 +277,13 @@
           </label>
 
           <div class="kr-panel-muted p-3 text-sm">
-            <p class="text-xs font-bold uppercase text-base-content/50">
-              Active Text Server
-            </p>
+            <p class="kr-text-dim-xs font-bold uppercase">Active Text Server</p>
 
             <p class="mt-1 font-semibold text-base-content/80">
               {{ activeServerName }}
             </p>
 
-            <p class="mt-1 text-xs text-base-content/50">
+            <p class="kr-text-dim-xs mt-1">
               Servers are selected at runtime. Bots stay portable.
             </p>
           </div>

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -246,9 +246,7 @@
               </div>
 
               <div class="min-w-0">
-                <p class="text-xs font-bold uppercase text-base-content/50">
-                  Current Bot
-                </p>
+                <p class="kr-text-dim-xs font-bold uppercase">Current Bot</p>
 
                 <h3 class="truncate text-base font-black text-base-content">
                   {{ selectedBotTitle }}

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -118,7 +118,7 @@
           {{ isBatchGenerating ? 'Brainstorming…' : activeCandidates.length ? 'Fresh batch' : (isArtPromptDomain ? 'Generate art prompts' : 'Generate ideas') }}
         </button>
 
-        <p class="max-w-xl text-xs leading-5 text-base-content/50">
+        <p class="kr-text-dim-xs max-w-xl leading-5">
           {{ resultCountModel }} distinct direction{{ resultCountModel === 1 ? '' : 's' }}. A fresh batch does not erase the previous one.
         </p>
       </div>
@@ -338,7 +338,7 @@
             Remove
           </button>
         </div>
-        <p v-else-if="isResolvingSource" class="mt-3 text-xs text-base-content/50">
+        <p v-else-if="isResolvingSource" class="kr-text-dim-xs mt-3">
           Loading selected source…
         </p>
 
@@ -398,7 +398,7 @@
               @click="pickSource(option)"
             >
               <span class="font-bold">{{ option.title }}</span>
-              <span v-if="option.subtitle" class="ml-2 text-xs text-base-content/50">{{ option.subtitle }}</span>
+              <span v-if="option.subtitle" class="kr-text-dim-xs ml-2">{{ option.subtitle }}</span>
             </button>
           </li>
         </ul>
@@ -522,7 +522,7 @@
                       {{ saved.name }}
                     </span>
                     <span
-                      class="mt-0.5 block truncate text-xs text-base-content/50"
+                      class="kr-text-dim-xs mt-0.5 block truncate"
                     >
                       {{ saved.premise || 'No premise recorded.' }}
                     </span>

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -116,7 +116,7 @@
               :key="stat.key"
               class="kr-panel-muted-sm"
             >
-              <p class="text-xs font-bold uppercase text-base-content/50">
+              <p class="kr-text-dim-xs font-bold uppercase">
                 {{ stat.label }}
               </p>
 
@@ -134,9 +134,7 @@
 
           <div class="mt-3 grid gap-2 text-sm">
             <div class="kr-tile-md">
-              <p class="text-xs font-bold uppercase text-base-content/50">
-                Character
-              </p>
+              <p class="kr-text-dim-xs font-bold uppercase">Character</p>
 
               <p class="mt-1 font-semibold">
                 {{ selectedCharacterName }}
@@ -144,9 +142,7 @@
             </div>
 
             <div class="kr-tile-md">
-              <p class="text-xs font-bold uppercase text-base-content/50">
-                Scenario
-              </p>
+              <p class="kr-text-dim-xs font-bold uppercase">Scenario</p>
 
               <p class="mt-1 font-semibold">
                 {{ selectedScenarioTitle }}
@@ -154,9 +150,7 @@
             </div>
 
             <div class="kr-tile-md">
-              <p class="text-xs font-bold uppercase text-base-content/50">
-                Reward
-              </p>
+              <p class="kr-text-dim-xs font-bold uppercase">Reward</p>
 
               <p class="mt-1 font-semibold">
                 {{ selectedRewardTitle }}

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -356,9 +356,7 @@
 
             <div class="mt-3 grid gap-2 text-sm">
               <div class="kr-tile-md">
-                <p class="text-xs font-bold uppercase text-base-content/50">
-                  Character
-                </p>
+                <p class="kr-text-dim-xs font-bold uppercase">Character</p>
 
                 <p class="mt-1 font-semibold">
                   {{ selectedCharacterName }}
@@ -366,9 +364,7 @@
               </div>
 
               <div class="kr-tile-md">
-                <p class="text-xs font-bold uppercase text-base-content/50">
-                  Scenario
-                </p>
+                <p class="kr-text-dim-xs font-bold uppercase">Scenario</p>
 
                 <p class="mt-1 font-semibold">
                   {{ selectedScenarioTitle }}
@@ -376,9 +372,7 @@
               </div>
 
               <div class="kr-tile-md">
-                <p class="text-xs font-bold uppercase text-base-content/50">
-                  Reward
-                </p>
+                <p class="kr-text-dim-xs font-bold uppercase">Reward</p>
 
                 <p class="mt-1 font-semibold">
                   {{ selectedRewardTitle }}

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -149,7 +149,7 @@
               </div>
 
               <div class="min-w-0">
-                <p class="text-xs font-bold uppercase text-base-content/50">
+                <p class="kr-text-dim-xs font-bold uppercase">
                   Current Character
                 </p>
 

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -106,7 +106,7 @@
             </span>
           </div>
           <h4 class="mt-3 font-black">{{ stage.label }}</h4>
-          <p class="mt-1 text-xs leading-relaxed text-base-content/50">
+          <p class="kr-text-dim-xs mt-1 leading-relaxed">
             {{ stage.detail }}
           </p>
         </article>
@@ -115,7 +115,7 @@
       <div class="grid gap-4 xl:grid-cols-2">
         <article class="kr-panel-section-flat">
           <h4 class="text-lg font-black">Source-production blockers</h4>
-          <p class="mt-1 text-xs text-base-content/50">
+          <p class="kr-text-dim-xs mt-1">
             {{ selectedPackage.finalPairCount }}/{{ selectedPackage.expectedInteriorCount }} final pairs ·
             cover {{ selectedPackage.coverStatus }}
           </p>
@@ -132,7 +132,7 @@
                   {{ blocker.values.length }}
                 </span>
               </div>
-              <p class="mt-1 break-words text-xs text-base-content/50">
+              <p class="kr-text-dim-xs mt-1 break-words">
                 {{ summarizeValues(blocker.values) }}
               </p>
             </div>
@@ -145,7 +145,7 @@
 
         <article class="kr-panel-section-flat">
           <h4 class="text-lg font-black">Layout and export blockers</h4>
-          <p class="mt-1 text-xs text-base-content/50">
+          <p class="kr-text-dim-xs mt-1">
             These fields stay unresolved until a printer, trim, binding, and template are chosen.
           </p>
 

--- a/components/coloring/coloring-book-production-toolbar.vue
+++ b/components/coloring/coloring-book-production-toolbar.vue
@@ -85,7 +85,7 @@
       />
       <div class="flex flex-col gap-2">
         <h4 class="font-black">Current B&amp;W production candidate</h4>
-        <p class="break-all text-xs text-base-content/50">
+        <p class="kr-text-dim-xs break-all">
           {{
             production?.bwRenderedPath ||
             proposal.bwPath ||

--- a/components/coloring/production-stage-card.vue
+++ b/components/coloring/production-stage-card.vue
@@ -14,7 +14,7 @@
       </span>
     </div>
     <h4 class="text-sm font-black">{{ label }}</h4>
-    <p class="line-clamp-2 break-all text-xs text-base-content/50">
+    <p class="kr-text-dim-xs line-clamp-2 break-all">
       {{ detail }}
     </p>
   </article>

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -130,7 +130,7 @@
               >
                 {{ run.protagonistName || run.title }}
               </p>
-              <p class="text-xs font-semibold text-base-content/50">
+              <p class="kr-text-dim-xs font-semibold">
                 <template v-if="narrationMode === 'ai'">
                   Chapter {{ chapterIndex }}
                   <span v-if="narratorName" class="text-base-content/40"
@@ -224,7 +224,7 @@
                   class="loading loading-dots loading-lg text-primary/70"
                   aria-hidden="true"
                 />
-                <p class="text-xs font-semibold text-base-content/50">
+                <p class="kr-text-dim-xs font-semibold">
                   {{ narratorName || 'The narrator' }} is writing chapter
                   {{ chapterIndex }}…
                 </p>

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -21,7 +21,7 @@
         </span>
         <div>
           <h3 class="text-base font-black text-base-content">Pack Generator</h3>
-          <p class="text-xs font-semibold text-base-content/50">
+          <p class="kr-text-dim-xs font-semibold">
             Admin only — items are created private until release is approved
           </p>
         </div>
@@ -141,7 +141,7 @@
               </span>
               <span
                 v-if="stateFor(item.id).refId"
-                class="text-xs font-mono text-base-content/50"
+                class="kr-text-dim-xs font-mono"
                 >#{{ stateFor(item.id).refId }}</span
               >
             </div>

--- a/components/conductor/project-deliverables-panel.vue
+++ b/components/conductor/project-deliverables-panel.vue
@@ -27,9 +27,7 @@
 
     <!-- Goal / expected final deliverable -->
     <div v-if="goalText || editing" class="mb-4">
-      <p class="mb-1 text-xs font-semibold text-base-content/50">
-        What 100% looks like
-      </p>
+      <p class="kr-text-dim-xs mb-1 font-semibold">What 100% looks like</p>
       <textarea
         v-if="editing"
         v-model="goalDraft"

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -340,7 +340,7 @@
                 {{ task.title }}
               </p>
               <div
-                class="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-base-content/50"
+                class="kr-text-dim-xs mt-1 flex flex-wrap items-center gap-1.5"
               >
                 <span>{{ task.id }}</span>
                 <span v-if="task.milestone">· {{ task.milestone }}</span>
@@ -361,7 +361,7 @@
               </div>
               <p
                 v-if="task.note"
-                class="mt-1.5 line-clamp-3 text-xs leading-relaxed text-base-content/50"
+                class="kr-text-dim-xs mt-1.5 line-clamp-3 leading-relaxed"
               >
                 {{ task.note }}
               </p>
@@ -380,7 +380,7 @@
           class="group rounded-xl border border-base-300 bg-base-200/50"
         >
           <summary
-            class="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs font-semibold text-base-content/50 marker:content-none"
+            class="kr-text-dim-xs flex cursor-pointer list-none items-center gap-2 px-3 py-2 font-semibold marker:content-none"
           >
             <Icon
               name="kind-icon:chevron-right"

--- a/components/conductor/project-front-page.vue
+++ b/components/conductor/project-front-page.vue
@@ -104,7 +104,7 @@
             <span class="text-sm font-black leading-none text-base-content">{{
               stat.value
             }}</span>
-            <span class="text-xs font-semibold text-base-content/50">{{
+            <span class="kr-text-dim-xs font-semibold">{{
               stat.label
             }}</span>
           </div>

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -22,7 +22,7 @@
         Hide settled designs
       </label>
 
-      <div class="ml-auto text-right text-xs text-base-content/50">
+      <div class="kr-text-dim-xs ml-auto text-right">
         <p class="font-black text-base-content/80">
           {{ visibleRows.length }} shown
         </p>
@@ -72,7 +72,7 @@
                 <h2 class="text-xl font-black">{{ fish.name }}</h2>
                 <span class="kr-badge-outline-sm">{{ fish.rarity }}</span>
               </div>
-              <p class="mt-1 text-xs italic text-base-content/50">
+              <p class="kr-text-dim-xs mt-1 italic">
                 {{ fish.species }}
               </p>
             </div>

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -274,7 +274,7 @@
                 >unsaved</span
               >
             </div>
-            <p class="mt-1 text-xs text-base-content/50">
+            <p class="kr-text-dim-xs mt-1">
               {{ selectedRow.cardKey }} · {{ selectedRow.source.sourceLabel }}
             </p>
           </div>

--- a/components/dreams/daily-digest-object-gallery.vue
+++ b/components/dreams/daily-digest-object-gallery.vue
@@ -10,7 +10,7 @@
         </p>
         <div class="mt-0.5 flex flex-wrap items-baseline gap-x-3 gap-y-1">
           <h3 class="text-lg font-black">Objects in this Daily Dream</h3>
-          <p class="hidden text-xs text-base-content/50 lg:block">
+          <p class="kr-text-dim-xs hidden lg:block">
             Open any object for full details, editing, and artwork controls.
           </p>
         </div>

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -323,7 +323,7 @@
               </div>
 
               <div class="min-w-0">
-                <p class="text-xs font-bold uppercase text-base-content/50">
+                <p class="kr-text-dim-xs font-bold uppercase">
                   Current Dream
                 </p>
 

--- a/components/dreams/dream-list.vue
+++ b/components/dreams/dream-list.vue
@@ -158,7 +158,7 @@
                 {{ entry.badge }}
               </span>
             </div>
-            <p v-if="entry.meta" class="mt-1 text-xs text-base-content/50">
+            <p v-if="entry.meta" class="kr-text-dim-xs mt-1">
               {{ entry.meta }}
             </p>
             <p class="kr-text-dim-sm-70 mt-2 line-clamp-3 whitespace-pre-wrap">

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -334,7 +334,7 @@
                   <p class="truncate text-xl font-black text-primary">
                     {{ dreamStore.dreamForm.title || 'Untitled Dream' }}
                   </p>
-                  <p class="mt-1 text-xs text-base-content/50">
+                  <p class="kr-text-dim-xs mt-1">
                     {{ dreamTypeLabel(dreamStore.dreamForm.dreamType) }} ·
                     {{ dreamStore.dreamForm.isPublic ? 'Public' : 'Private' }}
                   </p>

--- a/components/facets/facet-manager.vue
+++ b/components/facets/facet-manager.vue
@@ -95,7 +95,7 @@
         </div>
       </dl>
 
-      <p class="mt-4 text-xs text-base-content/50">
+      <p class="kr-text-dim-xs mt-4">
         {{ facetStore.facets.length }} canonical Facets ·
         {{
           facetStore.facets.length - facetStore.activeFacets.length

--- a/components/giftshop/checkout-cancel.vue
+++ b/components/giftshop/checkout-cancel.vue
@@ -21,7 +21,7 @@
         v-if="cartStore.hasItems"
         class="mx-auto mt-5 w-fit rounded-2xl border border-base-300 bg-base-200 px-5 py-3"
       >
-        <div class="text-xs font-black uppercase tracking-widest text-base-content/50">
+        <div class="kr-text-dim-xs font-black uppercase tracking-widest">
           Cart preserved
         </div>
         <div class="text-2xl font-black text-primary">

--- a/components/giftshop/checkout-success.vue
+++ b/components/giftshop/checkout-success.vue
@@ -21,7 +21,7 @@
         v-if="verifiedAmount"
         class="mx-auto mt-5 w-fit rounded-2xl border border-base-300 bg-base-200 px-5 py-3"
       >
-        <div class="text-xs font-black uppercase tracking-widest text-base-content/50">
+        <div class="kr-text-dim-xs font-black uppercase tracking-widest">
           Confirmed total
         </div>
         <div class="text-2xl font-black text-primary">

--- a/components/giftshop/shopping-cart.vue
+++ b/components/giftshop/shopping-cart.vue
@@ -117,7 +117,7 @@
       <div class="rounded-3xl border border-primary/30 bg-primary/10 p-5 sm:p-6">
         <div class="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <div class="text-xs font-black uppercase tracking-widest text-base-content/50">
+            <div class="kr-text-dim-xs font-black uppercase tracking-widest">
               Cart total
             </div>
             <div class="text-4xl font-black text-primary">

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -40,7 +40,7 @@
     <section class="kr-panel-muted rounded-xl p-2.5">
       <div class="mb-2 flex items-center justify-between gap-2">
         <span
-          class="text-xs font-bold uppercase tracking-wide text-base-content/50"
+          class="kr-text-dim-xs font-bold uppercase tracking-wide"
         >
           Automate all {{ group.items.length }}
         </span>
@@ -118,7 +118,7 @@
       class="kr-panel-muted rounded-xl p-2.5"
     >
       <span
-        class="mb-2 block text-xs font-bold uppercase tracking-wide text-base-content/50"
+        class="kr-text-dim-xs mb-2 block font-bold uppercase tracking-wide"
       >
         Set a field on all {{ group.items.length }}
       </span>
@@ -177,7 +177,7 @@
     <!-- Per-item fine-tune -->
     <section class="kr-panel-muted rounded-xl p-2.5">
       <span
-        class="mb-2 block text-xs font-bold uppercase tracking-wide text-base-content/50"
+        class="kr-text-dim-xs mb-2 block font-bold uppercase tracking-wide"
       >
         Fine-tune individual items
       </span>

--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -100,7 +100,7 @@
               {{ output.size }}
             </span>
           </div>
-          <p class="truncate text-xs text-base-content/50">
+          <p class="kr-text-dim-xs truncate">
             {{ output.description }}
           </p>
         </div>

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -241,7 +241,7 @@
           </span>
           <span
             v-if="subtitle(record)"
-            class="min-w-0 flex-1 truncate text-xs text-base-content/50"
+            class="kr-text-dim-xs min-w-0 flex-1 truncate"
           >
             {{ subtitle(record) }}
           </span>

--- a/components/narrative/narrative-art-status.vue
+++ b/components/narrative/narrative-art-status.vue
@@ -56,7 +56,7 @@
 
     <div
       v-else
-      class="flex min-h-20 items-center justify-center p-4 text-xs text-base-content/50"
+      class="kr-text-dim-xs flex min-h-20 items-center justify-center p-4"
     >
       {{ statusMessage }}
     </div>

--- a/components/narrative/narrative-ingredient-multi-picker.vue
+++ b/components/narrative/narrative-ingredient-multi-picker.vue
@@ -15,7 +15,7 @@
         <p
           v-if="helper"
           :id="helperId"
-          class="mt-1 max-w-3xl text-xs leading-relaxed text-base-content/50"
+          class="kr-text-dim-xs mt-1 max-w-3xl leading-relaxed"
         >
           {{ helper }}
         </p>
@@ -86,7 +86,7 @@
     <div
       v-else-if="!items.length"
       role="status"
-      class="rounded-2xl border border-dashed border-base-300 bg-base-100/60 p-5 text-center text-xs text-base-content/50"
+      class="kr-text-dim-xs rounded-2xl border border-dashed border-base-300 bg-base-100/60 p-5 text-center"
     >
       {{ emptyState }}
     </div>

--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -15,7 +15,7 @@
         <p
           v-if="helper"
           :id="helperId"
-          class="mt-1 max-w-3xl text-xs leading-relaxed text-base-content/50"
+          class="kr-text-dim-xs mt-1 max-w-3xl leading-relaxed"
         >
           {{ helper }}
         </p>
@@ -86,7 +86,7 @@
     <div
       v-else-if="!items.length"
       role="status"
-      class="rounded-2xl border border-dashed border-base-300 bg-base-100/60 p-5 text-center text-xs text-base-content/50"
+      class="kr-text-dim-xs rounded-2xl border border-dashed border-base-300 bg-base-100/60 p-5 text-center"
     >
       {{ emptyState }}
     </div>

--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -322,7 +322,7 @@
       <section v-if="canSeeNotifications" class="flex flex-col gap-1.5">
         <div class="flex items-center justify-between px-1">
           <p
-            class="text-xs font-black uppercase tracking-widest text-base-content/50"
+            class="kr-text-dim-xs font-black uppercase tracking-widest"
           >
             Notifications
           </p>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -23,7 +23,7 @@
             name="kind-icon:gearhammer"
             class="size-3.5 shrink-0 text-primary/70"
           />
-          <span class="text-xs font-semibold text-base-content/50">
+          <span class="kr-text-dim-xs font-semibold">
             {{ userStore.isAdmin ? 'Conductor' : 'Projects' }}
           </span>
           <span v-if="userStore.isAdmin" class="kr-badge-primary-xs"
@@ -248,7 +248,7 @@
               @submit.prevent="submitNewTodo"
             >
               <h4
-                class="text-xs font-bold uppercase tracking-wide text-base-content/50"
+                class="kr-text-dim-xs font-bold uppercase tracking-wide"
               >
                 New Task
               </h4>
@@ -363,7 +363,7 @@
               <p class="text-xs font-semibold text-accent/80">
                 🍯 Honey-Do Queue
               </p>
-              <p class="mt-0.5 text-xs text-base-content/50">
+              <p class="kr-text-dim-xs mt-0.5">
                 Action items your AI assigned to you. These help your projects
                 along — check them off as you go.
               </p>
@@ -473,7 +473,7 @@
                   </div>
                   <p
                     v-if="todo.description"
-                    class="ml-8 text-xs leading-relaxed text-base-content/50"
+                    class="kr-text-dim-xs ml-8 leading-relaxed"
                   >
                     {{ todo.description }}
                   </p>
@@ -610,7 +610,7 @@
             <!-- PROJECT TASK / COMMENT CREATION -->
             <div v-if="linkedProject" class="kr-panel-flat shrink-0 p-4">
               <h4
-                class="text-xs font-bold uppercase tracking-wide text-base-content/50"
+                class="kr-text-dim-xs font-bold uppercase tracking-wide"
               >
                 Add task / comment
               </h4>
@@ -930,7 +930,7 @@
                           {{ task.title }}
                         </p>
                         <div
-                          class="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-base-content/50"
+                          class="kr-text-dim-xs mt-1 flex flex-wrap items-center gap-1.5"
                         >
                           <span>{{ task.id }}</span>
                           <span v-if="task.milestone"
@@ -983,7 +983,7 @@
                         </div>
                         <p
                           v-if="task.note"
-                          class="mt-1.5 line-clamp-3 text-xs leading-relaxed text-base-content/50"
+                          class="kr-text-dim-xs mt-1.5 line-clamp-3 leading-relaxed"
                         >
                           {{ task.note }}
                         </p>
@@ -1005,7 +1005,7 @@
                     class="group rounded-2xl border border-base-300 bg-base-200/50"
                   >
                     <summary
-                      class="flex cursor-pointer list-none items-start gap-2 px-4 py-2 text-xs font-semibold text-base-content/50 marker:content-none"
+                      class="kr-text-dim-xs flex cursor-pointer list-none items-start gap-2 px-4 py-2 font-semibold marker:content-none"
                     >
                       <Icon
                         name="kind-icon:chevron-right"
@@ -1063,7 +1063,7 @@
               <div class="flex items-center gap-2">
                 <Icon name="kind-icon:check" class="size-4 text-primary" />
                 <h4
-                  class="text-xs font-bold uppercase tracking-wide text-base-content/50"
+                  class="kr-text-dim-xs font-bold uppercase tracking-wide"
                 >
                   Feature Wishlist
                 </h4>

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -22,7 +22,7 @@
               <h2 class="text-xl font-black tracking-tight sm:text-2xl">
                 Pitch Review
               </h2>
-              <p class="text-xs font-medium text-base-content/50 sm:text-sm">
+              <p class="kr-text-dim-xs font-medium sm:text-sm">
                 Decisions stay visible. Duplicates stop cosplaying as new projects.
               </p>
             </div>
@@ -202,7 +202,7 @@
                     {{ signal.label }}
                   </span>
                 </div>
-                <p class="mt-2 text-xs leading-relaxed text-base-content/50">
+                <p class="kr-text-dim-xs mt-2 leading-relaxed">
                   This is a warning, not an automatic verdict. The useful increment may belong inside an existing roadmap instead of becoming another project.
                 </p>
               </div>

--- a/components/pages/creator-earnings-page.vue
+++ b/components/pages/creator-earnings-page.vue
@@ -67,7 +67,7 @@
               <div class="text-5xl font-extrabold text-primary tabular-nums">
                 {{ formatUsdCents(summary.totalCents) }}
               </div>
-              <p class="mt-1 text-xs text-base-content/50">
+              <p class="kr-text-dim-xs mt-1">
                 {{ summary.interactionCount }}
                 {{
                   summary.interactionCount === 1

--- a/components/pages/giving-page.vue
+++ b/components/pages/giving-page.vue
@@ -30,7 +30,7 @@
         Donate at againstmalaria.com/amibot
       </a>
 
-      <p class="mt-2 text-xs text-base-content/50">
+      <p class="kr-text-dim-xs mt-2">
         Opens the Against Malaria Foundation's official fundraiser page in a new
         tab.
       </p>

--- a/components/pages/mermaids-page.vue
+++ b/components/pages/mermaids-page.vue
@@ -143,7 +143,7 @@
             aria-label="Signed copies note"
             class="textarea textarea-bordered min-h-20 w-full text-xs"
           />
-          <p v-else class="whitespace-pre-line text-xs text-base-content/50">
+          <p v-else class="kr-text-dim-xs whitespace-pre-line">
             {{ draft.signedCopiesNote }}
           </p>
         </div>

--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -70,9 +70,7 @@
           <article
             class="rounded-2xl border border-primary/20 bg-base-100 shadow-lg p-5 space-y-1"
           >
-            <h2 class="text-xs uppercase tracking-wide text-base-content/50">
-              Accrued
-            </h2>
+            <h2 class="kr-text-dim-xs uppercase tracking-wide">Accrued</h2>
             <div class="text-3xl font-extrabold text-primary tabular-nums">
               {{ formatUsdCents(data.accrual.totalCents) }}
             </div>
@@ -85,9 +83,7 @@
           <article
             class="rounded-2xl border border-success/20 bg-base-100 shadow-lg p-5 space-y-1"
           >
-            <h2 class="text-xs uppercase tracking-wide text-base-content/50">
-              Remitted
-            </h2>
+            <h2 class="kr-text-dim-xs uppercase tracking-wide">Remitted</h2>
             <div class="text-3xl font-extrabold text-success tabular-nums">
               {{ formatUsdCents(data.remittedTotalCents) }}
             </div>
@@ -100,9 +96,7 @@
           <article
             class="rounded-2xl border border-accent/20 bg-base-100 shadow-lg p-5 space-y-1"
           >
-            <h2 class="text-xs uppercase tracking-wide text-base-content/50">
-              Outstanding
-            </h2>
+            <h2 class="kr-text-dim-xs uppercase tracking-wide">Outstanding</h2>
             <div
               class="text-3xl font-extrabold tabular-nums"
               :class="

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -198,7 +198,7 @@
         class="kr-panel-flat border-dashed bg-base-100/70 p-5 text-center"
       >
         <p class="font-bold">No saved stories yet</p>
-        <p class="mt-1 text-xs text-base-content/50">
+        <p class="kr-text-dim-xs mt-1">
           Your first Storybook session will appear here automatically.
         </p>
       </div>

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -202,7 +202,7 @@
               >
                 <span class="min-w-0 flex-1">
                   <span class="block text-sm font-black">Recipe ingredients</span>
-                  <span class="block truncate text-xs text-base-content/50">
+                  <span class="kr-text-dim-xs block truncate">
                     {{ selectedTone }} · {{ selectedLocationLabel }} ·
                     {{ selectedGrammarLabel }}
                   </span>

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -45,7 +45,7 @@
           {{ selectedRewardName }}
         </h1>
 
-        <p class="hidden truncate text-xs text-base-content/50 sm:block">
+        <p class="kr-text-dim-xs hidden truncate sm:block">
           Set the scene, then let the narrative gremlin loose.
         </p>
       </div>
@@ -183,7 +183,7 @@
               <label class="form-control">
                 <span class="label py-1">
                   <span
-                    class="label-text text-xs font-bold uppercase tracking-wide text-base-content/50"
+                    class="kr-text-dim-xs label-text font-bold uppercase tracking-wide"
                   >
                     Customize the next move
                   </span>
@@ -244,7 +244,7 @@
               Copy Prompt
             </button>
 
-            <span class="ml-auto text-xs text-base-content/50">
+            <span class="kr-text-dim-xs ml-auto">
               {{ activeServerName }}
             </span>
           </div>

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -210,9 +210,7 @@
               </div>
 
               <div class="min-w-0">
-                <p class="text-xs font-bold uppercase text-base-content/50">
-                  Current Reward
-                </p>
+                <p class="kr-text-dim-xs font-bold uppercase">Current Reward</p>
 
                 <h3 class="truncate text-base font-black text-base-content">
                   {{ selectedRewardTitle }}

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -103,7 +103,7 @@
           >
             Freeform genre tags
           </summary>
-          <p class="mt-2 text-xs text-base-content/50">
+          <p class="kr-text-dim-xs mt-2">
             Quick comma-separated genre tags stored on this scenario. For
             reusable genre data shared across scenarios, add Facets above.
           </p>

--- a/components/servers/server-status.vue
+++ b/components/servers/server-status.vue
@@ -37,22 +37,22 @@
 
       <div v-if="activeServer" class="grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-4">
         <div class="rounded-xl bg-base-200 p-3">
-          <p class="text-xs font-black uppercase text-base-content/50">Type</p>
+          <p class="kr-text-dim-xs font-black uppercase">Type</p>
           <p class="font-bold">{{ activeServer.serverType }}</p>
         </div>
 
         <div class="rounded-xl bg-base-200 p-3">
-          <p class="text-xs font-black uppercase text-base-content/50">Access</p>
+          <p class="kr-text-dim-xs font-black uppercase">Access</p>
           <p class="font-bold">{{ activeServer.accessMode }}</p>
         </div>
 
         <div class="rounded-xl bg-base-200 p-3">
-          <p class="text-xs font-black uppercase text-base-content/50">Health</p>
+          <p class="kr-text-dim-xs font-black uppercase">Health</p>
           <p class="font-bold">{{ activeServer.lastStatus || 'UNKNOWN' }}</p>
         </div>
 
         <div class="rounded-xl bg-base-200 p-3">
-          <p class="text-xs font-black uppercase text-base-content/50">Model</p>
+          <p class="kr-text-dim-xs font-black uppercase">Model</p>
           <p class="truncate font-bold">{{ checkpointStore.currentApiModel || activeServer.model || 'n/a' }}</p>
         </div>
       </div>

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -24,7 +24,7 @@
           <h2 class="text-lg font-black text-base-content">
             Create a Performer
           </h2>
-          <p class="mt-0.5 text-xs text-base-content/50">
+          <p class="kr-text-dim-xs mt-0.5">
             Build a custom cast member from scratch.
           </p>
         </div>
@@ -64,7 +64,7 @@
           <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div class="flex flex-col gap-1.5">
               <label
-                class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+                class="kr-text-dim-xs font-bold uppercase tracking-widest"
                 >Name *</label
               >
               <input
@@ -77,7 +77,7 @@
             </div>
             <div class="flex flex-col gap-1.5">
               <label
-                class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+                class="kr-text-dim-xs font-bold uppercase tracking-widest"
               >
                 Voice / Notes
               </label>
@@ -145,7 +145,7 @@
           <div class="flex flex-col gap-1.5">
             <div class="flex items-center justify-between">
               <label
-                class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+                class="kr-text-dim-xs font-bold uppercase tracking-widest"
                 >Stage Prompt</label
               >
               <button
@@ -176,7 +176,7 @@
           <div class="flex flex-col gap-2">
             <div class="flex items-center justify-between">
               <label
-                class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+                class="kr-text-dim-xs font-bold uppercase tracking-widest"
                 >Avatar Image</label
               >
               <button

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -109,7 +109,7 @@
             <p class="text-xs font-black text-base-content">
               {{ store.selectedStage.label }}
             </p>
-            <p class="text-xs text-base-content/50 mt-0.5 line-clamp-2">
+            <p class="kr-text-dim-xs mt-0.5 line-clamp-2">
               {{ store.selectedStage.tagline }}
             </p>
           </div>
@@ -196,7 +196,7 @@
                 :style="`width: ${Math.min(100, (store.turnIndex / store.maxTurns) * 100)}%`"
               />
             </div>
-            <span class="text-xs text-base-content/50 shrink-0"
+            <span class="kr-text-dim-xs shrink-0"
               >{{ store.turnIndex }}/{{ store.maxTurns }}</span
             >
           </div>
@@ -333,7 +333,7 @@
                       <p class="text-xs font-bold text-base-content truncate">
                         {{ p.name }}
                       </p>
-                      <p class="text-xs text-base-content/50 truncate">
+                      <p class="kr-text-dim-xs truncate">
                         {{ p.species }}
                       </p>
                     </div>
@@ -425,7 +425,7 @@
                 </div>
                 <div class="flex items-center gap-1.5">
                   <span
-                    class="rounded-full border border-base-300 px-2 py-0.5 text-xs text-base-content/50"
+                    class="kr-text-dim-xs rounded-full border border-base-300 px-2 py-0.5"
                     >{{ role.min }}–{{ role.max }}</span
                   >
                   <button
@@ -513,7 +513,7 @@
             <!-- Show title -->
             <div class="flex flex-col gap-1.5">
               <label
-                class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+                class="kr-text-dim-xs font-bold uppercase tracking-widest"
                 >Show Title</label
               >
               <input
@@ -528,7 +528,7 @@
             <!-- Topic -->
             <div class="flex flex-col gap-1.5">
               <label
-                class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+                class="kr-text-dim-xs font-bold uppercase tracking-widest"
                 >Topic / Premise</label
               >
               <input
@@ -543,7 +543,7 @@
             <!-- Custom opening -->
             <div class="flex flex-col gap-1.5 sm:col-span-2">
               <label
-                class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+                class="kr-text-dim-xs font-bold uppercase tracking-widest"
                 >Custom Opening Cue</label
               >
               <input
@@ -560,7 +560,7 @@
             <!-- Turns -->
             <div class="flex flex-col gap-2">
               <label
-                class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+                class="kr-text-dim-xs font-bold uppercase tracking-widest"
                 >Turns ({{ store.maxTurns }})</label
               >
               <input
@@ -580,7 +580,7 @@
             <!-- Delay -->
             <div class="flex flex-col gap-2">
               <label
-                class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+                class="kr-text-dim-xs font-bold uppercase tracking-widest"
                 >Delay between turns ({{ store.turnDelayMs }}ms)</label
               >
               <input
@@ -600,7 +600,7 @@
             <!-- Server -->
             <div class="flex flex-col gap-1.5">
               <label
-                class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+                class="kr-text-dim-xs font-bold uppercase tracking-widest"
                 >Text Server</label
               >
               <select
@@ -622,7 +622,7 @@
             <!-- Model -->
             <div class="flex flex-col gap-1.5">
               <label
-                class="text-xs font-bold uppercase tracking-widest text-base-content/50"
+                class="kr-text-dim-xs font-bold uppercase tracking-widest"
                 >Model</label
               >
               <input
@@ -777,7 +777,7 @@
               <Icon name="mdi:skip-next" class="h-4 w-4" />
             </button>
 
-            <span class="flex-1 text-xs text-base-content/50">
+            <span class="kr-text-dim-xs flex-1">
               Turn {{ store.turnIndex }}/{{ store.maxTurns }}
               <span
                 v-if="store.isGenerating"

--- a/components/storybook/storybook-visual-setup.vue
+++ b/components/storybook/storybook-visual-setup.vue
@@ -322,7 +322,7 @@
       >
         <label class="form-control">
           <span class="font-black">One last note, if you want one</span>
-          <span class="mt-1 text-xs text-base-content/50">
+          <span class="kr-text-dim-xs mt-1">
             A boundary, relationship, running gag, or bit of direction the
             narrator should remember.
           </span>
@@ -347,7 +347,7 @@
           Clear the table
         </button>
         <div class="flex items-center gap-3">
-          <p class="hidden text-xs text-base-content/50 sm:block">
+          <p class="kr-text-dim-xs hidden sm:block">
             {{ canBegin ? 'Ready when you are.' : 'A premise unlocks the story.' }}
           </p>
           <button

--- a/components/taskmaster/taskmaster-sample-tasks.vue
+++ b/components/taskmaster/taskmaster-sample-tasks.vue
@@ -66,7 +66,7 @@
           <span class="block text-sm font-black leading-snug">
             {{ sample.task }}
           </span>
-          <span class="block text-xs leading-relaxed text-base-content/50">
+          <span class="kr-text-dim-xs block leading-relaxed">
             {{ sample.helper }}
           </span>
           <span

--- a/components/tasks/honeydo-card.vue
+++ b/components/tasks/honeydo-card.vue
@@ -81,7 +81,7 @@
     </div>
     <p
       v-if="todo.description"
-      class="ml-8 text-xs leading-relaxed text-base-content/50"
+      class="kr-text-dim-xs ml-8 leading-relaxed"
     >
       {{ todo.description }}
     </p>

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -137,7 +137,7 @@
       @submit.prevent="createCredential"
     >
       <div class="flex items-center justify-between gap-3">
-        <p class="text-xs font-black uppercase tracking-widest text-base-content/50">
+        <p class="kr-text-dim-xs font-black uppercase tracking-widest">
           {{ replacingCredentialId ? 'Replacement credential' : 'New credential' }}
         </p>
         <button

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -196,7 +196,7 @@
           <h3 class="truncate text-base font-black text-base-content">
             {{ activeThread.otherLabel }}
           </h3>
-          <p class="truncate text-xs text-base-content/50">
+          <p class="kr-text-dim-xs truncate">
             {{ activeThread.count }}
             {{ activeThread.count === 1 ? 'message' : 'messages' }}
           </p>

--- a/components/user/friend-gallery.vue
+++ b/components/user/friend-gallery.vue
@@ -57,7 +57,7 @@
                 'Unknown User'
               }}
             </h3>
-            <p class="text-xs text-base-content/50 uppercase tracking-widest">
+            <p class="kr-text-dim-xs uppercase tracking-widest">
               {{ formatRole(userById.get(Number(item.id))!.Role) }}
             </p>
 

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -227,7 +227,7 @@
 
               <div v-if="earnedAchievements.length" class="kr-panel-flat p-3">
                 <p
-                  class="mb-2 text-xs font-black uppercase tracking-widest text-base-content/50"
+                  class="kr-text-dim-xs mb-2 font-black uppercase tracking-widest"
                 >
                   Recent achievements
                 </p>

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -55,7 +55,7 @@
 
       <!-- Recent entries (BROWSE-UX.md §1) -- fixed global view, no filters -->
       <div v-if="recentEntries.length" class="kr-panel-section-flat">
-        <p class="mb-2 text-xs font-semibold uppercase text-base-content/50">
+        <p class="kr-text-dim-xs mb-2 font-semibold uppercase">
           Recent entries
         </p>
         <ul class="flex flex-col gap-1">
@@ -71,7 +71,7 @@
             <span class="truncate font-semibold text-base-content">{{
               entry.title
             }}</span>
-            <span class="ml-auto shrink-0 text-xs text-base-content/50">{{
+            <span class="kr-text-dim-xs ml-auto shrink-0">{{
               formatDate(entry)
             }}</span>
           </li>
@@ -89,9 +89,7 @@
           <span class="text-lg font-black text-base-content">{{
             stats.totalCount
           }}</span>
-          <span class="text-xs font-semibold text-base-content/50"
-            >entries</span
-          >
+          <span class="kr-text-dim-xs font-semibold">entries</span>
         </div>
         <div
           class="flex flex-col items-center gap-0.5 rounded-2xl p-2 text-center"
@@ -99,9 +97,7 @@
           <span class="text-lg font-black text-base-content">{{
             stats.starredCount
           }}</span>
-          <span class="text-xs font-semibold text-base-content/50"
-            >starred</span
-          >
+          <span class="kr-text-dim-xs font-semibold">starred</span>
         </div>
         <div
           class="flex flex-col items-center gap-0.5 rounded-2xl p-2 text-center"
@@ -109,9 +105,7 @@
           <span class="text-lg font-black text-base-content">{{
             Math.round(stats.audiobookHours)
           }}</span>
-          <span class="text-xs font-semibold text-base-content/50"
-            >audiobook hrs</span
-          >
+          <span class="kr-text-dim-xs font-semibold">audiobook hrs</span>
         </div>
         <div
           class="flex flex-col items-center gap-0.5 rounded-2xl p-2 text-center"
@@ -119,9 +113,7 @@
           <span class="text-lg font-black text-base-content">{{
             stats.pagesRead
           }}</span>
-          <span class="text-xs font-semibold text-base-content/50"
-            >pages read</span
-          >
+          <span class="kr-text-dim-xs font-semibold">pages read</span>
         </div>
         <div
           class="flex flex-col items-center gap-0.5 rounded-2xl p-2 text-center"
@@ -129,9 +121,7 @@
           <span class="text-lg font-black text-base-content">{{
             stats.comicIssuesRead
           }}</span>
-          <span class="text-xs font-semibold text-base-content/50"
-            >comics read</span
-          >
+          <span class="kr-text-dim-xs font-semibold">comics read</span>
         </div>
         <div
           class="flex flex-col items-center gap-0.5 rounded-2xl p-2 text-center"
@@ -139,7 +129,7 @@
           <span class="text-lg font-black text-base-content">{{
             stats.tvSeasonCount
           }}</span>
-          <span class="text-xs font-semibold text-base-content/50"
+          <span class="kr-text-dim-xs font-semibold"
             >TV seasons ({{ stats.tvShowCount }} shows)</span
           >
         </div>
@@ -151,9 +141,7 @@
         class="grid grid-cols-[repeat(auto-fit,minmax(16rem,1fr))] gap-4 kr-panel-section-flat"
       >
         <div v-if="mediaTypeBreakdown.length" class="flex flex-col gap-2">
-          <p class="text-xs font-semibold uppercase text-base-content/50">
-            By media type
-          </p>
+          <p class="kr-text-dim-xs font-semibold uppercase">By media type</p>
           <div
             v-for="row in mediaTypeBreakdown"
             :key="row.label"
@@ -165,7 +153,7 @@
               :value="row.count"
               :max="mediaTypeMax"
             />
-            <span class="w-6 shrink-0 text-right text-xs text-base-content/50">
+            <span class="kr-text-dim-xs w-6 shrink-0 text-right">
               {{ row.count }}
             </span>
           </div>
@@ -174,7 +162,7 @@
         <div class="flex flex-col gap-2">
           <p
             v-if="monthBreakdown.length"
-            class="text-xs font-semibold uppercase text-base-content/50"
+            class="kr-text-dim-xs font-semibold uppercase"
           >
             By month
           </p>
@@ -204,9 +192,7 @@
           </div>
 
           <template v-if="stats.topStarred.length">
-            <p
-              class="mt-2 text-xs font-semibold uppercase text-base-content/50"
-            >
+            <p class="kr-text-dim-xs mt-2 font-semibold uppercase">
               Top starred
             </p>
             <ul class="flex flex-col gap-1">
@@ -234,7 +220,7 @@
         v-if="stats && showYearComparison"
         class="overflow-x-auto kr-panel-section-flat"
       >
-        <p class="mb-2 text-xs font-semibold uppercase text-base-content/50">
+        <p class="kr-text-dim-xs mb-2 font-semibold uppercase">
           Year over year
         </p>
         <table class="table table-sm">
@@ -503,9 +489,7 @@
                 entry.title
               }}</span>
             </div>
-            <div
-              class="flex shrink-0 items-center gap-2 text-xs text-base-content/50"
-            >
+            <div class="kr-text-dim-xs flex shrink-0 items-center gap-2">
               <span
                 v-if="entry.rating"
                 class="kr-badge-warning-sm gap-0.5 rounded-lg"

--- a/pages/admin/achievement-art.vue
+++ b/pages/admin/achievement-art.vue
@@ -95,7 +95,7 @@
                   <p class="truncate text-sm font-black">
                     {{ achievement.label }}
                   </p>
-                  <p class="truncate text-xs text-base-content/50">
+                  <p class="kr-text-dim-xs truncate">
                     {{ achievement.triggerCode || achievement.message }}
                   </p>
                 </div>

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -234,10 +234,7 @@
                 >
                   {{ resourceLabel(resource) }}
                 </h2>
-                <p
-                  v-if="resource.generation"
-                  class="mt-1 text-xs text-base-content/50"
-                >
+                <p v-if="resource.generation" class="kr-text-dim-xs mt-1">
                   {{ resource.generation }}
                 </p>
                 <p

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -112,7 +112,7 @@
                   {{ preset.label }} · {{ preset.width }}×{{ preset.height }} · {{ preset.fps }} fps
                 </option>
               </select>
-              <span class="text-xs leading-relaxed text-base-content/50">
+              <span class="kr-text-dim-xs leading-relaxed">
                 {{ store.selectedPreset.description }}
               </span>
             </label>
@@ -120,7 +120,7 @@
             <label class="flex cursor-pointer items-center justify-between gap-4 kr-panel-compact">
               <div>
                 <span class="block text-sm font-black">Mature batch</span>
-                <span class="block text-xs text-base-content/50">
+                <span class="kr-text-dim-xs block">
                   Carries the existing ArtJob maturity flag into every generated clip.
                 </span>
               </div>
@@ -164,7 +164,7 @@
               </button>
             </div>
 
-            <p class="text-xs leading-relaxed text-base-content/50">
+            <p class="kr-text-dim-xs leading-relaxed">
               Resume is idempotent for the current source bytes and settings. Change the image,
               preset, duration, or maturity and it intentionally becomes a new render.
             </p>
@@ -181,7 +181,7 @@
                   :class="{ 'ring-2 ring-primary': statusFilter === tile.key }"
                   @click="statusFilter = statusFilter === tile.key ? 'all' : tile.key"
                 >
-                  <p class="text-xs font-bold text-base-content/50">{{ tile.label }}</p>
+                  <p class="kr-text-dim-xs font-bold">{{ tile.label }}</p>
                   <p class="text-2xl font-black">{{ tile.count }}</p>
                 </button>
               </div>
@@ -189,7 +189,7 @@
                 <progress class="progress progress-primary flex-1" :value="store.completionPercent" max="100" />
                 <span class="w-12 text-right text-sm font-black">{{ store.completionPercent }}%</span>
               </div>
-              <p v-if="statusFilter !== 'all'" class="mt-3 flex items-center gap-2 text-xs text-base-content/50">
+              <p v-if="statusFilter !== 'all'" class="kr-text-dim-xs mt-3 flex items-center gap-2">
                 Showing {{ filteredSources.length }} {{ statusFilter }} scene{{ filteredSources.length === 1 ? '' : 's' }} only.
                 <button type="button" class="link" @click="statusFilter = 'all'">Clear filter</button>
               </p>

--- a/pages/email-confirmation.vue
+++ b/pages/email-confirmation.vue
@@ -21,7 +21,7 @@
 
           <div class="flex flex-col gap-2">
             <p
-              class="text-xs font-black uppercase tracking-[0.2em] text-base-content/50"
+              class="kr-text-dim-xs font-black uppercase tracking-[0.2em]"
             >
               Email confirmation
             </p>

--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -113,7 +113,7 @@
             <Icon name="kind-icon:arrow-left" class="size-4" />
             Newer
           </button>
-          <p class="text-xs font-bold text-base-content/50">
+          <p class="kr-text-dim-xs font-bold">
             {{ Math.min(skip + tanks.length, total) }} of {{ total }}
           </p>
           <button

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -110,7 +110,7 @@
             <Icon name="kind-icon:arrow-left" class="size-4" />
             Higher ranks
           </button>
-          <p class="text-xs font-bold text-base-content/50">
+          <p class="kr-text-dim-xs font-bold">
             {{ Math.min(skip + entries.length, total) }} of {{ total }}
           </p>
           <button


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 160: complete the `.kr-text-dim-xs` migration's subset-match pool (kind: software)

### What changed / what I produced
- Slice 154 named `.kr-text-dim-xs` (`text-xs text-base-content/50`) but deliberately ran `kr_text_dim_xs_codemod.py` with `--exact-only`, covering only the 42 occurrences with no extra tokens and explicitly leaving the fuller subset-match pool for a later slice (the script's own `--exact-only` help text says as much).
- Re-ran the same, already-existing codemod without that flag: 150 further occurrences across 74 files carried the same base pair — in either token order (`text-base-content/50 text-xs` as well as `text-xs text-base-content/50`) — alongside extra utility classes (`ml-auto`, `mt-1`, `truncate`, `font-bold uppercase`, etc.), which the codemod already supported preserving via its subset-match convention.
- No CSS or script changes needed beyond a documentation comment update — just running the existing tool over its full scope.
- `.kr-text-dim-xs` now covers the family completely: 0 hand-rolled occurrences of `text-xs text-base-content/50` remain in `*.vue`.

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint` on all 74 changed `.vue` files: held at 35 pre-existing problems (33 errors, 2 warnings), confirmed unchanged before/after via `git stash`
- `test:layout-contract`: holds, no new violations (incidentally surfaced 2 pre-existing `viewport-grid` entries in `narrative-ingredient-multi-picker.vue` that no longer violate the contract — unrelated to this diff, left for a future slice's `--update` pass rather than folded in here)
- `prettier --check`: flagged 10 files with new collapsed-`<span>` fallout (shorter class strings letting multi-line tags fit prettier's print width, same pattern as slices 149/157); targeted `--write` on exactly those 10 brought the full 74-file set back to the pre-existing 44-file baseline (45 minus one file the migration coincidentally fixed), file-for-file, confirmed via `git stash` first

### Stakes
reversible

### Flags for Reviewer
- The 2 layout-contract `viewport-grid` entries that could now be ratcheted out of the baseline (`narrative-ingredient-multi-picker.vue`) are unrelated to this diff and left alone per scope discipline — a future slice can run `test:layout-contract -- --update` if desired.

### Kaizen suggestion
Several other already-named `kr-text-dim-*` primitives (`kr-text-dim-sm`, `kr-text-dim-sm-70`, `kr-text-dim-xs-45`, `kr-text-dim-xs-55`, `kr-text-dim-xs-60`) were likely also migrated `--exact-only` on their first pass — worth a quick subset-match re-run sweep across all of them the same way this slice did for `kr-text-dim-xs`, rather than waiting for each to resurface individually.

### Notes for reviewer

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGGtsiKFB3JYAu1kY3mbqd)_