### PR TITLE
refactor(ui): complete kr-text-dim-sm subset-match migration (slice 161)

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -112,7 +112,7 @@
 
                 <template #fallback>
                   <div
-                    class="rounded-2xl border border-dashed border-base-300 p-4 text-sm text-base-content/60"
+                    class="kr-text-dim-sm rounded-2xl border border-dashed border-base-300 p-4"
                   >
                     Loading workspace...
                   </div>

--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -50,7 +50,7 @@
           class="flex min-h-40 flex-col items-center justify-center gap-2 kr-panel-dashed-tint text-center"
         >
           <span class="text-3xl" aria-hidden="true">🏛️</span>
-          <p class="text-sm font-semibold text-base-content/60">
+          <p class="kr-text-dim-sm font-semibold">
             Select a style to see its story
           </p>
           <p class="text-xs text-base-content/40">

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -15,7 +15,7 @@
             </span>
             <div class="min-w-0">
               <h1 class="text-2xl font-black text-primary">Image Generator</h1>
-              <p class="mt-0.5 text-sm text-base-content/60">
+              <p class="kr-text-dim-sm mt-0.5">
                 Recipe → prompt → pixels. Everything here renders on ComfyUI.
               </p>
             </div>

--- a/components/art/forum-art-generation-context.vue
+++ b/components/art/forum-art-generation-context.vue
@@ -10,7 +10,7 @@
         <h2 class="mt-1 text-lg font-black text-primary">
           Build on this contribution
         </h2>
-        <p class="mt-1 text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mt-1">
           Turn a useful Commons contribution into a new canonical Kind Robots
           ArtImage. Existing objects are never overwritten: the finished work
           becomes another contribution in the same thread so people and agents

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -20,7 +20,7 @@
             </span>
           </p>
 
-          <p v-else class="truncate text-sm text-base-content/60">
+          <p v-else class="kr-text-dim-sm truncate">
             <span class="hidden md:inline">{{ subtitle }}</span>
           </p>
         </div>
@@ -252,7 +252,7 @@
                   {{ selectedBotTitle }}
                 </h3>
 
-                <p class="truncate text-sm text-base-content/60">
+                <p class="kr-text-dim-sm truncate">
                   {{ selectedBotSubtitle }}
                 </p>
               </div>

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -828,7 +828,7 @@
     >
       <p class="text-3xl" aria-hidden="true">✦</p>
       <h3 class="mt-2 text-xl font-black text-base-content">No candidates yet.</h3>
-      <p class="mx-auto mt-2 max-w-2xl text-sm leading-6 text-base-content/60">
+      <p class="kr-text-dim-sm mx-auto mt-2 max-w-2xl leading-6">
         The blank page is currently winning. Give Brainstorm something to push against, then decide which ideas deserve to survive.
       </p>
       <div class="mx-auto mt-5 flex max-w-4xl flex-wrap justify-center gap-2" aria-label="Brainstorm starters">

--- a/components/builder/builder-card.vue
+++ b/components/builder/builder-card.vue
@@ -66,7 +66,7 @@
           {{ card.tagline }}
         </p>
 
-        <p class="line-clamp-2 text-sm leading-relaxed text-base-content/60">
+        <p class="kr-text-dim-sm line-clamp-2 leading-relaxed">
           {{ card.narrative }}
         </p>
       </div>

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -39,9 +39,7 @@
                 {{ selectedCharacterName }}
               </h2>
 
-              <p class="truncate text-sm text-base-content/60">
-                Selected character cockpit.
-              </p>
+              <p class="kr-text-dim-sm truncate">Selected character cockpit.</p>
             </div>
 
             <button

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -122,7 +122,7 @@
             >
               <div
                 v-if="chatMessages.length === 0"
-                class="flex h-full min-h-32 items-center justify-center text-center text-sm text-base-content/60"
+                class="kr-text-dim-sm flex h-full min-h-32 items-center justify-center text-center"
               >
                 No messages yet. The void is listening, but it keeps forgetting
                 its password.

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -157,7 +157,7 @@
                   {{ selectedCharacterTitle }}
                 </h3>
 
-                <p class="truncate text-sm text-base-content/60">
+                <p class="kr-text-dim-sm truncate">
                   {{ selectedCharacterSubtitle }}
                 </p>
               </div>

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -8,7 +8,7 @@
           <icon name="kind-icon:book" class="size-6 text-primary" />
           <h3 class="text-2xl font-black">Coloring Book Production Studio</h3>
         </div>
-        <p class="mt-1 max-w-3xl text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mt-1 max-w-3xl">
           Three canonical books, 108 proposal slots, real Conductor prompts,
           paired art, queue state, and targeted revision requests.
         </p>

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -125,9 +125,7 @@
             class="flex flex-col gap-4"
           >
             <div class="flex flex-wrap items-center justify-between gap-2">
-              <p
-                class="text-sm font-black uppercase tracking-wide text-base-content/60"
-              >
+              <p class="kr-text-dim-sm font-black uppercase tracking-wide">
                 {{ run.protagonistName || run.title }}
               </p>
               <p class="kr-text-dim-xs font-semibold">

--- a/components/dreams/daily-digest-browser.vue
+++ b/components/dreams/daily-digest-browser.vue
@@ -144,7 +144,7 @@
           <div v-else class="py-5">
             <p class="text-lg font-black">No Daily Dreams have landed yet.</p>
             <p
-              class="mt-2 max-w-xl text-sm leading-relaxed text-base-content/60"
+              class="kr-text-dim-sm mt-2 max-w-xl leading-relaxed"
             >
               This space follows the current Daily Dream model. As the backlog is
               built and artwork finishes rendering, each day will appear here with

--- a/components/dreams/dream-art-chooser.vue
+++ b/components/dreams/dream-art-chooser.vue
@@ -155,7 +155,7 @@
 
       <div
         v-if="!visibleImages.length"
-        class="kr-panel-muted col-span-full flex min-h-40 flex-col items-center justify-center border-dashed text-center text-sm text-base-content/60"
+        class="kr-text-dim-sm kr-panel-muted col-span-full flex min-h-40 flex-col items-center justify-center border-dashed text-center"
       >
         <Icon name="kind-icon:image" class="h-10 w-10 text-primary/60" />
         <p class="mt-2 font-bold">No art found for this filter.</p>

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -331,7 +331,7 @@
                   {{ selectedDreamTitle }}
                 </h3>
 
-                <p class="truncate text-sm text-base-content/60">
+                <p class="kr-text-dim-sm truncate">
                   {{ selectedDreamSubtitle }}
                 </p>
               </div>

--- a/components/dreams/dream-narration.vue
+++ b/components/dreams/dream-narration.vue
@@ -7,7 +7,7 @@
           <h1 class="truncate text-lg font-black text-primary">
             {{ dreamTitle }}
           </h1>
-          <p class="truncate text-sm text-base-content/60">
+          <p class="kr-text-dim-sm truncate">
             {{ selectedSummary }}
           </p>
         </div>
@@ -79,7 +79,7 @@
 
         <section class="kr-panel-muted-sm">
           <h2 class="font-black">Organic Assets</h2>
-          <p class="mt-1 text-sm text-base-content/60">
+          <p class="kr-text-dim-sm mt-1">
             The selected Dream is the anchor. Use these panels to move through
             connected Dreams, Scenarios, Characters, Rewards, Art, and Chats.
           </p>
@@ -111,9 +111,7 @@
       >
         <section class="kr-panel-muted-sm">
           <h2 class="font-black">Dream Cast</h2>
-          <p class="mt-1 text-sm text-base-content/60">
-            Characters connected to this Dream.
-          </p>
+          <p class="kr-text-dim-sm mt-1">Characters connected to this Dream.</p>
         </section>
         <dream-list list-type="cast" view-mode="grid" :show-refresh="false" />
       </div>
@@ -124,7 +122,7 @@
       >
         <section class="kr-panel-muted-sm">
           <h2 class="font-black">Dream Rewards</h2>
-          <p class="mt-1 text-sm text-base-content/60">
+          <p class="kr-text-dim-sm mt-1">
             Rewards and narrative items connected to this Dream.
           </p>
         </section>
@@ -143,7 +141,7 @@
       <div v-else class="grid gap-3">
         <section class="kr-panel-muted-sm">
           <h2 class="font-black">Dream Chat</h2>
-          <p class="mt-1 text-sm text-base-content/60">
+          <p class="kr-text-dim-sm mt-1">
             Conversation threads attached to this Dream.
           </p>
         </section>

--- a/components/dreams/dream-relationship-gallery.vue
+++ b/components/dreams/dream-relationship-gallery.vue
@@ -11,7 +11,7 @@
           <h2 class="truncate text-lg font-black text-base-content">
             {{ title }}
           </h2>
-          <p class="truncate text-sm text-base-content/60">
+          <p class="kr-text-dim-sm truncate">
             {{ subtitleLine }}
           </p>
         </div>

--- a/components/giftshop/mana-wallet.vue
+++ b/components/giftshop/mana-wallet.vue
@@ -48,7 +48,7 @@
             :value="manaStore.pct"
             max="100"
           />
-          <div class="flex justify-between text-sm text-base-content/60">
+          <div class="kr-text-dim-sm flex justify-between">
             <span v-if="manaStore.refillReady" class="text-success font-medium">
               Refill ready on next load ✨
             </span>

--- a/components/giftshop/shopping-cart.vue
+++ b/components/giftshop/shopping-cart.vue
@@ -38,7 +38,7 @@
     >
       <Icon name="kind-icon:cart" class="mx-auto h-10 w-10 text-base-content/35" />
       <p class="mt-3 text-lg font-black text-base-content">Your cart is empty.</p>
-      <p class="mt-1 text-sm text-base-content/60">
+      <p class="kr-text-dim-sm mt-1">
         The butterflies have returned the receipt printer to sleep mode.
       </p>
       <div class="mt-5 flex flex-wrap justify-center gap-2">

--- a/components/home/home-object-sheet.vue
+++ b/components/home/home-object-sheet.vue
@@ -53,7 +53,7 @@
             </h2>
             <p
               v-if="detail?.subtitle"
-              class="mt-0.5 line-clamp-1 text-sm text-base-content/60"
+              class="kr-text-dim-sm mt-0.5 line-clamp-1"
             >
               {{ detail.subtitle }}
             </p>

--- a/components/manager/kr-manager.vue
+++ b/components/manager/kr-manager.vue
@@ -159,10 +159,7 @@
             <h2 class="text-xl font-black text-primary">
               {{ tabConfig.title }}
             </h2>
-            <p
-              v-if="tabConfig.summary"
-              class="mt-1 text-sm text-base-content/60"
-            >
+            <p v-if="tabConfig.summary" class="kr-text-dim-sm mt-1">
               {{ tabConfig.summary }}
             </p>
           </div>

--- a/components/model-builder/model-builder-manager.vue
+++ b/components/model-builder/model-builder-manager.vue
@@ -88,7 +88,7 @@
     >
       <div
         v-if="resumingRun"
-        class="flex min-h-32 flex-1 items-center justify-center gap-2 text-sm text-base-content/60"
+        class="kr-text-dim-sm flex min-h-32 flex-1 items-center justify-center gap-2"
         role="status"
         aria-live="polite"
       >

--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -34,7 +34,7 @@
     <div class="min-h-0 flex-1 overflow-y-auto">
       <div
         v-if="store.loadingRuns"
-        class="flex h-full min-h-32 items-center justify-center gap-2 text-sm text-base-content/60"
+        class="kr-text-dim-sm flex h-full min-h-32 items-center justify-center gap-2"
         role="status"
         aria-live="polite"
         aria-busy="true"

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -70,7 +70,7 @@
 
       <div
         v-else-if="store.loadingSources"
-        class="flex h-full min-h-32 items-center justify-center gap-2 text-sm text-base-content/60"
+        class="kr-text-dim-sm flex h-full min-h-32 items-center justify-center gap-2"
         role="status"
         aria-live="polite"
         aria-busy="true"

--- a/components/narrative/narrative-art-status.vue
+++ b/components/narrative/narrative-art-status.vue
@@ -24,7 +24,7 @@
 
     <div
       v-else-if="isBusy"
-      class="flex min-h-28 items-center justify-center gap-3 bg-base-200/50 p-4 text-sm text-base-content/60"
+      class="kr-text-dim-sm flex min-h-28 items-center justify-center gap-3 bg-base-200/50 p-4"
     >
       <span
         class="loading loading-spinner loading-sm motion-reduce:hidden"

--- a/components/navigation/navigation-trimmed.vue
+++ b/components/navigation/navigation-trimmed.vue
@@ -35,7 +35,7 @@
 
     <p
       v-if="!filteredChannels.length"
-      class="kr-panel-flat p-6 text-center text-sm text-base-content/60"
+      class="kr-text-dim-sm kr-panel-flat p-6 text-center"
     >
       No destinations match “{{ query }}”.
     </p>

--- a/components/navigation/server-selector.vue
+++ b/components/navigation/server-selector.vue
@@ -94,7 +94,7 @@
             <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div class="min-w-0">
                 <h3 class="font-black text-primary">Connections</h3>
-                <p class="text-sm leading-snug text-base-content/60">
+                <p class="kr-text-dim-sm leading-snug">
                   Provider keys and private local servers.
                 </p>
               </div>
@@ -242,7 +242,7 @@
 
               <p
                 v-if="!localServers.length"
-                class="rounded-2xl border border-dashed border-base-300 p-3 text-sm text-base-content/60"
+                class="kr-text-dim-sm rounded-2xl border border-dashed border-base-300 p-3"
               >
                 No local servers saved yet.
               </p>
@@ -330,7 +330,7 @@
             <div class="flex items-start justify-between gap-3">
               <div class="min-w-0">
                 <h3 class="font-black text-info">Edit Local Server</h3>
-                <p class="text-sm leading-snug text-base-content/60">
+                <p class="kr-text-dim-sm leading-snug">
                   Advanced options for endpoints and health checks.
                 </p>
               </div>

--- a/components/pages/about-page.vue
+++ b/components/pages/about-page.vue
@@ -8,7 +8,7 @@
           <Icon name="kind-icon:robot-color" class="h-8 w-8" />
         </span>
         <p class="text-3xl font-black text-base-content">Kind Robots</p>
-        <p class="max-w-md text-sm text-base-content/60">
+        <p class="kr-text-dim-sm max-w-md">
           A playground where creativity, technology, and goodness collide.
         </p>
       </div>
@@ -93,7 +93,7 @@
           </a>
         </div>
 
-        <p class="mt-4 text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mt-4">
           Interested in supporting the project?
           <a
             href="mailto:kindsponsors@kindrobots.org"

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -179,7 +179,7 @@
                 <p class="text-xs font-black uppercase tracking-widest text-base-content/35">
                   Why bother
                 </p>
-                <p class="mt-1 text-sm leading-relaxed text-base-content/60">
+                <p class="kr-text-dim-sm mt-1 leading-relaxed">
                   {{ pitch.whyDoIt }}
                 </p>
               </div>

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -34,7 +34,7 @@
             <h2 class="mt-1 text-xl font-black sm:text-2xl">
               Your attention desk
             </h2>
-            <p class="mt-1 max-w-3xl text-sm text-base-content/60">
+            <p class="kr-text-dim-sm mt-1 max-w-3xl">
               Decisions, proposals, and follow-ups gathered into one human-sized
               place.
             </p>

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -10,7 +10,7 @@
         >
           Story library
         </p>
-        <p class="mt-0.5 text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mt-0.5">
           {{ storyStore.recentStories.length }} saved
           {{ storyStore.recentStories.length === 1 ? 'story' : 'stories' }} on
           this account

--- a/components/projects/project-placement-manager.vue
+++ b/components/projects/project-placement-manager.vue
@@ -64,7 +64,7 @@
         >
           <div>
             <h2 class="font-black">Backfill controls</h2>
-            <p class="mt-1 text-sm text-base-content/60">
+            <p class="kr-text-dim-sm mt-1">
               Existing non-empty live URLs are preserved unless overwrite is
               enabled. Individual failures do not stop the remaining rows.
             </p>

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -116,7 +116,7 @@
 
                 <p
                   v-if="rewardStore.selectedReward.flavorText"
-                  class="mt-1 text-sm italic text-base-content/60"
+                  class="kr-text-dim-sm mt-1 italic"
                 >
                   "{{ rewardStore.selectedReward.flavorText }}"
                 </p>
@@ -156,7 +156,7 @@
             </div>
           </article>
 
-          <div v-else class="kr-panel-muted-md text-sm text-base-content/60">
+          <div v-else class="kr-text-dim-sm kr-panel-muted-md">
             No reward selected. Head back to the gallery and pick something.
           </div>
         </div>
@@ -367,7 +367,7 @@
         <section class="shrink-0 kr-panel-flat p-4 shadow-md">
           <h2 class="mb-1 text-lg font-bold text-base-content">About You</h2>
 
-          <p class="mb-3 text-sm text-base-content/60">
+          <p class="kr-text-dim-sm mb-3">
             Give the story engine some context about who's holding this thing.
             This stays local to the prompt.
           </p>
@@ -399,7 +399,7 @@
                 <span class="kr-badge-ghost-sm ml-2">Optional</span>
               </h2>
 
-              <p class="mt-0.5 truncate text-sm text-base-content/60">
+              <p class="kr-text-dim-sm mt-0.5 truncate">
                 {{ selectedCharacterSummary }}
               </p>
             </div>

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -37,7 +37,7 @@
           <!-- Inline, not a second line. The subtitle is orientation text and
                was costing a full row of a 768px-tall screen; `hidden md:inline`
                drops it entirely where the room is tightest. -->
-          <p v-else class="truncate text-sm text-base-content/60">
+          <p v-else class="kr-text-dim-sm truncate">
             <span class="hidden md:inline">{{ subtitle }}</span>
           </p>
         </div>
@@ -216,7 +216,7 @@
                   {{ selectedRewardTitle }}
                 </h3>
 
-                <p class="truncate text-sm text-base-content/60">
+                <p class="kr-text-dim-sm truncate">
                   {{ selectedRewardSubtitle }}
                 </p>
               </div>

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -98,9 +98,7 @@
         </label>
 
         <details class="kr-panel-flat p-4 lg:col-span-2">
-          <summary
-            class="cursor-pointer text-sm font-bold text-base-content/60"
-          >
+          <summary class="kr-text-dim-sm cursor-pointer font-bold">
             Freeform genre tags
           </summary>
           <p class="kr-text-dim-xs mt-2">

--- a/components/scenarios/choice-manager.vue
+++ b/components/scenarios/choice-manager.vue
@@ -45,7 +45,7 @@
       />
     </div>
 
-    <div class="text-right text-sm italic text-base-content/60">
+    <div class="kr-text-dim-sm text-right italic">
       Selected: <strong>{{ choiceEntry.selected || 'none' }}</strong>
     </div>
   </div>

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -11,7 +11,7 @@
             {{ title }}
           </h2>
 
-          <p class="truncate text-sm text-base-content/60">
+          <p class="kr-text-dim-sm truncate">
             <span class="hidden md:inline">{{ subtitle }}</span>
           </p>
         </div>
@@ -221,7 +221,7 @@
                 {{ selectedScenarioTitle }} Cast
               </h3>
 
-              <p class="truncate text-sm text-base-content/60">
+              <p class="kr-text-dim-sm truncate">
                 Character cards connected to this scenario.
               </p>
             </div>
@@ -370,7 +370,7 @@
                 {{ selectedScenarioTitle }} Cast
               </h3>
 
-              <p class="truncate text-sm text-base-content/60">
+              <p class="kr-text-dim-sm truncate">
                 Character cards connected to this scenario.
               </p>
             </div>

--- a/components/scenarios/scenario-relationship-gallery.vue
+++ b/components/scenarios/scenario-relationship-gallery.vue
@@ -11,7 +11,7 @@
           <h2 class="truncate text-lg font-black text-base-content">
             {{ title }}
           </h2>
-          <p class="truncate text-sm text-base-content/60">
+          <p class="kr-text-dim-sm truncate">
             {{ subtitleLine }}
           </p>
         </div>

--- a/components/servers/add-server.vue
+++ b/components/servers/add-server.vue
@@ -126,9 +126,7 @@
       </section>
 
       <section class="kr-panel-muted-md">
-        <h3
-          class="mb-3 text-sm font-black uppercase tracking-wide text-base-content/60"
-        >
+        <h3 class="kr-text-dim-sm mb-3 font-black uppercase tracking-wide">
           Auth
         </h3>
 
@@ -193,9 +191,7 @@
       </section>
 
       <section class="kr-panel-muted-md">
-        <h3
-          class="mb-3 text-sm font-black uppercase tracking-wide text-base-content/60"
-        >
+        <h3 class="kr-text-dim-sm mb-3 font-black uppercase tracking-wide">
           Visibility
         </h3>
 

--- a/components/servers/server-interact.vue
+++ b/components/servers/server-interact.vue
@@ -41,14 +41,14 @@
     <div class="grid gap-4 lg:grid-cols-2">
       <div class="kr-panel-flat p-4">
         <h2 class="font-black text-primary">Active Art Server</h2>
-        <p class="mt-1 text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mt-1">
           {{ artSummary }}
         </p>
       </div>
 
       <div class="kr-panel-flat p-4">
         <h2 class="font-black text-secondary">Active Text Server</h2>
-        <p class="mt-1 text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mt-1">
           {{ textSummary }}
         </p>
       </div>

--- a/components/servers/server-status.vue
+++ b/components/servers/server-status.vue
@@ -11,7 +11,7 @@
             </h2>
           </div>
 
-          <p class="mt-1 text-sm text-base-content/60">
+          <p class="kr-text-dim-sm mt-1">
             {{ summary }}
           </p>
         </div>
@@ -57,7 +57,7 @@
         </div>
       </div>
 
-      <div v-else class="rounded-xl border border-dashed border-base-300 bg-base-200 p-4 text-center text-sm text-base-content/60">
+      <div v-else class="kr-text-dim-sm rounded-xl border border-dashed border-base-300 bg-base-200 p-4 text-center">
         No active server selected.
       </div>
 

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -847,7 +847,7 @@
             <h2 class="text-2xl font-black text-base-content">
               Cast the chaos.
             </h2>
-            <p class="mt-2 text-sm text-base-content/60">
+            <p class="kr-text-dim-sm mt-2">
               Pick a stage, cast your performers, and run the show.
             </p>
           </div>

--- a/components/user/forum-thread.vue
+++ b/components/user/forum-thread.vue
@@ -46,10 +46,7 @@
         <h3 class="text-lg font-bold mb-2">
           🧵 New Thread in {{ channel.label }}
         </h3>
-        <p
-          v-if="channel.postingGuidance"
-          class="text-sm text-base-content/60 mb-2"
-        >
+        <p v-if="channel.postingGuidance" class="kr-text-dim-sm mb-2">
           {{ channel.postingGuidance }}
         </p>
         <input

--- a/components/user/user-galleries.vue
+++ b/components/user/user-galleries.vue
@@ -17,7 +17,7 @@
     >
       <div>
         <p class="text-lg font-black">No user selected.</p>
-        <p class="mt-1 text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mt-1">
           The shelves are waiting for an owner.
         </p>
       </div>
@@ -156,7 +156,7 @@
                 class="kr-panel-flat p-4 text-center"
               >
                 <p class="font-black">No {{ section.label }} yet.</p>
-                <p class="mt-1 text-sm text-base-content/60">
+                <p class="kr-text-dim-sm mt-1">
                   Suspiciously tidy. Possibly goblin-cleaned.
                 </p>
               </div>

--- a/components/user/user-manager.vue
+++ b/components/user/user-manager.vue
@@ -40,7 +40,7 @@
           <Icon name="kind-icon:user" class="h-8 w-8 text-primary" />
         </div>
         <h2 class="text-xl font-black text-base-content">Welcome, guest</h2>
-        <p class="max-w-xs text-sm text-base-content/60">
+        <p class="kr-text-dim-sm max-w-xs">
           Log in to save your progress, set an avatar, and access your full
           account.
         </p>

--- a/components/user/user-panel.vue
+++ b/components/user/user-panel.vue
@@ -100,7 +100,7 @@
     >
       <div>
         <p class="text-lg font-black">No user profile available.</p>
-        <p class="mt-1 text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mt-1">
           Guest mode is adorable, but it does not fill out forms.
         </p>
       </div>

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -38,7 +38,7 @@
   <section class="flex flex-col gap-4">
     <div v-if="!isAdmin" class="kr-panel-flat border-dashed p-6 text-center">
       <Icon name="kind-icon:lock" class="mx-auto size-8 text-base-content/30" />
-      <p class="mt-2 text-sm font-semibold text-base-content/60">
+      <p class="kr-text-dim-sm mt-2 font-semibold">
         This is a private personal log. Sign in as an admin to browse it.
       </p>
     </div>

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -76,7 +76,7 @@
       <aside class="kr-pane kr-panel-flat">
         <div class="shrink-0 kr-panel-header">
           <h2 class="text-lg font-black">Saved Colors</h2>
-          <p class="mt-1 text-sm text-base-content/60">
+          <p class="kr-text-dim-sm mt-1">
             Pick one, then click a section or flood a group.
           </p>
         </div>
@@ -213,7 +213,7 @@
       <aside class="kr-pane kr-panel-flat">
         <div class="shrink-0 kr-panel-header">
           <h2 class="text-lg font-black">Sections & Groups</h2>
-          <p class="mt-1 text-sm text-base-content/60">
+          <p class="kr-text-dim-sm mt-1">
             Use groups for shared paint IDs, then click exact sections for
             overrides.
           </p>

--- a/components/wonderlab/reaction-card.vue
+++ b/components/wonderlab/reaction-card.vue
@@ -22,7 +22,7 @@
           {{ targetTitle || formattedTargetType }}
         </h2>
 
-        <p class="mt-1 text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mt-1">
           {{ formattedTargetType }} #{{ targetId }}
         </p>
       </div>

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -19,7 +19,7 @@
 
       <p class="text-base font-bold text-info">Loading page…</p>
 
-      <p class="max-w-xl text-sm text-base-content/60">
+      <p class="kr-text-dim-sm max-w-xl">
         Looking for {{ contentPath }}
       </p>
     </div>
@@ -45,7 +45,7 @@
 
       <p class="text-base font-bold text-warning">Page not found</p>
 
-      <p class="max-w-xl text-sm text-base-content/60">
+      <p class="kr-text-dim-sm max-w-xl">
         No Nuxt Content page was found for {{ contentPath }}.
       </p>
     </div>

--- a/pages/admin/achievement-art.vue
+++ b/pages/admin/achievement-art.vue
@@ -9,7 +9,7 @@
             Achievement administration
           </p>
           <p class="mt-1 text-2xl font-black">Achievement artwork</p>
-          <p class="mt-1 text-sm text-base-content/60">
+          <p class="kr-text-dim-sm mt-1">
             Generate, upload, and replace the image attached to each achievement
             definition.
           </p>
@@ -36,7 +36,7 @@
         <p class="text-xl font-black text-base-content">
           Administrator access required
         </p>
-        <p class="mt-2 text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mt-2">
           Achievement artwork management is restricted to administrators.
         </p>
       </div>
@@ -127,7 +127,7 @@
                   <h2 class="mt-1 text-xl font-black">
                     {{ selectedAchievement.label }}
                   </h2>
-                  <p class="mt-2 max-w-3xl text-sm text-base-content/60">
+                  <p class="kr-text-dim-sm mt-2 max-w-3xl">
                     {{ selectedAchievement.message }}
                   </p>
                 </div>

--- a/pages/admin/curation-studio.vue
+++ b/pages/admin/curation-studio.vue
@@ -10,7 +10,7 @@
         class="kr-note kr-note-error p-8 text-center font-normal"
       >
         <p class="text-xl font-black text-base-content">Administrator access required</p>
-        <p class="mt-2 text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mt-2">
           This screen edits production curation data and can enqueue GPU work.
         </p>
       </div>

--- a/pages/admin/forum-moderation.vue
+++ b/pages/admin/forum-moderation.vue
@@ -9,7 +9,7 @@
             Forum moderation
           </p>
           <p class="mt-1 text-2xl font-black">Health-claim escalation queue</p>
-          <p class="mt-1 max-w-2xl text-sm text-base-content/60">
+          <p class="kr-text-dim-sm mt-1 max-w-2xl">
             Posts here were auto-hidden because at least two distinct people
             flagged them as misinformation or unsafe. Restore the post if the
             flag was wrong, or confirm removal if it should stay down.
@@ -37,7 +37,7 @@
         <p class="text-xl font-black text-base-content">
           Administrator access required
         </p>
-        <p class="mt-2 text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mt-2">
           The forum moderation queue is restricted to administrators.
         </p>
       </div>

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -9,7 +9,7 @@
             Temporary catalog cleanup
           </p>
           <div class="mt-1 text-2xl font-black">LoRA maturity triage</div>
-          <p class="mt-1 max-w-3xl text-sm text-base-content/60">
+          <p class="kr-text-dim-sm mt-1 max-w-3xl">
             Confirm LoRAs as SFW or NSFW here, then save the changed maturity
             flags in one pass. Review progress stays in this browser until this
             cleanup page is removed.
@@ -55,7 +55,7 @@
         <p class="text-xl font-black text-base-content">
           Administrator access required
         </p>
-        <p class="mt-2 text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mt-2">
           LoRA maturity triage is restricted to administrators.
         </p>
       </div>

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -36,7 +36,7 @@
         class="kr-note kr-note-error p-8 text-center font-normal"
       >
         <p class="text-xl font-black text-base-content">Administrator access required</p>
-        <p class="mt-2 text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mt-2">
           Folder animation can enqueue substantial local GPU work, so this surface is admin-only.
         </p>
       </div>

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -9,7 +9,7 @@
             AMI social pipeline administration
           </p>
           <p class="mt-1 text-2xl font-black">Social post review queue</p>
-          <p class="mt-1 max-w-2xl text-sm text-base-content/60">
+          <p class="kr-text-dim-sm mt-1 max-w-2xl">
             Draft-only. AMI, our labelled-AI fundraiser character, proposes
             posts from the daily dream/digest cycle. Nothing here posts anywhere
             -- approving a draft only marks it reviewed. Every draft carries a
@@ -38,7 +38,7 @@
         <p class="text-xl font-black text-base-content">
           Administrator access required
         </p>
-        <p class="mt-2 text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mt-2">
           The social post review queue is restricted to administrators.
         </p>
       </div>

--- a/pages/coloring-page.vue
+++ b/pages/coloring-page.vue
@@ -22,7 +22,7 @@
             </p>
             <span class="kr-badge-primary-sm font-bold">New</span>
           </div>
-          <p class="max-w-2xl text-sm text-base-content/60">
+          <p class="kr-text-dim-sm max-w-2xl">
             Turn any photo or finished design into a printable black-and-white
             coloring page. Upload an image or pick one from your gallery, choose
             <b class="text-base-content/80">Coloring Page</b> for crisp line art

--- a/pages/play/aquarium/browse/[username]/[slug].vue
+++ b/pages/play/aquarium/browse/[username]/[slug].vue
@@ -137,7 +137,7 @@
           class="rounded-3xl border border-dashed border-base-300 bg-base-100 px-6 py-16 text-center"
         >
           <Icon name="kind-icon:fish" class="mx-auto size-12 text-primary/40" />
-          <p class="mt-3 text-sm text-base-content/60">
+          <p class="kr-text-dim-sm mt-3">
             Nothing in this tank yet.
           </p>
         </section>

--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -59,7 +59,7 @@
       >
         <Icon name="kind-icon:fish" class="mx-auto size-12 text-primary/40" />
         <h2 class="mt-4 text-2xl font-black uppercase">Nothing public yet</h2>
-        <p class="mx-auto mt-2 max-w-xl text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mx-auto mt-2 max-w-xl">
           No owner has made their tank public. Yours defaults to public -- check
           the toggle at the bottom of your own tank.
         </p>

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -59,7 +59,7 @@
       >
         <Icon name="kind-icon:fish" class="mx-auto size-12 text-primary/40" />
         <h2 class="mt-4 text-2xl font-black uppercase">No ranks yet</h2>
-        <p class="mx-auto mt-2 max-w-xl text-sm text-base-content/60">
+        <p class="kr-text-dim-sm mx-auto mt-2 max-w-xl">
           Nobody with a public tank has collected a species yet.
         </p>
       </div>

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -422,7 +422,7 @@
           <h2 class="mt-4 text-2xl font-black uppercase">
             Waiting for contenders
           </h2>
-          <p class="mx-auto mt-2 max-w-xl text-sm text-base-content/60">
+          <p class="kr-text-dim-sm mx-auto mt-2 max-w-xl">
             The challenge is live, but no ready submissions have entered the
             arena yet.
           </p>


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Re-ran `kr_text_dim_sm_codemod.py` without `--exact-only` — the subset-match sweep kaizen-flagged after slice 160 did the same for `kr-text-dim-xs`.
- 86 occurrences across 61 files carried the `text-sm text-base-content/60` base pair alongside extra utility tokens; migrated to `.kr-text-dim-sm`, preserving the extra tokens verbatim.
- No CSS changes — `.kr-text-dim-sm` already exists from an earlier slice.
- Also surveyed the other already-named `kr-text-dim-*` primitives for the same re-run per the slice 160 kaizen note: `kr-text-dim-sm-70`, `kr-text-dim-xs-45`, `kr-text-dim-xs-55` all found 0 further candidates — their first pass already covered the full subset-match pool, so this slice is the only one with real scope.

### How I verified
- `vue-tsc --noEmit` clean
- `eslint .`: 333 problems (327 errors, 6 warnings) — identical before/after (confirmed via `git stash`)
- `npm run test:layout-contract`: holds, no new violations (an unrelated -2 ratchet opportunity in `narrative-ingredient-multi-picker.vue` surfaced by the same run is out of scope for this slice, left untouched)
- `npm run test:lint-ratchet`: holds at 333/-59
- `npx prettier --check`: needed `--write` on 7 files for collapsed-line fallout from shortened class strings; confirmed via `git stash` that the other 23 flagged files carry pre-existing debt; final `--check` matches that 23-file baseline exactly

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
The frequency survey behind slices 153-161 has now worked through the `text-{xs,sm} text-base-content/NN` family fairly thoroughly. Worth a fresh full-repo class-frequency survey next slice to find the next largest bounded family from scratch, rather than continuing to re-run subset-match sweeps on primitives that are already exhausted.

### Notes for reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEewmRrdQkh9S3LNiwipYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEewmRrdQkh9S3LNiwipYW)_