### PR TITLE
refactor(ui): add kr-text-dim-xs-40 for text-xs text-base-content/40 (slice 162)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1742,6 +1742,23 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply text-xs text-base-content/55;
   }
 
+  /* The most-dimmed caption-size metadata line in the `text-xs
+   * text-base-content/NN` family -- `text-xs text-base-content/40`, one
+   * notch quieter than `.kr-text-dim-xs-45`, used for the least-emphasized
+   * annotation on a card or list row (interface-vision t-104 slice 162) --
+   * previously hand-rolled identically in 56 occurrences, the largest
+   * bounded family surfaced by re-running slice 152's original frequency
+   * survey against the sibling opacity variants left open in slice 159's
+   * own note (`/40`, `/70`). Named `kr-text-dim-xs-40` for the same reason
+   * as its siblings -- each size/opacity pairing is a real,
+   * independently-repeated exact shape in the wild, not one that "should
+   * normalize" to a neighboring opacity. The remaining `/70` sibling (51
+   * occurrences) is left for a future slice, same convention as
+   * `.kr-spinner-xs`/`.kr-spinner-sm`. */
+  .kr-text-dim-xs-40 {
+    @apply text-xs text-base-content/40;
+  }
+
   /* A large, primary-colored busy indicator -- `loading loading-spinner
    * loading-lg text-primary`, the centered spinner shown while a gallery,
    * list, or manager view's main content is still loading (interface-vision

--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -53,7 +53,7 @@
           <p class="kr-text-dim-sm font-semibold">
             Select a style to see its story
           </p>
-          <p class="text-xs text-base-content/40">
+          <p class="kr-text-dim-xs-40">
             Every remix comes with a free history lesson. We're sneaky like
             that.
           </p>

--- a/components/achievements/achievement-gallery.vue
+++ b/components/achievements/achievement-gallery.vue
@@ -70,7 +70,7 @@
 
             <template #empty>
               <div
-                class="flex min-h-32 flex-col items-center justify-center rounded-xl border border-dashed border-base-300 p-4 text-center text-xs text-base-content/40"
+                class="kr-text-dim-xs-40 flex min-h-32 flex-col items-center justify-center rounded-xl border border-dashed border-base-300 p-4 text-center"
               >
                 <Icon name="kind-icon:trophy" class="mb-2 h-8 w-8 opacity-30" />
                 No achievements earned yet.

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -91,7 +91,7 @@
                 `Image #${selectedSourceImage.id}`
               }}
             </p>
-            <p class="text-xs text-base-content/40">Ready to style</p>
+            <p class="kr-text-dim-xs-40">Ready to style</p>
           </div>
           <button
             type="button"
@@ -222,7 +222,7 @@
           class="flex min-h-28 flex-col items-center justify-center rounded-xl border border-base-300 bg-base-200/60 text-center"
         >
           <Icon name="kind-icon:image" class="h-8 w-8 text-base-content/20" />
-          <p class="mt-1 text-xs text-base-content/40">No images found</p>
+          <p class="kr-text-dim-xs-40 mt-1">No images found</p>
         </div>
       </div>
 
@@ -280,7 +280,7 @@
           class="flex min-h-28 flex-col items-center justify-center rounded-xl border border-base-300 bg-base-200/60 text-center"
         >
           <Icon name="kind-icon:image" class="h-8 w-8 text-base-content/20" />
-          <p class="mt-1 text-xs text-base-content/40">No starters found</p>
+          <p class="kr-text-dim-xs-40 mt-1">No starters found</p>
         </div>
       </div>
     </div>
@@ -353,9 +353,7 @@
             <Icon name="mdi:palette" class="h-3 w-3" />
             {{ selectedStyle.label }}
           </p>
-          <p v-else class="text-xs text-base-content/40 italic">
-            Pick a style below
-          </p>
+          <p v-else class="kr-text-dim-xs-40 italic">Pick a style below</p>
         </div>
       </div>
     </Transition>
@@ -479,7 +477,7 @@
         <div class="flex items-center gap-1.5">
           <Icon name="kind-icon:edit" class="h-4 w-4 text-primary" />
           <span class="text-xs font-black text-base-content">Prompt</span>
-          <span class="ml-auto text-xs text-base-content/40">
+          <span class="kr-text-dim-xs-40 ml-auto">
             {{
               selectedStyle?.loraPath
                 ? 'LoRA trigger auto-prepended'

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -129,7 +129,7 @@
             </p>
           </article>
         </div>
-        <p v-else class="py-6 text-center text-xs text-base-content/40">
+        <p v-else class="kr-text-dim-xs-40 py-6 text-center">
           No saved {{ selectedSlot.label.toLowerCase() }} versions.
         </p>
       </aside>
@@ -330,7 +330,7 @@
           </select>
         </label>
         <span v-if="loadingResources" class="loading loading-spinner loading-sm self-end mb-1" />
-        <p v-else class="self-end pb-2 text-xs text-base-content/40">
+        <p v-else class="kr-text-dim-xs-40 self-end pb-2">
           Leave unchanged to use the same default workflow that is producing the current quality.
         </p>
       </div>

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -44,9 +44,7 @@
             >browse</span
           >
         </p>
-        <p class="mt-0.5 text-xs text-base-content/40">
-          PNG · JPEG · WebP · multiple OK
-        </p>
+        <p class="kr-text-dim-xs-40 mt-0.5">PNG · JPEG · WebP · multiple OK</p>
       </div>
     </div>
 
@@ -148,7 +146,7 @@
           <div class="mb-3 flex items-center gap-2">
             <icon name="kind-icon:settings" class="h-4 w-4 text-primary" />
             <h3 class="text-sm font-black text-base-content">Image Metadata</h3>
-            <span class="text-xs text-base-content/40"
+            <span class="kr-text-dim-xs-40"
               >Optional — added to every image in this batch</span
             >
           </div>

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -23,7 +23,7 @@
     </form>
 
     <p v-if="photoError" class="rounded-xl bg-error/10 p-2 text-xs text-error">{{ photoError }}</p>
-    <p v-if="!superkate.sortedCustomers.length" class="text-xs text-base-content/40">
+    <p v-if="!superkate.sortedCustomers.length" class="kr-text-dim-xs-40">
       No clients yet — add one above, or save an appointment and the client is created automatically.
     </p>
 

--- a/components/art/stylist-history.vue
+++ b/components/art/stylist-history.vue
@@ -29,7 +29,7 @@
       </button>
     </div>
 
-    <p v-if="!results.length" class="text-xs text-base-content/40">
+    <p v-if="!results.length" class="kr-text-dim-xs-40">
       {{
         superkate.sortedAppointments.length
           ? 'No appointments match those filters.'

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -390,7 +390,7 @@
       <p v-if="stylist.historyError" class="text-xs text-error">{{ stylist.historyError }}</p>
       <p
         v-else-if="!clientHistory.length && !stylist.isLoadingHistory"
-        class="text-xs text-base-content/40"
+        class="kr-text-dim-xs-40"
       >
         No saved looks yet{{ clientName.trim() ? ' for this client' : '' }}.
       </p>

--- a/components/art/stylist-settings.vue
+++ b/components/art/stylist-settings.vue
@@ -50,7 +50,7 @@
       <pre class="whitespace-pre-wrap text-xs text-base-content/70">{{ preview }}</pre>
     </div>
 
-    <p class="text-xs text-base-content/40">
+    <p class="kr-text-dim-xs-40">
       Settings save automatically on this device. "Superkate loves you!" is not
       configurable. It's the law.
     </p>

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -592,7 +592,7 @@
             selected
           </span>
         </span>
-        <span class="text-xs text-base-content/40"
+        <span class="kr-text-dim-xs-40"
           >Copy or export without leaving this page</span
         >
       </summary>

--- a/components/builder/builder-card.vue
+++ b/components/builder/builder-card.vue
@@ -76,7 +76,7 @@
       </p>
 
       <div class="mt-auto flex items-center justify-between gap-2 pt-1">
-        <span class="text-xs font-bold text-base-content/40">
+        <span class="kr-text-dim-xs-40 font-bold">
           {{ card.steps.length }} step{{ card.steps.length === 1 ? '' : 's' }}
         </span>
 

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -78,7 +78,7 @@
           </span>
           <span class="min-w-0 flex-1">
             <span class="block truncate text-sm font-semibold">{{ facet.title }}</span>
-            <span class="block truncate text-xs text-base-content/40">
+            <span class="kr-text-dim-xs-40 block truncate">
               {{ facet.aliases.join(' · ') }}
             </span>
           </span>
@@ -86,7 +86,7 @@
         </button>
         <p
           v-if="!searchResults.length"
-          class="px-3 py-3 text-xs text-base-content/40"
+          class="kr-text-dim-xs-40 px-3 py-3"
         >
           No matching Facet.
         </p>

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -8,7 +8,7 @@
       <div>
         <div class="flex flex-wrap items-center gap-2">
           <span class="badge badge-accent rounded-2xl">Cover source art</span>
-          <span class="text-xs font-black uppercase tracking-widest text-base-content/40">
+          <span class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
             {{ book.title }}
           </span>
         </div>

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -243,7 +243,7 @@
             </div>
           </div>
 
-          <p class="mt-auto text-xs text-base-content/40">
+          <p class="kr-text-dim-xs-40 mt-auto">
             Tap a region to fill it with the selected color. Everything saves
             locally as you go.
           </p>

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -49,7 +49,7 @@
       >
         <div class="flex items-start justify-between gap-3">
           <div>
-            <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+            <p class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
               Book {{ book.order }}
             </p>
             <h4 class="text-xl font-black">{{ book.title }}</h4>
@@ -150,7 +150,7 @@
           </p>
 
           <div class="mt-4">
-            <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+            <p class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
               Missing layout decisions
             </p>
             <div class="mt-2 flex flex-wrap gap-2">
@@ -171,7 +171,7 @@
           </div>
 
           <div class="mt-4">
-            <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+            <p class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
               Missing exports
             </p>
             <div class="mt-2 flex flex-wrap gap-2">

--- a/components/coloring/coloring-book-production-toolbar.vue
+++ b/components/coloring/coloring-book-production-toolbar.vue
@@ -7,7 +7,7 @@
       <div>
         <div class="flex flex-wrap items-center gap-2">
           <span class="badge badge-primary rounded-2xl">Production actions</span>
-          <span class="text-xs font-black uppercase tracking-widest text-base-content/40">
+          <span class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
             {{ book?.title }} · {{ proposal.id }}
           </span>
         </div>

--- a/components/coloring/coloring-book-readiness.vue
+++ b/components/coloring/coloring-book-readiness.vue
@@ -31,7 +31,7 @@
       >
         <div class="flex items-start justify-between gap-3">
           <div>
-            <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+            <p class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
               Book {{ item.book.order }}
             </p>
             <h4 class="text-xl font-black">{{ item.book.title }}</h4>
@@ -114,7 +114,7 @@
         >
           <div class="flex items-start justify-between gap-3">
             <div>
-              <p class="text-xs font-black uppercase tracking-widest text-base-content/40">
+              <p class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
                 Slot {{ entry.proposal.slot }} · {{ entry.proposal.id }}
               </p>
               <h5 class="font-black">{{ entry.proposal.title }}</h5>

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -78,7 +78,7 @@
           <div class="flex items-start justify-between gap-3">
             <div>
               <p
-                class="text-xs font-black uppercase tracking-widest text-base-content/40"
+                class="kr-text-dim-xs-40 font-black uppercase tracking-widest"
               >
                 Book {{ book.order }}
               </p>
@@ -141,7 +141,7 @@
           <div class="flex items-start justify-between gap-3">
             <div>
               <p
-                class="text-xs font-black uppercase tracking-widest text-base-content/40"
+                class="kr-text-dim-xs-40 font-black uppercase tracking-widest"
               >
                 {{ book.slug }}
               </p>
@@ -269,7 +269,7 @@
               <div class="flex items-start justify-between gap-3">
                 <div>
                   <p
-                    class="text-xs font-black uppercase tracking-widest text-base-content/40"
+                    class="kr-text-dim-xs-40 font-black uppercase tracking-widest"
                   >
                     Slot {{ proposal.slot }} · {{ proposal.id }}
                   </p>
@@ -304,7 +304,7 @@
           >
             <div>
               <p
-                class="text-xs font-black uppercase tracking-widest text-base-content/40"
+                class="kr-text-dim-xs-40 font-black uppercase tracking-widest"
               >
                 {{ studio.selectedBook?.title }} · Slot
                 {{ studio.selectedProposal.slot }} ·

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -223,7 +223,7 @@
           actionMessage
         }}</span>
       </div>
-      <p class="text-xs text-base-content/40">
+      <p class="kr-text-dim-xs-40">
         Ready is local bookkeeping. Making pack items public and wiring the
         storefront remain separate, human-approved steps.
       </p>

--- a/components/conductor/packmaker-pack-editor.vue
+++ b/components/conductor/packmaker-pack-editor.vue
@@ -49,7 +49,7 @@
           >{{ scaffoldMessage }}</span
         >
       </div>
-      <p class="text-xs text-base-content/40">
+      <p class="kr-text-dim-xs-40">
         The draft loads below for review — nothing is saved or generated until
         you say so.
       </p>

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -85,7 +85,7 @@
             <span class="block truncate text-sm font-semibold">{{
               facet.title
             }}</span>
-            <span class="block truncate text-xs text-base-content/40">
+            <span class="kr-text-dim-xs-40 block truncate">
               {{ facet.aliases.join(' · ') }}
             </span>
           </span>
@@ -94,7 +94,7 @@
 
         <p
           v-if="!searchResults.length"
-          class="px-3 py-3 text-xs text-base-content/40"
+          class="kr-text-dim-xs-40 px-3 py-3"
         >
           No matching Facet. Create one below.
         </p>

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -84,7 +84,7 @@
         >
           {{ sourceBlurb }}
         </p>
-        <p v-else class="mt-0.5 text-xs italic text-base-content/40">
+        <p v-else class="kr-text-dim-xs-40 mt-0.5 italic">
           No description on this record yet.
         </p>
       </div>

--- a/components/newsfeed/newsfeed-feed.vue
+++ b/components/newsfeed/newsfeed-feed.vue
@@ -247,7 +247,7 @@
       Show more
     </button>
 
-    <p v-if="sourceErrorCount" class="text-center text-xs text-base-content/40">
+    <p v-if="sourceErrorCount" class="kr-text-dim-xs-40 text-center">
       {{ sourceErrorCount }} source{{ sourceErrorCount === 1 ? '' : 's' }}
       couldn't be reached this refresh — showing what did load.
     </p>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -614,7 +614,7 @@
               >
                 Add task / comment
               </h4>
-              <p class="mb-3 mt-1 text-xs text-base-content/40">
+              <p class="kr-text-dim-xs-40 mb-3 mt-1">
                 Agent items are picked up asynchronously by the project worker.
                 Honey-dos stay human-facing; feature ideas stay in this project's wishlist.
               </p>
@@ -766,7 +766,7 @@
               </div>
               <div
                 v-else
-                class="kr-panel-flat border-dashed bg-base-100/50 p-4 text-center text-xs text-base-content/40"
+                class="kr-text-dim-xs-40 kr-panel-flat border-dashed bg-base-100/50 p-4 text-center"
               >
                 <Icon
                   name="kind-icon:dream"
@@ -1132,7 +1132,7 @@
                   </div>
                 </div>
               </div>
-              <p v-else class="text-xs text-base-content/40">
+              <p v-else class="kr-text-dim-xs-40">
                 No feature ideas yet. Add one from the task / comment panel above.
               </p>
             </div>

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -78,7 +78,7 @@
           </span>
           <span class="min-w-0 flex-1">
             <span class="block truncate text-sm font-semibold">{{ facet.title }}</span>
-            <span class="block truncate text-xs text-base-content/40">
+            <span class="kr-text-dim-xs-40 block truncate">
               {{ facet.aliases.join(' · ') }}
             </span>
           </span>
@@ -86,7 +86,7 @@
         </button>
         <p
           v-if="!searchResults.length"
-          class="px-3 py-3 text-xs text-base-content/40"
+          class="kr-text-dim-xs-40 px-3 py-3"
         >
           No matching Facet.
         </p>

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -126,7 +126,7 @@
             <button
               v-if="!form.species"
               type="button"
-              class="rounded-full border border-dashed border-secondary/40 px-2.5 py-0.5 text-xs text-base-content/40 hover:border-secondary hover:text-secondary"
+              class="kr-text-dim-xs-40 rounded-full border border-dashed border-secondary/40 px-2.5 py-0.5 hover:border-secondary hover:text-secondary"
               @click="activeTab = 'species'"
             >
               + species
@@ -134,7 +134,7 @@
             <button
               v-if="!selectedTraits.length"
               type="button"
-              class="rounded-full border border-dashed border-primary/40 px-2.5 py-0.5 text-xs text-base-content/40 hover:border-primary hover:text-primary"
+              class="kr-text-dim-xs-40 rounded-full border border-dashed border-primary/40 px-2.5 py-0.5 hover:border-primary hover:text-primary"
               @click="activeTab = 'personality'"
             >
               + personality
@@ -363,7 +363,7 @@
               </button>
             </span>
             <span
-              class="rounded-full bg-base-200 px-2.5 py-0.5 text-xs text-base-content/40"
+              class="kr-text-dim-xs-40 rounded-full bg-base-200 px-2.5 py-0.5"
             >
               {{ selectedTraits.length }} selected
             </span>
@@ -469,7 +469,7 @@
       <div
         class="flex shrink-0 items-center justify-between border-t border-base-300 px-5 py-4"
       >
-        <div class="text-xs text-base-content/40 flex flex-wrap gap-1.5">
+        <div class="kr-text-dim-xs-40 flex flex-wrap gap-1.5">
           <span v-if="form.species" class="font-semibold text-secondary">{{
             form.species
           }}</span>

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -89,7 +89,7 @@
         class="kr-pane-scroll flex flex-col border-r border-base-300 bg-base-100/60 backdrop-blur-sm p-4 gap-3"
       >
         <p
-          class="text-xs font-bold uppercase tracking-widest text-base-content/40"
+          class="kr-text-dim-xs-40 font-bold uppercase tracking-widest"
         >
           Show Status
         </p>
@@ -128,7 +128,7 @@
         <!-- Cast status -->
         <div v-if="store.selectedStage" class="flex flex-col gap-1.5">
           <p
-            class="text-xs font-bold uppercase tracking-widest text-base-content/40"
+            class="kr-text-dim-xs-40 font-bold uppercase tracking-widest"
           >
             Cast
           </p>
@@ -185,7 +185,7 @@
         <!-- Turn progress -->
         <div v-if="store.transcript.length" class="flex flex-col gap-1.5">
           <p
-            class="text-xs font-bold uppercase tracking-widest text-base-content/40"
+            class="kr-text-dim-xs-40 font-bold uppercase tracking-widest"
           >
             Progress
           </p>
@@ -786,7 +786,7 @@
             </span>
             <span
               v-if="!store.castReady"
-              class="text-xs italic text-base-content/40"
+              class="kr-text-dim-xs-40 italic"
               >Fill required roles to start.</span
             >
           </div>

--- a/components/tasks/honeydo-card.vue
+++ b/components/tasks/honeydo-card.vue
@@ -52,7 +52,7 @@
       >
       <span
         v-if="showRelativeTime"
-        class="shrink-0 text-xs text-base-content/40"
+        class="kr-text-dim-xs-40 shrink-0"
         >{{ relativeTime(todo.createdAt) }}</span
       >
       <div

--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -114,9 +114,7 @@
       />
 
       <div class="flex items-center justify-between">
-        <span class="text-xs text-base-content/40"
-          >{{ draft.length }} / 4000</span
-        >
+        <span class="kr-text-dim-xs-40">{{ draft.length }} / 4000</span>
         <div class="flex items-center gap-2">
           <button
             type="button"

--- a/pages/admin/forum-moderation.vue
+++ b/pages/admin/forum-moderation.vue
@@ -63,7 +63,7 @@
                   {{ post.channel }}
                 </span>
               </div>
-              <span class="text-xs text-base-content/40">#{{ post.id }}</span>
+              <span class="kr-text-dim-xs-40">#{{ post.id }}</span>
             </div>
 
             <p class="whitespace-pre-line text-sm">{{ post.content }}</p>

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -273,7 +273,7 @@
                         class="size-full object-cover"
                       />
                     </template>
-                    <div v-else class="grid size-full place-items-center p-3 text-center text-xs text-base-content/40">
+                    <div v-else class="kr-text-dim-xs-40 grid size-full place-items-center p-3 text-center">
                       <template v-if="source.status === 'rendering' || source.status === 'queued'">
                         <span class="kr-spinner-sm" />
                         <span class="mt-1 block">{{ elapsedLabel(source) }}</span>

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -140,7 +140,7 @@
                   {{ draft.status }}
                 </span>
               </div>
-              <span class="text-xs text-base-content/40">#{{ draft.id }}</span>
+              <span class="kr-text-dim-xs-40">#{{ draft.id }}</span>
             </div>
 
             <img

--- a/pages/play/challenges/leaderboard.vue
+++ b/pages/play/challenges/leaderboard.vue
@@ -178,9 +178,7 @@
             >
               {{ signedScore(entry.score.netScore) }}
             </p>
-            <p
-              class="text-xs font-black uppercase tracking-widest text-base-content/40"
-            >
+            <p class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
               total score
             </p>
             <div class="mt-5 grid grid-cols-3 gap-2 text-sm">

--- a/utils/scripts/codemods/kr_text_dim_xs_40_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_xs_40_codemod.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `text-xs text-base-content/40` metadata
+caption text to `kr-text-dim-xs-40`.
+
+Sibling of kr_text_dim_sm_codemod.py / kr_text_dim_xs_codemod.py /
+kr_text_dim_sm_70_codemod.py / kr_text_dim_xs_45_codemod.py /
+kr_text_dim_xs_55_codemod.py / kr_text_dim_xs_60_codemod.py, same
+conventions: dry-run by default, --write to update matching Vue files in
+place. Only the exact `text-xs text-base-content/40` shape is touched, and
+only in static `class="..."` attributes -- never `:class`/`v-bind:class`
+bindings, and regardless of the base tokens' order in the source. A source
+that already carries `kr-text-dim-xs-40`, or is missing either base token,
+is left untouched. Extra tokens beyond the base set are preserved verbatim
+after the primitive class, matching the kr-badge-*/kr-spinner-*/
+kr-label-bold/kr-text-dim-* codemods' subset-match convention -- pass
+--exact-only to restrict a slice to sources with no extra tokens at all,
+the safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-dim-xs-40"
+BASE_TOKENS = {"text-xs", "text-base-content/40"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-dim-xs-40 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- New primitive `.kr-text-dim-xs-40` (`@apply text-xs text-base-content/40`), the most-dimmed caption-size metadata line in the `text-xs text-base-content/NN` family — one notch quieter than `.kr-text-dim-xs-45`.
- A full re-survey of the remaining `text-{xs,sm} text-base-content/NN` space (since slice 161's kaizen flagged the family as nearly exhausted) found this the largest still-uncovered bounded family: 56 occurrences across 33 files, migrated to `.kr-text-dim-xs-40` with extra tokens preserved verbatim.
- New codemod `kr_text_dim_xs_40_codemod.py`, sibling of the existing `kr_text_dim_*` codemods, same conventions (dry-run default, `--write`, `--exact-only`, subset-match).

### How I verified
- `vue-tsc --noEmit` clean
- `eslint .`: 333 problems (327 errors, 6 warnings) — identical before/after (confirmed via `git stash`)
- `npm run test:layout-contract`: holds, no new violations (the same unrelated -2 ratchet opportunity in `narrative-ingredient-multi-picker.vue` from prior slices, left untouched, out of scope)
- `npm run test:lint-ratchet`: holds at 333/-59
- `npx prettier --check`: needed `--write` on 4 files for collapsed-line fallout from shortened class strings; confirmed via `git stash` that the other 24 flagged files carry pre-existing debt; final `--check` matches that 24-file baseline exactly

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Only `text-xs text-base-content/70` (51 occurrences) remains as a sizeable bounded family in the `text-{xs,sm} text-base-content/NN` space after this slice; everything else surveyed is single digits. Worth doing that one next slice, then genuinely moving to a fresh full-repo class-frequency survey outside this family for slice 164+.

### Notes for reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEewmRrdQkh9S3LNiwipYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEewmRrdQkh9S3LNiwipYW)_