### PR TITLE
refactor(ui): add kr-text-dim-xs-70 for text-xs text-base-content/70 (slice 163)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1759,6 +1759,24 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply text-xs text-base-content/40;
   }
 
+  /* The last remaining named opacity in the `text-xs text-base-content/NN`
+   * family -- `text-xs text-base-content/70`, the lightest dim of the set
+   * (least muted, closest to full-opacity body text), used for secondary
+   * caption text that still needs to read clearly rather than recede like
+   * the `/40`-`/60` metadata-line siblings (interface-vision t-104 slice
+   * 163) -- previously hand-rolled identically in 35 files (51
+   * occurrences), the sibling explicitly left open by slice 162's own note
+   * after the `/40` shape was named. Named `kr-text-dim-xs-70` for the same
+   * reason as its siblings -- each size/opacity pairing is a real,
+   * independently-repeated exact shape in the wild, not one that "should
+   * normalize" to a neighboring opacity. This closes out the `text-xs
+   * text-base-content/NN` family surveyed since slice 152 (`/40`, `/45`,
+   * `/50`, `/55`, `/60`, `/70` all now named); the next slice should run a
+   * genuinely fresh full-repo class-frequency survey outside this family. */
+  .kr-text-dim-xs-70 {
+    @apply text-xs text-base-content/70;
+  }
+
   /* A large, primary-colored busy indicator -- `loading loading-spinner
    * loading-lg text-primary`, the centered spinner shown while a gallery,
    * list, or manager view's main content is still loading (interface-vision

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -294,7 +294,7 @@
             </div>
 
             <div class="rounded-2xl bg-base-100/70 p-3">
-              <p class="text-xs font-bold text-base-content/70">What to expect</p>
+              <p class="kr-text-dim-xs-70 font-bold">What to expect</p>
               <p class="kr-text-dim-xs-60 mt-1 leading-relaxed">
                 The remix should keep hold of the cues above, especially
                 {{ lesson.recognitionCues[0]?.toLowerCase() }}. If it just looks like a generic old painting, the style did not fully take.
@@ -302,7 +302,7 @@
             </div>
 
             <div class="rounded-2xl bg-base-100/70 p-3">
-              <p class="text-xs font-bold text-base-content/70">{{ tryItFailureLabel }}</p>
+              <p class="kr-text-dim-xs-70 font-bold">{{ tryItFailureLabel }}</p>
               <p class="kr-text-dim-xs-60 mt-1 leading-relaxed">
                 {{ tryItFailureNote }}
               </p>

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -111,7 +111,7 @@
         <label
           class="flex cursor-pointer items-center gap-1.5 rounded-lg border border-base-300 bg-base-100 px-2 py-1"
         >
-          <span class="text-xs font-bold text-base-content/70">Mature</span>
+          <span class="kr-text-dim-xs-70 font-bold">Mature</span>
           <input
             v-model="showMature"
             type="checkbox"

--- a/components/art/collection-card.vue
+++ b/components/art/collection-card.vue
@@ -180,10 +180,10 @@
       </div>
 
       <details v-if="showDebug" class="kr-panel-compact-xs" @click.stop>
-        <summary class="cursor-pointer text-xs font-bold text-base-content/70">
+        <summary class="kr-text-dim-xs-70 cursor-pointer font-bold">
           Debug
         </summary>
-        <pre class="mt-2 max-h-48 overflow-auto text-xs text-base-content/70">{{
+        <pre class="kr-text-dim-xs-70 mt-2 max-h-48 overflow-auto">{{
           JSON.stringify(debugCollection, null, 2)
         }}</pre>
       </details>

--- a/components/art/generate-button.vue
+++ b/components/art/generate-button.vue
@@ -67,7 +67,7 @@
     </div>
 
     <div
-      class="rounded-2xl border border-base-300 bg-base-200/70 p-3 text-xs font-semibold text-base-content/70"
+      class="kr-text-dim-xs-70 rounded-2xl border border-base-300 bg-base-200/70 p-3 font-semibold"
     >
       <div class="flex flex-wrap items-center gap-2">
         <span class="kr-badge-sm rounded-2xl" :class="selectionBadgeClass">

--- a/components/art/image-card.vue
+++ b/components/art/image-card.vue
@@ -279,10 +279,10 @@
       </div>
 
       <details v-if="showDebug" class="kr-panel-compact-xs" @click.stop>
-        <summary class="cursor-pointer text-xs font-bold text-base-content/70">
+        <summary class="kr-text-dim-xs-70 cursor-pointer font-bold">
           Debug
         </summary>
-        <pre class="mt-2 max-h-48 overflow-auto text-xs text-base-content/70">{{
+        <pre class="kr-text-dim-xs-70 mt-2 max-h-48 overflow-auto">{{
           JSON.stringify(debugImage, null, 2)
         }}</pre>
       </details>

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -112,9 +112,7 @@
             for="image-upload-collection"
           >
             <icon name="kind-icon:folder" class="h-4 w-4 text-secondary" />
-            <span class="text-xs font-bold text-base-content/70"
-              >Add to collection</span
-            >
+            <span class="kr-text-dim-xs-70 font-bold">Add to collection</span>
           </label>
 
           <select
@@ -332,7 +330,7 @@
           for="image-upload-model-connect"
         >
           <icon name="kind-icon:link" class="h-4 w-4 text-accent" />
-          <span class="text-xs font-bold text-base-content/70"
+          <span class="kr-text-dim-xs-70 font-bold"
             >Link image owner to model</span
           >
         </label>

--- a/components/art/stylist-calculator.vue
+++ b/components/art/stylist-calculator.vue
@@ -100,7 +100,7 @@
 
     <!-- Live total -->
     <div class="flex items-center justify-between rounded-xl bg-primary/10 p-3">
-      <span class="text-xs text-base-content/70">
+      <span class="kr-text-dim-xs-70">
         {{ formatCents(hourlyRateCents) }}/hr × {{ formatMinutes(totalMinutes) }} +
         {{ formatCents(productCostCents) }} products
       </span>

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -128,7 +128,7 @@
 
       <label v-if="sourceImageData" class="flex items-center gap-2">
         <input v-model="maskEnabled" type="checkbox" class="kr-checkbox-primary-xs" />
-        <span class="text-xs text-base-content/70">
+        <span class="kr-text-dim-xs-70">
           Only restyle the hair (paint a mask instead of changing the whole photo)
         </span>
       </label>
@@ -190,7 +190,7 @@
       </label>
 
       <label class="flex flex-col gap-1">
-        <span class="text-xs font-bold text-base-content/70">Extra notes (optional)</span>
+        <span class="kr-text-dim-xs-70 font-bold">Extra notes (optional)</span>
         <input
           v-model="extraNotes"
           type="text"
@@ -199,7 +199,7 @@
         />
       </label>
 
-      <p v-if="changeSummary" class="rounded-lg bg-base-200 p-2 text-xs text-base-content/70">
+      <p v-if="changeSummary" class="kr-text-dim-xs-70 rounded-lg bg-base-200 p-2">
         {{ changeSummary }}
       </p>
     </div>
@@ -225,7 +225,7 @@
       </div>
       <label class="flex items-start gap-2 pt-1">
         <input v-model="protectIdentity" type="checkbox" class="kr-checkbox-primary-xs mt-0.5" />
-        <span class="text-xs text-base-content/70">
+        <span class="kr-text-dim-xs-70">
           Extra-protect the face &amp; identity (a little slower — guards against turning
           them into someone else)
         </span>
@@ -281,7 +281,7 @@
 
     <div
       v-if="isFirstRun"
-      class="flex flex-col gap-1 rounded-xl border border-primary/30 bg-primary/5 p-3 text-xs text-base-content/70"
+      class="kr-text-dim-xs-70 flex flex-col gap-1 rounded-xl border border-primary/30 bg-primary/5 p-3"
     >
       <span class="font-black text-primary">First time in the studio?</span>
       <span>

--- a/components/art/stylist-settings.vue
+++ b/components/art/stylist-settings.vue
@@ -47,7 +47,7 @@
 
     <div class="flex flex-col gap-1 kr-panel-compact">
       <span class="text-xs font-black text-base-content">Receipt preview</span>
-      <pre class="whitespace-pre-wrap text-xs text-base-content/70">{{ preview }}</pre>
+      <pre class="kr-text-dim-xs-70 whitespace-pre-wrap">{{ preview }}</pre>
     </div>
 
     <p class="kr-text-dim-xs-40">

--- a/components/bots/bot-card.vue
+++ b/components/bots/bot-card.vue
@@ -94,13 +94,13 @@
 
         <details v-if="showDebug" class="kr-panel-flat p-2" @click.stop>
           <summary
-            class="cursor-pointer text-xs font-bold text-base-content/70"
+            class="kr-text-dim-xs-70 cursor-pointer font-bold"
           >
             Debug
           </summary>
 
           <pre
-            class="mt-2 max-h-48 overflow-auto text-xs text-base-content/70"
+            class="kr-text-dim-xs-70 mt-2 max-h-48 overflow-auto"
             >{{ JSON.stringify(bot, null, 2) }}</pre
           >
         </details>

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -369,7 +369,7 @@
         </div>
 
         <pre
-          class="kr-tile-md max-h-80 overflow-auto whitespace-pre-wrap text-xs text-base-content/70"
+          class="kr-text-dim-xs-70 kr-tile-md max-h-80 overflow-auto whitespace-pre-wrap"
           >{{ promptPreview }}</pre>
       </section>
     </aside>

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -310,7 +310,7 @@
 
           <div
             v-if="botStore.currentBot"
-            class="kr-panel-muted p-3 text-xs text-base-content/70"
+            class="kr-text-dim-xs-70 kr-panel-muted p-3"
           >
             <p class="line-clamp-3">
               {{ selectedBotDescription }}

--- a/components/characters/character-card.vue
+++ b/components/characters/character-card.vue
@@ -149,13 +149,13 @@
 
         <details v-if="showDebug" class="kr-panel-flat p-2">
           <summary
-            class="cursor-pointer text-xs font-bold text-base-content/70"
+            class="kr-text-dim-xs-70 cursor-pointer font-bold"
           >
             Debug
           </summary>
 
           <pre
-            class="mt-2 max-h-48 overflow-auto text-xs text-base-content/70"
+            class="kr-text-dim-xs-70 mt-2 max-h-48 overflow-auto"
             >{{ JSON.stringify(character, null, 2) }}</pre>
         </details>
       </section>

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -450,11 +450,9 @@
               Raw Character Context
             </h2>
 
-            <pre
-              class="kr-tile-md max-h-96 overflow-auto text-xs text-base-content/70"
-              >{{
-                JSON.stringify(characterStore.selectedCharacter, null, 2)
-              }}</pre>
+            <pre class="kr-text-dim-xs-70 kr-tile-md max-h-96 overflow-auto">{{
+              JSON.stringify(characterStore.selectedCharacter, null, 2)
+            }}</pre>
           </article>
         </section>
       </main>

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -340,11 +340,9 @@
               Raw Character Context
             </h2>
 
-            <pre
-              class="kr-tile-md max-h-96 overflow-auto text-xs text-base-content/70"
-              >{{
-                JSON.stringify(characterStore.selectedCharacter, null, 2)
-              }}</pre>
+            <pre class="kr-text-dim-xs-70 kr-tile-md max-h-96 overflow-auto">{{
+              JSON.stringify(characterStore.selectedCharacter, null, 2)
+            }}</pre>
           </article>
         </div>
 

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -209,7 +209,7 @@
 
           <div
             v-if="characterStore.selectedCharacter"
-            class="kr-panel-muted-sm text-xs text-base-content/70"
+            class="kr-text-dim-xs-70 kr-panel-muted-sm"
           >
             <p class="line-clamp-3">
               {{ selectedCharacterDescription }}

--- a/components/conductor/packmaker-pack-editor.vue
+++ b/components/conductor/packmaker-pack-editor.vue
@@ -24,7 +24,7 @@
     <div
       class="flex flex-col gap-2 rounded-xl border border-secondary/30 bg-base-100 p-3"
     >
-      <label class="text-xs font-bold text-base-content/70">
+      <label class="kr-text-dim-xs-70 font-bold">
         Describe the pack and let the model draft a scaffold
       </label>
       <textarea
@@ -100,7 +100,7 @@
     <!-- Items -->
     <div class="flex flex-col gap-2">
       <div class="flex items-center justify-between">
-        <span class="text-xs font-bold text-base-content/70"
+        <span class="kr-text-dim-xs-70 font-bold"
           >Items ({{ draft.items.length }})</span
         >
         <button class="kr-btn-ghost-xs" @click="addItem">

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -408,7 +408,7 @@
                   />
                   <div class="min-w-0 flex-1">
                     <p
-                      class="break-words text-xs font-medium leading-snug text-base-content/70"
+                      class="kr-text-dim-xs-70 break-words font-medium leading-snug"
                     >
                       {{ task.title }}
                     </p>

--- a/components/conductor/voice-lab-page.vue
+++ b/components/conductor/voice-lab-page.vue
@@ -61,7 +61,7 @@
           <p
             v-for="message in voice.recentMessages.slice(-6)"
             :key="message.id"
-            class="text-xs text-base-content/70"
+            class="kr-text-dim-xs-70"
           >
             <span class="font-bold uppercase">{{ message.role }}:</span>
             {{ message.text }}

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -370,7 +370,7 @@
 
           <div
             v-if="dreamStore.selectedDream"
-            class="kr-panel-muted-sm text-xs text-base-content/70"
+            class="kr-text-dim-xs-70 kr-panel-muted-sm"
           >
             <p class="line-clamp-3">
               {{ selectedDreamDescription }}

--- a/components/giftshop/mermaids-pdf-purchase.vue
+++ b/components/giftshop/mermaids-pdf-purchase.vue
@@ -19,7 +19,7 @@
 
     <div v-if="!userStore.isLoggedIn" class="flex flex-wrap items-center gap-2">
       <span
-        class="badge badge-outline badge-lg gap-1 rounded-2xl text-xs text-base-content/70"
+        class="kr-text-dim-xs-70 badge badge-outline badge-lg gap-1 rounded-2xl"
       >
         <Icon name="kind-icon:sparkles" class="h-3.5 w-3.5" />
         PDF edition — $9.99

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -311,7 +311,7 @@
 
         <div
           v-if="isQueued"
-          class="mt-1.5 flex items-center gap-1.5 rounded-lg bg-base-200 px-2 py-1 text-xs text-base-content/70"
+          class="kr-text-dim-xs-70 mt-1.5 flex items-center gap-1.5 rounded-lg bg-base-200 px-2 py-1"
           role="status"
           aria-live="polite"
           aria-busy="true"
@@ -367,7 +367,7 @@
 
       <div
         v-if="preview"
-        class="space-y-1 rounded-lg bg-base-200 p-2 text-xs text-base-content/70"
+        class="kr-text-dim-xs-70 space-y-1 rounded-lg bg-base-200 p-2"
       >
         <div>
           <span class="font-bold text-base-content">{{ preview.action }}</span>

--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -141,7 +141,7 @@
           selected
         </span>
         <label
-          class="flex cursor-pointer items-center gap-1.5 text-xs text-base-content/70"
+          class="kr-text-dim-xs-70 flex cursor-pointer items-center gap-1.5"
         >
           <input
             type="checkbox"

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -34,7 +34,7 @@
         <!-- Sub-view context label -->
         <span
           v-if="viewMode === 'tasks'"
-          class="text-xs font-bold text-base-content/70"
+          class="kr-text-dim-xs-70 font-bold"
           >· Tasks
           <span
             v-if="todoStore.openTodos.length"
@@ -583,7 +583,7 @@
                         :value="selectedProject.progress"
                         max="100"
                       />
-                      <span class="text-xs font-bold text-base-content/70"
+                      <span class="kr-text-dim-xs-70 font-bold"
                         >{{ selectedProject.progress }}%</span
                       >
                     </div>
@@ -1030,7 +1030,7 @@
                         />
                         <div class="min-w-0 flex-1">
                           <p
-                            class="break-words text-xs font-medium leading-snug text-base-content/70"
+                            class="kr-text-dim-xs-70 break-words font-medium leading-snug"
                           >
                             {{ task.title }}
                           </p>

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -205,7 +205,7 @@
                     />
                   </summary>
                   <p
-                    class="whitespace-pre-wrap border-t border-base-300 px-3 py-3 text-xs leading-relaxed text-base-content/70"
+                    class="kr-text-dim-xs-70 whitespace-pre-wrap border-t border-base-300 px-3 py-3 leading-relaxed"
                   >
                     {{ gate.task.note }}
                   </p>

--- a/components/rewards/reward-card.vue
+++ b/components/rewards/reward-card.vue
@@ -119,15 +119,13 @@
           class="mx-0.5 mt-2.5 kr-panel-flat p-2"
           @click.stop
         >
-          <summary
-            class="cursor-pointer text-xs font-bold text-base-content/70"
-          >
+          <summary class="kr-text-dim-xs-70 cursor-pointer font-bold">
             Debug
           </summary>
 
-          <pre
-            class="mt-2 max-h-48 overflow-auto text-xs text-base-content/70"
-            >{{ JSON.stringify(reward, null, 2) }}</pre>
+          <pre class="kr-text-dim-xs-70 mt-2 max-h-48 overflow-auto">{{
+            JSON.stringify(reward, null, 2)
+          }}</pre>
         </details>
       </kr-entity-card-body>
     </reactable-card>

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -470,7 +470,7 @@
 
           <pre
             v-if="showPromptPreview"
-            class="kr-tile-md mt-3 max-h-72 overflow-auto whitespace-pre-wrap text-xs text-base-content/70"
+            class="kr-text-dim-xs-70 kr-tile-md mt-3 max-h-72 overflow-auto whitespace-pre-wrap"
             >{{ rewardPromptPreview }}</pre>
         </section>
       </aside>

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -256,7 +256,7 @@
 
           <div
             v-if="rewardStore.selectedReward"
-            class="kr-panel-muted-sm text-xs text-base-content/70"
+            class="kr-text-dim-xs-70 kr-panel-muted-sm"
           >
             <p class="line-clamp-3">
               {{ selectedRewardDescription }}

--- a/components/scenarios/scenario-card.vue
+++ b/components/scenarios/scenario-card.vue
@@ -107,9 +107,7 @@
             Inspirations
           </p>
 
-          <p
-            class="mt-0.5 line-clamp-2 text-xs leading-relaxed text-base-content/70"
-          >
+          <p class="kr-text-dim-xs-70 mt-0.5 line-clamp-2 leading-relaxed">
             {{ scenario.inspirations }}
           </p>
         </div>

--- a/components/screenfx/animation-selector.vue
+++ b/components/screenfx/animation-selector.vue
@@ -29,7 +29,7 @@
 
     <div class="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(0,1fr)_auto]">
       <label class="form-control min-w-0">
-        <span class="label-text mb-1 text-xs font-black text-base-content/70">
+        <span class="kr-text-dim-xs-70 label-text mb-1 font-black">
           Startup animation
         </span>
 

--- a/components/servers/checkpoint-card.vue
+++ b/components/servers/checkpoint-card.vue
@@ -123,10 +123,10 @@
       class="rounded-2xl border border-base-300 bg-base-200 p-2"
       @click.stop
     >
-      <summary class="cursor-pointer text-xs font-bold text-base-content/70">
+      <summary class="kr-text-dim-xs-70 cursor-pointer font-bold">
         Debug
       </summary>
-      <pre class="mt-2 max-h-48 overflow-auto text-xs text-base-content/70">{{
+      <pre class="kr-text-dim-xs-70 mt-2 max-h-48 overflow-auto">{{
         JSON.stringify(checkpoint, null, 2)
       }}</pre>
     </details>

--- a/components/user/account-settings.vue
+++ b/components/user/account-settings.vue
@@ -57,7 +57,7 @@
             <span v-else>{{ userEmail }} is not verified yet.</span>
           </div>
           <div class="flex items-center gap-2">
-            <span v-if="verifyFeedback" class="text-xs text-base-content/70">
+            <span v-if="verifyFeedback" class="kr-text-dim-xs-70">
               {{ verifyFeedback }}
             </span>
             <button

--- a/components/user/user-galleries.vue
+++ b/components/user/user-galleries.vue
@@ -145,7 +145,7 @@
                 </div>
                 <p
                   v-if="getItemSummary(item)"
-                  class="mt-2 line-clamp-3 text-xs text-base-content/70"
+                  class="kr-text-dim-xs-70 mt-2 line-clamp-3"
                 >
                   {{ getItemSummary(item) }}
                 </p>

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -199,7 +199,7 @@
               <li
                 v-for="top in stats.topStarred"
                 :key="top.id"
-                class="flex items-center gap-1.5 text-xs text-base-content/70"
+                class="kr-text-dim-xs-70 flex items-center gap-1.5"
               >
                 <Icon
                   name="kind-icon:star"

--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -150,7 +150,7 @@
         <li
           v-for="related in relatedEntries"
           :key="related.id"
-          class="flex items-center gap-2 text-xs text-base-content/70"
+          class="kr-text-dim-xs-70 flex items-center gap-2"
         >
           <Icon
             v-if="related.starred"

--- a/utils/scripts/codemods/kr_text_dim_xs_70_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_xs_70_codemod.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `text-xs text-base-content/70` metadata
+caption text to `kr-text-dim-xs-70`.
+
+Sibling of kr_text_dim_sm_codemod.py / kr_text_dim_xs_codemod.py /
+kr_text_dim_sm_70_codemod.py / kr_text_dim_xs_45_codemod.py /
+kr_text_dim_xs_55_codemod.py / kr_text_dim_xs_60_codemod.py /
+kr_text_dim_xs_40_codemod.py, same conventions: dry-run by default, --write
+to update matching Vue files in place. Only the exact `text-xs
+text-base-content/70` shape is touched, and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings, and regardless of the
+base tokens' order in the source. A source that already carries
+`kr-text-dim-xs-70`, or is missing either base token, is left untouched.
+Extra tokens beyond the base set are preserved verbatim after the primitive
+class, matching the kr-badge-*/kr-spinner-*/kr-label-bold/kr-text-dim-*
+codemods' subset-match convention -- pass --exact-only to restrict a slice
+to sources with no extra tokens at all, the safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-dim-xs-70"
+BASE_TOKENS = {"text-xs", "text-base-content/70"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-dim-xs-70 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

Slice 163 of the recurring consistency umbrella.

### What changed / what I produced
- Added `.kr-text-dim-xs-70` primitive (`text-xs text-base-content/70`) to `assets/css/tailwind.css`, closing out the `text-xs text-base-content/NN` family surveyed since slice 152 (`/40`, `/45`, `/50`, `/55`, `/60`, `/70` all now named).
- New codemod `utils/scripts/codemods/kr_text_dim_xs_70_codemod.py`, sibling of the five existing `kr_text_dim_*` codemods, same dry-run-by-default / `--write` / subset-match conventions.
- Migrated all 51 occurrences across 35 files carrying the exact `text-xs text-base-content/70` base pair (token-order-independent); extra utility tokens preserved verbatim after the primitive class. No geometry or behavior change.

### How I verified
- `vue-tsc --noEmit`: clean before and after.
- `eslint .`: 333 problems (327 errors, 6 warnings) — identical before/after, confirmed via `git stash`.
- `npm run test:layout-contract`: holds, no new violations (the same pre-existing `-2` ratchet opportunity in `narrative-ingredient-multi-picker.vue` flagged by prior slices was left untouched, out of scope).
- `npm run test:lint-ratchet`: holds at 333/-59.
- `npx prettier --check .`: flagged 5 genuinely new fallout files (collapsed `<span>`/`<p>` tags now fitting prettier's print width after the shortened class strings), confirmed via `git stash` diffing against the pre-existing repo-wide baseline; a targeted `--write` on exactly those 5 files landed back at the identical pre-existing baseline (confirmed by diffing `prettier --check` output before/after byte-for-byte).

### Stakes
reversible

### Flags for Reviewer
- None — this follows the identical pattern as slices 154-162, and this closes out the whole `text-xs/sm text-base-content/NN` family that's been the umbrella's focus since slice 152.

### Kaizen suggestion
The `text-xs/sm text-base-content/NN` family is now fully mined (all six opacity/size pairings named). Slice 164 should run a genuinely fresh full-repo class-frequency survey outside this family to find the next largest bounded hand-rolled pattern, rather than re-surveying siblings of an already-covered family.

### Notes for reviewer
Conductor companion PR (roadmap `status: review`) follows in the same session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNdz4n7ZrCCDdGUE2QtetA

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNdz4n7ZrCCDdGUE2QtetA)_