### PR TITLE
refactor(ui): add kr-text-black-lg for font-black text-lg (slice 164)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1796,6 +1796,21 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply loading loading-spinner loading-lg text-primary;
   }
 
+  /* The heaviest-weight heading-emphasis text -- `font-black text-lg`, the
+   * bold label/title/stat line used across user, gallery, watchlist, and
+   * challenge surfaces (interface-vision t-104 slice 164) -- previously
+   * hand-rolled identically in 39 files (115 subset-match occurrences), the
+   * largest bounded family surfaced by a fresh full-repo class-frequency
+   * survey once the `text-xs/sm text-base-content/NN` family (slices
+   * 152-163) was fully mined. First of a new `kr-text-black-*` family,
+   * sibling in spirit to `kr-text-dim-*` but for weight instead of opacity;
+   * the sibling sizes surveyed alongside this one (`font-black text-xl`, 78
+   * occurrences; `font-black text-sm`, 109 occurrences) are left for future
+   * slices, same convention as `.kr-text-dim-xs`/`.kr-text-dim-sm`. */
+  .kr-text-black-lg {
+    @apply font-black text-lg;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -16,7 +16,7 @@
         />
         <div class="absolute inset-0 bg-linear-to-t from-black/80 via-transparent to-transparent" />
         <div class="absolute inset-x-0 bottom-0 p-4 text-white">
-          <p class="text-lg font-black leading-tight">{{ lesson.name }}</p>
+          <p class="kr-text-black-lg leading-tight">{{ lesson.name }}</p>
           <p class="mt-1 text-xs text-white/70">{{ lesson.era }} · {{ lesson.region }}</p>
         </div>
       </div>
@@ -330,7 +330,7 @@
             <Icon name="kind-icon:chat" class="h-4 w-4" />
             Reflect
           </p>
-          <h4 class="mt-2 text-lg font-black text-base-content">Look again after you remix</h4>
+          <h4 class="kr-text-black-lg mt-2 text-base-content">Look again after you remix</h4>
           <ul class="mt-3 flex flex-col gap-2">
             <li
               v-for="prompt in reflectPrompts"

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -124,7 +124,7 @@
             </div>
 
             <div class="absolute inset-x-0 bottom-0 p-4">
-              <p class="text-lg font-black leading-tight text-white drop-shadow sm:text-xl">
+              <p class="kr-text-black-lg leading-tight text-white drop-shadow sm:text-xl">
                 {{ style.name }}
               </p>
             </div>

--- a/components/achievements/achievement-gallery.vue
+++ b/components/achievements/achievement-gallery.vue
@@ -14,7 +14,7 @@
           <Icon name="kind-icon:jellybean" class="h-6 w-6" />
         </span>
         <div>
-          <h1 class="text-lg font-black text-base-content">
+          <h1 class="kr-text-black-lg text-base-content">
             {{ userStore.username }}'s Achievements
           </h1>
           <p class="kr-text-dim-xs">

--- a/components/achievements/achievement-popup.vue
+++ b/components/achievements/achievement-popup.vue
@@ -65,7 +65,7 @@
             >
               Reward
             </p>
-            <p class="text-lg font-black text-accent">
+            <p class="kr-text-black-lg text-accent">
               +{{ achievement.karma ?? 0 }} karma
             </p>
             <p class="kr-text-dim-xs-55">

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -12,7 +12,7 @@
           <Icon name="kind-icon:sparkles" class="h-6 w-6" />
         </span>
         <div>
-          <h2 class="text-lg font-black leading-tight text-base-content">
+          <h2 class="kr-text-black-lg leading-tight text-base-content">
             Animation Manager
           </h2>
           <p class="kr-text-dim-xs-60">
@@ -131,7 +131,7 @@
             <p class="text-xs font-black uppercase tracking-wide text-primary">
               Catalog effect
             </p>
-            <h3 class="mt-1 text-lg font-black text-base-content">
+            <h3 class="kr-text-black-lg mt-1 text-base-content">
               {{ store.selectedItem.label }}
             </h3>
           </div>

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -167,7 +167,7 @@
         class="flex min-h-56 flex-col items-center justify-center rounded-xl border border-base-300 bg-base-100 p-6 text-center text-base-content/60"
       >
         <Icon name="kind-icon:folder" class="h-12 w-12 text-primary" />
-        <p class="mt-2 text-lg font-black text-base-content">Nothing to show.</p>
+        <p class="kr-text-black-lg mt-2 text-base-content">Nothing to show.</p>
         <p class="text-sm">No collections match the current filters.</p>
       </div>
 
@@ -451,7 +451,7 @@
               class="flex min-h-56 w-full flex-col items-center justify-center rounded-xl border border-base-300 bg-base-100 p-6 text-center text-base-content/60"
             >
               <Icon name="kind-icon:image" class="h-12 w-12 text-primary" />
-              <p class="mt-2 text-lg font-black text-base-content">
+              <p class="kr-text-black-lg mt-2 text-base-content">
                 No images here.
               </p>
               <p class="text-sm">No art images match the current filters.</p>

--- a/components/art/artjob-slideshow.vue
+++ b/components/art/artjob-slideshow.vue
@@ -160,7 +160,7 @@
               v-if="overlay.title"
               class="flex flex-wrap items-baseline gap-2"
             >
-              <span class="text-lg font-black">{{ slideTitle }}</span>
+              <span class="kr-text-black-lg">{{ slideTitle }}</span>
               <span
                 v-if="currentJob?.projectSlug"
                 class="kr-badge-secondary-sm rounded-2xl"

--- a/components/art/forum-art-generation-context.vue
+++ b/components/art/forum-art-generation-context.vue
@@ -7,7 +7,7 @@
         <p class="text-xs font-black uppercase tracking-widest text-primary/70">
           Rainbow Butterflies Commons handoff
         </p>
-        <h2 class="mt-1 text-lg font-black text-primary">
+        <h2 class="kr-text-black-lg mt-1 text-primary">
           Build on this contribution
         </h2>
         <p class="kr-text-dim-sm mt-1">

--- a/components/art/hair-studio-manager.vue
+++ b/components/art/hair-studio-manager.vue
@@ -8,7 +8,7 @@
         <Icon name="kind-icon:magic" class="h-6 w-6" />
       </span>
       <div class="min-w-0 flex-1">
-        <h2 class="text-lg font-black">Hair Studio</h2>
+        <h2 class="kr-text-black-lg">Hair Studio</h2>
         <p class="kr-text-dim-sm">
           Preview a new color or cut on a private client photo.
         </p>

--- a/components/art/stylist-calculator.vue
+++ b/components/art/stylist-calculator.vue
@@ -104,7 +104,7 @@
         {{ formatCents(hourlyRateCents) }}/hr × {{ formatMinutes(totalMinutes) }} +
         {{ formatCents(productCostCents) }} products
       </span>
-      <span class="text-lg font-black text-primary">{{ formatCents(totalCents) }}</span>
+      <span class="kr-text-black-lg text-primary">{{ formatCents(totalCents) }}</span>
     </div>
 
     <button

--- a/components/brainstorm/brainstorm-candidate-card.vue
+++ b/components/brainstorm/brainstorm-candidate-card.vue
@@ -73,7 +73,7 @@
         </template>
         <h3
           v-else-if="candidate.title"
-          class="break-words text-lg font-black leading-snug text-base-content"
+          class="kr-text-black-lg break-words leading-snug text-base-content"
         >
           {{ candidate.title }}
         </h3>

--- a/components/builder/builder-card.vue
+++ b/components/builder/builder-card.vue
@@ -50,7 +50,7 @@
             {{ card.label }}
           </p>
 
-          <h3 class="line-clamp-2 text-lg font-black leading-tight text-base-content xl:text-sm">
+          <h3 class="kr-text-black-lg line-clamp-2 leading-tight text-base-content xl:text-sm">
             {{ card.title }}
           </h3>
         </div>

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -118,7 +118,7 @@
                 {{ stat.label }}
               </p>
 
-              <p class="mt-1 text-lg font-black text-primary">
+              <p class="kr-text-black-lg mt-1 text-primary">
                 {{ stat.value }}
               </p>
             </div>

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -114,7 +114,7 @@
 
       <div class="grid gap-4 xl:grid-cols-2">
         <article class="kr-panel-section-flat">
-          <h4 class="text-lg font-black">Source-production blockers</h4>
+          <h4 class="kr-text-black-lg">Source-production blockers</h4>
           <p class="kr-text-dim-xs mt-1">
             {{ selectedPackage.finalPairCount }}/{{ selectedPackage.expectedInteriorCount }} final pairs ·
             cover {{ selectedPackage.coverStatus }}
@@ -144,7 +144,7 @@
         </article>
 
         <article class="kr-panel-section-flat">
-          <h4 class="text-lg font-black">Layout and export blockers</h4>
+          <h4 class="kr-text-black-lg">Layout and export blockers</h4>
           <p class="kr-text-dim-xs mt-1">
             These fields stay unresolved until a printer, trim, binding, and template are chosen.
           </p>

--- a/components/coloring/coloring-book-page.vue
+++ b/components/coloring/coloring-book-page.vue
@@ -15,7 +15,7 @@
             class="flex cursor-pointer list-none flex-wrap items-center justify-between gap-3 p-4 marker:hidden"
           >
             <div>
-              <h3 class="flex items-center gap-2 text-lg font-black">
+              <h3 class="kr-text-black-lg flex items-center gap-2">
                 <Icon name="kind-icon:activity" class="size-5 text-primary" />
                 Production controls & diagnostics
               </h3>

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -155,21 +155,21 @@
           <dl class="grid grid-cols-2 gap-3 text-sm">
             <div class="kr-tile-md">
               <dt class="text-base-content/50">Pending color</dt>
-              <dd class="text-lg font-black">{{ book.counts.pending }}</dd>
+              <dd class="kr-text-black-lg">{{ book.counts.pending }}</dd>
             </div>
             <div class="kr-tile-md">
               <dt class="text-base-content/50">Needs attention</dt>
-              <dd class="text-lg font-black">
+              <dd class="kr-text-black-lg">
                 {{ book.counts.needsReview + book.counts.blocked }}
               </dd>
             </div>
             <div class="kr-tile-md">
               <dt class="text-base-content/50">Accepted color</dt>
-              <dd class="text-lg font-black">{{ book.counts.acceptedColor }}</dd>
+              <dd class="kr-text-black-lg">{{ book.counts.acceptedColor }}</dd>
             </div>
             <div class="kr-tile-md">
               <dt class="text-base-content/50">Final pairs</dt>
-              <dd class="text-lg font-black">{{ book.counts.finalPairs }}</dd>
+              <dd class="kr-text-black-lg">{{ book.counts.finalPairs }}</dd>
             </div>
           </dl>
 

--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -248,7 +248,7 @@
             class="rounded-3xl border border-dashed border-base-300 bg-base-200/40 px-6 py-16 text-center"
           >
             <Icon name="kind-icon:trophy" class="mx-auto size-10 text-primary/50" />
-            <h4 class="mt-4 text-lg font-black uppercase">No fights on this card</h4>
+            <h4 class="kr-text-black-lg mt-4 uppercase">No fights on this card</h4>
             <p class="mx-auto mt-2 max-w-md text-sm text-base-content/55">
               Try another division or status. The seeded challenges remain in the
               arena even when this particular bracket is empty.

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -124,7 +124,7 @@
           class="space-y-4 rounded-2xl border border-primary/20 bg-primary/5 p-4"
         >
           <div>
-            <h2 class="text-lg font-black">The spark</h2>
+            <h2 class="kr-text-black-lg">The spark</h2>
             <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
               Begin with the promise of the story. A sentence is enough; a
               strange paragraph is welcome.
@@ -224,7 +224,7 @@
           class="space-y-4 rounded-2xl border border-primary/20 bg-primary/5 p-4"
         >
           <div>
-            <h2 class="text-lg font-black">The cast</h2>
+            <h2 class="kr-text-black-lg">The cast</h2>
             <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
               Choose up to five existing characters. Leaving the cast empty lets
               Storybook invent whoever the premise requires.
@@ -257,7 +257,7 @@
           class="space-y-5 rounded-2xl border border-primary/20 bg-primary/5 p-4"
         >
           <div>
-            <h2 class="text-lg font-black">The world and its flavor</h2>
+            <h2 class="kr-text-black-lg">The world and its flavor</h2>
             <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
               Use canonical Dreams, Facets, and Rewards as ingredients. Their
               artwork becomes part of the setup surface while technical art
@@ -339,7 +339,7 @@
           class="space-y-4 rounded-2xl border border-primary/20 bg-primary/5 p-4"
         >
           <div>
-            <h2 class="text-lg font-black">Story bible</h2>
+            <h2 class="kr-text-black-lg">Story bible</h2>
             <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
               Review the creative contract before Storybook writes the opening
               scene.

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -831,7 +831,7 @@
             class="h-32 w-24"
             placeholder-icon="kind-icon:fish"
           />
-          <h3 class="text-lg font-black">
+          <h3 class="kr-text-black-lg">
             {{ tankStore.revealedUnlock.Monster.name }}
           </h3>
           <p
@@ -889,7 +889,7 @@
             class="h-32 w-24"
             placeholder-icon="kind-icon:fish"
           />
-          <h3 class="text-lg font-black">
+          <h3 class="kr-text-black-lg">
             {{ tankStore.revealedHatch.Monster.name }}
           </h3>
           <p
@@ -948,7 +948,7 @@
             class="h-32 w-24"
             placeholder-icon="kind-icon:fish"
           />
-          <h3 class="text-lg font-black">
+          <h3 class="kr-text-black-lg">
             {{ breedConfirmPair.a.Monster.name }}
           </h3>
           <p class="text-sm opacity-80">
@@ -1021,7 +1021,7 @@
             class="h-32 w-24"
             placeholder-icon="kind-icon:fish"
           />
-          <h3 class="text-lg font-black">
+          <h3 class="kr-text-black-lg">
             {{ tankStore.revealedBreed.stock.Monster.name }}
           </h3>
           <p
@@ -1071,7 +1071,7 @@
           <p class="text-xs font-black uppercase tracking-wide text-primary">
             The bestiary is complete
           </p>
-          <h3 class="text-lg font-black">Every species, observed.</h3>
+          <h3 class="kr-text-black-lg">Every species, observed.</h3>
           <p class="text-sm opacity-80">
             Nothing here resets and nothing leaves the collection -- the tank
             keeps running exactly as it was. This is just the beat that says so.
@@ -1121,7 +1121,7 @@
           <p class="text-xs font-black uppercase tracking-wide text-primary">
             The last aquarium
           </p>
-          <h3 class="text-lg font-black">
+          <h3 class="kr-text-black-lg">
             Everything is exactly as you left it.
           </h3>
           <p class="text-sm opacity-80">
@@ -1163,7 +1163,7 @@
           <p class="text-xs font-black uppercase tracking-wide text-primary">
             While you were away
           </p>
-          <h3 class="text-lg font-black">
+          <h3 class="kr-text-black-lg">
             {{ tankStore.offlineEarnings }} coins
           </h3>
           <p class="text-sm opacity-80">

--- a/components/dreams/daily-digest-browser.vue
+++ b/components/dreams/daily-digest-browser.vue
@@ -142,7 +142,7 @@
           </template>
 
           <div v-else class="py-5">
-            <p class="text-lg font-black">No Daily Dreams have landed yet.</p>
+            <p class="kr-text-black-lg">No Daily Dreams have landed yet.</p>
             <p
               class="kr-text-dim-sm mt-2 max-w-xl leading-relaxed"
             >

--- a/components/dreams/daily-digest-object-dialog.vue
+++ b/components/dreams/daily-digest-object-dialog.vue
@@ -112,7 +112,7 @@
               class="rounded-2xl border border-primary/25 bg-primary/5 p-4"
             >
               <p class="text-xs font-black uppercase tracking-[0.15em] text-primary">Object editor</p>
-              <h3 class="mt-1 text-lg font-black">Revise the useful fields</h3>
+              <h3 class="kr-text-black-lg mt-1">Revise the useful fields</h3>
               <p class="mt-1 text-sm leading-relaxed text-base-content/55">
                 These save directly to the existing {{ typeLabel.toLowerCase() }} record. System fields and relationships stay out of reach.
               </p>
@@ -176,7 +176,7 @@
               class="flex min-h-72 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-8 text-center"
             >
               <Icon name="kind-icon:lock" class="size-10 text-base-content/25" />
-              <p class="text-lg font-black text-base-content/65">This object is view-only.</p>
+              <p class="kr-text-black-lg text-base-content/65">This object is view-only.</p>
               <p class="max-w-lg text-sm text-base-content/45">
                 Only its owner or an administrator can submit content changes.
               </p>

--- a/components/dreams/daily-digest-object-gallery.vue
+++ b/components/dreams/daily-digest-object-gallery.vue
@@ -9,7 +9,7 @@
           Complete bundle
         </p>
         <div class="mt-0.5 flex flex-wrap items-baseline gap-x-3 gap-y-1">
-          <h3 class="text-lg font-black">Objects in this Daily Dream</h3>
+          <h3 class="kr-text-black-lg">Objects in this Daily Dream</h3>
           <p class="kr-text-dim-xs hidden lg:block">
             Open any object for full details, editing, and artwork controls.
           </p>

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -59,7 +59,7 @@
             <p class="text-xs font-black uppercase tracking-[0.16em] text-secondary">
               Art workbench
             </p>
-            <h3 class="mt-1 text-lg font-black">
+            <h3 class="kr-text-black-lg mt-1">
               Rebuild or modify {{ selectedSlot.label.toLowerCase() }} art
             </h3>
             <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -210,7 +210,7 @@
           <section class="kr-panel-muted-sm">
             <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
               <div>
-                <h2 class="text-lg font-black">Fresh Ideas</h2>
+                <h2 class="kr-text-black-lg">Fresh Ideas</h2>
                 <p class="kr-text-dim-xs-60">
                   Accept, reject, edit, and save.
                 </p>
@@ -347,7 +347,7 @@
                 class="h-14 w-14 text-primary/60"
               />
               <div>
-                <p class="text-lg font-black">No fresh ideas yet.</p>
+                <p class="kr-text-black-lg">No fresh ideas yet.</p>
                 <p class="mt-1 text-sm">
                   Feed Brainstorm a pitch and let the text server cook.
                 </p>
@@ -397,7 +397,7 @@
 
       <aside class="kr-pane gap-3 kr-panel-flat p-3">
         <section class="kr-panel-muted-sm">
-          <h2 class="mb-3 text-lg font-black">Text Server</h2>
+          <h2 class="kr-text-black-lg mb-3">Text Server</h2>
           <div class="grid gap-3">
             <label class="form-control">
               <span class="label"
@@ -448,7 +448,7 @@
         </section>
 
         <section class="kr-panel-muted-sm">
-          <h2 class="mb-3 text-lg font-black">Examples</h2>
+          <h2 class="kr-text-black-lg mb-3">Examples</h2>
           <div class="flex flex-wrap gap-2">
             <button
               type="button"

--- a/components/dreams/dream-list.vue
+++ b/components/dreams/dream-list.vue
@@ -5,7 +5,7 @@
       class="flex shrink-0 items-start justify-between gap-2 kr-panel-header-muted"
     >
       <div class="min-w-0">
-        <h3 class="truncate text-lg font-black text-primary">{{ title }}</h3>
+        <h3 class="kr-text-black-lg truncate text-primary">{{ title }}</h3>
         <p class="kr-text-dim-xs-60">{{ subtitle }}</p>
       </div>
 

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -190,7 +190,7 @@
           <div class="kr-panel-flat p-4">
             <div class="flex flex-wrap items-center justify-between gap-2">
               <div>
-                <h2 class="text-lg font-black">Art Prompt</h2>
+                <h2 class="kr-text-black-lg">Art Prompt</h2>
                 <p class="kr-text-dim-sm">
                   Used by Interact when generating art around this Dream.
                 </p>
@@ -273,7 +273,7 @@
 
         <aside class="grid h-fit gap-3 xl:sticky xl:top-3">
           <section class="kr-panel-flat p-4">
-            <h2 class="text-lg font-black">Visibility</h2>
+            <h2 class="kr-text-black-lg">Visibility</h2>
             <div class="mt-3 grid gap-2">
               <label class="kr-toggle-row-sm">
                 <span class="kr-label-bold">Public</span>
@@ -321,7 +321,7 @@
           </section>
 
           <section class="kr-panel-flat p-4">
-            <h2 class="text-lg font-black">Preview</h2>
+            <h2 class="kr-text-black-lg">Preview</h2>
             <div
               class="mt-3 kr-panel-muted-sm"
             >
@@ -351,7 +351,7 @@
           </section>
 
           <section class="kr-panel-flat p-4">
-            <h2 class="text-lg font-black">Checks</h2>
+            <h2 class="kr-text-black-lg">Checks</h2>
             <div class="mt-3 grid gap-2 text-sm">
               <div
                 v-for="check in checks"

--- a/components/dreams/dream-narration.vue
+++ b/components/dreams/dream-narration.vue
@@ -4,7 +4,7 @@
     <header class="shrink-0 kr-panel-flat p-3">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div class="min-w-0">
-          <h1 class="truncate text-lg font-black text-primary">
+          <h1 class="kr-text-black-lg truncate text-primary">
             {{ dreamTitle }}
           </h1>
           <p class="kr-text-dim-sm truncate">

--- a/components/dreams/dream-relationship-gallery.vue
+++ b/components/dreams/dream-relationship-gallery.vue
@@ -8,7 +8,7 @@
     <header class="shrink-0 kr-panel-flat px-3 py-2">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div class="min-w-0">
-          <h2 class="truncate text-lg font-black text-base-content">
+          <h2 class="kr-text-black-lg truncate text-base-content">
             {{ title }}
           </h2>
           <p class="kr-text-dim-sm truncate">

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -72,7 +72,7 @@
         class="space-y-3"
       >
         <div class="flex items-baseline gap-2">
-          <h2 class="text-lg font-black">
+          <h2 class="kr-text-black-lg">
             {{ taxonomyLabel(group.taxonomy) }}
           </h2>
           <span class="kr-badge-secondary-sm">{{ group.total }}</span>

--- a/components/gallery/kr-card-back.vue
+++ b/components/gallery/kr-card-back.vue
@@ -96,7 +96,7 @@
       </div>
 
       <div v-if="resolvedArtSrc" class="min-w-0 px-3 pb-3 pt-2">
-        <h2 class="break-words text-lg font-black leading-tight">
+        <h2 class="kr-text-black-lg break-words leading-tight">
           {{ title }}
         </h2>
 
@@ -108,7 +108,7 @@
       <!-- No art: the title has to carry the header on its own, so it keeps
            the badges beside it rather than leaving an empty plate. -->
       <div v-else class="min-w-0 flex-1 p-3">
-        <h2 class="break-words text-lg font-black leading-tight">
+        <h2 class="kr-text-black-lg break-words leading-tight">
           {{ title }}
         </h2>
 

--- a/components/giftshop/shopping-cart.vue
+++ b/components/giftshop/shopping-cart.vue
@@ -37,7 +37,7 @@
       class="kr-panel-flat border-dashed p-8 text-center"
     >
       <Icon name="kind-icon:cart" class="mx-auto h-10 w-10 text-base-content/35" />
-      <p class="mt-3 text-lg font-black text-base-content">Your cart is empty.</p>
+      <p class="kr-text-black-lg mt-3 text-base-content">Your cart is empty.</p>
       <p class="kr-text-dim-sm mt-1">
         The butterflies have returned the receipt printer to sleep mode.
       </p>
@@ -66,7 +66,7 @@
 
           <div class="min-w-0 flex-1 space-y-2">
             <div>
-              <h2 class="text-lg font-black text-base-content">
+              <h2 class="kr-text-black-lg text-base-content">
                 {{ item.notes || itemLabel(item.type) }}
               </h2>
               <p v-if="item.type === 'donation'" class="kr-text-dim-xs-60">

--- a/components/home/home-object-sheet.vue
+++ b/components/home/home-object-sheet.vue
@@ -48,7 +48,7 @@
             >
               {{ kindLabel }}
             </p>
-            <h2 class="truncate text-lg font-black sm:text-xl">
+            <h2 class="kr-text-black-lg truncate sm:text-xl">
               {{ detail?.title || card.title }}
             </h2>
             <p

--- a/components/lora/add-lora.vue
+++ b/components/lora/add-lora.vue
@@ -13,7 +13,7 @@
   >
     <div class="flex items-start justify-between gap-3">
       <div class="min-w-0">
-        <h3 class="text-lg font-black text-primary">
+        <h3 class="kr-text-black-lg text-primary">
           {{ isEditing ? 'Edit LoRA' : 'Add LoRA' }}
         </h3>
 

--- a/components/manager/kr-manager.vue
+++ b/components/manager/kr-manager.vue
@@ -191,7 +191,7 @@
       <Icon name="kind-icon:warning" class="h-10 w-10" />
 
       <div>
-        <p class="text-lg font-black">Unknown tab: {{ activeTab }}</p>
+        <p class="kr-text-black-lg">Unknown tab: {{ activeTab }}</p>
         <p class="mt-1 text-sm opacity-80">Expected one of: {{ slotTabs }}</p>
       </div>
 

--- a/components/model/add-model.vue
+++ b/components/model/add-model.vue
@@ -14,7 +14,7 @@
   >
     <div class="flex items-start justify-between gap-3">
       <div class="min-w-0">
-        <h3 class="text-lg font-black text-primary">
+        <h3 class="kr-text-black-lg text-primary">
           {{ isEditing ? 'Edit Model' : 'Add Model' }}
         </h3>
 

--- a/components/narrative/narrative-ingredient-multi-picker.vue
+++ b/components/narrative/narrative-ingredient-multi-picker.vue
@@ -9,7 +9,7 @@
   >
     <div class="flex flex-wrap items-start gap-2">
       <div class="min-w-0 flex-1">
-        <h3 :id="headingId" class="text-lg font-black">
+        <h3 :id="headingId" class="kr-text-black-lg">
           {{ label }}
         </h3>
         <p

--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -9,7 +9,7 @@
   >
     <div class="flex flex-wrap items-start gap-2">
       <div class="min-w-0 flex-1">
-        <h3 :id="headingId" class="text-lg font-black">
+        <h3 :id="headingId" class="kr-text-black-lg">
           {{ label }}
         </h3>
         <p

--- a/components/navigation/card-picker.vue
+++ b/components/navigation/card-picker.vue
@@ -2,7 +2,7 @@
 <template>
   <div class="flex h-full w-full flex-col gap-4 p-4">
     <header class="flex flex-col gap-1">
-      <h2 class="text-lg font-black text-base-content">Card Back</h2>
+      <h2 class="kr-text-black-lg text-base-content">Card Back</h2>
       <p class="kr-text-dim-sm">
         Pick the design shown when your workspace cards flip.
       </p>

--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -140,7 +140,7 @@
                 <Icon :name="channel.icon" class="h-5 w-5" />
               </span>
               <div class="min-w-0">
-                <h2 class="truncate text-lg font-black">{{ channel.label }}</h2>
+                <h2 class="kr-text-black-lg truncate">{{ channel.label }}</h2>
                 <p class="kr-text-dim-xs-45 truncate font-bold">
                   {{ channel.channelKey }} · {{ channel.route }}
                 </p>

--- a/components/navigation/server-selector.vue
+++ b/components/navigation/server-selector.vue
@@ -19,7 +19,7 @@
           class="sticky top-0 z-10 flex shrink-0 items-start justify-between gap-3 border-b border-base-300 bg-base-100/95 p-4 backdrop-blur"
         >
           <div class="min-w-0">
-            <h2 class="truncate text-lg font-black text-primary sm:text-xl">
+            <h2 class="kr-text-black-lg truncate text-primary sm:text-xl">
               Server Connections
             </h2>
             <p class="kr-text-dim-xs-60 mt-1 leading-snug sm:text-sm">

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -197,7 +197,7 @@
             -->
             <p
               v-if="greeting"
-              class="hidden min-w-0 flex-1 truncate text-right text-lg font-black text-base-content/80 xl:block xl:text-xl"
+              class="kr-text-black-lg hidden min-w-0 flex-1 truncate text-right text-base-content/80 xl:block xl:text-xl"
               :title="greeting"
             >
               {{ greeting }}

--- a/components/navigation/workspace-narrator.vue
+++ b/components/navigation/workspace-narrator.vue
@@ -160,7 +160,7 @@
                   <div class="flex items-center justify-between gap-3">
                     <div class="min-w-0">
                       <h2
-                        class="truncate text-lg font-black leading-tight text-base-content"
+                        class="kr-text-black-lg truncate leading-tight text-base-content"
                       >
                         {{ narratorName }}
                       </h2>

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -68,7 +68,7 @@
             <span class="block truncate text-xs font-black uppercase tracking-wide">
               {{ tab.label }}
             </span>
-            <span class="text-lg font-black leading-none">{{ tab.count }}</span>
+            <span class="kr-text-black-lg leading-none">{{ tab.count }}</span>
           </span>
         </button>
       </div>
@@ -142,7 +142,7 @@
 
               <div class="min-w-0 flex-1">
                 <div class="flex flex-wrap items-start justify-between gap-2">
-                  <h3 class="min-w-0 flex-1 text-lg font-black leading-tight">
+                  <h3 class="kr-text-black-lg min-w-0 flex-1 leading-tight">
                     {{ pitch.title }}
                   </h3>
                   <span

--- a/components/pages/giving-page.vue
+++ b/components/pages/giving-page.vue
@@ -40,7 +40,7 @@
       <div class="kr-panel p-5">
         <Icon name="kind-icon:heart" class="h-6 w-6 text-secondary" />
 
-        <h2 class="mt-2 text-lg font-black text-base-content">Why AMF?</h2>
+        <h2 class="kr-text-black-lg mt-2 text-base-content">Why AMF?</h2>
 
         <p class="kr-text-dim-sm-70 mt-1 leading-relaxed">
           {{ trivia }}
@@ -50,7 +50,7 @@
       <div class="kr-panel p-5">
         <Icon name="kind-icon:cart" class="h-6 w-6 text-secondary" />
 
-        <h2 class="mt-2 text-lg font-black text-base-content">
+        <h2 class="kr-text-black-lg mt-2 text-base-content">
           Prefer It On Your Receipt?
         </h2>
 

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -120,7 +120,7 @@
     >
       <div class="flex flex-wrap items-start justify-between gap-2">
         <div>
-          <h2 class="text-lg font-black">Recent stories</h2>
+          <h2 class="kr-text-black-lg">Recent stories</h2>
           <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
             Open an existing branch, duplicate it safely, or export a portable
             copy.

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -84,7 +84,7 @@
                 >
                   Your guide
                 </p>
-                <h3 class="truncate text-lg font-black">Serendipity</h3>
+                <h3 class="kr-text-black-lg truncate">Serendipity</h3>
               </div>
             </div>
             <p class="mt-3 text-xs font-medium leading-relaxed text-base-content/65">
@@ -117,7 +117,7 @@
                 >
                   Your objective
                 </p>
-                <h3 class="mt-1 text-lg font-black sm:text-xl">
+                <h3 class="kr-text-black-lg mt-1 sm:text-xl">
                   What needs to move?
                 </h3>
                 <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
@@ -189,7 +189,7 @@
                 >
                   Quest recipe
                 </p>
-                <h3 class="mt-1 text-lg font-black">Shape the journey</h3>
+                <h3 class="kr-text-black-lg mt-1">Shape the journey</h3>
                 <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">
                   Choose story ingredients, never model machinery.
                 </p>

--- a/components/scenarios/scenario-relationship-gallery.vue
+++ b/components/scenarios/scenario-relationship-gallery.vue
@@ -8,7 +8,7 @@
     <header class="shrink-0 kr-panel-flat px-3 py-2">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div class="min-w-0">
-          <h2 class="truncate text-lg font-black text-base-content">
+          <h2 class="kr-text-black-lg truncate text-base-content">
             {{ title }}
           </h2>
           <p class="kr-text-dim-sm truncate">

--- a/components/screenfx/animation-selector.vue
+++ b/components/screenfx/animation-selector.vue
@@ -12,7 +12,7 @@
         </span>
 
         <div class="min-w-0">
-          <h2 class="text-lg font-black text-base-content">
+          <h2 class="kr-text-black-lg text-base-content">
             Animation preferences
           </h2>
           <p class="kr-text-dim-xs-55">

--- a/components/servers/add-checkpoint.vue
+++ b/components/servers/add-checkpoint.vue
@@ -6,7 +6,7 @@
   >
     <div class="flex items-start justify-between gap-3">
       <div class="min-w-0">
-        <h3 class="text-lg font-black text-primary">
+        <h3 class="kr-text-black-lg text-primary">
           {{ title }}
         </h3>
 

--- a/components/servers/server-status.vue
+++ b/components/servers/server-status.vue
@@ -6,7 +6,7 @@
         <div class="min-w-0">
           <div class="flex items-center gap-2">
             <Icon :name="statusIcon" class="h-5 w-5 shrink-0" />
-            <h2 class="text-lg font-black text-base-content">
+            <h2 class="kr-text-black-lg text-base-content">
               Server Status
             </h2>
           </div>

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -21,7 +21,7 @@
         class="flex shrink-0 items-center justify-between border-b border-base-300 px-5 py-4"
       >
         <div>
-          <h2 class="text-lg font-black text-base-content">
+          <h2 class="kr-text-black-lg text-base-content">
             Create a Performer
           </h2>
           <p class="kr-text-dim-xs mt-0.5">

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -13,7 +13,7 @@
     >
       <div class="flex items-center gap-2.5">
         <Icon name="mdi:theater" class="h-5 w-5 text-primary" />
-        <h1 class="text-lg font-black tracking-tight">Stage</h1>
+        <h1 class="kr-text-black-lg tracking-tight">Stage</h1>
         <span
           v-if="store.selectedStage"
           class="rounded-full border border-primary/30 bg-primary/10 px-2.5 py-0.5 text-xs font-bold text-primary"
@@ -682,7 +682,7 @@
                 class="mx-auto h-32 w-auto rounded-2xl object-cover opacity-60"
               />
               <div>
-                <p class="text-lg font-black text-base-content/40">
+                <p class="kr-text-black-lg text-base-content/40">
                   {{
                     store.castReady ? 'Cast is ready.' : 'Cast is not ready.'
                   }}

--- a/components/storybook/storybook-visual-setup.vue
+++ b/components/storybook/storybook-visual-setup.vue
@@ -46,7 +46,7 @@
               <Icon name="kind-icon:sparkles" class="size-5" />
             </div>
             <div>
-              <h2 class="text-lg font-black">The spark</h2>
+              <h2 class="kr-text-black-lg">The spark</h2>
               <p class="kr-text-dim-xs">
                 One premise is enough. Everything else can stay loose.
               </p>
@@ -230,7 +230,7 @@
               class="absolute inset-0 bg-linear-to-t from-black/85 via-black/20 to-transparent"
             />
             <span class="absolute inset-x-0 bottom-0 p-4 text-white">
-              <span class="block text-lg font-black">{{ option.label }}</span>
+              <span class="kr-text-black-lg block">{{ option.label }}</span>
               <span class="mt-1 block text-xs leading-relaxed text-white/80">
                 {{ option.description }}
               </span>

--- a/components/user/account-settings.vue
+++ b/components/user/account-settings.vue
@@ -33,7 +33,7 @@
 
       <!-- ── Security ─────────────────────────────────────────────── -->
       <div class="kr-panel-flat p-5">
-        <h2 class="mb-1 text-lg font-black">Security</h2>
+        <h2 class="kr-text-black-lg mb-1">Security</h2>
         <p class="kr-text-dim-sm-70 mb-4">
           Update your password and verify your email address.
         </p>
@@ -129,7 +129,7 @@
 
       <!-- ── Privacy & Consent ────────────────────────────────────── -->
       <div class="kr-panel-flat p-5">
-        <h2 class="mb-1 text-lg font-black">Privacy &amp; Consent</h2>
+        <h2 class="kr-text-black-lg mb-1">Privacy &amp; Consent</h2>
         <p class="kr-text-dim-sm-70 mb-4">
           Consent is the default here. Choose what you see and what others can
           do.
@@ -234,7 +234,7 @@
 
       <!-- ── Newsletter ───────────────────────────────────────────── -->
       <div class="kr-panel-flat p-5">
-        <h2 class="mb-1 text-lg font-black">Updates &amp; Promotions</h2>
+        <h2 class="kr-text-black-lg mb-1">Updates &amp; Promotions</h2>
         <p class="kr-text-dim-sm-70 mb-4">
           Can we email you updates? Pick a rhythm — we only send what you ask
           for, and we'll email you once to confirm.

--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -21,7 +21,7 @@
       </span>
 
       <div class="min-w-0 flex-1">
-        <h1 class="text-lg font-black leading-tight text-base-content">
+        <h1 class="kr-text-black-lg leading-tight text-base-content">
           Choose your avatar
         </h1>
         <p class="kr-text-dim-xs-55 truncate">

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -88,7 +88,7 @@
       >
         <Icon name="kind-icon:chat" class="h-12 w-12 text-base-content/30" />
         <div>
-          <p class="text-lg font-black text-base-content">No messages found.</p>
+          <p class="kr-text-black-lg text-base-content">No messages found.</p>
           <p class="kr-text-dim-sm">
             When a message arrives, human or otherwise, it will show up here.
           </p>
@@ -105,7 +105,7 @@
             @click="openThread(thread)"
           >
             <div
-              class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-primary/15 text-lg font-black text-primary"
+              class="kr-text-black-lg flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-primary/15 text-primary"
             >
               <img
                 v-if="thread.otherAvatar"

--- a/components/user/first-launch-intro.vue
+++ b/components/user/first-launch-intro.vue
@@ -15,7 +15,7 @@
           <p class="text-xs font-black uppercase tracking-widest text-primary">
             {{ step + 1 }} / {{ steps.length }}
           </p>
-          <h2 class="mt-0.5 truncate text-lg font-black sm:text-xl">
+          <h2 class="kr-text-black-lg mt-0.5 truncate sm:text-xl">
             {{ currentStep.title }}
           </h2>
         </div>

--- a/components/user/friends-panel.vue
+++ b/components/user/friends-panel.vue
@@ -15,7 +15,7 @@
 
     <!-- Incoming requests -->
     <div v-if="friends.allIncomingRequests.length" class="kr-panel-flat p-4">
-      <h2 class="mb-3 text-lg font-black">Requests</h2>
+      <h2 class="kr-text-black-lg mb-3">Requests</h2>
       <div class="flex flex-col gap-2">
         <div
           v-for="r in friends.allIncomingRequests"
@@ -45,7 +45,7 @@
 
     <!-- Your friends -->
     <div class="kr-panel-flat p-4">
-      <h2 class="mb-3 text-lg font-black">
+      <h2 class="kr-text-black-lg mb-3">
         Your friends ({{ friends.friendCount }})
       </h2>
       <p v-if="!friends.friendIds.length" class="text-sm text-base-content/50">
@@ -95,7 +95,7 @@
 
     <!-- Find people -->
     <div class="kr-panel-flat p-4">
-      <h2 class="mb-3 text-lg font-black">Find people</h2>
+      <h2 class="kr-text-black-lg mb-3">Find people</h2>
       <input
         v-model="search"
         type="search"
@@ -158,7 +158,7 @@
 
     <!-- Blocked -->
     <div v-if="friends.blockedIds.length" class="kr-panel-flat p-4">
-      <h2 class="mb-3 text-lg font-black">Blocked</h2>
+      <h2 class="kr-text-black-lg mb-3">Blocked</h2>
       <div class="flex flex-col gap-2">
         <div
           v-for="id in friends.blockedIds"

--- a/components/user/login-page.vue
+++ b/components/user/login-page.vue
@@ -150,7 +150,7 @@
 
           <button
             type="submit"
-            class="group mt-1 flex w-full items-center justify-center gap-2 rounded-2xl bg-linear-to-r from-primary via-secondary to-accent px-6 py-3.5 text-lg font-black text-primary-content shadow-[0_14px_34px_rgba(80,80,220,0.32)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_18px_42px_rgba(80,80,220,0.42)] active:translate-y-0"
+            class="kr-text-black-lg group mt-1 flex w-full items-center justify-center gap-2 rounded-2xl bg-linear-to-r from-primary via-secondary to-accent px-6 py-3.5 text-primary-content shadow-[0_14px_34px_rgba(80,80,220,0.32)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_18px_42px_rgba(80,80,220,0.42)] active:translate-y-0"
           >
             <span>Sign In</span>
             <Icon
@@ -178,7 +178,7 @@
         >
           <Icon name="kind-icon:check" class="mx-auto h-10 w-10 text-success" />
 
-          <p class="text-lg font-black text-success">
+          <p class="kr-text-black-lg text-success">
             You are already signed in.
           </p>
 

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -53,7 +53,7 @@
           </span>
 
           <div>
-            <p class="text-lg font-black text-base-content">Guest mode.</p>
+            <p class="kr-text-black-lg text-base-content">Guest mode.</p>
             <p class="mt-1 text-sm text-base-content/55">
               Charming, mysterious, and tragically short on saved stuff.
             </p>

--- a/components/user/user-galleries.vue
+++ b/components/user/user-galleries.vue
@@ -16,7 +16,7 @@
       class="flex min-h-48 flex-1 items-center justify-center kr-panel text-center"
     >
       <div>
-        <p class="text-lg font-black">No user selected.</p>
+        <p class="kr-text-black-lg">No user selected.</p>
         <p class="kr-text-dim-sm mt-1">
           The shelves are waiting for an owner.
         </p>

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -166,7 +166,7 @@
     <!-- Create user modal -->
     <dialog ref="createDialog" class="modal">
       <div class="modal-box rounded-2xl">
-        <h3 class="mb-3 text-lg font-black">Create user</h3>
+        <h3 class="kr-text-black-lg mb-3">Create user</h3>
         <div class="flex flex-col gap-3">
           <input
             v-model="createForm.username"
@@ -220,7 +220,7 @@
     <!-- Reset password modal -->
     <dialog ref="passwordDialog" class="modal">
       <div class="modal-box rounded-2xl">
-        <h3 class="mb-1 text-lg font-black">Reset password</h3>
+        <h3 class="kr-text-black-lg mb-1">Reset password</h3>
         <p class="kr-text-dim-sm-70 mb-3">
           Set a new password for <strong>{{ pwTarget?.username }}</strong
           >.

--- a/components/user/user-panel.vue
+++ b/components/user/user-panel.vue
@@ -43,7 +43,7 @@
       @submit.prevent="updateProfile"
     >
       <div class="mb-4">
-        <h3 class="text-lg font-black">Profile Details</h3>
+        <h3 class="kr-text-black-lg">Profile Details</h3>
       </div>
 
       <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -99,7 +99,7 @@
       class="flex min-h-48 flex-1 items-center justify-center kr-panel text-center"
     >
       <div>
-        <p class="text-lg font-black">No user profile available.</p>
+        <p class="kr-text-black-lg">No user profile available.</p>
         <p class="kr-text-dim-sm mt-1">
           Guest mode is adorable, but it does not fill out forms.
         </p>

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -86,7 +86,7 @@
         <div
           class="flex flex-col items-center gap-0.5 rounded-2xl p-2 text-center"
         >
-          <span class="text-lg font-black text-base-content">{{
+          <span class="kr-text-black-lg text-base-content">{{
             stats.totalCount
           }}</span>
           <span class="kr-text-dim-xs font-semibold">entries</span>
@@ -94,7 +94,7 @@
         <div
           class="flex flex-col items-center gap-0.5 rounded-2xl p-2 text-center"
         >
-          <span class="text-lg font-black text-base-content">{{
+          <span class="kr-text-black-lg text-base-content">{{
             stats.starredCount
           }}</span>
           <span class="kr-text-dim-xs font-semibold">starred</span>
@@ -102,7 +102,7 @@
         <div
           class="flex flex-col items-center gap-0.5 rounded-2xl p-2 text-center"
         >
-          <span class="text-lg font-black text-base-content">{{
+          <span class="kr-text-black-lg text-base-content">{{
             Math.round(stats.audiobookHours)
           }}</span>
           <span class="kr-text-dim-xs font-semibold">audiobook hrs</span>
@@ -110,7 +110,7 @@
         <div
           class="flex flex-col items-center gap-0.5 rounded-2xl p-2 text-center"
         >
-          <span class="text-lg font-black text-base-content">{{
+          <span class="kr-text-black-lg text-base-content">{{
             stats.pagesRead
           }}</span>
           <span class="kr-text-dim-xs font-semibold">pages read</span>
@@ -118,7 +118,7 @@
         <div
           class="flex flex-col items-center gap-0.5 rounded-2xl p-2 text-center"
         >
-          <span class="text-lg font-black text-base-content">{{
+          <span class="kr-text-black-lg text-base-content">{{
             stats.comicIssuesRead
           }}</span>
           <span class="kr-text-dim-xs font-semibold">comics read</span>
@@ -126,7 +126,7 @@
         <div
           class="flex flex-col items-center gap-0.5 rounded-2xl p-2 text-center"
         >
-          <span class="text-lg font-black text-base-content">{{
+          <span class="kr-text-black-lg text-base-content">{{
             stats.tvSeasonCount
           }}</span>
           <span class="kr-text-dim-xs font-semibold"

--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -23,7 +23,7 @@
             :class="entry.starred ? 'text-warning' : 'text-base-content/25'"
           />
         </button>
-        <h2 class="truncate text-lg font-black text-base-content">
+        <h2 class="kr-text-black-lg truncate text-base-content">
           {{ entry.title }}
         </h2>
       </div>

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -75,7 +75,7 @@
     >
       <aside class="kr-pane kr-panel-flat">
         <div class="shrink-0 kr-panel-header">
-          <h2 class="text-lg font-black">Saved Colors</h2>
+          <h2 class="kr-text-black-lg">Saved Colors</h2>
           <p class="kr-text-dim-sm mt-1">
             Pick one, then click a section or flood a group.
           </p>
@@ -212,7 +212,7 @@
 
       <aside class="kr-pane kr-panel-flat">
         <div class="shrink-0 kr-panel-header">
-          <h2 class="text-lg font-black">Sections & Groups</h2>
+          <h2 class="kr-text-black-lg">Sections & Groups</h2>
           <p class="kr-text-dim-sm mt-1">
             Use groups for shared paint IDs, then click exact sections for
             overrides.
@@ -229,7 +229,7 @@
             >
               Selected section
             </p>
-            <h3 class="mt-1 text-lg font-black text-primary">
+            <h3 class="kr-text-black-lg mt-1 text-primary">
               {{ selectedSection.label }}
             </h3>
             <p class="mt-1 text-sm text-base-content/65">

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -477,7 +477,7 @@
                 {{ entry.score.booed }} · ✕ {{ entry.score.hated }}
               </span>
               <span
-                class="text-lg font-black"
+                class="kr-text-black-lg"
                 :class="scoreClass(entry.score.netScore)"
               >
                 {{ signedScore(entry.score.netScore) }}

--- a/pages/play/challenges/leaderboard.vue
+++ b/pages/play/challenges/leaderboard.vue
@@ -261,7 +261,7 @@
                   <td class="text-right font-bold">{{ entry.winRate }}%</td>
                   <td class="text-right font-bold">{{ entry.score.votes }}</td>
                   <td
-                    class="text-right text-lg font-black"
+                    class="kr-text-black-lg text-right"
                     :class="scoreClass(entry.score.netScore)"
                   >
                     {{ signedScore(entry.score.netScore) }}

--- a/utils/scripts/codemods/kr_text_black_lg_codemod.py
+++ b/utils/scripts/codemods/kr_text_black_lg_codemod.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `font-black text-lg` heading-emphasis text to
+`kr-text-black-lg`.
+
+First of a new `kr-text-black-*` family (interface-vision t-104 slice 164),
+sibling in spirit to `kr-text-dim-*` but for the *heaviest* weight instead of
+opacity: dry-run by default, --write to update matching Vue files in place.
+Only the exact `font-black text-lg` shape is touched, and only in static
+`class="..."` attributes -- never `:class`/`v-bind:class` bindings, and
+regardless of the base tokens' order in the source. A source that already
+carries `kr-text-black-lg`, or is missing either base token, is left
+untouched. Extra tokens beyond the base set are preserved verbatim after the
+primitive class, matching the kr-badge-*/kr-spinner-*/kr-label-bold/
+kr-text-dim-* codemods' subset-match convention -- pass --exact-only to
+restrict a slice to sources with no extra tokens at all, the safest and most
+literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-black-lg"
+BASE_TOKENS = {"font-black", "text-lg"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-black-lg {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: recurring live front-end consistency umbrella, slice 164 (kind: software)

### What changed / what I produced
- Fresh full-repo class-frequency survey outside the now fully-mined `text-xs/sm text-base-content/NN` family (slices 152-163, per slice 163's own kaizen note) found `font-black text-lg` the largest bounded family: 115 subset-match occurrences across 69 files (39 of them the exact base pair with no extra tokens).
- Added `.kr-text-black-lg` (`font-black text-lg`) to `assets/css/tailwind.css` — first of a new `kr-text-black-*` family, sibling in spirit to `kr-text-dim-*` but for weight instead of opacity.
- Added `utils/scripts/codemods/kr_text_black_lg_codemod.py`, same subset-match convention as the existing `kr-badge-*`/`kr-spinner-*`/`kr-text-dim-*` codemods (dry-run by default, `--write` to apply, `--exact-only` to restrict to the literal pool).
- Migrated all 115 occurrences across 69 files.

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint` on all touched files: 30 problems (28 errors, 2 warnings) unchanged before/after, confirmed via `git stash`
- `test:layout-contract`: holds, no new violations (same unrelated pre-existing -2 ratchet opportunity in `narrative-ingredient-multi-picker.vue` left untouched, out of scope)
- `test:lint-ratchet`: holds at 333/-59
- `prettier --check`: flagged the same 39 files before and after (confirmed via `git stash`) — all pre-existing debt, no new fallout, no `--write` needed
- Grepped `utils/scripts/*.{mjs,ts}` for the literal old class string — no contract script depends on it

### Stakes
reversible

### Flags for Reviewer
- Sibling sizes surveyed alongside this one (`font-black text-xl`, 78 occurrences; `font-black text-sm`, 109 occurrences) are left for future slices, same convention as `kr-text-dim-xs`/`kr-text-dim-sm`.

### Kaizen suggestion
Slice 165 could take `font-black text-xl` (78 occurrences) as the next sibling in the new `kr-text-black-*` family, following the same subset-match convention.

### Notes for reviewer
No geometry or behavior change — purely a mechanical class-string consolidation, same pattern as the prior 12 `kr-text-dim-*`/`kr-badge-*`/`kr-spinner-*` slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZN6DW7bYyW1JwZVRVsMeE

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZN6DW7bYyW1JwZVRVsMeE)_