### PR TITLE
refactor(ui): add kr-text-black-sm for font-black text-sm (slice 166)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1814,11 +1814,17 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
   /* Sibling of `.kr-text-black-lg` one size up -- `font-black text-xl`
    * (interface-vision t-104 slice 165) -- previously hand-rolled
    * identically across admin, aquarium, challenge, and user-profile
-   * surfaces: 72 subset-match occurrences. The other sibling surveyed
-   * alongside this one (`font-black text-sm`, 108 occurrences) is left for
-   * a future slice, same convention as `.kr-text-dim-xs`/`.kr-text-dim-sm`. */
+   * surfaces: 72 subset-match occurrences. */
   .kr-text-black-xl {
     @apply font-black text-xl;
+  }
+
+  /* Third and final sibling in the `kr-text-black-*` family -- `font-black
+   * text-sm` (interface-vision t-104 slice 166) -- 108 subset-match
+   * occurrences across 70 files. Closes out the family entirely (`-lg`,
+   * `-xl`, `-sm` all now named), same convention as `.kr-text-dim-*`. */
+  .kr-text-black-sm {
+    @apply font-black text-sm;
   }
 
   .text-smart {

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -172,7 +172,7 @@
           />
           <div class="absolute inset-0 bg-linear-to-t from-black/85 via-black/5 to-transparent" />
           <div class="absolute inset-x-0 bottom-0 p-3 text-white sm:p-4">
-            <p class="text-sm font-black leading-tight drop-shadow sm:text-base">
+            <p class="kr-text-black-sm leading-tight drop-shadow sm:text-base">
               {{ work.workTitle }}
             </p>
             <p class="mt-1 text-xs text-white/75">

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -67,10 +67,10 @@
       <div class="min-w-[min(100%,20rem)] flex-1">
         <div class="flex items-center justify-between gap-3">
           <div>
-            <p class="text-sm font-black text-base-content">{{ progressHeadline }}</p>
+            <p class="kr-text-black-sm text-base-content">{{ progressHeadline }}</p>
             <p class="kr-text-dim-xs-55 mt-0.5">{{ progressMessage }}</p>
           </div>
-          <span class="text-sm font-black text-primary">{{ progressPercent }}%</span>
+          <span class="kr-text-black-sm text-primary">{{ progressPercent }}%</span>
         </div>
         <progress
           class="progress progress-primary mt-3 w-full"

--- a/components/achievements/achievement-gallery.vue
+++ b/components/achievements/achievement-gallery.vue
@@ -46,7 +46,7 @@
           >
             <Icon name="kind-icon:check" class="h-4 w-4" />
           </span>
-          <h2 class="text-sm font-black text-base-content">Earned</h2>
+          <h2 class="kr-text-black-sm text-base-content">Earned</h2>
           <span class="ml-auto badge badge-success badge-sm">{{
             earnedAchievements.length
           }}</span>
@@ -88,7 +88,7 @@
           >
             <Icon name="kind-icon:trophy" class="h-4 w-4" />
           </span>
-          <h2 class="text-sm font-black text-base-content">Leaderboard</h2>
+          <h2 class="kr-text-black-sm text-base-content">Leaderboard</h2>
         </div>
         <div class="p-3">
           <achievement-leaderboard />
@@ -103,7 +103,7 @@
           >
             <Icon name="kind-icon:question" class="h-4 w-4" />
           </span>
-          <h2 class="text-sm font-black text-base-content">Undiscovered</h2>
+          <h2 class="kr-text-black-sm text-base-content">Undiscovered</h2>
           <span class="kr-badge-ghost-sm ml-auto">{{
             unearnedAchievements.length
           }}</span>

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -212,7 +212,7 @@
             :name="activeGroup.isVirtual ? 'kind-icon:archive' : 'kind-icon:folder'"
             class="h-4 w-4 shrink-0 text-primary"
           />
-          <h3 class="min-w-0 truncate text-sm font-black text-base-content">
+          <h3 class="kr-text-black-sm min-w-0 truncate text-base-content">
             {{ activeGroup.title }}
           </h3>
           <span
@@ -482,7 +482,7 @@
                 >
                   Selected Image
                 </p>
-                <h3 class="truncate text-sm font-black text-base-content">
+                <h3 class="kr-text-black-sm truncate text-base-content">
                   #{{ selectedImageForOverlay.id }}
                 </h3>
               </div>

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -142,7 +142,7 @@
             class="flex cursor-pointer list-none items-center justify-between gap-2"
           >
             <span>
-              <span class="block text-sm font-black text-base-content"
+              <span class="kr-text-black-sm block text-base-content"
                 >Generation Source</span
               >
               <span class="kr-text-dim-xs-55 block truncate">
@@ -388,7 +388,7 @@
                 class="absolute left-0 right-0 top-full z-30 mt-2 kr-panel-flat p-3 shadow-xl"
               >
                 <div class="mb-2 flex items-center justify-between gap-2">
-                  <p class="text-sm font-black text-base-content">
+                  <p class="kr-text-black-sm text-base-content">
                     Collection Membership
                   </p>
                   <button

--- a/components/art/artjob-slideshow.vue
+++ b/components/art/artjob-slideshow.vue
@@ -58,9 +58,7 @@
             class="absolute inset-x-0 top-0 flex flex-wrap items-center justify-between gap-2 bg-gradient-to-b from-base-300/90 to-transparent p-3"
           >
             <div class="flex flex-wrap items-center gap-2">
-              <span class="text-sm font-black tracking-wide"
-                >Art slideshow</span
-              >
+              <span class="kr-text-black-sm tracking-wide">Art slideshow</span>
               <span
                 class="kr-badge-sm rounded-2xl"
                 :class="isPlaying ? 'badge-success' : 'badge-ghost'"
@@ -238,7 +236,7 @@
             class="absolute inset-y-0 right-0 flex w-80 max-w-full flex-col gap-4 overflow-y-auto overscroll-contain border-l border-base-content/10 bg-base-100/95 p-4"
           >
             <div class="flex items-center justify-between gap-2">
-              <h3 class="text-sm font-black">Slideshow options</h3>
+              <h3 class="kr-text-black-sm">Slideshow options</h3>
               <button
                 type="button"
                 class="kr-btn-ghost-xs-2xl"

--- a/components/art/collection-picker.vue
+++ b/components/art/collection-picker.vue
@@ -48,7 +48,7 @@
           @click="useAllArt"
         >
           <span class="flex w-full items-start justify-between gap-2">
-            <span class="text-sm font-black">All available art</span>
+            <span class="kr-text-black-sm">All available art</span>
             <Icon
               :name="!hasSelection ? 'kind-icon:check-circle' : 'kind-icon:circle'"
               class="h-5 w-5 shrink-0"
@@ -72,7 +72,7 @@
           @click="toggleCollection(collection.id)"
         >
           <span class="flex w-full items-start justify-between gap-2">
-            <span class="line-clamp-2 text-sm font-black">
+            <span class="kr-text-black-sm line-clamp-2">
               {{ getCollectionLabel(collection) }}
             </span>
             <Icon

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -5,7 +5,7 @@
       <div class="min-w-0 flex-1">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:palette" class="size-4 text-secondary" />
-          <h3 class="text-sm font-black">Artwork</h3>
+          <h3 class="kr-text-black-sm">Artwork</h3>
           <span class="kr-badge-ghost-xs">{{ entityLabel }}</span>
         </div>
         <p class="kr-text-dim-xs mt-1">
@@ -241,7 +241,7 @@
     >
       <div class="flex items-start gap-2">
         <div class="min-w-0 flex-1">
-          <p class="text-sm font-black">Generate {{ selectedSlot.label }} replacement</p>
+          <p class="kr-text-black-sm">Generate {{ selectedSlot.label }} replacement</p>
           <p class="kr-text-dim-xs">
             Recreate starts fresh with Krea. Img2img uses the current image and defaults to SDXL.
           </p>
@@ -404,7 +404,7 @@
     >
       <div class="flex items-start gap-2">
         <div class="min-w-0 flex-1">
-          <p class="text-sm font-black">Upload {{ selectedSlot.label }} replacement</p>
+          <p class="kr-text-black-sm">Upload {{ selectedSlot.label }} replacement</p>
           <p class="kr-text-dim-xs">
             Upload a finished PNG, JPEG, or WebP, then choose whether the old image remains as inspiration.
           </p>

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -143,7 +143,7 @@
           <!-- Metadata section header -->
           <div class="mb-3 flex items-center gap-2">
             <icon name="kind-icon:settings" class="h-4 w-4 text-primary" />
-            <h3 class="text-sm font-black text-base-content">Image Metadata</h3>
+            <h3 class="kr-text-black-sm text-base-content">Image Metadata</h3>
             <span class="kr-text-dim-xs-40"
               >Optional — added to every image in this batch</span
             >

--- a/components/art/stylist-manager.vue
+++ b/components/art/stylist-manager.vue
@@ -5,7 +5,7 @@
       class="flex flex-wrap items-center gap-1 rounded-2xl border border-base-300 bg-base-200 p-2"
     >
       <Icon name="kind-icon:sparkles" class="ml-1 h-5 w-5 text-primary" />
-      <span class="mr-2 text-sm font-black text-base-content">
+      <span class="kr-text-black-sm mr-2 text-base-content">
         {{ superkate.settings.salonName }} Services
       </span>
       <button

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -49,7 +49,7 @@
       </div>
 
       <div class="mt-5">
-        <label for="brainstorm-premise" class="text-sm font-black text-base-content">
+        <label for="brainstorm-premise" class="kr-text-black-sm text-base-content">
           Premise
         </label>
         <textarea
@@ -217,7 +217,7 @@
                 @change="store.toggleReturnType(option.id)"
               />
               <span class="min-w-0">
-                <span class="block text-sm font-black text-base-content">{{ option.label }}</span>
+                <span class="kr-text-black-sm block text-base-content">{{ option.label }}</span>
                 <span class="kr-text-dim-xs-55 mt-1 block leading-5">{{ option.description }}</span>
               </span>
             </label>
@@ -321,7 +321,7 @@
             🧩
           </div>
           <div class="min-w-0 flex-1">
-            <p class="truncate text-sm font-black text-base-content">
+            <p class="kr-text-black-sm truncate text-base-content">
               {{ resolvedSource.title }}
             </p>
             <p class="kr-text-dim-xs-55 truncate">

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -113,7 +113,7 @@
           v-if="cover.semanticReasons.length"
           class="rounded-2xl border border-warning/40 bg-warning/10 p-3"
         >
-          <p class="text-sm font-black text-warning">Latest review notes</p>
+          <p class="kr-text-black-sm text-warning">Latest review notes</p>
           <ul class="mt-2 list-disc space-y-1 pl-5 text-xs text-warning">
             <li v-for="reason in cover.semanticReasons" :key="reason">
               {{ reason }}

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -24,7 +24,7 @@
 
       <div v-for="set in sets" :key="set.slug" class="flex flex-col gap-2">
         <div class="flex items-baseline gap-2">
-          <h3 class="text-sm font-black text-base-content">{{ set.title }}</h3>
+          <h3 class="kr-text-black-sm text-base-content">{{ set.title }}</h3>
           <span class="kr-badge-ghost-sm">
             {{ set.pages.length }} pages
           </span>
@@ -108,7 +108,7 @@
             <Icon name="mdi:arrow-left" class="h-4 w-4" />
             Library
           </button>
-          <h2 class="text-sm font-black text-base-content">
+          <h2 class="kr-text-black-sm text-base-content">
             {{ openDefinition.title }}
           </h2>
         </div>

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -127,7 +127,7 @@
               class="rounded-2xl bg-base-200/60 p-3"
             >
               <div class="flex items-center justify-between gap-2">
-                <span class="text-sm font-black">{{ blocker.label }}</span>
+                <span class="kr-text-black-sm">{{ blocker.label }}</span>
                 <span class="badge badge-error badge-sm rounded-2xl">
                   {{ blocker.values.length }}
                 </span>

--- a/components/coloring/coloring-book-production-history.vue
+++ b/components/coloring/coloring-book-production-history.vue
@@ -79,7 +79,7 @@
           </div>
 
           <div>
-            <p class="text-sm font-black">
+            <p class="kr-text-black-sm">
               {{ item.status || item.verdict || historyLabel(item.kind) }}
             </p>
             <p v-if="item.createdAt" class="kr-text-dim-xs-45">

--- a/components/coloring/production-stage-card.vue
+++ b/components/coloring/production-stage-card.vue
@@ -13,7 +13,7 @@
         {{ done ? 'Ready' : 'Waiting' }}
       </span>
     </div>
-    <h4 class="text-sm font-black">{{ label }}</h4>
+    <h4 class="kr-text-black-sm">{{ label }}</h4>
     <p class="kr-text-dim-xs line-clamp-2 break-all">
       {{ detail }}
     </p>

--- a/components/conductor/packmaker-pack-editor.vue
+++ b/components/conductor/packmaker-pack-editor.vue
@@ -12,7 +12,7 @@
     class="flex flex-col gap-4 kr-panel-tint-md"
   >
     <div class="flex items-center justify-between gap-2">
-      <h4 class="text-sm font-black text-base-content">
+      <h4 class="kr-text-black-sm text-base-content">
         {{ editingExisting ? `Edit pack: ${draft.title}` : 'New pack' }}
       </h4>
       <button class="kr-btn-ghost-xs" @click="emit('close')">

--- a/components/conductor/project-front-page.vue
+++ b/components/conductor/project-front-page.vue
@@ -101,7 +101,7 @@
               :name="stat.icon"
               class="size-4 text-primary/70"
             />
-            <span class="text-sm font-black leading-none text-base-content">{{
+            <span class="kr-text-black-sm leading-none text-base-content">{{
               stat.value
             }}</span>
             <span class="kr-text-dim-xs font-semibold">{{

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -210,7 +210,7 @@
                 :aria-pressed="store.setupDraft.structure === structure.value"
                 @click="store.setupDraft.structure = structure.value"
               >
-                <span class="text-sm font-black">{{ structure.label }}</span>
+                <span class="kr-text-black-sm">{{ structure.label }}</span>
                 <span class="kr-text-dim-xs-55 mt-1 block leading-relaxed">
                   {{ structure.description }}
                 </span>
@@ -559,7 +559,7 @@
     <div v-else class="flex min-h-0 flex-1 flex-col gap-3">
       <div class="shrink-0 space-y-3">
         <details class="rounded-2xl border border-primary/25 bg-primary/5 p-3">
-          <summary class="cursor-pointer text-sm font-black text-primary">
+          <summary class="kr-text-black-sm cursor-pointer text-primary">
             {{ store.session.bible.title }} · Story bible
           </summary>
           <div class="mt-3 grid gap-2 text-xs leading-relaxed sm:grid-cols-2">

--- a/components/dreams/daily-digest-object-dialog.vue
+++ b/components/dreams/daily-digest-object-dialog.vue
@@ -124,7 +124,7 @@
                 :key="field.key"
                 class="form-control gap-1.5"
               >
-                <span class="text-sm font-black">{{ field.label }}</span>
+                <span class="kr-text-black-sm">{{ field.label }}</span>
                 <textarea
                   v-if="field.multiline"
                   v-model="draft[field.key]"

--- a/components/dreams/daily-digest-object-gallery.vue
+++ b/components/dreams/daily-digest-object-gallery.vue
@@ -67,7 +67,7 @@
                 <p class="truncate text-[0.58rem] font-black uppercase tracking-[0.12em] text-primary/70">
                   {{ item.typeLabel }}
                 </p>
-                <h4 class="mt-0.5 line-clamp-2 text-sm font-black leading-tight">
+                <h4 class="kr-text-black-sm mt-0.5 line-clamp-2 leading-tight">
                   {{ item.title }}
                 </h4>
               </div>

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -37,7 +37,7 @@
         >
           <Icon name="kind-icon:dream" class="h-4 w-4 text-primary" />
           <h2
-            class="max-w-36 truncate text-sm font-black text-primary sm:max-w-48"
+            class="kr-text-black-sm max-w-36 truncate text-primary sm:max-w-48"
           >
             {{ title }}
           </h2>

--- a/components/dreams/dream-pitch-sheet.vue
+++ b/components/dreams/dream-pitch-sheet.vue
@@ -53,7 +53,7 @@
             <Icon name="kind-icon:robot" class="h-5 w-5" />
           </span>
           <span
-            class="truncate text-sm font-black uppercase tracking-[0.18em] text-(--sheet-ink) sm:text-base"
+            class="kr-text-black-sm truncate uppercase tracking-[0.18em] text-(--sheet-ink) sm:text-base"
           >
             Kind Robots
           </span>

--- a/components/gallery/kr-card-back.vue
+++ b/components/gallery/kr-card-back.vue
@@ -169,7 +169,7 @@
       -->
       <template v-if="editing">
         <div class="mb-3 flex items-center justify-between gap-2">
-          <h3 class="text-sm font-black uppercase tracking-wide opacity-60">
+          <h3 class="kr-text-black-sm uppercase tracking-wide opacity-60">
             Editing
           </h3>
 

--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -94,7 +94,7 @@
       is what made a single chip cost a third of the row's height.
     -->
     <div class="min-w-0 flex-1 pr-1">
-      <h2 class="truncate text-sm font-black leading-tight" :title="title">
+      <h2 class="kr-text-black-sm truncate leading-tight" :title="title">
         {{ title }}
       </h2>
 

--- a/components/home/home-dream-hero.vue
+++ b/components/home/home-dream-hero.vue
@@ -119,7 +119,7 @@
         </p>
 
         <h2
-          class="text-sm font-black leading-tight text-base-content xl:text-base"
+          class="kr-text-black-sm leading-tight text-base-content xl:text-base"
         >
           {{ hero.dream.title }}
         </h2>

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -136,7 +136,7 @@
         </div>
 
         <div class="flex flex-1 flex-col gap-2 p-3 text-center">
-          <h3 class="line-clamp-2 text-sm font-black" :title="card.name">
+          <h3 class="kr-text-black-sm line-clamp-2" :title="card.name">
             {{ card.name }}
           </h3>
           <p v-if="card.creator" class="kr-text-dim-xs">

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -12,7 +12,7 @@
     <div class="flex items-start justify-between gap-2">
       <div>
         <h4
-          class="flex items-center gap-1.5 text-sm font-black text-base-content"
+          class="kr-text-black-sm flex items-center gap-1.5 text-base-content"
         >
           <Icon name="kind-icon:layers" class="h-4 w-4 text-primary" />
           Batch edit — {{ group.label }}

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -2,7 +2,7 @@
 <template>
   <div v-if="item" class="flex min-h-0 flex-1 flex-col gap-2 kr-panel-flat p-3">
     <div class="flex items-center gap-2">
-      <h4 class="text-sm font-black text-base-content">{{ item.label }}</h4>
+      <h4 class="kr-text-black-sm text-base-content">{{ item.label }}</h4>
       <span class="kr-badge-ghost-sm">{{ item.action }}</span>
       <span class="kr-badge-ghost-sm">{{ item.generation }}</span>
       <button

--- a/components/model-builder/model-builder-manager.vue
+++ b/components/model-builder/model-builder-manager.vue
@@ -10,7 +10,7 @@
       <Icon name="kind-icon:blueprint" class="h-4 w-4 shrink-0 text-primary" />
 
       <h2
-        class="truncate text-sm font-black leading-none text-base-content sm:text-base"
+        class="kr-text-black-sm truncate leading-none text-base-content sm:text-base"
       >
         Model Builder
       </h2>

--- a/components/narrative/kr-narrator-stage.vue
+++ b/components/narrative/kr-narrator-stage.vue
@@ -38,7 +38,7 @@
             class="min-w-0 rounded-2xl border border-primary/20 bg-base-100/90 px-3 py-1.5 backdrop-blur"
           >
             <p
-              class="truncate text-sm font-black leading-tight text-base-content"
+              class="kr-text-black-sm truncate leading-tight text-base-content"
             >
               {{ narratorName }}
             </p>

--- a/components/narrative/narrative-ingredient-card.vue
+++ b/components/narrative/narrative-ingredient-card.vue
@@ -53,7 +53,7 @@
     </span>
 
     <span class="relative z-10 mt-auto flex min-w-0 flex-col gap-1.5 p-3 text-white">
-      <span class="text-sm font-black leading-tight sm:text-base">
+      <span class="kr-text-black-sm leading-tight sm:text-base">
         {{ item.title }}
       </span>
       <span

--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -128,7 +128,7 @@
           <Icon name="kind-icon:check" class="size-4" />
         </span>
         <span class="absolute inset-x-0 bottom-0 p-3 text-white">
-          <span class="block text-sm font-black sm:text-base">
+          <span class="kr-text-black-sm block sm:text-base">
             {{ emptyLabel }}
           </span>
           <span

--- a/components/narrative/narrative-role-assigner.vue
+++ b/components/narrative/narrative-role-assigner.vue
@@ -17,7 +17,7 @@
   <div v-if="members.length" class="space-y-4">
     <div class="flex flex-wrap items-baseline justify-between gap-2">
       <div>
-        <p class="text-sm font-black">The casting board</p>
+        <p class="kr-text-black-sm">The casting board</p>
         <p class="kr-text-dim-xs-55 mt-0.5 leading-relaxed">
           Drag a card onto a part, or use its buttons. Leave a card blank and
           the story decides.

--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -125,7 +125,7 @@
           />
 
           <span class="min-w-0 flex-1">
-            <span class="block truncate text-sm font-black text-base-content">
+            <span class="kr-text-black-sm block truncate text-base-content">
               {{ userStore.isLoggedIn ? userStore.username : 'Guest' }}
             </span>
 

--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -24,7 +24,7 @@
         />
       </span>
 
-      <span class="min-w-0 truncate text-sm font-black sm:text-base xl:text-lg">
+      <span class="kr-text-black-sm min-w-0 truncate sm:text-base xl:text-lg">
         {{ activeChannel.label }}
       </span>
 
@@ -96,9 +96,7 @@
               <span
                 class="flex min-w-0 flex-1 flex-col items-start leading-tight"
               >
-                <span
-                  class="max-w-full truncate text-sm font-black xl:text-base"
-                >
+                <span class="kr-text-black-sm max-w-full truncate xl:text-base">
                   {{ channel.label }}
                 </span>
                 <span

--- a/components/navigation/channel-tab-list.vue
+++ b/components/navigation/channel-tab-list.vue
@@ -69,7 +69,7 @@
                 the width that had been hiding it.
               -->
               <span class="flex w-full max-w-full items-center gap-1">
-                <span class="min-w-0 truncate text-sm font-black">
+                <span class="kr-text-black-sm min-w-0 truncate">
                   {{ tab.label }}
                 </span>
                 <span

--- a/components/navigation/navigation-trimmed.vue
+++ b/components/navigation/navigation-trimmed.vue
@@ -92,7 +92,7 @@
               class="flex min-w-0 flex-1 flex-col items-start leading-tight"
             >
               <span class="flex max-w-full items-center gap-1">
-                <span class="truncate text-sm font-black">
+                <span class="kr-text-black-sm truncate">
                   {{ tab.label }}
                 </span>
                 <span

--- a/components/navigation/tab-select.vue
+++ b/components/navigation/tab-select.vue
@@ -49,7 +49,7 @@
         />
       </span>
 
-      <span class="min-w-0 flex-1 truncate text-sm font-black sm:text-base">
+      <span class="kr-text-black-sm min-w-0 flex-1 truncate sm:text-base">
         {{ activeTab?.label || channel.label }}
       </span>
 

--- a/components/navigation/tutorial-flyer.vue
+++ b/components/navigation/tutorial-flyer.vue
@@ -199,7 +199,7 @@
             >
               <div class="flex items-start gap-3.5 p-4 sm:p-5">
                 <span
-                  class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary text-sm font-black text-primary-content shadow-sm ring-2 ring-primary/15 transition group-hover:scale-105"
+                  class="kr-text-black-sm flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-content shadow-sm ring-2 ring-primary/15 transition group-hover:scale-105"
                 >
                   {{ index + 1 }}
                 </span>

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -215,7 +215,7 @@
             :name="activeTabConfig.icon || fallbackIcon"
             class="h-4 w-4 shrink-0 text-primary/70"
           />
-          <span class="min-w-0 truncate text-sm font-black xl:text-base">
+          <span class="kr-text-black-sm min-w-0 truncate xl:text-base">
             {{ activeTitle }}
           </span>
         </div>

--- a/components/navigation/workspace-narrator.vue
+++ b/components/navigation/workspace-narrator.vue
@@ -309,7 +309,7 @@
 
                       <span class="min-w-0 flex-1">
                         <span
-                          class="block truncate text-sm font-black text-base-content"
+                          class="kr-text-black-sm block truncate text-base-content"
                         >
                           {{ topic.title }}
                         </span>

--- a/components/navigation/workspace-sheet.vue
+++ b/components/navigation/workspace-sheet.vue
@@ -30,7 +30,7 @@
 
         <div class="absolute bottom-0 left-0 right-0 p-4 sm:p-5">
           <p
-            class="inline-flex max-w-full items-center gap-2 rounded-full border border-primary/20 bg-base-100/85 px-3 py-1 text-sm font-black uppercase tracking-widest text-primary shadow-sm backdrop-blur"
+            class="kr-text-black-sm inline-flex max-w-full items-center gap-2 rounded-full border border-primary/20 bg-base-100/85 px-3 py-1 uppercase tracking-widest text-primary shadow-sm backdrop-blur"
           >
             <Icon :name="placeholderIcon" class="h-4 w-4 shrink-0" />
             <span class="truncate">{{ label }}</span>
@@ -96,13 +96,13 @@
       <div class="kr-panel p-4">
         <div class="mb-3 flex items-center justify-between gap-3">
           <p
-            class="flex items-center gap-2 text-sm font-black uppercase tracking-widest text-base-content/45"
+            class="kr-text-black-sm flex items-center gap-2 uppercase tracking-widest text-base-content/45"
           >
             <Icon name="kind-icon:sparkles" class="h-4 w-4 text-primary/70" />
             Progress
           </p>
 
-          <p class="text-sm font-black tabular-nums text-primary">
+          <p class="kr-text-black-sm tabular-nums text-primary">
             {{ completedCount }}/{{ requiredCount }}
           </p>
         </div>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -114,7 +114,7 @@
       <template v-if="!userStore.isAdmin && projectStore.loaded">
         <span class="mx-0.5 h-3.5 w-px shrink-0 bg-base-content/10" />
         <span class="flex items-baseline gap-0.5">
-          <span class="text-sm font-black leading-none text-primary">{{
+          <span class="kr-text-black-sm leading-none text-primary">{{
             projectStore.publicProjects.length
           }}</span>
           <span class="text-[0.62rem] font-semibold text-base-content/50"

--- a/components/pages/creator-earnings-page.vue
+++ b/components/pages/creator-earnings-page.vue
@@ -124,7 +124,7 @@
         <template v-else>
           <section class="space-y-3">
             <h2
-              class="text-sm font-black uppercase tracking-widest text-base-content/50"
+              class="kr-text-black-sm uppercase tracking-widest text-base-content/50"
             >
               By what you made
             </h2>
@@ -136,7 +136,7 @@
               >
                 <div class="flex items-start justify-between gap-2">
                   <div class="min-w-0">
-                    <p class="truncate text-sm font-black text-base-content">
+                    <p class="kr-text-black-sm truncate text-base-content">
                       {{ group.title }}
                     </p>
                     <p class="kr-text-dim-xs">
@@ -200,7 +200,7 @@
 
           <section class="space-y-3">
             <h2
-              class="text-sm font-black uppercase tracking-widest text-base-content/50"
+              class="kr-text-black-sm uppercase tracking-widest text-base-content/50"
             >
               By period
             </h2>

--- a/components/pages/memory-dungeon.vue
+++ b/components/pages/memory-dungeon.vue
@@ -8,7 +8,7 @@
     >
       <div class="flex min-w-0 items-center gap-2 px-2 py-1.5 sm:px-3">
         <div class="min-w-0 flex-1 leading-tight">
-          <p class="truncate text-sm font-black tracking-tight sm:text-base">
+          <p class="kr-text-black-sm truncate tracking-tight sm:text-base">
             🏰 Memory Dungeon
           </p>
           <p class="truncate text-[10px] text-base-content/50 sm:text-xs">

--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -120,7 +120,7 @@
         <section class="space-y-3">
           <div class="flex items-center justify-between">
             <h2
-              class="text-sm font-black uppercase tracking-widest text-base-content/50"
+              class="kr-text-black-sm uppercase tracking-widest text-base-content/50"
             >
               Log a remittance
             </h2>
@@ -192,7 +192,7 @@
 
         <section v-else class="space-y-3">
           <h2
-            class="text-sm font-black uppercase tracking-widest text-base-content/50"
+            class="kr-text-black-sm uppercase tracking-widest text-base-content/50"
           >
             Remittance log
           </h2>

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -201,7 +201,7 @@
                 class="flex cursor-pointer list-none items-center gap-3 rounded-2xl border border-secondary/25 bg-base-100/85 p-3 md:hidden [&::-webkit-details-marker]:hidden"
               >
                 <span class="min-w-0 flex-1">
-                  <span class="block text-sm font-black">Recipe ingredients</span>
+                  <span class="kr-text-black-sm block">Recipe ingredients</span>
                   <span class="kr-text-dim-xs block truncate">
                     {{ selectedTone }} · {{ selectedLocationLabel }} ·
                     {{ selectedGrammarLabel }}
@@ -360,7 +360,7 @@
                   >
                     Serendipity says
                   </p>
-                  <p class="text-sm font-black">Small steps still count as adventure.</p>
+                  <p class="kr-text-black-sm">Small steps still count as adventure.</p>
                 </div>
               </div>
             </div>
@@ -614,7 +614,7 @@
             >
               Current quest
             </p>
-            <p class="truncate text-sm font-black sm:text-base">
+            <p class="kr-text-black-sm truncate sm:text-base">
               {{ store.session.seed.taskTitle || 'Linked project objective' }}
             </p>
           </div>
@@ -668,7 +668,7 @@
                   class="space-y-3 rounded-2xl border border-secondary/30 bg-secondary/10 p-4"
                 >
                   <div class="text-center">
-                    <p class="text-sm font-black text-secondary">Quest complete</p>
+                    <p class="kr-text-black-sm text-secondary">Quest complete</p>
                     <p class="kr-text-dim-xs-60 mt-1">
                       Review any real-world updates below before applying them.
                     </p>
@@ -795,7 +795,7 @@
               >
                 Real objective
               </p>
-              <p class="mt-1 text-sm font-black leading-relaxed">
+              <p class="kr-text-black-sm mt-1 leading-relaxed">
                 {{ store.session.seed.taskTitle }}
               </p>
             </section>
@@ -811,7 +811,7 @@
                   >
                     Practical checkpoint plan
                   </p>
-                  <p v-if="store.currentCheckpoint" class="mt-1 text-sm font-black">
+                  <p v-if="store.currentCheckpoint" class="kr-text-black-sm mt-1">
                     Current action: {{ store.currentCheckpoint.title }}
                   </p>
                   <p v-else class="kr-text-dim-xs-55 mt-1">
@@ -889,7 +889,7 @@
               class="taskmaster-panel space-y-2 border border-success/30 p-3"
             >
               <div>
-                <p class="text-sm font-black text-success">
+                <p class="kr-text-black-sm text-success">
                   All checkpoints have an outcome
                 </p>
                 <p class="kr-text-dim-xs-55 mt-0.5">

--- a/components/resources/resource-card.vue
+++ b/components/resources/resource-card.vue
@@ -30,7 +30,7 @@
 
     <div class="flex flex-1 flex-col gap-2 p-3">
       <h3
-        class="line-clamp-3 break-words text-sm font-black leading-snug"
+        class="kr-text-black-sm line-clamp-3 break-words leading-snug"
         :title="label"
       >
         {{ label }}

--- a/components/reviews/review-list.vue
+++ b/components/reviews/review-list.vue
@@ -20,7 +20,7 @@
       <p class="kr-text-dim-xs-45 font-black uppercase tracking-widest">
         {{ headingLabel }}
       </p>
-      <span v-if="averageRating" class="text-sm font-black text-warning">
+      <span v-if="averageRating" class="kr-text-black-sm text-warning">
         {{ averageRating }} ★
       </span>
     </header>
@@ -75,7 +75,7 @@
             {{ roleFor(review) }}
           </span>
 
-          <span v-if="review.rating > 0" class="ml-auto shrink-0 text-sm font-black text-warning">
+          <span v-if="review.rating > 0" class="kr-text-black-sm ml-auto shrink-0 text-warning">
             {{ review.rating }} ★
           </span>
         </div>

--- a/components/screenfx/animation-selector.vue
+++ b/components/screenfx/animation-selector.vue
@@ -74,7 +74,7 @@
       class="flex cursor-pointer items-center justify-between gap-4 rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
     >
       <span>
-        <span class="block text-sm font-black text-base-content">
+        <span class="kr-text-black-sm block text-base-content">
           Adaptive guardrails
         </span>
         <span class="kr-text-dim-xs-55 block">

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -239,7 +239,7 @@
             v-if="form.species"
             class="flex items-center gap-2 rounded-xl border border-secondary/30 bg-secondary/8 px-3 py-2"
           >
-            <span class="text-sm font-black text-secondary">{{
+            <span class="kr-text-black-sm text-secondary">{{
               form.species
             }}</span>
             <button

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -382,7 +382,7 @@
                 </div>
 
                 <div class="min-w-0 flex-1">
-                  <p class="truncate text-sm font-black text-primary">
+                  <p class="kr-text-black-sm truncate text-primary">
                     {{ pendingCastName }}
                   </p>
                   <p class="kr-text-dim-xs-60 truncate">
@@ -415,7 +415,7 @@
                     class="h-10 w-10 rounded-2xl border border-base-300 object-cover"
                   />
                   <div>
-                    <h3 class="text-sm font-black text-base-content">
+                    <h3 class="kr-text-black-sm text-base-content">
                       {{ role.label }}
                     </h3>
                     <p class="kr-text-dim-xs-60">

--- a/components/storybook/storybook-state-panel.vue
+++ b/components/storybook/storybook-state-panel.vue
@@ -4,7 +4,7 @@
     class="rounded-2xl border border-secondary/25 bg-secondary/5 p-3"
     :open="session.branchHistory.length > 0 || session.inventory.length > 0"
   >
-    <summary class="cursor-pointer text-sm font-black text-secondary">
+    <summary class="kr-text-black-sm cursor-pointer text-secondary">
       Story state · {{ session.branchHistory.length }}
       {{ session.branchHistory.length === 1 ? 'choice' : 'choices' }} ·
       {{ session.inventory.length }}

--- a/components/storybook/storybook-visual-setup.vue
+++ b/components/storybook/storybook-visual-setup.vue
@@ -184,7 +184,7 @@
               <Icon name="kind-icon:check" class="size-4" />
             </span>
             <span class="absolute inset-x-0 bottom-0 p-3 text-white">
-              <span class="block text-sm font-black sm:text-base">
+              <span class="kr-text-black-sm block sm:text-base">
                 {{ option.label }}
               </span>
               <span class="mt-1 block text-[0.68rem] leading-snug text-white/75">

--- a/components/taskmaster/taskmaster-sample-tasks.vue
+++ b/components/taskmaster/taskmaster-sample-tasks.vue
@@ -63,7 +63,7 @@
               class="mt-1 size-4 shrink-0 text-base-content/25 transition group-hover:translate-x-0.5 group-hover:text-accent motion-reduce:transition-none"
             />
           </span>
-          <span class="block text-sm font-black leading-snug">
+          <span class="kr-text-black-sm block leading-snug">
             {{ sample.task }}
           </span>
           <span class="kr-text-dim-xs block leading-relaxed">

--- a/components/themes/theme-gallery.vue
+++ b/components/themes/theme-gallery.vue
@@ -153,7 +153,7 @@
                   <div
                     class="mt-2 flex min-w-0 items-center justify-between gap-2"
                   >
-                    <h3 class="truncate text-sm font-black capitalize">
+                    <h3 class="kr-text-black-sm truncate capitalize">
                       {{ String(item.id) }}
                     </h3>
 
@@ -239,7 +239,7 @@
                   <div
                     class="mt-2 flex min-w-0 items-center justify-between gap-2"
                   >
-                    <h3 class="truncate text-sm font-black">
+                    <h3 class="kr-text-black-sm truncate">
                       {{ sharedById.get(Number(item.id))!.name }}
                     </h3>
 
@@ -331,7 +331,7 @@
             <div class="flex min-w-0 items-center gap-2">
               <Icon name="kind-icon:code" class="h-4 w-4 text-primary" />
 
-              <h2 class="truncate text-sm font-black text-base-content">
+              <h2 class="kr-text-black-sm truncate text-base-content">
                 Active Theme Snapshot
               </h2>
             </div>

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -2,7 +2,7 @@
   <div id="agent-credentials" class="kr-panel-flat p-4">
     <div class="mb-2 flex items-center gap-2">
       <Icon name="kind-icon:key" class="h-5 w-5 text-primary" />
-      <span class="text-sm font-black">Agent credentials</span>
+      <span class="kr-text-black-sm">Agent credentials</span>
     </div>
 
     <p class="kr-text-dim-xs-55 mb-3">

--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -48,7 +48,7 @@
       <button
         v-for="tab in TABS"
         :key="tab.value"
-        class="flex flex-1 items-center justify-center gap-1.5 rounded-xl px-3 py-2 text-sm font-black transition"
+        class="kr-text-black-sm flex flex-1 items-center justify-center gap-1.5 rounded-xl px-3 py-2 transition"
         :class="
           activeTab === tab.value
             ? 'bg-primary text-primary-content shadow-sm shadow-primary/30'

--- a/components/user/login-page.vue
+++ b/components/user/login-page.vue
@@ -97,7 +97,7 @@
           </div>
 
           <label for="login" class="flex flex-col gap-2">
-            <span class="pl-1 text-sm font-black text-base-content/80">
+            <span class="kr-text-black-sm pl-1 text-base-content/80">
               Username
             </span>
             <span
@@ -120,7 +120,7 @@
           </label>
 
           <label for="password" class="flex flex-col gap-2">
-            <span class="pl-1 text-sm font-black text-base-content/80">
+            <span class="kr-text-black-sm pl-1 text-base-content/80">
               Password
             </span>
             <span
@@ -225,7 +225,7 @@
             </div>
 
             <div class="min-w-0 flex-1">
-              <p class="text-sm font-black text-warning">
+              <p class="kr-text-black-sm text-warning">
                 Oops, the gate robot got suspicious.
               </p>
               <p class="mt-1 text-sm leading-snug text-base-content/75">

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -147,7 +147,7 @@
                       name="kind-icon:jellybean"
                       class="h-5 w-5 text-accent"
                     />
-                    <span class="text-sm font-black">Karma</span>
+                    <span class="kr-text-black-sm">Karma</span>
                   </div>
 
                   <p class="mt-2 text-2xl font-black text-accent">
@@ -175,7 +175,7 @@
                       name="kind-icon:sparkles"
                       class="h-5 w-5 text-secondary"
                     />
-                    <span class="text-sm font-black">Mana</span>
+                    <span class="kr-text-black-sm">Mana</span>
                   </div>
 
                   <p class="mt-2 text-2xl font-black text-secondary">
@@ -206,7 +206,7 @@
                       name="kind-icon:trophy"
                       class="h-5 w-5 text-success"
                     />
-                    <span class="text-sm font-black">Achievements</span>
+                    <span class="kr-text-black-sm">Achievements</span>
                   </div>
 
                   <p class="mt-2 text-2xl font-black text-success">
@@ -250,7 +250,7 @@
                       name="kind-icon:paintbrush"
                       class="h-5 w-5 text-primary"
                     />
-                    <span class="text-sm font-black">Theme</span>
+                    <span class="kr-text-black-sm">Theme</span>
                   </div>
 
                   <p class="kr-text-dim-sm-70 truncate">
@@ -269,7 +269,7 @@
                 <div class="flex flex-col gap-2 kr-panel-flat p-4">
                   <label class="flex cursor-pointer items-center gap-2">
                     <Icon name="kind-icon:eye" class="h-5 w-5 text-warning" />
-                    <span class="text-sm font-black">Show mature content</span>
+                    <span class="kr-text-black-sm">Show mature content</span>
                   </label>
 
                   <p class="kr-text-dim-xs-55">
@@ -295,7 +295,7 @@
                 <div class="flex flex-col gap-2 kr-panel-flat p-4">
                   <div class="flex items-center gap-2">
                     <Icon name="kind-icon:server" class="h-5 w-5 text-info" />
-                    <span class="text-sm font-black">Server preferences</span>
+                    <span class="kr-text-black-sm">Server preferences</span>
                   </div>
 
                   <p class="kr-text-dim-xs-55">

--- a/components/user/user-galleries.vue
+++ b/components/user/user-galleries.vue
@@ -133,7 +133,7 @@
               >
                 <div class="flex items-start justify-between gap-3">
                   <div class="min-w-0">
-                    <p class="truncate text-sm font-black">{{ getItemTitle(item) }}</p>
+                    <p class="kr-text-black-sm truncate">{{ getItemTitle(item) }}</p>
                     <p class="kr-text-dim-xs-60">ID {{ item.id }}</p>
                   </div>
                   <span

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -103,7 +103,7 @@
                   :style="{ backgroundColor: color.value }"
                 />
                 <span class="min-w-0">
-                  <span class="block truncate text-sm font-black">
+                  <span class="kr-text-black-sm block truncate">
                     {{ color.name }}
                   </span>
                   <span class="kr-text-dim-xs-55 block font-mono">

--- a/error.vue
+++ b/error.vue
@@ -14,7 +14,7 @@
       <div
         class="kr-panel w-full max-w-3xl rounded-3xl bg-base-100/95 text-center shadow-xl backdrop-blur sm:p-8"
       >
-        <p class="text-sm font-black uppercase tracking-[0.2em] text-primary">
+        <p class="kr-text-black-sm uppercase tracking-[0.2em] text-primary">
           {{ statusCode }} · Lost & Found Room
         </p>
         <h1 class="mt-2 text-3xl font-black sm:text-4xl">

--- a/pages/admin/achievement-art.vue
+++ b/pages/admin/achievement-art.vue
@@ -92,7 +92,7 @@
                   />
                 </div>
                 <div class="min-w-0 flex-1">
-                  <p class="truncate text-sm font-black">
+                  <p class="kr-text-black-sm truncate">
                     {{ achievement.label }}
                   </p>
                   <p class="kr-text-dim-xs truncate">

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -229,7 +229,7 @@
             <div class="space-y-3 p-3">
               <div class="min-w-0">
                 <h2
-                  class="line-clamp-2 break-words text-sm font-black"
+                  class="kr-text-black-sm line-clamp-2 break-words"
                   :title="resourceLabel(resource)"
                 >
                   {{ resourceLabel(resource) }}

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -119,7 +119,7 @@
 
             <label class="flex cursor-pointer items-center justify-between gap-4 kr-panel-compact">
               <div>
-                <span class="block text-sm font-black">Mature batch</span>
+                <span class="kr-text-black-sm block">Mature batch</span>
                 <span class="kr-text-dim-xs block">
                   Carries the existing ArtJob maturity flag into every generated clip.
                 </span>
@@ -187,7 +187,7 @@
               </div>
               <div class="mt-3 flex items-center gap-3">
                 <progress class="progress progress-primary flex-1" :value="store.completionPercent" max="100" />
-                <span class="w-12 text-right text-sm font-black">{{ store.completionPercent }}%</span>
+                <span class="kr-text-black-sm w-12 text-right">{{ store.completionPercent }}%</span>
               </div>
               <p v-if="statusFilter !== 'all'" class="kr-text-dim-xs mt-3 flex items-center gap-2">
                 Showing {{ filteredSources.length }} {{ statusFilter }} scene{{ filteredSources.length === 1 ? '' : 's' }} only.
@@ -287,7 +287,7 @@
                 <div class="space-y-2 p-3">
                   <div class="flex items-start justify-between gap-2">
                     <div class="min-w-0">
-                      <p class="truncate text-sm font-black" :title="source.name">{{ source.name }}</p>
+                      <p class="kr-text-black-sm truncate" :title="source.name">{{ source.name }}</p>
                       <p class="kr-text-dim-xs-45">
                         {{ formatBytes(source.bytes) }}
                         <template v-if="source.jobId"> · ArtJob #{{ source.jobId }}</template>

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -52,7 +52,7 @@
             class="flex items-center gap-3 rounded-xl border border-base-300 bg-base-100 px-4 py-2"
           >
             <span class="badge badge-outline">{{ row.platform }}</span>
-            <span class="text-sm font-black">
+            <span class="kr-text-black-sm">
               {{ row.approvedToday }}/{{ row.ceiling }}
             </span>
             <span class="kr-text-dim-xs">approved today</span>

--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -90,7 +90,7 @@
                 />
               </div>
               <div class="min-w-0">
-                <p class="truncate text-sm font-black">{{ tank.title }}</p>
+                <p class="kr-text-black-sm truncate">{{ tank.title }}</p>
                 <p class="kr-text-dim-xs-55 truncate">
                   @{{ tank.User.username }}
                 </p>

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -94,7 +94,7 @@
             <p class="min-w-0 flex-1 truncate text-sm font-bold">
               @{{ entry.username }}
             </p>
-            <p class="shrink-0 text-sm font-black text-primary">
+            <p class="kr-text-black-sm shrink-0 text-primary">
               {{ entry.speciesCollected }} species
             </p>
           </li>

--- a/utils/scripts/codemods/kr_text_black_sm_codemod.py
+++ b/utils/scripts/codemods/kr_text_black_sm_codemod.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `font-black text-sm` heading-emphasis text to
+`kr-text-black-sm`.
+
+Third and final sibling of kr_text_black_lg_codemod.py /
+kr_text_black_xl_codemod.py, closing out the `kr-text-black-*` family
+(interface-vision t-104 slice 166): dry-run by default, --write to update
+matching Vue files in place. Only the exact `font-black text-sm` shape is
+touched, and only in static `class="..."` attributes -- never
+`:class`/`v-bind:class` bindings, and regardless of the base tokens' order
+in the source. A source that already carries `kr-text-black-sm`, or is
+missing either base token, is left untouched. Extra tokens beyond the base
+set are preserved verbatim after the primitive class, matching the
+kr-badge-*/kr-spinner-*/kr-label-bold/kr-text-dim-*/kr-text-black-{lg,xl}
+codemods' subset-match convention -- pass --exact-only to restrict a slice
+to sources with no extra tokens at all, the safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-black-sm"
+BASE_TOKENS = {"font-black", "text-sm"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-black-sm {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104 (recurring): "Drive live front-end consistency onto shared kr-* components and composition rules" — slice 166.

### What changed / what I produced
- `assets/css/tailwind.css` — added `.kr-text-black-sm { @apply font-black text-sm; }`, third and final sibling of `.kr-text-black-lg`/`.kr-text-black-xl`, closing out the `kr-text-black-*` family.
- `utils/scripts/codemods/kr_text_black_sm_codemod.py` — new codemod, sibling of `kr_text_black_lg_codemod.py`/`kr_text_black_xl_codemod.py`, same subset-match convention (dry-run by default, `--write` to migrate, `--exact-only` to restrict to no-extra-tokens).
- Migrated all 108 subset-match occurrences of `font-black text-sm` across 70 files to `.kr-text-black-sm`, extra tokens preserved verbatim. No geometry or behavior change.

### How I verified
- `vue-tsc --noEmit`: clean.
- `eslint .`: 333 problems (327 errors, 6 warnings), unchanged before/after (confirmed via `git stash`).
- `npm run test:layout-contract`: holds — same unrelated pre-existing -2 ratchet opportunity in `narrative-ingredient-multi-picker.vue` (left untouched, out of scope for this slice).
- `npm run test:lint-ratchet`: holds at 333/-59.
- `prettier --check .`: flagged 2 genuinely new fallout files (`components/art/artjob-slideshow.vue`, `components/navigation/channel-select.vue` — pre-existing multi-line wrapped `class`/attribute formatting that collapsed once the class string shortened); ran a targeted `prettier --write` on just those two, confirmed the full repo-wide warning list then matched the pre-change baseline exactly (`git stash` diff, byte-for-byte).

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
The `kr-text-black-*` family (`-lg`, `-xl`, `-sm`) is now fully mined, alongside the earlier `kr-text-dim-*` family. Slice 167 should run a fresh full-repo class-frequency survey outside both families to find the next largest bounded hand-rolled pattern, rather than re-surveying an already-covered family. Recorded in the roadmap task note; no separate kaizen task filed, matching the established convention for this recurring umbrella.

### Notes for reviewer
Standard recurring-slice PR, same shape as kind_robots#2536/#2537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119cvMYhxsePaNsxYi145JY

---
_Generated by [Claude Code](https://claude.ai/code/session_0119cvMYhxsePaNsxYi145JY)_