### PR TITLE
refactor(ui): add kr-text-eyebrow for font-black uppercase (slice 167)

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -91,7 +91,7 @@
               class="flex shrink-0 items-center justify-between gap-3 border-b border-base-300 bg-base-100 px-3 py-2"
             >
               <p
-                class="truncate text-xs font-black uppercase tracking-widest text-primary"
+                class="kr-text-eyebrow truncate text-xs tracking-widest text-primary"
               >
                 Workspace
               </p>
@@ -208,7 +208,7 @@
 
       <template #fallback>
         <div
-          class="fixed inset-x-0 bottom-0 z-40 border-t border-base-300 bg-base-100/90 p-3 text-center text-xs font-black uppercase tracking-widest text-primary shadow-xl backdrop-blur"
+          class="kr-text-eyebrow fixed inset-x-0 bottom-0 z-40 border-t border-base-300 bg-base-100/90 p-3 text-center text-xs tracking-widest text-primary shadow-xl backdrop-blur"
         >
           Loading workspace tools...
         </div>

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1827,6 +1827,18 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply font-black text-sm;
   }
 
+  /* `font-black uppercase` eyebrow/label text (interface-vision t-104 slice
+   * 167) -- a fresh full-repo class-frequency survey once both the
+   * `kr-text-black-*` and `kr-text-dim-*` families closed out found this
+   * shape at 257 subset-match occurrences across 94 files, the largest
+   * bounded pattern surfaced yet (bigger than any single `kr-text-black-*`
+   * sibling). `tracking-wide` frequently rides along (56 of the 257) but is
+   * left as a caller-supplied extra token rather than folded into the base
+   * set, since plenty of call sites use the base pair alone. */
+  .kr-text-eyebrow {
+    @apply font-black uppercase;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -76,7 +76,7 @@
         </div>
 
         <div class="max-w-4xl">
-          <p class="mb-2 text-xs font-black uppercase tracking-[0.18em] text-white/65">
+          <p class="kr-text-eyebrow mb-2 text-xs tracking-[0.18em] text-white/65">
             Enter the movement
           </p>
           <h3 class="text-3xl font-black leading-none drop-shadow sm:text-4xl lg:text-5xl">
@@ -142,7 +142,7 @@
     >
       <div class="mb-4 flex flex-wrap items-end justify-between gap-2">
         <div>
-          <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-primary">
+          <p class="kr-text-eyebrow flex items-center gap-1.5 text-xs tracking-[0.16em] text-primary">
             <Icon name="kind-icon:gallery" class="h-4 w-4" />
             Gallery wall
           </p>
@@ -192,7 +192,7 @@
     >
       <div class="flex min-w-0 flex-col gap-5">
         <section class="kr-panel-section sm:p-6">
-          <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-primary">
+          <p class="kr-text-eyebrow flex items-center gap-1.5 text-xs tracking-[0.16em] text-primary">
             <Icon name="kind-icon:search" class="h-4 w-4" />
             How to spot it
           </p>
@@ -216,7 +216,7 @@
         <section class="kr-panel-section sm:p-6">
           <div class="flex flex-wrap items-end justify-between gap-2">
             <div>
-              <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-secondary">
+              <p class="kr-text-eyebrow flex items-center gap-1.5 text-xs tracking-[0.16em] text-secondary">
                 <Icon name="kind-icon:user" class="h-4 w-4" />
                 Meet the masters
               </p>
@@ -276,7 +276,7 @@
       <aside class="flex min-w-0 flex-col gap-5 xl:sticky xl:top-3">
         <section class="overflow-hidden rounded-3xl border border-primary/25 bg-primary/5 shadow-sm">
           <div class="border-b border-primary/15 bg-primary/10 p-5">
-            <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-primary">
+            <p class="kr-text-eyebrow flex items-center gap-1.5 text-xs tracking-[0.16em] text-primary">
               <Icon name="kind-icon:flask" class="h-4 w-4" />
               Try it
             </p>
@@ -287,7 +287,7 @@
 
           <div class="flex flex-col gap-4 p-5">
             <div>
-              <p class="kr-text-dim-xs-45 font-black uppercase tracking-wide">Remix instruction</p>
+              <p class="kr-text-eyebrow kr-text-dim-xs-45 tracking-wide">Remix instruction</p>
               <p class="mt-1 text-sm leading-relaxed text-base-content/80">
                 {{ lesson.remix.template }}
               </p>
@@ -326,7 +326,7 @@
         </section>
 
         <section class="kr-panel-section">
-          <p class="kr-text-dim-xs-45 flex items-center gap-1.5 font-black uppercase tracking-[0.16em]">
+          <p class="kr-text-eyebrow kr-text-dim-xs-45 flex items-center gap-1.5 tracking-[0.16em]">
             <Icon name="kind-icon:chat" class="h-4 w-4" />
             Reflect
           </p>

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -5,7 +5,7 @@
       class="kr-panel-section flex flex-col gap-4 p-4 sm:p-5 lg:flex-row lg:items-end lg:justify-between"
     >
       <div class="min-w-0 max-w-2xl">
-        <p class="flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.16em] text-primary">
+        <p class="kr-text-eyebrow flex items-center gap-1.5 text-xs tracking-[0.16em] text-primary">
           <Icon name="kind-icon:palette" class="h-4 w-4" aria-hidden="true" />
           Browse the collection
         </p>
@@ -151,7 +151,7 @@
           <p class="mt-2 line-clamp-2 text-xs leading-relaxed text-white/78">
             {{ style.recognitionCues[0] }}
           </p>
-          <div class="mt-3 flex items-center gap-1 text-[0.68rem] font-black uppercase tracking-wide text-white/90">
+          <div class="kr-text-eyebrow mt-3 flex items-center gap-1 text-[0.68rem] tracking-wide text-white/90">
             Open lesson
             <Icon name="kind-icon:arrow-right" class="h-3.5 w-3.5 transition-transform group-hover:translate-x-1" aria-hidden="true" />
           </div>

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -7,7 +7,7 @@
       <div class="flex flex-col justify-center gap-4 p-5 sm:p-7">
         <div class="flex items-center gap-2 text-primary">
           <Icon name="kind-icon:map" class="h-5 w-5" aria-hidden="true" />
-          <span class="text-xs font-black uppercase tracking-[0.18em]">
+          <span class="kr-text-eyebrow text-xs tracking-[0.18em]">
             Art history, room by room
           </span>
         </div>
@@ -62,7 +62,7 @@
 
     <div class="flex flex-wrap items-end justify-between gap-3 px-1">
       <div>
-        <p class="kr-text-dim-xs-45 font-black uppercase tracking-[0.16em]">
+        <p class="kr-text-eyebrow kr-text-dim-xs-45 tracking-[0.16em]">
           Chronological gallery
         </p>
         <p class="mt-1 text-sm text-base-content/65">

--- a/components/achievements/achievement-popup.vue
+++ b/components/achievements/achievement-popup.vue
@@ -61,7 +61,7 @@
           <Icon name="kind-icon:jellybean" class="h-10 w-10 text-accent" />
           <div class="text-left">
             <p
-              class="text-xs font-black uppercase tracking-wider text-accent/70"
+              class="kr-text-eyebrow text-xs tracking-wider text-accent/70"
             >
               Reward
             </p>

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -128,7 +128,7 @@
       >
         <div class="flex items-start justify-between gap-3">
           <div>
-            <p class="text-xs font-black uppercase tracking-wide text-primary">
+            <p class="kr-text-eyebrow text-xs tracking-wide text-primary">
               Catalog effect
             </p>
             <h3 class="kr-text-black-lg mt-1 text-base-content">

--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -67,7 +67,7 @@
       >
         <template v-for="group in groupedResults" :key="group.taxonomy">
           <div
-            class="sticky top-0 z-10 flex items-center gap-2 bg-base-100/95 px-2 py-1 text-[10px] font-black uppercase tracking-wide text-base-content/45 backdrop-blur"
+            class="kr-text-eyebrow sticky top-0 z-10 flex items-center gap-2 bg-base-100/95 px-2 py-1 text-[10px] tracking-wide text-base-content/45 backdrop-blur"
           >
             <Icon name="kind-icon:tag" class="size-3" />
             {{ group.label }}

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -478,7 +478,7 @@
               </span>
               <div class="min-w-0">
                 <p
-                  class="text-[0.6rem] font-black uppercase tracking-widest text-base-content/40"
+                  class="kr-text-eyebrow text-[0.6rem] tracking-widest text-base-content/40"
                 >
                   Selected Image
                 </p>

--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -39,7 +39,7 @@
         class="flex h-full w-full flex-col items-center justify-center gap-3 border-dashed border-base-300 bg-base-100 p-5 text-center"
       >
         <span
-          class="text-xs font-black uppercase tracking-widest text-base-content/35"
+          class="kr-text-eyebrow text-xs tracking-widest text-base-content/35"
         >
           {{ canShowJobContent ? previewPlaceholder : 'Mature hidden' }}
         </span>

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -97,7 +97,7 @@
       <aside v-if="history.length" class="kr-panel-tint-compact-50">
         <div class="mb-2 flex items-center gap-2">
           <Icon name="kind-icon:history" class="size-3.5 text-base-content/50" />
-          <h4 class="kr-text-dim-xs-55 font-black uppercase tracking-wide">
+          <h4 class="kr-text-eyebrow kr-text-dim-xs-55 tracking-wide">
             Inspiration history
           </h4>
           <span class="kr-badge-ghost-xs ml-auto">{{ filteredHistory.length }}</span>

--- a/components/art/forum-art-generation-context.vue
+++ b/components/art/forum-art-generation-context.vue
@@ -4,7 +4,7 @@
       class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between"
     >
       <div class="min-w-0 flex-1">
-        <p class="text-xs font-black uppercase tracking-widest text-primary/70">
+        <p class="kr-text-eyebrow text-xs tracking-widest text-primary/70">
           Rainbow Butterflies Commons handoff
         </p>
         <h2 class="kr-text-black-lg mt-1 text-primary">

--- a/components/art/generate-button.vue
+++ b/components/art/generate-button.vue
@@ -12,7 +12,7 @@
     >
       <label class="form-control w-full">
         <div class="label py-1">
-          <span class="label-text text-xs font-black uppercase tracking-wide">
+          <span class="kr-text-eyebrow label-text text-xs tracking-wide">
             Image Server
           </span>
         </div>

--- a/components/art/image-card.vue
+++ b/components/art/image-card.vue
@@ -212,7 +212,7 @@
       >
         <div>
           <p
-            class="text-[0.58rem] font-black uppercase tracking-widest text-base-content/40"
+            class="kr-text-eyebrow text-[0.58rem] tracking-widest text-base-content/40"
           >
             Image ID
           </p>
@@ -220,7 +220,7 @@
         </div>
         <div>
           <p
-            class="text-[0.58rem] font-black uppercase tracking-widest text-base-content/40"
+            class="kr-text-eyebrow text-[0.58rem] tracking-widest text-base-content/40"
           >
             Steps
           </p>
@@ -228,7 +228,7 @@
         </div>
         <div>
           <p
-            class="text-[0.58rem] font-black uppercase tracking-widest text-base-content/40"
+            class="kr-text-eyebrow text-[0.58rem] tracking-widest text-base-content/40"
           >
             CFG
           </p>
@@ -243,7 +243,7 @@
           @click.stop="copySeed"
         >
           <p
-            class="text-[0.58rem] font-black uppercase tracking-widest text-base-content/40"
+            class="kr-text-eyebrow text-[0.58rem] tracking-widest text-base-content/40"
           >
             Seed
           </p>
@@ -253,7 +253,7 @@
         </button>
         <div v-if="displayImage.imagePath" class="col-span-2">
           <p
-            class="text-[0.58rem] font-black uppercase tracking-widest text-base-content/40"
+            class="kr-text-eyebrow text-[0.58rem] tracking-widest text-base-content/40"
           >
             Path
           </p>

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -114,15 +114,15 @@
           <template #details>
             <dl class="grid grid-cols-2 gap-2 text-xs">
               <div v-if="infoBot.personality" class="col-span-2">
-                <dt class="font-black uppercase opacity-55">Personality</dt>
+                <dt class="kr-text-eyebrow opacity-55">Personality</dt>
                 <dd class="whitespace-pre-wrap">{{ infoBot.personality }}</dd>
               </div>
               <div v-if="infoBot.BotType">
-                <dt class="font-black uppercase opacity-55">Type</dt>
+                <dt class="kr-text-eyebrow opacity-55">Type</dt>
                 <dd>{{ infoBot.BotType }}</dd>
               </div>
               <div v-if="infoBot.name">
-                <dt class="font-black uppercase opacity-55">Handle</dt>
+                <dt class="kr-text-eyebrow opacity-55">Handle</dt>
                 <dd class="break-words">{{ infoBot.name }}</dd>
               </div>
             </dl>

--- a/components/brainstorm/brainstorm-candidate-card.vue
+++ b/components/brainstorm/brainstorm-candidate-card.vue
@@ -9,7 +9,7 @@
       <div class="min-w-0 flex-1">
         <div class="mb-2 flex flex-wrap items-center gap-2">
           <span
-            class="rounded-full px-2.5 py-1 text-[0.68rem] font-black uppercase tracking-[0.14em]"
+            class="kr-text-eyebrow rounded-full px-2.5 py-1 text-[0.68rem] tracking-[0.14em]"
             :class="statusBadgeClass"
           >
             {{ statusLabel }}
@@ -177,7 +177,7 @@
       data-testid="brainstorm-branch-lineage"
     >
       <summary
-        class="cursor-pointer select-none text-xs font-black uppercase tracking-[0.12em] text-secondary/80"
+        class="kr-text-eyebrow cursor-pointer select-none text-xs tracking-[0.12em] text-secondary/80"
       >
         Branch lineage · parent v{{
           candidate.meta.branchOrigin.revisionIndex + 1
@@ -213,7 +213,7 @@
       data-testid="brainstorm-revision-history"
     >
       <summary
-        class="kr-text-dim-xs-60 cursor-pointer select-none font-black uppercase tracking-[0.12em]"
+        class="kr-text-eyebrow kr-text-dim-xs-60 cursor-pointer select-none tracking-[0.12em]"
       >
         History · {{ candidate.revisions.length }} versions
       </summary>
@@ -283,7 +283,7 @@
     >
       <label
         :for="`${candidate.id}-feedback`"
-        class="text-xs font-black uppercase tracking-[0.12em] text-error/80"
+        class="kr-text-eyebrow text-xs tracking-[0.12em] text-error/80"
       >
         What missed?
       </label>

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -12,7 +12,7 @@
       <div class="flex flex-wrap items-start justify-between gap-4">
         <div class="min-w-[min(100%,28rem)] flex-1">
           <div
-            class="mb-2 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-black uppercase tracking-[0.16em] text-primary"
+            class="kr-text-eyebrow mb-2 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs tracking-[0.16em] text-primary"
             data-testid="brainstorm-persona-badge"
           >
             <img
@@ -67,7 +67,7 @@
 
       <div class="mt-4" data-testid="brainstorm-output-domain">
         <div class="flex flex-wrap items-baseline justify-between gap-2">
-          <p class="kr-text-dim-xs-55 font-black uppercase tracking-[0.12em]">
+          <p class="kr-text-eyebrow kr-text-dim-xs-55 tracking-[0.12em]">
             Output
           </p>
         </div>
@@ -93,7 +93,7 @@
 
       <div class="mt-4 flex flex-wrap items-end gap-3">
         <div>
-          <label for="brainstorm-count" class="kr-text-dim-xs-55 font-black uppercase tracking-[0.12em]">
+          <label for="brainstorm-count" class="kr-text-eyebrow kr-text-dim-xs-55 tracking-[0.12em]">
             {{ isArtPromptDomain ? 'Prompts' : 'Ideas' }}
           </label>
           <input
@@ -125,7 +125,7 @@
 
       <div class="mt-4" data-testid="brainstorm-creative-directions">
         <div class="flex flex-wrap items-baseline justify-between gap-2">
-          <p class="kr-text-dim-xs-55 font-black uppercase tracking-[0.12em]">
+          <p class="kr-text-eyebrow kr-text-dim-xs-55 tracking-[0.12em]">
             Push the batch
           </p>
           <p class="kr-text-dim-xs-45">Creative moves, not model knobs.</p>
@@ -261,7 +261,7 @@
         </summary>
         <div class="mt-4 grid grid-cols-[repeat(auto-fit,minmax(min(100%,18rem),1fr))] gap-4">
           <div>
-            <label for="brainstorm-constraints" class="kr-text-dim-xs-55 font-black uppercase tracking-[0.12em]">
+            <label for="brainstorm-constraints" class="kr-text-eyebrow kr-text-dim-xs-55 tracking-[0.12em]">
               Constraints
             </label>
             <textarea
@@ -274,7 +274,7 @@
             />
           </div>
           <div>
-            <label for="brainstorm-examples" class="kr-text-dim-xs-55 font-black uppercase tracking-[0.12em]">
+            <label for="brainstorm-examples" class="kr-text-eyebrow kr-text-dim-xs-55 tracking-[0.12em]">
               Your examples
             </label>
             <textarea
@@ -425,7 +425,7 @@
 
         <div class="mt-4 grid grid-cols-[repeat(auto-fit,minmax(min(100%,18rem),1fr))] gap-4">
           <div class="rounded-2xl border border-base-content/10 bg-base-100/75 p-3">
-            <label for="brainstorm-session-name" class="kr-text-dim-xs-55 font-black uppercase tracking-[0.12em]">
+            <label for="brainstorm-session-name" class="kr-text-eyebrow kr-text-dim-xs-55 tracking-[0.12em]">
               Session name
             </label>
             <input
@@ -476,7 +476,7 @@
 
           <div class="rounded-2xl border border-base-content/10 bg-base-100/75 p-3">
             <div class="flex flex-wrap items-center justify-between gap-2">
-              <p class="kr-text-dim-xs-55 font-black uppercase tracking-[0.12em]">
+              <p class="kr-text-eyebrow kr-text-dim-xs-55 tracking-[0.12em]">
                 History
               </p>
               <button
@@ -653,7 +653,7 @@
       class="kr-panel-flat flex flex-wrap items-center gap-2 border border-base-content/10 bg-base-100/85 p-3"
       aria-label="Brainstorm batch history"
     >
-      <span class="kr-text-dim-xs-45 mr-1 font-black uppercase tracking-[0.12em]">Batches</span>
+      <span class="kr-text-eyebrow kr-text-dim-xs-45 mr-1 tracking-[0.12em]">Batches</span>
       <button
         v-for="(batch, index) in batches"
         :key="batch.id"
@@ -672,7 +672,7 @@
       class="flex flex-wrap items-center justify-between gap-3 px-1"
     >
       <div>
-        <p class="kr-text-dim-xs-45 font-black uppercase tracking-[0.14em]">Current batch</p>
+        <p class="kr-text-eyebrow kr-text-dim-xs-45 tracking-[0.14em]">Current batch</p>
         <p class="mt-1 text-sm text-base-content/65">
           {{ activeCandidates.length }} candidate{{ activeCandidates.length === 1 ? '' : 's' }} ·
           {{ keptCandidates.length }} kept · {{ rejectedCandidates.length }} rejected
@@ -690,7 +690,7 @@
     >
       <div class="min-w-0">
         <p
-          class="text-xs font-black uppercase tracking-[0.14em] text-secondary/80"
+          class="kr-text-eyebrow text-xs tracking-[0.14em] text-secondary/80"
         >
           Generate art
         </p>

--- a/components/builder/builder-card.vue
+++ b/components/builder/builder-card.vue
@@ -45,7 +45,7 @@
       <div class="flex items-start justify-between gap-2">
         <div class="min-w-0">
           <p
-            class="text-xs font-black uppercase tracking-widest text-primary/70"
+            class="kr-text-eyebrow text-xs tracking-widest text-primary/70"
           >
             {{ card.label }}
           </p>

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -54,19 +54,19 @@
           <template #details>
             <dl class="grid grid-cols-2 gap-2 text-xs">
               <div v-if="infoCharacter.class">
-                <dt class="font-black uppercase opacity-55">Class</dt>
+                <dt class="kr-text-eyebrow opacity-55">Class</dt>
                 <dd>{{ infoCharacter.class }}</dd>
               </div>
               <div v-if="infoCharacter.genre">
-                <dt class="font-black uppercase opacity-55">Genre</dt>
+                <dt class="kr-text-eyebrow opacity-55">Genre</dt>
                 <dd>{{ infoCharacter.genre }}</dd>
               </div>
               <div v-if="infoCharacter.charm">
-                <dt class="font-black uppercase opacity-55">Charm</dt>
+                <dt class="kr-text-eyebrow opacity-55">Charm</dt>
                 <dd>{{ infoCharacter.charm }}</dd>
               </div>
               <div v-if="infoCharacter.empathy">
-                <dt class="font-black uppercase opacity-55">Empathy</dt>
+                <dt class="kr-text-eyebrow opacity-55">Empathy</dt>
                 <dd>{{ infoCharacter.empathy }}</dd>
               </div>
             </dl>

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -8,7 +8,7 @@
       <div>
         <div class="flex flex-wrap items-center gap-2">
           <span class="badge badge-accent rounded-2xl">Cover source art</span>
-          <span class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
+          <span class="kr-text-eyebrow kr-text-dim-xs-40 tracking-widest">
             {{ book.title }}
           </span>
         </div>
@@ -178,7 +178,7 @@
           <div class="kr-panel-tint-sm">
             <label class="form-control">
               <div class="label py-1">
-                <span class="label-text text-xs font-black uppercase tracking-wide">
+                <span class="kr-text-eyebrow label-text text-xs tracking-wide">
                   Adopt an existing set-local cover file
                 </span>
               </div>

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -173,7 +173,7 @@
 
         <aside class="flex flex-col gap-3 kr-panel-flat p-3">
           <p
-            class="kr-text-dim-xs-60 flex items-center gap-1.5 font-black uppercase tracking-wide"
+            class="kr-text-eyebrow kr-text-dim-xs-60 flex items-center gap-1.5 tracking-wide"
           >
             <Icon name="kind-icon:palette" class="h-3.5 w-3.5" />
             Palette
@@ -226,7 +226,7 @@
             class="flex flex-col gap-1.5 kr-panel-divider"
           >
             <p
-              class="kr-text-dim-xs-60 font-black uppercase tracking-wide"
+              class="kr-text-eyebrow kr-text-dim-xs-60 tracking-wide"
             >
               Fill a whole group
             </p>

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -49,7 +49,7 @@
       >
         <div class="flex items-start justify-between gap-3">
           <div>
-            <p class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
+            <p class="kr-text-eyebrow kr-text-dim-xs-40 tracking-widest">
               Book {{ book.order }}
             </p>
             <h4 class="kr-text-black-xl">{{ book.title }}</h4>
@@ -150,7 +150,7 @@
           </p>
 
           <div class="mt-4">
-            <p class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
+            <p class="kr-text-eyebrow kr-text-dim-xs-40 tracking-widest">
               Missing layout decisions
             </p>
             <div class="mt-2 flex flex-wrap gap-2">
@@ -171,7 +171,7 @@
           </div>
 
           <div class="mt-4">
-            <p class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
+            <p class="kr-text-eyebrow kr-text-dim-xs-40 tracking-widest">
               Missing exports
             </p>
             <div class="mt-2 flex flex-wrap gap-2">

--- a/components/coloring/coloring-book-production-toolbar.vue
+++ b/components/coloring/coloring-book-production-toolbar.vue
@@ -7,7 +7,7 @@
       <div>
         <div class="flex flex-wrap items-center gap-2">
           <span class="badge badge-primary rounded-2xl">Production actions</span>
-          <span class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
+          <span class="kr-text-eyebrow kr-text-dim-xs-40 tracking-widest">
             {{ book?.title }} · {{ proposal.id }}
           </span>
         </div>

--- a/components/coloring/coloring-book-readiness.vue
+++ b/components/coloring/coloring-book-readiness.vue
@@ -31,7 +31,7 @@
       >
         <div class="flex items-start justify-between gap-3">
           <div>
-            <p class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
+            <p class="kr-text-eyebrow kr-text-dim-xs-40 tracking-widest">
               Book {{ item.book.order }}
             </p>
             <h4 class="kr-text-black-xl">{{ item.book.title }}</h4>
@@ -114,7 +114,7 @@
         >
           <div class="flex items-start justify-between gap-3">
             <div>
-              <p class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
+              <p class="kr-text-eyebrow kr-text-dim-xs-40 tracking-widest">
                 Slot {{ entry.proposal.slot }} · {{ entry.proposal.id }}
               </p>
               <h5 class="font-black">{{ entry.proposal.title }}</h5>

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -78,7 +78,7 @@
           <div class="flex items-start justify-between gap-3">
             <div>
               <p
-                class="kr-text-dim-xs-40 font-black uppercase tracking-widest"
+                class="kr-text-eyebrow kr-text-dim-xs-40 tracking-widest"
               >
                 Book {{ book.order }}
               </p>
@@ -141,7 +141,7 @@
           <div class="flex items-start justify-between gap-3">
             <div>
               <p
-                class="kr-text-dim-xs-40 font-black uppercase tracking-widest"
+                class="kr-text-eyebrow kr-text-dim-xs-40 tracking-widest"
               >
                 {{ book.slug }}
               </p>
@@ -269,7 +269,7 @@
               <div class="flex items-start justify-between gap-3">
                 <div>
                   <p
-                    class="kr-text-dim-xs-40 font-black uppercase tracking-widest"
+                    class="kr-text-eyebrow kr-text-dim-xs-40 tracking-widest"
                   >
                     Slot {{ proposal.slot }} · {{ proposal.id }}
                   </p>
@@ -304,7 +304,7 @@
           >
             <div>
               <p
-                class="kr-text-dim-xs-40 font-black uppercase tracking-widest"
+                class="kr-text-eyebrow kr-text-dim-xs-40 tracking-widest"
               >
                 {{ studio.selectedBook?.title }} · Slot
                 {{ studio.selectedProposal.slot }} ·
@@ -530,7 +530,7 @@
         >
           <div>
             <p
-              class="kr-text-dim-xs-45 font-black uppercase tracking-widest"
+              class="kr-text-eyebrow kr-text-dim-xs-45 tracking-widest"
             >
               {{ problem.bookTitle }} · {{ problem.proposal.id }}
             </p>

--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -28,11 +28,11 @@
 
             <div class="min-w-0 flex-1 basis-full sm:basis-auto">
               <p
-                class="text-xs font-black uppercase tracking-[0.28em] text-primary"
+                class="kr-text-eyebrow text-xs tracking-[0.28em] text-primary"
               >
                 Select your matchup
               </p>
-              <h3 class="mt-1 text-2xl font-black uppercase sm:text-4xl">
+              <h3 class="kr-text-eyebrow mt-1 text-2xl sm:text-4xl">
                 The Arena
               </h3>
               <p class="mt-2 max-w-2xl text-sm text-base-content/65">
@@ -70,7 +70,7 @@
           <div class="grid gap-4 lg:grid-cols-[1fr_auto] lg:items-end">
             <fieldset>
               <legend
-                class="mb-2 text-[0.65rem] font-black uppercase tracking-[0.22em] text-base-content/50"
+                class="kr-text-eyebrow mb-2 text-[0.65rem] tracking-[0.22em] text-base-content/50"
               >
                 Division
               </legend>
@@ -94,7 +94,7 @@
 
             <fieldset>
               <legend
-                class="mb-2 text-[0.65rem] font-black uppercase tracking-[0.22em] text-base-content/50"
+                class="kr-text-eyebrow mb-2 text-[0.65rem] tracking-[0.22em] text-base-content/50"
               >
                 Fight status
               </legend>
@@ -163,7 +163,7 @@
                   {{ challenge.status }}
                 </span>
                 <span
-                  class="ml-auto text-[0.65rem] font-black uppercase tracking-[0.18em] text-base-content/40"
+                  class="kr-text-eyebrow ml-auto text-[0.65rem] tracking-[0.18em] text-base-content/40"
                 >
                   Fight {{ String(index + 1).padStart(2, '0') }}
                 </span>
@@ -182,7 +182,7 @@
 
               <div class="relative mt-5 space-y-3 border-t border-base-300 pt-4">
                 <div class="flex items-center justify-between gap-3 text-xs">
-                  <span class="font-black uppercase tracking-wider text-base-content/45">
+                  <span class="kr-text-eyebrow tracking-wider text-base-content/45">
                     Difficulty
                   </span>
                   <span
@@ -199,7 +199,7 @@
                 </div>
 
                 <div class="flex items-center justify-between gap-3 text-xs">
-                  <span class="font-black uppercase tracking-wider text-base-content/45">
+                  <span class="kr-text-eyebrow tracking-wider text-base-content/45">
                     Entrants
                   </span>
                   <span class="font-black">
@@ -217,7 +217,7 @@
                   </div>
                   <div class="min-w-0 flex-1">
                     <p
-                      class="text-[0.6rem] font-black uppercase tracking-[0.18em] text-base-content/40"
+                      class="kr-text-eyebrow text-[0.6rem] tracking-[0.18em] text-base-content/40"
                     >
                       Current leader
                     </p>
@@ -234,7 +234,7 @@
                 </div>
 
                 <div
-                  class="flex items-center justify-between text-xs font-black uppercase tracking-wider text-primary"
+                  class="kr-text-eyebrow flex items-center justify-between text-xs tracking-wider text-primary"
                 >
                   <span>Enter matchup</span>
                   <span class="transition-transform group-hover:translate-x-1">→</span>

--- a/components/conductor/coat-dance-page.vue
+++ b/components/conductor/coat-dance-page.vue
@@ -5,7 +5,7 @@
       <section class="flex flex-col gap-3 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:sparkles" class="size-5 text-primary" />
-          <h3 class="kr-text-dim-sm-70 font-black uppercase tracking-wide">
+          <h3 class="kr-text-eyebrow kr-text-dim-sm-70 tracking-wide">
             Behind the coat
           </h3>
         </div>

--- a/components/conductor/conductor-app-page.vue
+++ b/components/conductor/conductor-app-page.vue
@@ -9,7 +9,7 @@
       <section class="flex flex-col items-start gap-3 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:server" class="size-5 text-primary" />
-          <h3 class="kr-text-dim-sm-70 font-black uppercase tracking-wide">
+          <h3 class="kr-text-eyebrow kr-text-dim-sm-70 tracking-wide">
             Build progress
           </h3>
         </div>

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -5,7 +5,7 @@
       <section class="flex flex-col gap-4 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:castle" class="size-5 text-primary" />
-          <h3 class="kr-text-dim-sm-70 font-black uppercase tracking-wide">
+          <h3 class="kr-text-eyebrow kr-text-dim-sm-70 tracking-wide">
             Live a life
           </h3>
         </div>
@@ -125,7 +125,7 @@
             class="flex flex-col gap-4"
           >
             <div class="flex flex-wrap items-center justify-between gap-2">
-              <p class="kr-text-dim-sm font-black uppercase tracking-wide">
+              <p class="kr-text-eyebrow kr-text-dim-sm tracking-wide">
                 {{ run.protagonistName || run.title }}
               </p>
               <p class="kr-text-dim-xs font-semibold">
@@ -175,7 +175,7 @@
                 :title="`${DIMENSION_LABELS[dim]}: ${statMap[dim] ?? 0}`"
               >
                 <span
-                  class="text-[0.55rem] font-black uppercase tracking-wide text-base-content/60"
+                  class="kr-text-eyebrow text-[0.55rem] tracking-wide text-base-content/60"
                 >
                   {{ DIMENSION_LABELS[dim] }}
                 </span>
@@ -403,7 +403,7 @@
       <section class="flex flex-col items-start gap-3 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:trophy" class="size-5 text-primary" />
-          <h3 class="kr-text-dim-sm-70 font-black uppercase tracking-wide">
+          <h3 class="kr-text-eyebrow kr-text-dim-sm-70 tracking-wide">
             Endings on record
           </h3>
         </div>

--- a/components/conductor/project-deliverables-panel.vue
+++ b/components/conductor/project-deliverables-panel.vue
@@ -8,7 +8,7 @@
   <section class="kr-panel-section">
     <div class="mb-3 flex items-center gap-2">
       <Icon name="kind-icon:check-circle" class="size-5 text-primary" />
-      <h3 class="kr-text-dim-sm-70 font-black uppercase tracking-wide">
+      <h3 class="kr-text-eyebrow kr-text-dim-sm-70 tracking-wide">
         Deliverables &amp; status
       </h3>
       <button

--- a/components/conductor/project-gallery-strip.vue
+++ b/components/conductor/project-gallery-strip.vue
@@ -8,7 +8,7 @@
   <section v-if="images.length" class="kr-panel-section">
     <div class="mb-3 flex items-center gap-2">
       <Icon name="kind-icon:image" class="size-5 text-primary" />
-      <h3 class="kr-text-dim-sm-70 font-black uppercase tracking-wide">
+      <h3 class="kr-text-eyebrow kr-text-dim-sm-70 tracking-wide">
         {{ title }}
       </h3>
       <span class="kr-badge-ghost-sm ml-auto rounded-lg">{{

--- a/components/conductor/sketchy-page.vue
+++ b/components/conductor/sketchy-page.vue
@@ -5,7 +5,7 @@
       <section class="flex flex-col items-start gap-3 kr-panel-section">
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:pencil" class="size-5 text-primary" />
-          <h3 class="kr-text-dim-sm-70 font-black uppercase tracking-wide">
+          <h3 class="kr-text-eyebrow kr-text-dim-sm-70 tracking-wide">
             Try today's assignment
           </h3>
         </div>

--- a/components/conductor/voice-lab-page.vue
+++ b/components/conductor/voice-lab-page.vue
@@ -7,7 +7,7 @@
           <div class="flex items-center gap-2">
             <Icon name="kind-icon:server" class="size-5 text-primary" />
             <h3
-              class="kr-text-dim-sm-70 font-black uppercase tracking-wide"
+              class="kr-text-eyebrow kr-text-dim-sm-70 tracking-wide"
             >
               Relay status
             </h3>
@@ -84,7 +84,7 @@
         <div class="flex items-center gap-2">
           <Icon name="kind-icon:book" class="size-5 text-primary" />
           <h3
-            class="kr-text-dim-sm-70 font-black uppercase tracking-wide"
+            class="kr-text-eyebrow kr-text-dim-sm-70 tracking-wide"
           >
             What you can say
           </h3>

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -196,7 +196,7 @@
 
       <div class="flex flex-col gap-2">
         <div class="flex items-center justify-between">
-          <p class="text-xs font-black uppercase tracking-wide opacity-60">
+          <p class="kr-text-eyebrow text-xs tracking-wide opacity-60">
             The tank
           </p>
         </div>
@@ -311,7 +311,7 @@
       </div>
 
       <div class="flex flex-col gap-2">
-        <p class="text-xs font-black uppercase tracking-wide opacity-60">
+        <p class="kr-text-eyebrow text-xs tracking-wide opacity-60">
           Unlock a new occupant
         </p>
         <!-- t-030: the shop rotates -- this is a slice of what's never been
@@ -386,7 +386,7 @@
           class="flex items-center justify-between gap-2 text-left"
           @click="onToggleBestiary"
         >
-          <span class="text-xs font-black uppercase tracking-wide opacity-60">
+          <span class="kr-text-eyebrow text-xs tracking-wide opacity-60">
             The Ichthyonomicon
             <span v-if="tankStore.bestiaryTotalCount > 0" class="opacity-80">
               — {{ tankStore.bestiaryCollectedCount }}/{{
@@ -478,7 +478,7 @@
           class="flex items-center justify-between gap-2 text-left"
           @click="onToggleSets"
         >
-          <span class="text-xs font-black uppercase tracking-wide opacity-60">
+          <span class="kr-text-eyebrow text-xs tracking-wide opacity-60">
             Set pieces
             <span class="opacity-80">
               — {{ tankStore.equippedSets.length }}/{{ tankStore.setSlotsCap }}
@@ -556,7 +556,7 @@
           class="flex items-center justify-between gap-2 text-left"
           @click="onToggleDecor"
         >
-          <span class="text-xs font-black uppercase tracking-wide opacity-60">
+          <span class="kr-text-eyebrow text-xs tracking-wide opacity-60">
             Decorate
             <span v-if="tankStore.placedDecor.length" class="opacity-80">
               — {{ tankStore.placedDecor.length }} placed
@@ -629,7 +629,7 @@
           class="flex items-center justify-between gap-2 text-left"
           @click="onToggleEggs"
         >
-          <span class="text-xs font-black uppercase tracking-wide opacity-60">
+          <span class="kr-text-eyebrow text-xs tracking-wide opacity-60">
             Eggs
             <span v-if="tankStore.eggs.length > 0" class="opacity-80">
               — {{ tankStore.eggs.length }} waiting to hatch
@@ -819,7 +819,7 @@
         <div
           class="modal-box flex max-w-sm flex-col items-center gap-3 rounded-3xl border border-base-300 bg-base-100 text-center shadow-2xl"
         >
-          <p class="text-xs font-black uppercase tracking-wide text-primary">
+          <p class="kr-text-eyebrow text-xs tracking-wide text-primary">
             New occupant
           </p>
           <kr-art-plate
@@ -877,7 +877,7 @@
         <div
           class="modal-box flex max-w-sm flex-col items-center gap-3 rounded-3xl border border-base-300 bg-base-100 text-center shadow-2xl"
         >
-          <p class="text-xs font-black uppercase tracking-wide text-primary">
+          <p class="kr-text-eyebrow text-xs tracking-wide text-primary">
             It hatched
           </p>
           <kr-art-plate
@@ -936,7 +936,7 @@
         <div
           class="modal-box flex max-w-sm flex-col items-center gap-3 rounded-3xl border border-base-300 bg-base-100 text-center shadow-2xl"
         >
-          <p class="text-xs font-black uppercase tracking-wide text-primary">
+          <p class="kr-text-eyebrow text-xs tracking-wide text-primary">
             Breed these two?
           </p>
           <kr-art-plate
@@ -1005,7 +1005,7 @@
             name="kind-icon:sparkles"
             class="size-8 text-warning"
           />
-          <p class="text-xs font-black uppercase tracking-wide text-primary">
+          <p class="kr-text-eyebrow text-xs tracking-wide text-primary">
             {{
               tankStore.revealedBreed.evolved
                 ? 'A secret evolution!'
@@ -1068,7 +1068,7 @@
           class="modal-box flex max-w-sm flex-col items-center gap-3 rounded-3xl border border-base-300 bg-base-100 text-center shadow-2xl"
         >
           <Icon name="kind-icon:trophy" class="size-10 text-warning" />
-          <p class="text-xs font-black uppercase tracking-wide text-primary">
+          <p class="kr-text-eyebrow text-xs tracking-wide text-primary">
             The bestiary is complete
           </p>
           <h3 class="kr-text-black-lg">Every species, observed.</h3>
@@ -1118,7 +1118,7 @@
             class="w-full"
             placeholder-icon="kind-icon:eye"
           />
-          <p class="text-xs font-black uppercase tracking-wide text-primary">
+          <p class="kr-text-eyebrow text-xs tracking-wide text-primary">
             The last aquarium
           </p>
           <h3 class="kr-text-black-lg">
@@ -1160,7 +1160,7 @@
           class="modal-box flex max-w-sm flex-col items-center gap-3 rounded-3xl border border-base-300 bg-base-100 text-center shadow-2xl"
         >
           <Icon name="kind-icon:coin" class="size-8 text-warning" />
-          <p class="text-xs font-black uppercase tracking-wide text-primary">
+          <p class="kr-text-eyebrow text-xs tracking-wide text-primary">
             While you were away
           </p>
           <h3 class="kr-text-black-lg">

--- a/components/curation/coloring-book-curation.vue
+++ b/components/curation/coloring-book-curation.vue
@@ -166,9 +166,7 @@
 
         <div class="space-y-4 p-4">
           <div>
-            <p
-              class="text-[11px] font-black uppercase tracking-wider text-primary"
-            >
+            <p class="kr-text-eyebrow text-[11px] tracking-wider text-primary">
               Slot {{ proposal.slot }}
             </p>
             <h2 class="kr-text-black-xl mt-1 leading-tight">

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -89,9 +89,7 @@
           <div
             class="mt-3 rounded-xl border border-base-content/10 bg-base-100/70 p-3"
           >
-            <p
-              class="text-[11px] font-black uppercase tracking-wider text-primary"
-            >
+            <p class="kr-text-eyebrow text-[11px] tracking-wider text-primary">
               Ichthyonomicon
             </p>
             <p class="mt-1 text-sm leading-6">
@@ -318,7 +316,7 @@
           </div>
 
           <div v-if="fish.curation.candidateImageIds.length" class="space-y-2">
-            <p class="kr-text-dim-xs-45 font-black uppercase tracking-wider">
+            <p class="kr-text-eyebrow kr-text-dim-xs-45 tracking-wider">
               Candidates
             </p>
             <div class="flex flex-wrap gap-2">

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -301,7 +301,7 @@
           <div
             class="rounded-xl border border-base-300 bg-base-200/40 p-3 text-xs leading-5"
           >
-            <p class="font-black uppercase tracking-wide text-base-content/55">
+            <p class="kr-text-eyebrow tracking-wide text-base-content/55">
               Immutable source
             </p>
             <p class="mt-1">

--- a/components/dreams/daily-digest-browser.vue
+++ b/components/dreams/daily-digest-browser.vue
@@ -59,7 +59,7 @@
 
           <div class="absolute inset-x-0 bottom-0 p-5 text-base-100 sm:p-7">
             <p
-              class="text-xs font-black uppercase tracking-[0.18em] text-base-100/70"
+              class="kr-text-eyebrow text-xs tracking-[0.18em] text-base-100/70"
             >
               {{
                 activeDream

--- a/components/dreams/daily-digest-object-dialog.vue
+++ b/components/dreams/daily-digest-object-dialog.vue
@@ -89,7 +89,7 @@
                 :key="row.key"
                 class="kr-panel p-4"
               >
-                <p class="text-xs font-black uppercase tracking-[0.14em] text-primary/75">
+                <p class="kr-text-eyebrow text-xs tracking-[0.14em] text-primary/75">
                   {{ row.label }}
                 </p>
                 <p class="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-base-content/75">
@@ -111,7 +111,7 @@
               v-if="canEdit"
               class="rounded-2xl border border-primary/25 bg-primary/5 p-4"
             >
-              <p class="text-xs font-black uppercase tracking-[0.15em] text-primary">Object editor</p>
+              <p class="kr-text-eyebrow text-xs tracking-[0.15em] text-primary">Object editor</p>
               <h3 class="kr-text-black-lg mt-1">Revise the useful fields</h3>
               <p class="mt-1 text-sm leading-relaxed text-base-content/55">
                 These save directly to the existing {{ typeLabel.toLowerCase() }} record. System fields and relationships stay out of reach.

--- a/components/dreams/daily-digest-object-gallery.vue
+++ b/components/dreams/daily-digest-object-gallery.vue
@@ -5,7 +5,7 @@
   >
     <header class="flex items-center justify-between gap-3">
       <div class="min-w-0 flex-1">
-        <p class="text-[0.65rem] font-black uppercase tracking-[0.16em] text-primary">
+        <p class="kr-text-eyebrow text-[0.65rem] tracking-[0.16em] text-primary">
           Complete bundle
         </p>
         <div class="mt-0.5 flex flex-wrap items-baseline gap-x-3 gap-y-1">
@@ -64,7 +64,7 @@
           <div class="flex min-h-0 flex-1 flex-col p-2.5">
             <div class="flex items-start gap-1.5">
               <div class="min-w-0 flex-1">
-                <p class="truncate text-[0.58rem] font-black uppercase tracking-[0.12em] text-primary/70">
+                <p class="kr-text-eyebrow truncate text-[0.58rem] tracking-[0.12em] text-primary/70">
                   {{ item.typeLabel }}
                 </p>
                 <h4 class="kr-text-black-sm mt-0.5 line-clamp-2 leading-tight">

--- a/components/dreams/daily-dream-generator.vue
+++ b/components/dreams/daily-dream-generator.vue
@@ -81,7 +81,7 @@
       <div v-if="blueprint" class="mt-3 grid gap-2 md:grid-cols-3">
         <div class="rounded-xl bg-base-100 p-3">
           <p
-            class="text-[11px] font-black uppercase tracking-wide text-base-content/45"
+            class="kr-text-eyebrow text-[11px] tracking-wide text-base-content/45"
           >
             Dream
           </p>
@@ -92,7 +92,7 @@
         </div>
         <div class="rounded-xl bg-base-100 p-3">
           <p
-            class="text-[11px] font-black uppercase tracking-wide text-base-content/45"
+            class="kr-text-eyebrow text-[11px] tracking-wide text-base-content/45"
           >
             Cast
           </p>
@@ -107,7 +107,7 @@
         </div>
         <div class="rounded-xl bg-base-100 p-3">
           <p
-            class="text-[11px] font-black uppercase tracking-wide text-base-content/45"
+            class="kr-text-eyebrow text-[11px] tracking-wide text-base-content/45"
           >
             Objects
           </p>

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -56,7 +56,7 @@
       >
         <div class="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <p class="text-xs font-black uppercase tracking-[0.16em] text-secondary">
+            <p class="kr-text-eyebrow text-xs tracking-[0.16em] text-secondary">
               Art workbench
             </p>
             <h3 class="kr-text-black-lg mt-1">

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -216,15 +216,15 @@
           <template #details>
             <dl class="grid grid-cols-2 gap-2 text-xs">
               <div v-if="infoDream.pitch" class="col-span-2">
-                <dt class="font-black uppercase opacity-55">Pitch</dt>
+                <dt class="kr-text-eyebrow opacity-55">Pitch</dt>
                 <dd class="whitespace-pre-wrap">{{ infoDream.pitch }}</dd>
               </div>
               <div v-if="infoDream.dreamType">
-                <dt class="font-black uppercase opacity-55">Type</dt>
+                <dt class="kr-text-eyebrow opacity-55">Type</dt>
                 <dd>{{ infoDream.dreamType }}</dd>
               </div>
               <div v-if="infoDream.flavorText" class="col-span-2">
-                <dt class="font-black uppercase opacity-55">Flavor</dt>
+                <dt class="kr-text-eyebrow opacity-55">Flavor</dt>
                 <dd class="whitespace-pre-wrap">{{ infoDream.flavorText }}</dd>
               </div>
             </dl>

--- a/components/dreams/dream-sheet-toolbar.vue
+++ b/components/dreams/dream-sheet-toolbar.vue
@@ -3,7 +3,7 @@
   <aside class="kr-panel-flat bg-base-100/90 p-3 shadow-sm backdrop-blur">
     <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div class="min-w-0">
-        <p class="flex items-center gap-2 text-xs font-black uppercase tracking-[0.22em] text-primary">
+        <p class="kr-text-eyebrow flex items-center gap-2 text-xs tracking-[0.22em] text-primary">
           <Icon name="kind-icon:file-sparkles" class="h-4 w-4" />
           PitchSheets
         </p>

--- a/components/giftshop/checkout-cancel.vue
+++ b/components/giftshop/checkout-cancel.vue
@@ -21,7 +21,7 @@
         v-if="cartStore.hasItems"
         class="mx-auto mt-5 w-fit rounded-2xl border border-base-300 bg-base-200 px-5 py-3"
       >
-        <div class="kr-text-dim-xs font-black uppercase tracking-widest">
+        <div class="kr-text-eyebrow kr-text-dim-xs tracking-widest">
           Cart preserved
         </div>
         <div class="text-2xl font-black text-primary">

--- a/components/giftshop/checkout-success.vue
+++ b/components/giftshop/checkout-success.vue
@@ -21,7 +21,7 @@
         v-if="verifiedAmount"
         class="mx-auto mt-5 w-fit rounded-2xl border border-base-300 bg-base-200 px-5 py-3"
       >
-        <div class="kr-text-dim-xs font-black uppercase tracking-widest">
+        <div class="kr-text-eyebrow kr-text-dim-xs tracking-widest">
           Confirmed total
         </div>
         <div class="text-2xl font-black text-primary">

--- a/components/giftshop/shopping-cart.vue
+++ b/components/giftshop/shopping-cart.vue
@@ -117,7 +117,7 @@
       <div class="rounded-3xl border border-primary/30 bg-primary/10 p-5 sm:p-6">
         <div class="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <div class="kr-text-dim-xs font-black uppercase tracking-widest">
+            <div class="kr-text-eyebrow kr-text-dim-xs tracking-widest">
               Cart total
             </div>
             <div class="text-4xl font-black text-primary">

--- a/components/home/home-attention.vue
+++ b/components/home/home-attention.vue
@@ -70,9 +70,7 @@
     class="flex min-h-0 flex-col gap-1 kr-panel-flat p-2"
   >
     <header class="flex shrink-0 items-baseline justify-between gap-2">
-      <h2
-        class="text-[0.7rem] font-black uppercase tracking-[0.16em] text-primary"
-      >
+      <h2 class="kr-text-eyebrow text-[0.7rem] tracking-[0.16em] text-primary">
         Needs you
         <span v-if="gates.length" class="text-base-content/40"
           >· {{ gates.length }}</span
@@ -130,7 +128,7 @@
           @click="toggle(gate)"
         >
           <p
-            class="truncate text-[0.6rem] font-black uppercase tracking-[0.12em] text-primary"
+            class="kr-text-eyebrow truncate text-[0.6rem] tracking-[0.12em] text-primary"
           >
             {{ gate.project.name || gate.project.slug }}
             <span v-if="gate.task.softGate" class="text-base-content/35"

--- a/components/home/home-dream-hero.vue
+++ b/components/home/home-dream-hero.vue
@@ -112,9 +112,7 @@
       </div>
 
       <div class="min-w-0 shrink-0">
-        <p
-          class="text-[0.6rem] font-black uppercase tracking-[0.18em] text-primary"
-        >
+        <p class="kr-text-eyebrow text-[0.6rem] tracking-[0.18em] text-primary">
           {{ kicker }}
         </p>
 
@@ -276,7 +274,7 @@
               max-w + truncate because "CHARACTER" is wider than a 4rem tile.
             -->
               <span
-                class="absolute left-1 top-1 max-w-[calc(100%-0.5rem)] truncate rounded bg-base-100/90 px-1 text-[0.45rem] font-black uppercase tracking-[0.08em] text-base-content backdrop-blur"
+                class="kr-text-eyebrow absolute left-1 top-1 max-w-[calc(100%-0.5rem)] truncate rounded bg-base-100/90 px-1 text-[0.45rem] tracking-[0.08em] text-base-content backdrop-blur"
               >
                 {{ member.badge }}
               </span>

--- a/components/home/home-object-sheet.vue
+++ b/components/home/home-object-sheet.vue
@@ -44,7 +44,7 @@
         >
           <div class="min-w-0 flex-1">
             <p
-              class="text-[0.6rem] font-black uppercase tracking-[0.18em] text-primary"
+              class="kr-text-eyebrow text-[0.6rem] tracking-[0.18em] text-primary"
             >
               {{ kindLabel }}
             </p>
@@ -134,7 +134,7 @@
                   class="min-w-0 rounded-lg border border-base-300 bg-base-200/50 px-2 py-1"
                 >
                   <dt
-                    class="text-[0.55rem] font-black uppercase tracking-[0.14em] text-base-content/45"
+                    class="kr-text-eyebrow text-[0.55rem] tracking-[0.14em] text-base-content/45"
                   >
                     {{ fact.label }}
                   </dt>
@@ -197,7 +197,7 @@
         >
           <label
             :for="`redo-prompt-${card.kind}-${card.id}`"
-            class="text-[0.65rem] font-black uppercase tracking-[0.14em] text-primary"
+            class="kr-text-eyebrow text-[0.65rem] tracking-[0.14em] text-primary"
           >
             New art prompt
           </label>

--- a/components/home/home-page.vue
+++ b/components/home/home-page.vue
@@ -204,7 +204,7 @@
             type="button"
             role="tab"
             :aria-selected="currentPane === pane.key"
-            class="flex-1 rounded-lg px-2 py-1.5 text-[0.7rem] font-black uppercase tracking-[0.1em] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+            class="kr-text-eyebrow flex-1 rounded-lg px-2 py-1.5 text-[0.7rem] tracking-[0.1em] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
             :class="
               currentPane === pane.key
                 ? 'bg-primary text-primary-content'
@@ -233,7 +233,7 @@
           >
             <header class="flex flex-wrap items-baseline justify-between gap-3">
               <h2
-                class="text-[0.7rem] font-black uppercase tracking-[0.16em] text-primary"
+                class="kr-text-eyebrow text-[0.7rem] tracking-[0.16em] text-primary"
               >
                 What we're building
               </h2>
@@ -333,7 +333,7 @@
             -->
               <template #lead>
                 <h2
-                  class="hidden shrink-0 text-[0.7rem] font-black uppercase tracking-[0.16em] text-primary lg:block"
+                  class="kr-text-eyebrow hidden shrink-0 text-[0.7rem] tracking-[0.16em] text-primary lg:block"
                 >
                   News
                 </h2>

--- a/components/home/home-rail.vue
+++ b/components/home/home-rail.vue
@@ -96,7 +96,7 @@
         -->
         <span
           v-if="showLabel"
-          class="truncate text-[0.6rem] font-black uppercase tracking-[0.14em]"
+          class="kr-text-eyebrow truncate text-[0.6rem] tracking-[0.14em]"
           >{{ label }}</span
         >
         <span
@@ -239,7 +239,7 @@
           -->
           <template v-if="item.status" #overlay>
             <span
-              class="absolute left-1 top-1 max-w-[calc(100%-0.5rem)] truncate rounded px-1 text-[0.45rem] font-black uppercase tracking-[0.08em] backdrop-blur"
+              class="kr-text-eyebrow absolute left-1 top-1 max-w-[calc(100%-0.5rem)] truncate rounded px-1 text-[0.45rem] tracking-[0.08em] backdrop-blur"
               :class="statusChipClass(item.status)"
             >
               {{ item.status }}

--- a/components/narrative/kr-chat-window.vue
+++ b/components/narrative/kr-chat-window.vue
@@ -90,7 +90,7 @@
         >
           <p
             v-if="turn.speaker && turn.from !== 'user'"
-            class="text-[0.65rem] font-black uppercase tracking-wide text-primary/70"
+            class="kr-text-eyebrow text-[0.65rem] tracking-wide text-primary/70"
           >
             {{ turn.speaker }}
           </p>

--- a/components/narrative/kr-narrator-stage.vue
+++ b/components/narrative/kr-narrator-stage.vue
@@ -43,7 +43,7 @@
               {{ narratorName }}
             </p>
             <p
-              class="truncate text-[0.65rem] font-black uppercase tracking-widest text-primary/75"
+              class="kr-text-eyebrow truncate text-[0.65rem] tracking-widest text-primary/75"
             >
               {{ currentEmotionLabel }}
             </p>

--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -322,7 +322,7 @@
       <section v-if="canSeeNotifications" class="flex flex-col gap-1.5">
         <div class="flex items-center justify-between px-1">
           <p
-            class="kr-text-dim-xs font-black uppercase tracking-widest"
+            class="kr-text-eyebrow kr-text-dim-xs tracking-widest"
           >
             Notifications
           </p>

--- a/components/navigation/channel-tab-list.vue
+++ b/components/navigation/channel-tab-list.vue
@@ -15,7 +15,7 @@
     >
       <p
         v-if="group.label"
-        class="px-3 pb-1 text-[0.65rem] font-black uppercase tracking-[0.18em] text-base-content/45"
+        class="kr-text-eyebrow px-3 pb-1 text-[0.65rem] tracking-[0.18em] text-base-content/45"
       >
         {{ group.label }}
       </p>

--- a/components/navigation/tutorial-flyer.vue
+++ b/components/navigation/tutorial-flyer.vue
@@ -124,7 +124,7 @@
 
             <div class="min-w-0 flex-1 pr-8">
               <p
-                class="inline-flex items-center gap-1.5 rounded-full border border-primary/25 bg-base-100/70 px-3 py-1 text-[0.65rem] font-black uppercase tracking-[0.18em] text-primary shadow-sm backdrop-blur"
+                class="kr-text-eyebrow inline-flex items-center gap-1.5 rounded-full border border-primary/25 bg-base-100/70 px-3 py-1 text-[0.65rem] tracking-[0.18em] text-primary shadow-sm backdrop-blur"
               >
                 <Icon name="kind-icon:info" class="h-3 w-3" />
                 Tutorial

--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -163,7 +163,7 @@
               :title="headerMessage"
             >
               <span
-                class="truncate text-[0.65rem] font-black uppercase tracking-[0.18em] text-primary/75"
+                class="kr-text-eyebrow truncate text-[0.65rem] tracking-[0.18em] text-primary/75"
               >
                 {{ brandLine }}
               </span>

--- a/components/navigation/workspace-narrator.vue
+++ b/components/navigation/workspace-narrator.vue
@@ -31,7 +31,7 @@
                 <div class="relative flex items-start justify-between gap-3">
                   <div class="min-w-0">
                     <p
-                      class="truncate text-xs font-black uppercase tracking-widest text-primary"
+                      class="kr-text-eyebrow truncate text-xs tracking-widest text-primary"
                     >
                       Narrator Remote
                     </p>
@@ -120,7 +120,7 @@
 
                         <div class="min-w-0 flex-1">
                           <p
-                            class="text-[0.65rem] font-black uppercase tracking-wide text-primary/70"
+                            class="kr-text-eyebrow text-[0.65rem] tracking-wide text-primary/70"
                           >
                             {{ latestMusing.label }}
                           </p>
@@ -166,7 +166,7 @@
                       </h2>
 
                       <p
-                        class="mt-1 truncate text-xs font-black uppercase tracking-widest text-primary/75"
+                        class="kr-text-eyebrow mt-1 truncate text-xs tracking-widest text-primary/75"
                       >
                         {{ currentEmotionLabel }}
                       </p>
@@ -213,7 +213,7 @@
                     </p>
 
                     <p
-                      class="mt-1 truncate text-[0.65rem] font-black uppercase tracking-widest text-primary/75"
+                      class="kr-text-eyebrow mt-1 truncate text-[0.65rem] tracking-widest text-primary/75"
                     >
                       {{ currentEmotionLabel }}
                     </p>
@@ -278,7 +278,7 @@
                 >
                   <div class="flex items-center justify-between gap-2">
                     <p
-                      class="text-xs font-black uppercase tracking-wide text-primary"
+                      class="kr-text-eyebrow text-xs tracking-wide text-primary"
                     >
                       Topics & Threads
                     </p>
@@ -372,7 +372,7 @@
 
                       <div class="min-w-0 flex-1">
                         <p
-                          class="text-xs font-black uppercase tracking-wide text-primary"
+                          class="kr-text-eyebrow text-xs tracking-wide text-primary"
                         >
                           {{ selectedTopicTitle }}
                         </p>
@@ -479,7 +479,7 @@
 
             <div class="min-w-0 flex-1">
               <p
-                class="text-[0.65rem] font-black uppercase tracking-wide text-primary/70"
+                class="kr-text-eyebrow text-[0.65rem] tracking-wide text-primary/70"
               >
                 {{ latestMusing.label }}
               </p>

--- a/components/navigation/workspace-sheet.vue
+++ b/components/navigation/workspace-sheet.vue
@@ -72,7 +72,7 @@
         <span class="flex items-center gap-2">
           <Icon name="kind-icon:info" class="h-5 w-5 text-primary" />
           <span
-            class="kr-text-dim-sm-70 font-black uppercase tracking-widest"
+            class="kr-text-eyebrow kr-text-dim-sm-70 tracking-widest"
           >
             {{ showTutorial ? 'Hide tutorial' : 'Show tutorial' }}
           </span>
@@ -229,7 +229,7 @@
                   <div class="flex items-end justify-between gap-3">
                     <div class="min-w-0">
                       <p
-                        class="text-xs font-black uppercase tracking-widest text-primary drop-shadow-sm"
+                        class="kr-text-eyebrow text-xs tracking-widest text-primary drop-shadow-sm"
                       >
                         {{ formatFieldKey(field.key) }}
                       </p>
@@ -270,7 +270,7 @@
                 <div class="flex items-start justify-between gap-3">
                   <div class="min-w-0">
                     <p
-                      class="text-xs font-black uppercase tracking-widest text-base-content/35"
+                      class="kr-text-eyebrow text-xs tracking-widest text-base-content/35"
                     >
                       {{ formatFieldKey(field.key) }}
                     </p>

--- a/components/newsfeed/feed-card.vue
+++ b/components/newsfeed/feed-card.vue
@@ -40,7 +40,7 @@
         />
         <span
           v-if="primaryCategory"
-          class="absolute left-1.5 top-1.5 rounded bg-base-100/90 px-1 text-[0.55rem] font-black uppercase tracking-[0.08em] text-base-content backdrop-blur"
+          class="kr-text-eyebrow absolute left-1.5 top-1.5 rounded bg-base-100/90 px-1 text-[0.55rem] tracking-[0.08em] text-base-content backdrop-blur"
         >
           {{ primaryCategory }}
         </span>

--- a/components/pages/about-page.vue
+++ b/components/pages/about-page.vue
@@ -26,7 +26,7 @@
               <Icon :name="card.icon" class="h-5 w-5" />
             </span>
             <h2
-              class="text-base font-black uppercase tracking-wider text-base-content"
+              class="kr-text-eyebrow text-base tracking-wider text-base-content"
             >
               {{ card.title }}
             </h2>
@@ -44,7 +44,7 @@
           >
             <Icon name="kind-icon:heart" class="h-5 w-5" />
           </span>
-          <h2 class="text-base font-black uppercase tracking-wider text-base-content">
+          <h2 class="kr-text-eyebrow text-base tracking-wider text-base-content">
             Community & Sponsors
           </h2>
         </div>

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -65,7 +65,7 @@
             <Icon :name="tab.icon" class="size-4" />
           </span>
           <span class="min-w-0 flex-1">
-            <span class="block truncate text-xs font-black uppercase tracking-wide">
+            <span class="kr-text-eyebrow block truncate text-xs tracking-wide">
               {{ tab.label }}
             </span>
             <span class="kr-text-black-lg leading-none">{{ tab.count }}</span>
@@ -167,7 +167,7 @@
 
             <div class="space-y-4 p-4">
               <div>
-                <p class="text-xs font-black uppercase tracking-widest text-base-content/35">
+                <p class="kr-text-eyebrow text-xs tracking-widest text-base-content/35">
                   The idea
                 </p>
                 <p class="mt-1 text-sm leading-relaxed text-base-content/75">
@@ -176,7 +176,7 @@
               </div>
 
               <div v-if="pitch.whyDoIt">
-                <p class="text-xs font-black uppercase tracking-widest text-base-content/35">
+                <p class="kr-text-eyebrow text-xs tracking-widest text-base-content/35">
                   Why bother
                 </p>
                 <p class="kr-text-dim-sm mt-1 leading-relaxed">
@@ -188,7 +188,7 @@
                 v-if="overlapSignals(pitch).length"
                 class="rounded-2xl border border-warning/30 bg-warning/8 p-3"
               >
-                <div class="flex items-center gap-2 text-xs font-black uppercase tracking-wide text-warning">
+                <div class="kr-text-eyebrow flex items-center gap-2 text-xs tracking-wide text-warning">
                   <Icon name="kind-icon:warning" class="size-4" />
                   Existing-work check
                 </div>

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -27,9 +27,7 @@
           <div class="min-w-0">
             <div class="flex items-center gap-2 text-accent">
               <Icon name="kind-icon:sparkles" class="size-5" />
-              <p class="text-xs font-black uppercase tracking-[0.18em]">
-                For You
-              </p>
+              <p class="kr-text-eyebrow text-xs tracking-[0.18em]">For You</p>
             </div>
             <h2 class="kr-text-black-xl mt-1 sm:text-2xl">
               Your attention desk
@@ -92,7 +90,7 @@
             <div class="flex flex-wrap items-end justify-between gap-3 px-1">
               <div>
                 <p
-                  class="text-xs font-black uppercase tracking-[0.16em] text-warning"
+                  class="kr-text-eyebrow text-xs tracking-[0.16em] text-warning"
                 >
                   Conductor
                 </p>
@@ -320,7 +318,7 @@
             <div class="flex flex-wrap items-end justify-between gap-3 px-1">
               <div>
                 <p
-                  class="text-xs font-black uppercase tracking-[0.16em] text-secondary"
+                  class="kr-text-eyebrow text-xs tracking-[0.16em] text-secondary"
                 >
                   Possibilities
                 </p>
@@ -418,9 +416,7 @@
         <section class="space-y-3">
           <div class="flex flex-wrap items-end justify-between gap-3 px-1">
             <div>
-              <p
-                class="text-xs font-black uppercase tracking-[0.16em] text-accent"
-              >
+              <p class="kr-text-eyebrow text-xs tracking-[0.16em] text-accent">
                 Kind Robots
               </p>
               <h2 class="kr-text-black-xl">Personal follow-ups</h2>

--- a/components/pages/memory-dungeon.vue
+++ b/components/pages/memory-dungeon.vue
@@ -406,7 +406,7 @@
         class="absolute inset-y-2 left-2 right-2 z-40 flex flex-col overflow-hidden rounded-2xl border border-base-content/20 bg-base-300/95 text-base-content shadow-2xl backdrop-blur-md sm:left-auto sm:w-72 xl:w-80"
       >
         <div
-          class="flex shrink-0 items-center justify-between gap-2 border-b border-base-content/20 bg-base-100/80 px-3 py-2 text-xs font-black uppercase tracking-widest text-base-content"
+          class="kr-text-eyebrow flex shrink-0 items-center justify-between gap-2 border-b border-base-content/20 bg-base-100/80 px-3 py-2 text-xs tracking-widest text-base-content"
         >
           <span>📜 Dungeon Log</span>
           <button

--- a/components/pages/mermaids-page.vue
+++ b/components/pages/mermaids-page.vue
@@ -97,11 +97,11 @@
               v-if="editing"
               v-model="draft.bookHeading"
               aria-label="Book section heading"
-              class="input input-bordered w-full font-black uppercase tracking-wider"
+              class="kr-text-eyebrow input input-bordered w-full tracking-wider"
             />
             <h2
               v-else
-              class="text-base font-black uppercase tracking-wider text-base-content"
+              class="kr-text-eyebrow text-base tracking-wider text-base-content"
             >
               {{ draft.bookHeading }}
             </h2>
@@ -162,11 +162,11 @@
             v-if="editing"
             v-model="draft.personalNoteHeading"
             aria-label="Personal note heading"
-            class="input input-bordered w-full font-black uppercase tracking-wider"
+            class="kr-text-eyebrow input input-bordered w-full tracking-wider"
           />
           <h2
             v-else
-            class="text-base font-black uppercase tracking-wider text-base-content"
+            class="kr-text-eyebrow text-base tracking-wider text-base-content"
           >
             {{ draft.personalNoteHeading }}
           </h2>
@@ -195,11 +195,11 @@
             v-if="editing"
             v-model="draft.aiNoteHeading"
             aria-label="AI disclosure heading"
-            class="input input-bordered w-full font-black uppercase tracking-wider"
+            class="kr-text-eyebrow input input-bordered w-full tracking-wider"
           />
           <h2
             v-else
-            class="text-base font-black uppercase tracking-wider text-base-content"
+            class="kr-text-eyebrow text-base tracking-wider text-base-content"
           >
             {{ draft.aiNoteHeading }}
           </h2>

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -120,7 +120,7 @@
             class="flex items-start gap-2"
           >
             <span
-              class="mt-0.5 rounded-full px-2 py-0.5 text-[0.65rem] font-black uppercase"
+              class="kr-text-eyebrow mt-0.5 rounded-full px-2 py-0.5 text-[0.65rem]"
               :class="roleClass(message.role)"
             >
               {{ message.role }}

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -37,7 +37,7 @@
         <header class="taskmaster-hero relative flex min-h-64 items-start p-4 sm:min-h-72 sm:p-6 lg:min-h-80 lg:p-8">
           <div class="taskmaster-hero-copy max-w-2xl">
             <span
-              class="inline-flex items-center gap-2 rounded-full border border-secondary/30 bg-base-100/80 px-3 py-1.5 text-[0.68rem] font-black uppercase tracking-[0.16em] text-secondary shadow-sm backdrop-blur"
+              class="kr-text-eyebrow inline-flex items-center gap-2 rounded-full border border-secondary/30 bg-base-100/80 px-3 py-1.5 text-[0.68rem] tracking-[0.16em] text-secondary shadow-sm backdrop-blur"
             >
               <Icon name="kind-icon:gearhammer" class="size-4" />
               The Quest Desk
@@ -80,7 +80,7 @@
               </span>
               <div class="min-w-0">
                 <p
-                  class="text-[0.65rem] font-black uppercase tracking-[0.14em] text-secondary"
+                  class="kr-text-eyebrow text-[0.65rem] tracking-[0.14em] text-secondary"
                 >
                   Your guide
                 </p>
@@ -113,7 +113,7 @@
               </span>
               <div class="min-w-0 flex-1">
                 <p
-                  class="text-[0.68rem] font-black uppercase tracking-[0.15em] text-info"
+                  class="kr-text-eyebrow text-[0.68rem] tracking-[0.15em] text-info"
                 >
                   Your objective
                 </p>
@@ -138,7 +138,7 @@
             <label class="form-control w-full">
               <div class="label py-1">
                 <span
-                  class="label-text text-[0.68rem] font-black uppercase tracking-[0.12em] text-base-content/55"
+                  class="kr-text-eyebrow label-text text-[0.68rem] tracking-[0.12em] text-base-content/55"
                 >
                   Project or task source
                   <span class="font-normal normal-case tracking-normal">(optional)</span>
@@ -185,7 +185,7 @@
               </span>
               <div class="min-w-0 flex-1">
                 <p
-                  class="text-[0.68rem] font-black uppercase tracking-[0.15em] text-secondary"
+                  class="kr-text-eyebrow text-[0.68rem] tracking-[0.15em] text-secondary"
                 >
                   Quest recipe
                 </p>
@@ -216,7 +216,7 @@
               <div class="taskmaster-recipe-body space-y-4 pt-4 md:pt-0">
                 <div class="space-y-2">
                   <p
-                    class="text-[0.68rem] font-black uppercase tracking-[0.12em] text-base-content/55"
+                    class="kr-text-eyebrow text-[0.68rem] tracking-[0.12em] text-base-content/55"
                   >
                     Tone
                   </p>
@@ -244,7 +244,7 @@
                     </span>
                     <span class="min-w-0 flex-1">
                       <span
-                        class="block text-[0.65rem] font-black uppercase tracking-[0.12em] text-base-content/45"
+                        class="kr-text-eyebrow block text-[0.65rem] tracking-[0.12em] text-base-content/45"
                       >
                         Setting
                       </span>
@@ -288,7 +288,7 @@
                     </span>
                     <span class="min-w-0 flex-1">
                       <span
-                        class="block text-[0.65rem] font-black uppercase tracking-[0.12em] text-base-content/45"
+                        class="kr-text-eyebrow block text-[0.65rem] tracking-[0.12em] text-base-content/45"
                       >
                         Genre, mood, and style
                       </span>
@@ -322,7 +322,7 @@
                 <label class="form-control w-full">
                   <div class="label py-1">
                     <span
-                      class="label-text text-[0.68rem] font-black uppercase tracking-[0.12em] text-base-content/55"
+                      class="kr-text-eyebrow label-text text-[0.68rem] tracking-[0.12em] text-base-content/55"
                     >
                       Extra flavor
                       <span class="font-normal normal-case tracking-normal">(optional)</span>
@@ -356,7 +356,7 @@
                 </span>
                 <div>
                   <p
-                    class="text-[0.65rem] font-black uppercase tracking-[0.13em] text-secondary"
+                    class="kr-text-eyebrow text-[0.65rem] tracking-[0.13em] text-secondary"
                   >
                     Serendipity says
                   </p>
@@ -418,7 +418,7 @@
           <div class="flex flex-wrap items-start justify-between gap-3">
             <div class="max-w-2xl">
               <p
-                class="text-[0.68rem] font-black uppercase tracking-[0.16em] text-secondary"
+                class="kr-text-eyebrow text-[0.68rem] tracking-[0.16em] text-secondary"
               >
                 Quest briefing
               </p>
@@ -452,7 +452,7 @@
             <div class="flex flex-wrap items-start justify-between gap-3">
               <div>
                 <p
-                  class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-secondary"
+                  class="kr-text-eyebrow text-[0.68rem] tracking-[0.14em] text-secondary"
                 >
                   Practical route
                 </p>
@@ -510,7 +510,7 @@
                 </span>
                 <div>
                   <p
-                    class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-info"
+                    class="kr-text-eyebrow text-[0.68rem] tracking-[0.14em] text-info"
                   >
                     Quest briefing
                   </p>
@@ -570,7 +570,7 @@
                 </span>
                 <div>
                   <p
-                    class="text-[0.65rem] font-black uppercase tracking-[0.14em] text-secondary"
+                    class="kr-text-eyebrow text-[0.65rem] tracking-[0.14em] text-secondary"
                   >
                     Serendipity's handrail
                   </p>
@@ -610,7 +610,7 @@
           </span>
           <div class="min-w-0 flex-1">
             <p
-              class="text-[0.65rem] font-black uppercase tracking-[0.14em] text-info"
+              class="kr-text-eyebrow text-[0.65rem] tracking-[0.14em] text-info"
             >
               Current quest
             </p>
@@ -695,7 +695,7 @@
                   <div class="flex items-center gap-2">
                     <Icon name="kind-icon:gearhammer" class="size-4 text-warning" />
                     <h3
-                      class="text-xs font-black uppercase tracking-wide text-warning"
+                      class="kr-text-eyebrow text-xs tracking-wide text-warning"
                     >
                       Quest ledger
                     </h3>
@@ -748,7 +748,7 @@
             >
               <div>
                 <p
-                  class="text-[0.7rem] font-black uppercase tracking-wide text-info"
+                  class="kr-text-eyebrow text-[0.7rem] tracking-wide text-info"
                 >
                   What happened in the real world?
                 </p>
@@ -791,7 +791,7 @@
               class="taskmaster-panel border border-info/30 p-3"
             >
               <p
-                class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-info"
+                class="kr-text-eyebrow text-[0.68rem] tracking-[0.14em] text-info"
               >
                 Real objective
               </p>
@@ -807,7 +807,7 @@
               <div class="flex flex-wrap items-center justify-between gap-2">
                 <div>
                   <p
-                    class="text-[0.68rem] font-black uppercase tracking-[0.14em] text-secondary"
+                    class="kr-text-eyebrow text-[0.68rem] tracking-[0.14em] text-secondary"
                   >
                     Practical checkpoint plan
                   </p>
@@ -824,7 +824,7 @@
               </div>
               <details class="mt-3">
                 <summary
-                  class="cursor-pointer text-[0.68rem] font-black uppercase tracking-wide text-secondary/75"
+                  class="kr-text-eyebrow cursor-pointer text-[0.68rem] tracking-wide text-secondary/75"
                 >
                   Full checkpoint plan
                 </summary>

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -484,15 +484,15 @@ onMounted(async () => {
           <template #details>
             <dl class="grid grid-cols-2 gap-2 text-xs">
               <div v-if="infoResourceTrigger" class="col-span-2">
-                <dt class="font-black uppercase opacity-55">Trigger</dt>
+                <dt class="kr-text-eyebrow opacity-55">Trigger</dt>
                 <dd class="break-words font-mono">{{ infoResourceTrigger }}</dd>
               </div>
               <div v-if="infoResource.supportedServer">
-                <dt class="font-black uppercase opacity-55">Server</dt>
+                <dt class="kr-text-eyebrow opacity-55">Server</dt>
                 <dd>{{ infoResource.supportedServer }}</dd>
               </div>
               <div v-if="infoResource.localPath" class="col-span-2">
-                <dt class="font-black uppercase opacity-55">Path</dt>
+                <dt class="kr-text-eyebrow opacity-55">Path</dt>
                 <dd class="break-all font-mono">
                   {{ infoResource.localPath }}
                 </dd>

--- a/components/reviews/review-list.vue
+++ b/components/reviews/review-list.vue
@@ -17,7 +17,7 @@
 <template>
   <section class="grid gap-3">
     <header v-if="showHeader" class="flex flex-wrap items-baseline justify-between gap-2">
-      <p class="kr-text-dim-xs-45 font-black uppercase tracking-widest">
+      <p class="kr-text-eyebrow kr-text-dim-xs-45 tracking-widest">
         {{ headingLabel }}
       </p>
       <span v-if="averageRating" class="kr-text-black-sm text-warning">

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -119,15 +119,15 @@
           <template #details>
             <dl class="grid grid-cols-2 gap-2 text-xs">
               <div v-if="infoReward.effect" class="col-span-2">
-                <dt class="font-black uppercase opacity-55">Effect</dt>
+                <dt class="kr-text-eyebrow opacity-55">Effect</dt>
                 <dd class="whitespace-pre-wrap">{{ infoReward.effect }}</dd>
               </div>
               <div v-if="infoReward.rarity">
-                <dt class="font-black uppercase opacity-55">Rarity</dt>
+                <dt class="kr-text-eyebrow opacity-55">Rarity</dt>
                 <dd>{{ infoReward.rarity }}</dd>
               </div>
               <div v-if="infoReward.rewardType">
-                <dt class="font-black uppercase opacity-55">Type</dt>
+                <dt class="kr-text-eyebrow opacity-55">Type</dt>
                 <dd>{{ infoReward.rewardType }}</dd>
               </div>
             </dl>

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -88,19 +88,19 @@
           <template #details>
             <dl class="grid grid-cols-2 gap-2 text-xs">
               <div v-if="infoScenario.locations" class="col-span-2">
-                <dt class="font-black uppercase opacity-55">Locations</dt>
+                <dt class="kr-text-eyebrow opacity-55">Locations</dt>
                 <dd class="whitespace-pre-wrap">
                   {{ infoScenario.locations }}
                 </dd>
               </div>
               <div v-if="infoScenario.inspirations" class="col-span-2">
-                <dt class="font-black uppercase opacity-55">Inspirations</dt>
+                <dt class="kr-text-eyebrow opacity-55">Inspirations</dt>
                 <dd class="whitespace-pre-wrap">
                   {{ infoScenario.inspirations }}
                 </dd>
               </div>
               <div v-if="infoScenario.genres">
-                <dt class="font-black uppercase opacity-55">Genres</dt>
+                <dt class="kr-text-eyebrow opacity-55">Genres</dt>
                 <dd>{{ infoScenario.genres }}</dd>
               </div>
             </dl>

--- a/components/scenarios/scenario-story.vue
+++ b/components/scenarios/scenario-story.vue
@@ -278,7 +278,7 @@
           <div class="flex items-start justify-between gap-3">
             <div class="min-w-0">
               <p
-                class="text-smart-caption font-black uppercase tracking-widest text-secondary"
+                class="kr-text-eyebrow text-smart-caption tracking-widest text-secondary"
               >
                 Selected action
               </p>

--- a/components/servers/add-server.vue
+++ b/components/servers/add-server.vue
@@ -126,9 +126,7 @@
       </section>
 
       <section class="kr-panel-muted-md">
-        <h3 class="kr-text-dim-sm mb-3 font-black uppercase tracking-wide">
-          Auth
-        </h3>
+        <h3 class="kr-text-eyebrow kr-text-dim-sm mb-3 tracking-wide">Auth</h3>
 
         <div class="grid gap-3 md:grid-cols-2">
           <label class="form-control">
@@ -191,7 +189,7 @@
       </section>
 
       <section class="kr-panel-muted-md">
-        <h3 class="kr-text-dim-sm mb-3 font-black uppercase tracking-wide">
+        <h3 class="kr-text-eyebrow kr-text-dim-sm mb-3 tracking-wide">
           Visibility
         </h3>
 

--- a/components/servers/server-status.vue
+++ b/components/servers/server-status.vue
@@ -37,22 +37,22 @@
 
       <div v-if="activeServer" class="grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-4">
         <div class="rounded-xl bg-base-200 p-3">
-          <p class="kr-text-dim-xs font-black uppercase">Type</p>
+          <p class="kr-text-eyebrow kr-text-dim-xs">Type</p>
           <p class="font-bold">{{ activeServer.serverType }}</p>
         </div>
 
         <div class="rounded-xl bg-base-200 p-3">
-          <p class="kr-text-dim-xs font-black uppercase">Access</p>
+          <p class="kr-text-eyebrow kr-text-dim-xs">Access</p>
           <p class="font-bold">{{ activeServer.accessMode }}</p>
         </div>
 
         <div class="rounded-xl bg-base-200 p-3">
-          <p class="kr-text-dim-xs font-black uppercase">Health</p>
+          <p class="kr-text-eyebrow kr-text-dim-xs">Health</p>
           <p class="font-bold">{{ activeServer.lastStatus || 'UNKNOWN' }}</p>
         </div>
 
         <div class="rounded-xl bg-base-200 p-3">
-          <p class="kr-text-dim-xs font-black uppercase">Model</p>
+          <p class="kr-text-eyebrow kr-text-dim-xs">Model</p>
           <p class="truncate font-bold">{{ checkpointStore.currentApiModel || activeServer.model || 'n/a' }}</p>
         </div>
       </div>

--- a/components/storybook/storybook-visual-setup.vue
+++ b/components/storybook/storybook-visual-setup.vue
@@ -17,7 +17,7 @@
     <div class="relative space-y-7 p-4 sm:p-6 lg:p-8">
       <header class="mx-auto max-w-5xl text-center">
         <p
-          class="text-xs font-black uppercase tracking-[0.28em] text-primary/75"
+          class="kr-text-eyebrow text-xs tracking-[0.28em] text-primary/75"
         >
           Storybook
         </p>
@@ -58,7 +58,7 @@
           >
             <label class="form-control">
               <span
-                class="mb-1 text-[0.68rem] font-black uppercase tracking-wider text-base-content/50"
+                class="kr-text-eyebrow mb-1 text-[0.68rem] tracking-wider text-base-content/50"
               >
                 Working title
               </span>
@@ -72,7 +72,7 @@
 
             <label class="form-control">
               <span
-                class="mb-1 text-[0.68rem] font-black uppercase tracking-wider text-base-content/50"
+                class="kr-text-eyebrow mb-1 text-[0.68rem] tracking-wider text-base-content/50"
               >
                 Premise
               </span>
@@ -90,7 +90,7 @@
           class="rounded-[1.75rem] border border-secondary/20 bg-base-100/90 p-4 shadow-lg backdrop-blur sm:p-5"
         >
           <p
-            class="text-[0.68rem] font-black uppercase tracking-[0.2em] text-secondary/75"
+            class="kr-text-eyebrow text-[0.68rem] tracking-[0.2em] text-secondary/75"
           >
             Your spread
           </p>
@@ -146,7 +146,7 @@
       <section class="mx-auto max-w-7xl space-y-3">
         <div>
           <p
-            class="text-[0.68rem] font-black uppercase tracking-[0.2em] text-base-content/45"
+            class="kr-text-eyebrow text-[0.68rem] tracking-[0.2em] text-base-content/45"
           >
             How it feels
           </p>
@@ -198,7 +198,7 @@
       <section class="mx-auto max-w-7xl space-y-3">
         <div>
           <p
-            class="text-[0.68rem] font-black uppercase tracking-[0.2em] text-base-content/45"
+            class="kr-text-eyebrow text-[0.68rem] tracking-[0.2em] text-base-content/45"
           >
             How it unfolds
           </p>

--- a/components/taskmaster/taskmaster-sample-tasks.vue
+++ b/components/taskmaster/taskmaster-sample-tasks.vue
@@ -8,7 +8,7 @@
     <div class="flex flex-wrap items-start justify-between gap-2">
       <div class="min-w-0">
         <p
-          class="text-[0.68rem] font-black uppercase tracking-[0.15em] text-accent"
+          class="kr-text-eyebrow text-[0.68rem] tracking-[0.15em] text-accent"
         >
           Serendipity's sparks
         </p>
@@ -71,7 +71,7 @@
           </span>
           <span
             v-if="sample.id === 'conductor-gates' && gateProject"
-            class="mt-auto block text-[0.65rem] font-black uppercase tracking-wide text-warning"
+            class="kr-text-eyebrow mt-auto block text-[0.65rem] tracking-wide text-warning"
           >
             Starts with {{ gateProject.name }}
           </span>

--- a/components/themes/theme-gallery.vue
+++ b/components/themes/theme-gallery.vue
@@ -108,7 +108,7 @@
           -->
           <h2
             v-if="showBothGroups"
-            class="kr-text-dim-xs-55 mb-2 truncate font-black uppercase tracking-wide"
+            class="kr-text-eyebrow kr-text-dim-xs-55 mb-2 truncate tracking-wide"
           >
             Default
           </h2>
@@ -201,7 +201,7 @@
           <!-- Same separator rule as Default above. -->
           <h2
             v-if="showBothGroups"
-            class="kr-text-dim-xs-55 mb-2 truncate font-black uppercase tracking-wide"
+            class="kr-text-eyebrow kr-text-dim-xs-55 mb-2 truncate tracking-wide"
           >
             Shared
           </h2>

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -137,7 +137,7 @@
       @submit.prevent="createCredential"
     >
       <div class="flex items-center justify-between gap-3">
-        <p class="kr-text-dim-xs font-black uppercase tracking-widest">
+        <p class="kr-text-eyebrow kr-text-dim-xs tracking-widest">
           {{ replacingCredentialId ? 'Replacement credential' : 'New credential' }}
         </p>
         <button

--- a/components/user/first-launch-intro.vue
+++ b/components/user/first-launch-intro.vue
@@ -12,7 +12,7 @@
         class="flex shrink-0 items-start justify-between gap-3 border-b border-base-300 bg-base-100 p-4"
       >
         <div class="min-w-0">
-          <p class="text-xs font-black uppercase tracking-widest text-primary">
+          <p class="kr-text-eyebrow text-xs tracking-widest text-primary">
             {{ step + 1 }} / {{ steps.length }}
           </p>
           <h2 class="kr-text-black-lg mt-0.5 truncate sm:text-xl">

--- a/components/user/login-page.vue
+++ b/components/user/login-page.vue
@@ -194,7 +194,7 @@
         <div v-if="!returnTarget" class="my-5 flex items-center gap-3">
           <span class="h-px flex-1 bg-base-content/15" />
           <span
-            class="kr-text-dim-xs-45 rounded-full border border-base-content/10 bg-base-100/80 px-3 py-1 font-black uppercase tracking-widest"
+            class="kr-text-eyebrow kr-text-dim-xs-45 rounded-full border border-base-content/10 bg-base-100/80 px-3 py-1 tracking-widest"
           >
             or
           </span>

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -226,9 +226,7 @@
               </div>
 
               <div v-if="earnedAchievements.length" class="kr-panel-flat p-3">
-                <p
-                  class="kr-text-dim-xs mb-2 font-black uppercase tracking-widest"
-                >
+                <p class="kr-text-eyebrow kr-text-dim-xs mb-2 tracking-widest">
                   Recent achievements
                 </p>
 

--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -89,9 +89,7 @@
     <!-- Review editor -->
     <div class="flex flex-col gap-2">
       <div class="flex items-center justify-between">
-        <h3 class="kr-text-dim-xs-60 font-black uppercase tracking-wide">
-          Review
-        </h3>
+        <h3 class="kr-text-eyebrow kr-text-dim-xs-60 tracking-wide">Review</h3>
         <span
           v-if="entry.reviewPublic"
           class="badge badge-success badge-sm gap-1 rounded-lg"
@@ -141,7 +139,7 @@
 
     <!-- Related entries -->
     <div class="flex flex-col gap-1">
-      <h3 class="kr-text-dim-xs-60 font-black uppercase tracking-wide">
+      <h3 class="kr-text-eyebrow kr-text-dim-xs-60 tracking-wide">
         Related entries
       </h3>
       <p v-if="isLoadingRelated" class="kr-text-dim-xs-45">Loading…</p>
@@ -167,7 +165,7 @@
 
     <!-- External links -->
     <div v-if="entry.externalUrl" class="flex flex-col gap-1">
-      <h3 class="kr-text-dim-xs-60 font-black uppercase tracking-wide">
+      <h3 class="kr-text-eyebrow kr-text-dim-xs-60 tracking-wide">
         External links
       </h3>
       <a

--- a/pages/admin/achievement-art.vue
+++ b/pages/admin/achievement-art.vue
@@ -5,7 +5,7 @@
         class="kr-toolbar flex flex-wrap items-start justify-between gap-4"
       >
         <div>
-          <p class="text-xs font-black uppercase tracking-widest text-primary">
+          <p class="kr-text-eyebrow text-xs tracking-widest text-primary">
             Achievement administration
           </p>
           <p class="mt-1 text-2xl font-black">Achievement artwork</p>
@@ -120,7 +120,7 @@
                 <div>
                   <p
                     v-if="selectedAchievement.triggerCode"
-                    class="text-xs font-black uppercase tracking-wide text-primary"
+                    class="kr-text-eyebrow text-xs tracking-wide text-primary"
                   >
                     {{ selectedAchievement.triggerCode }}
                   </p>

--- a/pages/admin/forum-moderation.vue
+++ b/pages/admin/forum-moderation.vue
@@ -5,7 +5,7 @@
         class="kr-toolbar flex flex-wrap items-start justify-between gap-4"
       >
         <div>
-          <p class="text-xs font-black uppercase tracking-widest text-primary">
+          <p class="kr-text-eyebrow text-xs tracking-widest text-primary">
             Forum moderation
           </p>
           <p class="mt-1 text-2xl font-black">Health-claim escalation queue</p>

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -5,7 +5,7 @@
         class="kr-toolbar flex flex-wrap items-start justify-between gap-4"
       >
         <div>
-          <p class="text-xs font-black uppercase tracking-widest text-primary">
+          <p class="kr-text-eyebrow text-xs tracking-widest text-primary">
             Temporary catalog cleanup
           </p>
           <div class="mt-1 text-2xl font-black">LoRA maturity triage</div>
@@ -63,27 +63,25 @@
       <template v-else>
         <section class="grid grid-cols-2 gap-2 sm:grid-cols-4">
           <div class="kr-panel p-3">
-            <p class="kr-text-dim-xs-45 font-black uppercase">LoRAs</p>
+            <p class="kr-text-eyebrow kr-text-dim-xs-45">LoRAs</p>
             <p class="mt-1 text-2xl font-black">
               {{ triageStore.loras.length }}
             </p>
           </div>
           <div class="kr-panel p-3">
-            <p class="kr-text-dim-xs-45 font-black uppercase">Confirmed</p>
+            <p class="kr-text-eyebrow kr-text-dim-xs-45">Confirmed</p>
             <p class="mt-1 text-2xl font-black text-success">
               {{ triageStore.confirmedCount }}
             </p>
           </div>
           <div class="kr-panel p-3">
-            <p class="kr-text-dim-xs-45 font-black uppercase">Remaining</p>
+            <p class="kr-text-eyebrow kr-text-dim-xs-45">Remaining</p>
             <p class="mt-1 text-2xl font-black">
               {{ triageStore.remainingCount }}
             </p>
           </div>
           <div class="kr-panel p-3">
-            <p class="kr-text-dim-xs-45 font-black uppercase">
-              Unsaved changes
-            </p>
+            <p class="kr-text-eyebrow kr-text-dim-xs-45">Unsaved changes</p>
             <p class="mt-1 text-2xl font-black text-warning">
               {{ triageStore.pendingChanges.length }}
             </p>

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -3,7 +3,7 @@
     <div class="kr-scroll kr-container-wide space-y-5 p-4 md:p-6">
       <header class="kr-toolbar flex flex-wrap items-start justify-between gap-4">
         <div class="max-w-3xl">
-          <p class="text-xs font-black uppercase tracking-widest text-primary">
+          <p class="kr-text-eyebrow text-xs tracking-widest text-primary">
             Admin production
           </p>
           <p class="mt-1 text-3xl font-black">Scene Animator</p>
@@ -45,7 +45,7 @@
         <section class="grid gap-4 xl:grid-cols-[minmax(270px,0.34fr)_minmax(0,1fr)]">
           <aside class="kr-panel space-y-4 p-4 md:p-5">
             <div>
-              <p class="text-xs font-black uppercase tracking-wider text-primary">Batch setup</p>
+              <p class="kr-text-eyebrow text-xs tracking-wider text-primary">Batch setup</p>
               <h2 class="kr-text-black-xl mt-1">Choose the source, then motion</h2>
             </div>
 

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -5,7 +5,7 @@
         class="kr-toolbar flex flex-wrap items-start justify-between gap-4"
       >
         <div>
-          <p class="text-xs font-black uppercase tracking-widest text-primary">
+          <p class="kr-text-eyebrow text-xs tracking-widest text-primary">
             AMI social pipeline administration
           </p>
           <p class="mt-1 text-2xl font-black">Social post review queue</p>

--- a/pages/email-confirmation.vue
+++ b/pages/email-confirmation.vue
@@ -21,7 +21,7 @@
 
           <div class="flex flex-col gap-2">
             <p
-              class="kr-text-dim-xs font-black uppercase tracking-[0.2em]"
+              class="kr-text-eyebrow kr-text-dim-xs tracking-[0.2em]"
             >
               Email confirmation
             </p>

--- a/pages/play/aquarium/browse/[username]/[slug].vue
+++ b/pages/play/aquarium/browse/[username]/[slug].vue
@@ -66,7 +66,7 @@
             </div>
             <div class="min-w-0">
               <p
-                class="text-xs font-black uppercase tracking-widest text-primary"
+                class="kr-text-eyebrow text-xs tracking-widest text-primary"
               >
                 @{{ tank.User.username }}'s tank
               </p>

--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -17,12 +17,10 @@
       </nav>
 
       <header class="kr-panel-flat rounded-3xl p-5 shadow-lg sm:p-7">
-        <p class="text-xs font-black uppercase tracking-[0.25em] text-primary">
+        <p class="kr-text-eyebrow text-xs tracking-[0.25em] text-primary">
           Cthulhuquarium
         </p>
-        <h2 class="mt-1 text-3xl font-black uppercase sm:text-4xl">
-          Public tanks
-        </h2>
+        <h2 class="kr-text-eyebrow mt-1 text-3xl sm:text-4xl">Public tanks</h2>
         <p class="mt-2 max-w-2xl text-sm text-base-content/65">
           Every owner viewable, per the pitch. Read-only -- no feeding, no
           clicking, no writes from a visitor session.
@@ -58,7 +56,7 @@
         class="kr-panel-flat border-dashed rounded-3xl px-6 py-16 text-center"
       >
         <Icon name="kind-icon:fish" class="mx-auto size-12 text-primary/40" />
-        <h2 class="mt-4 text-2xl font-black uppercase">Nothing public yet</h2>
+        <h2 class="kr-text-eyebrow mt-4 text-2xl">Nothing public yet</h2>
         <p class="kr-text-dim-sm mx-auto mt-2 max-w-xl">
           No owner has made their tank public. Yours defaults to public -- check
           the toggle at the bottom of your own tank.

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -18,12 +18,10 @@
       </nav>
 
       <header class="kr-panel-section-plain shadow-lg sm:p-7">
-        <p class="text-xs font-black uppercase tracking-[0.25em] text-primary">
+        <p class="kr-text-eyebrow text-xs tracking-[0.25em] text-primary">
           Cthulhuquarium
         </p>
-        <h2 class="mt-1 text-3xl font-black uppercase sm:text-4xl">
-          Leaderboard
-        </h2>
+        <h2 class="kr-text-eyebrow mt-1 text-3xl sm:text-4xl">Leaderboard</h2>
         <p class="mt-2 max-w-2xl text-sm text-base-content/65">
           Ranked by species collected. Coins aren't scored here.
         </p>
@@ -58,7 +56,7 @@
         class="kr-panel-flat border-dashed rounded-3xl px-6 py-16 text-center"
       >
         <Icon name="kind-icon:fish" class="mx-auto size-12 text-primary/40" />
-        <h2 class="mt-4 text-2xl font-black uppercase">No ranks yet</h2>
+        <h2 class="kr-text-eyebrow mt-4 text-2xl">No ranks yet</h2>
         <p class="kr-text-dim-sm mx-auto mt-2 max-w-xl">
           Nobody with a public tank has collected a species yet.
         </p>

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -75,12 +75,12 @@
               </div>
 
               <p
-                class="mt-5 text-xs font-black uppercase tracking-[0.3em] text-primary"
+                class="kr-text-eyebrow mt-5 text-xs tracking-[0.3em] text-primary"
               >
                 Championship matchup
               </p>
               <p
-                class="mt-2 max-w-4xl text-3xl font-black uppercase leading-none sm:text-5xl"
+                class="kr-text-eyebrow mt-2 max-w-4xl text-3xl leading-none sm:text-5xl"
               >
                 {{ challenge.title }}
               </p>
@@ -95,7 +95,7 @@
                 class="mt-5 max-w-4xl rounded-2xl border border-secondary/25 bg-secondary/10 p-4"
               >
                 <p
-                  class="text-[0.65rem] font-black uppercase tracking-[0.22em] text-secondary"
+                  class="kr-text-eyebrow text-[0.65rem] tracking-[0.22em] text-secondary"
                 >
                   Judges' brief
                 </p>
@@ -109,7 +109,7 @@
               class="grid min-w-40 place-items-center rounded-3xl border border-primary/20 bg-base-100/75 p-5 text-center shadow-lg backdrop-blur"
             >
               <span
-                class="kr-text-dim-xs-45 font-black uppercase tracking-[0.2em]"
+                class="kr-text-eyebrow kr-text-dim-xs-45 tracking-[0.2em]"
               >
                 Difficulty
               </span>
@@ -225,7 +225,7 @@
                     {{ signedScore(submission.score.netScore) }}
                   </p>
                   <p
-                    class="text-[0.65rem] font-black uppercase tracking-wider text-base-content/40"
+                    class="kr-text-eyebrow text-[0.65rem] tracking-wider text-base-content/40"
                   >
                     {{ submission.score.votes }} votes
                   </p>
@@ -247,7 +247,7 @@
                   class="rounded-2xl border border-primary/20 bg-primary/5 p-5"
                 >
                   <p
-                    class="text-xs font-black uppercase tracking-[0.2em] text-primary"
+                    class="kr-text-eyebrow text-xs tracking-[0.2em] text-primary"
                   >
                     Character entry
                   </p>
@@ -266,7 +266,7 @@
                   class="rounded-2xl border border-secondary/20 bg-secondary/5 p-5"
                 >
                   <p
-                    class="text-xs font-black uppercase tracking-[0.2em] text-secondary"
+                    class="kr-text-eyebrow text-xs tracking-[0.2em] text-secondary"
                   >
                     Scenario entry
                   </p>
@@ -318,7 +318,7 @@
                   class="collapse collapse-arrow kr-panel-flat mt-4"
                 >
                   <summary
-                    class="collapse-title min-h-0 py-3 text-xs font-black uppercase tracking-wider"
+                    class="kr-text-eyebrow collapse-title min-h-0 py-3 text-xs tracking-wider"
                   >
                     Exact prompt used
                   </summary>
@@ -334,7 +334,7 @@
                   class="collapse collapse-arrow kr-panel-flat mt-3"
                 >
                   <summary
-                    class="collapse-title min-h-0 py-3 text-xs font-black uppercase tracking-wider"
+                    class="kr-text-eyebrow collapse-title min-h-0 py-3 text-xs tracking-wider"
                   >
                     Random rolls used
                   </summary>
@@ -372,7 +372,7 @@
 
                 <div>
                   <p
-                    class="mb-2 text-[0.65rem] font-black uppercase tracking-[0.2em] text-base-content/45"
+                    class="kr-text-eyebrow mb-2 text-[0.65rem] tracking-[0.2em] text-base-content/45"
                   >
                     Cast or change your vote
                   </p>
@@ -419,7 +419,7 @@
             name="kind-icon:trophy"
             class="mx-auto size-12 text-primary/40"
           />
-          <h2 class="mt-4 text-2xl font-black uppercase">
+          <h2 class="kr-text-eyebrow mt-4 text-2xl">
             Waiting for contenders
           </h2>
           <p class="kr-text-dim-sm mx-auto mt-2 max-w-xl">
@@ -435,11 +435,11 @@
           <div class="flex flex-wrap items-end justify-between gap-3">
             <div>
               <p
-                class="text-xs font-black uppercase tracking-[0.25em] text-primary"
+                class="kr-text-eyebrow text-xs tracking-[0.25em] text-primary"
               >
                 Live scorecard
               </p>
-              <h2 class="mt-1 text-2xl font-black uppercase">
+              <h2 class="kr-text-eyebrow mt-1 text-2xl">
                 Challenge rankings
               </h2>
             </div>

--- a/pages/play/challenges/leaderboard.vue
+++ b/pages/play/challenges/leaderboard.vue
@@ -33,14 +33,10 @@
           class="relative grid gap-6 lg:grid-cols-[1fr_auto] lg:items-center"
         >
           <div>
-            <p
-              class="text-xs font-black uppercase tracking-[0.3em] text-warning"
-            >
+            <p class="kr-text-eyebrow text-xs tracking-[0.3em] text-warning">
               Championship standings
             </p>
-            <p
-              class="mt-2 text-4xl font-black uppercase leading-none sm:text-6xl"
-            >
+            <p class="kr-text-eyebrow mt-2 text-4xl leading-none sm:text-6xl">
               Hall of contenders
             </p>
             <p class="mt-4 max-w-3xl text-base text-base-content/70">
@@ -56,7 +52,7 @@
                 name="kind-icon:trophy"
                 class="mx-auto size-10 text-warning"
               />
-              <p class="mt-1 text-xs font-black uppercase tracking-widest">
+              <p class="kr-text-eyebrow mt-1 text-xs tracking-widest">
                 Champion
               </p>
             </div>
@@ -68,7 +64,7 @@
         <div class="flex flex-wrap items-end justify-between gap-4">
           <fieldset>
             <legend
-              class="mb-2 text-[0.65rem] font-black uppercase tracking-[0.22em] text-base-content/45"
+              class="kr-text-eyebrow mb-2 text-[0.65rem] tracking-[0.22em] text-base-content/45"
             >
               Weight class
             </legend>
@@ -101,7 +97,7 @@
         <div class="mt-4 border-t border-base-300 pt-4">
           <fieldset>
             <legend
-              class="mb-2 text-[0.65rem] font-black uppercase tracking-[0.22em] text-base-content/45"
+              class="kr-text-eyebrow mb-2 text-[0.65rem] tracking-[0.22em] text-base-content/45"
             >
               Comparison axis
             </legend>
@@ -178,7 +174,7 @@
             >
               {{ signedScore(entry.score.netScore) }}
             </p>
-            <p class="kr-text-dim-xs-40 font-black uppercase tracking-widest">
+            <p class="kr-text-eyebrow kr-text-dim-xs-40 tracking-widest">
               total score
             </p>
             <div class="mt-5 grid grid-cols-3 gap-2 text-sm">

--- a/pages/users/[id].vue
+++ b/pages/users/[id].vue
@@ -36,9 +36,7 @@
 
           <div class="mt-4 flex flex-wrap items-start justify-between gap-3">
             <div class="min-w-0">
-              <p
-                class="text-xs font-black uppercase tracking-widest text-primary"
-              >
+              <p class="kr-text-eyebrow text-xs tracking-widest text-primary">
                 Public Kind Robots profile
               </p>
               <p class="mt-1 break-words text-3xl font-black">

--- a/utils/scripts/codemods/kr_text_eyebrow_codemod.py
+++ b/utils/scripts/codemods/kr_text_eyebrow_codemod.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `font-black uppercase` eyebrow/label text to
+`kr-text-eyebrow`.
+
+First of a new `kr-text-eyebrow-*`-in-spirit family (interface-vision t-104
+slice 167): dry-run by default, --write to update matching Vue files in
+place. A fresh full-repo class-frequency survey once the `kr-text-black-*`
+and `kr-text-dim-*` families both closed out found `font-black uppercase`
+at 257 subset-match occurrences across 94 files -- the largest bounded
+pattern surfaced, larger than any single `kr-text-black-*`/`kr-text-dim-*`
+sibling. `tracking-wide` frequently rides along (56 of the 257) but is
+preserved as an extra token rather than folded into the base set, matching
+how prior families left genuinely optional companions as caller-supplied
+tokens. Only the exact `font-black uppercase` shape is touched, and only in
+static `class="..."` attributes -- never `:class`/`v-bind:class` bindings,
+regardless of the base tokens' order in the source. A source that already
+carries `kr-text-eyebrow`, or is missing either base token, is left
+untouched. Extra tokens beyond the base set are preserved verbatim after
+the primitive class, matching the kr-badge-*/kr-spinner-*/kr-label-bold/
+kr-text-dim-*/kr-text-black-* codemods' subset-match convention -- pass
+--exact-only to restrict a slice to sources with no extra tokens at all,
+the safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-eyebrow"
+BASE_TOKENS = {"font-black", "uppercase"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-eyebrow {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104 (recurring): "Drive live front-end consistency onto shared kr-* components and composition rules" — slice 167.

### What changed / what I produced
- `assets/css/tailwind.css` — added `.kr-text-eyebrow { @apply font-black uppercase; }`, first of a new eyebrow/label primitive.
- `utils/scripts/codemods/kr_text_eyebrow_codemod.py` — new codemod, same subset-match convention as `kr_text_black_*_codemod.py`/`kr_text_dim_*_codemod.py` (dry-run by default, `--write` to migrate, `--exact-only` to restrict to no-extra-tokens).
- Migrated all 257 subset-match occurrences of `font-black uppercase` across 94 files to `.kr-text-eyebrow`, extra tokens (`tracking-wide`/`tracking-widest`, sizes, colors) preserved verbatim. No geometry or behavior change.

### Why this pattern
A fresh full-repo class-frequency survey once both the `kr-text-black-*` and `kr-text-dim-*` families closed out (per slice 166's kaizen note) found `font-black uppercase` as the largest bounded pattern remaining — 257 occurrences, bigger than any single prior slice.

### How I verified
- `vue-tsc --noEmit`: clean.
- `eslint .`: 333 problems (327 errors, 6 warnings), identical before/after (`git stash` confirmed).
- `npm run test:layout-contract`: holds (same unrelated pre-existing -2 ratchet opportunity in `narrative-ingredient-multi-picker.vue`, left untouched, out of scope).
- `npm run test:lint-ratchet`: holds at 333/-59.
- `prettier --check .`: flagged 13 genuinely new fallout files (pre-existing multi-line class-attribute formatting that collapsed once the class string shortened); ran a targeted `prettier --write` on just those, confirmed the full repo-wide warning list then matched the pre-change baseline exactly (`git stash` diff, byte-for-byte).

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
`kr-text-eyebrow` intentionally left `tracking-wide`/`tracking-widest` as a caller-supplied extra token rather than folding it in, since a meaningful minority of call sites use the base pair alone. Slice 168 should run a fresh full-repo class-frequency survey outside the now-covered `kr-text-black-*`/`kr-text-dim-*`/`kr-text-eyebrow` families to find the next largest bounded hand-rolled pattern. Recorded in the roadmap task note; no separate kaizen task filed, matching the established convention for this recurring umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M11BHpX5YHMDLff78KnbJU

---
_Generated by [Claude Code](https://claude.ai/code/session_01M11BHpX5YHMDLff78KnbJU)_