### PR TITLE
refactor(ui): add kr-text-eyebrow-bold for font-bold uppercase (slice 168)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1839,6 +1839,17 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply font-black uppercase;
   }
 
+  /* Sibling of `.kr-text-eyebrow` -- same eyebrow/label-text usage
+   * (`bot-card.vue`, `bot-chat.vue`, `model-builder-item-panel.vue`, etc.)
+   * but `font-bold` instead of `font-black` (interface-vision t-104 slice
+   * 168). A fresh full-repo class-frequency survey outside the now-closed
+   * `kr-text-black-*`/`kr-text-dim-*`/`kr-text-eyebrow` families found
+   * `font-bold uppercase` at 127 subset-match occurrences across 44 files,
+   * the next largest bounded pattern surfaced. */
+  .kr-text-eyebrow-bold {
+    @apply font-bold uppercase;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -154,7 +154,9 @@
 
           <div class="mt-3 grid gap-2 text-xs">
             <div class="kr-panel-muted-compact-xs">
-              <p class="font-bold uppercase text-base-content/45">Checkpoint</p>
+              <p class="kr-text-eyebrow-bold text-base-content/45">
+                Checkpoint
+              </p>
               <p class="mt-1 break-all font-semibold">
                 {{ currentArtImage.checkpoint || 'n/a' }}
               </p>
@@ -162,13 +164,13 @@
 
             <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
               <div class="kr-panel-muted-compact-xs">
-                <p class="font-bold uppercase text-base-content/45">Sampler</p>
+                <p class="kr-text-eyebrow-bold text-base-content/45">Sampler</p>
                 <p class="mt-1 truncate font-semibold">
                   {{ currentArtImage.sampler || 'n/a' }}
                 </p>
               </div>
               <div class="kr-panel-muted-compact-xs">
-                <p class="font-bold uppercase text-base-content/45">Seed</p>
+                <p class="kr-text-eyebrow-bold text-base-content/45">Seed</p>
                 <p class="mt-1 truncate font-mono">
                   {{ currentArtImage.seed ?? 'n/a' }}
                 </p>
@@ -176,7 +178,7 @@
             </div>
 
             <div class="kr-panel-muted-compact-xs">
-              <p class="font-bold uppercase text-base-content/45">Server</p>
+              <p class="kr-text-eyebrow-bold text-base-content/45">Server</p>
               <p class="mt-1 truncate font-semibold">
                 {{ currentArtImage.serverName || 'n/a' }}
               </p>

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -749,7 +749,7 @@ onMounted(async () => {
       <aside class="flex flex-col gap-6">
         <div class="kr-panel-muted-md">
           <div
-            class="mb-3 text-sm font-bold uppercase tracking-widest opacity-60"
+            class="kr-text-eyebrow-bold mb-3 text-sm tracking-widest opacity-60"
           >
             Endpoint
           </div>
@@ -778,7 +778,7 @@ onMounted(async () => {
 
         <div class="kr-panel-muted-md">
           <div
-            class="mb-3 text-sm font-bold uppercase tracking-widest opacity-60"
+            class="kr-text-eyebrow-bold mb-3 text-sm tracking-widest opacity-60"
           >
             Art Server
           </div>
@@ -817,7 +817,7 @@ onMounted(async () => {
 
         <div class="kr-panel-muted-md">
           <div
-            class="mb-3 text-sm font-bold uppercase tracking-widest opacity-60"
+            class="kr-text-eyebrow-bold mb-3 text-sm tracking-widest opacity-60"
           >
             Parameters
           </div>
@@ -968,7 +968,7 @@ onMounted(async () => {
 
         <div class="kr-panel-muted-md">
           <div
-            class="mb-3 text-sm font-bold uppercase tracking-widest opacity-60"
+            class="kr-text-eyebrow-bold mb-3 text-sm tracking-widest opacity-60"
           >
             Debug
           </div>
@@ -1002,7 +1002,7 @@ onMounted(async () => {
           <div v-if="endpointDef.mode === 'text'" class="flex flex-col gap-6">
             <div class="flex flex-col gap-3">
               <div
-                class="text-sm font-bold uppercase tracking-widest opacity-60"
+                class="kr-text-eyebrow-bold text-sm tracking-widest opacity-60"
               >
                 Subject Animal
               </div>
@@ -1055,7 +1055,7 @@ onMounted(async () => {
           >
             <div class="flex flex-col gap-3">
               <div
-                class="text-sm font-bold uppercase tracking-widest opacity-60"
+                class="kr-text-eyebrow-bold text-sm tracking-widest opacity-60"
               >
                 Source Animal
               </div>
@@ -1124,7 +1124,7 @@ onMounted(async () => {
             <div class="grid gap-6 lg:grid-cols-2">
               <div class="flex flex-col gap-3">
                 <div
-                  class="text-sm font-bold uppercase tracking-widest opacity-60"
+                  class="kr-text-eyebrow-bold text-sm tracking-widest opacity-60"
                 >
                   Animal A
                 </div>
@@ -1150,7 +1150,7 @@ onMounted(async () => {
 
               <div class="flex flex-col gap-3">
                 <div
-                  class="text-sm font-bold uppercase tracking-widest opacity-60"
+                  class="kr-text-eyebrow-bold text-sm tracking-widest opacity-60"
                 >
                   Animal B
                 </div>

--- a/components/art/collection-card.vue
+++ b/components/art/collection-card.vue
@@ -145,23 +145,23 @@
         class="grid grid-cols-2 gap-1.5 kr-panel-compact-xs text-xs"
       >
         <div>
-          <p class="font-bold uppercase text-base-content/40">Images</p>
+          <p class="kr-text-eyebrow-bold text-base-content/40">Images</p>
           <p class="text-base-content/75">{{ imageCount }}</p>
         </div>
         <div>
-          <p class="font-bold uppercase text-base-content/40">Visibility</p>
+          <p class="kr-text-eyebrow-bold text-base-content/40">Visibility</p>
           <p class="text-base-content/75">
             {{ collection.isPublic ? 'Public' : 'Private' }}
           </p>
         </div>
         <div>
-          <p class="font-bold uppercase text-base-content/40">Mature</p>
+          <p class="kr-text-eyebrow-bold text-base-content/40">Mature</p>
           <p class="text-base-content/75">
             {{ collection.isMature ? 'Yes' : 'No' }}
           </p>
         </div>
         <div>
-          <p class="font-bold uppercase text-base-content/40">Updated</p>
+          <p class="kr-text-eyebrow-bold text-base-content/40">Updated</p>
           <p class="text-base-content/75">{{ updatedLabel }}</p>
         </div>
       </div>

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -158,7 +158,7 @@
       >
         <Icon name="kind-icon:image" class="size-3.5 text-secondary" />
         <span
-          class="kr-text-dim-xs-60 font-bold uppercase tracking-wide"
+          class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide"
         >
           Artwork &amp; inspirations
         </span>

--- a/components/bots/bot-card.vue
+++ b/components/bots/bot-card.vue
@@ -52,7 +52,7 @@
           v-if="showPersonality && bot.personality"
           class="kr-panel-flat p-3 text-sm"
         >
-          <p class="kr-text-dim-xs font-bold uppercase">
+          <p class="kr-text-eyebrow-bold kr-text-dim-xs">
             Personality
           </p>
 
@@ -65,7 +65,7 @@
           v-if="showPromptPreview && bot.prompt"
           class="kr-panel-flat p-3 text-sm"
         >
-          <p class="kr-text-dim-xs font-bold uppercase">Prompt</p>
+          <p class="kr-text-eyebrow-bold kr-text-dim-xs">Prompt</p>
 
           <p class="mt-1 line-clamp-4 text-base-content/70">
             {{ bot.prompt }}

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -277,7 +277,9 @@
           </label>
 
           <div class="kr-panel-muted p-3 text-sm">
-            <p class="kr-text-dim-xs font-bold uppercase">Active Text Server</p>
+            <p class="kr-text-eyebrow-bold kr-text-dim-xs">
+              Active Text Server
+            </p>
 
             <p class="mt-1 font-semibold text-base-content/80">
               {{ activeServerName }}

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -246,7 +246,7 @@
               </div>
 
               <div class="min-w-0">
-                <p class="kr-text-dim-xs font-bold uppercase">Current Bot</p>
+                <p class="kr-text-eyebrow-bold kr-text-dim-xs">Current Bot</p>
 
                 <h3 class="truncate text-base font-black text-base-content">
                   {{ selectedBotTitle }}

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -345,7 +345,7 @@
         <div class="mt-4 grid grid-cols-[auto_minmax(0,1fr)_auto] items-end gap-2">
           <label class="form-control">
             <span class="label py-1"
-              ><span class="kr-text-dim-xs-55 label-text font-bold uppercase tracking-[0.12em]"
+              ><span class="kr-text-eyebrow-bold kr-text-dim-xs-55 label-text tracking-[0.12em]"
                 >Type</span
               ></span
             >
@@ -361,7 +361,7 @@
           </label>
           <label class="form-control">
             <span class="label py-1"
-              ><span class="kr-text-dim-xs-55 label-text font-bold uppercase tracking-[0.12em]"
+              ><span class="kr-text-eyebrow-bold kr-text-dim-xs-55 label-text tracking-[0.12em]"
                 >Search</span
               ></span
             >

--- a/components/characters/character-card.vue
+++ b/components/characters/character-card.vue
@@ -96,7 +96,7 @@
             class="kr-panel-muted-compact-xs text-center"
           >
             <div
-              class="truncate text-[10px] font-bold uppercase text-base-content/60"
+              class="kr-text-eyebrow-bold truncate text-[10px] text-base-content/60"
             >
               {{ stat.label }}
             </div>

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -114,7 +114,7 @@
               :key="stat.key"
               class="kr-panel-muted-sm"
             >
-              <p class="kr-text-dim-xs font-bold uppercase">
+              <p class="kr-text-eyebrow-bold kr-text-dim-xs">
                 {{ stat.label }}
               </p>
 
@@ -132,7 +132,7 @@
 
           <div class="mt-3 grid gap-2 text-sm">
             <div class="kr-tile-md">
-              <p class="kr-text-dim-xs font-bold uppercase">Character</p>
+              <p class="kr-text-eyebrow-bold kr-text-dim-xs">Character</p>
 
               <p class="mt-1 font-semibold">
                 {{ selectedCharacterName }}
@@ -140,7 +140,7 @@
             </div>
 
             <div class="kr-tile-md">
-              <p class="kr-text-dim-xs font-bold uppercase">Scenario</p>
+              <p class="kr-text-eyebrow-bold kr-text-dim-xs">Scenario</p>
 
               <p class="mt-1 font-semibold">
                 {{ selectedScenarioTitle }}
@@ -148,7 +148,7 @@
             </div>
 
             <div class="kr-tile-md">
-              <p class="kr-text-dim-xs font-bold uppercase">Reward</p>
+              <p class="kr-text-eyebrow-bold kr-text-dim-xs">Reward</p>
 
               <p class="mt-1 font-semibold">
                 {{ selectedRewardTitle }}
@@ -159,7 +159,7 @@
               v-if="selectedPrompt"
               class="rounded-2xl border border-primary/30 bg-primary/10 p-3"
             >
-              <p class="text-xs font-bold uppercase text-primary">
+              <p class="kr-text-eyebrow-bold text-xs text-primary">
                 Active Prompt
               </p>
 
@@ -286,7 +286,7 @@
               v-if="selectedGettingToKnowYouQuestion"
               class="mb-3 rounded-2xl border border-secondary/40 bg-secondary/10 p-3 text-sm"
             >
-              <p class="text-xs font-bold uppercase text-secondary">
+              <p class="kr-text-eyebrow-bold text-xs text-secondary">
                 Selected getting-to-know-you prompt
               </p>
 

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -186,7 +186,7 @@
               v-if="selectedGettingToKnowYouQuestion"
               class="mb-3 rounded-2xl border border-secondary/40 bg-secondary/10 p-3 text-sm"
             >
-              <p class="text-xs font-bold uppercase text-secondary">
+              <p class="kr-text-eyebrow-bold text-xs text-secondary">
                 Selected getting-to-know-you prompt
               </p>
 
@@ -354,7 +354,7 @@
 
             <div class="mt-3 grid gap-2 text-sm">
               <div class="kr-tile-md">
-                <p class="kr-text-dim-xs font-bold uppercase">Character</p>
+                <p class="kr-text-eyebrow-bold kr-text-dim-xs">Character</p>
 
                 <p class="mt-1 font-semibold">
                   {{ selectedCharacterName }}
@@ -362,7 +362,7 @@
               </div>
 
               <div class="kr-tile-md">
-                <p class="kr-text-dim-xs font-bold uppercase">Scenario</p>
+                <p class="kr-text-eyebrow-bold kr-text-dim-xs">Scenario</p>
 
                 <p class="mt-1 font-semibold">
                   {{ selectedScenarioTitle }}
@@ -370,7 +370,7 @@
               </div>
 
               <div class="kr-tile-md">
-                <p class="kr-text-dim-xs font-bold uppercase">Reward</p>
+                <p class="kr-text-eyebrow-bold kr-text-dim-xs">Reward</p>
 
                 <p class="mt-1 font-semibold">
                   {{ selectedRewardTitle }}
@@ -381,7 +381,7 @@
                 v-if="selectedPrompt"
                 class="rounded-2xl border border-primary/30 bg-primary/10 p-3"
               >
-                <p class="text-xs font-bold uppercase text-primary">
+                <p class="kr-text-eyebrow-bold text-xs text-primary">
                   Active Prompt
                 </p>
 

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -149,7 +149,7 @@
               </div>
 
               <div class="min-w-0">
-                <p class="kr-text-dim-xs font-bold uppercase">
+                <p class="kr-text-eyebrow-bold kr-text-dim-xs">
                   Current Character
                 </p>
 

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -149,7 +149,7 @@
             class="flex items-center gap-2 border-b border-base-300/70 px-3 py-2"
           >
             <Icon name="kind-icon:dream" class="size-4 text-primary" />
-            <span class="kr-text-dim-xs-60 font-bold uppercase tracking-wide">
+            <span class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide">
               Project Profile
             </span>
             <span class="ml-auto text-[0.65rem] text-base-content/35"
@@ -259,7 +259,7 @@
         >
           <label class="min-w-0">
             <span
-              class="mb-1 block text-[0.65rem] font-bold uppercase tracking-wide text-base-content/50"
+              class="kr-text-eyebrow-bold mb-1 block text-[0.65rem] tracking-wide text-base-content/50"
             >
               Add task / comment
             </span>
@@ -315,7 +315,7 @@
           name="kind-icon:chevron-right"
           class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
         />
-        <span class="kr-text-dim-xs-60 font-bold uppercase tracking-wide">
+        <span class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide">
           Roadmap
         </span>
         <span class="kr-badge-ghost-xs ml-auto">
@@ -392,7 +392,7 @@
           <div class="space-y-2 px-3 pb-3">
             <div v-for="group in doneTasksByMilestone" :key="group.id">
               <p
-                class="mb-1 text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40"
+                class="kr-text-eyebrow-bold mb-1 text-[0.65rem] tracking-wide text-base-content/40"
               >
                 {{ group.title }}
               </p>
@@ -436,7 +436,7 @@
           name="kind-icon:chevron-right"
           class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
         />
-        <span class="kr-text-dim-xs-60 font-bold uppercase tracking-wide">
+        <span class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide">
           Milestones
         </span>
         <span class="kr-badge-ghost-xs ml-auto">
@@ -492,7 +492,7 @@
           class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
         />
         <Icon name="kind-icon:document" class="size-4 text-info" />
-        <span class="kr-text-dim-xs-60 font-bold uppercase tracking-wide">
+        <span class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide">
           Project Notes
         </span>
         <span class="ml-auto text-xs text-base-content/35">Conductor</span>

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -138,7 +138,7 @@
           <div class="kr-panel-flat space-y-3 p-3">
             <label class="form-control w-full">
               <span
-                class="label-text mb-1 text-xs font-bold uppercase tracking-wide"
+                class="kr-text-eyebrow-bold label-text mb-1 text-xs tracking-wide"
               >
                 Working title (optional)
               </span>
@@ -152,7 +152,7 @@
 
             <label class="form-control w-full">
               <span
-                class="label-text mb-1 text-xs font-bold uppercase tracking-wide"
+                class="kr-text-eyebrow-bold label-text mb-1 text-xs tracking-wide"
               >
                 Premise
               </span>
@@ -170,7 +170,7 @@
           </div>
 
           <div class="kr-panel-flat space-y-2 p-3">
-            <h3 class="kr-text-dim-xs-55 font-bold uppercase tracking-wide">
+            <h3 class="kr-text-eyebrow-bold kr-text-dim-xs-55 tracking-wide">
               Narrator voice
             </h3>
             <div class="flex flex-wrap gap-2">
@@ -193,7 +193,7 @@
           </div>
 
           <div class="kr-panel-flat space-y-2 p-3">
-            <h3 class="kr-text-dim-xs-55 font-bold uppercase tracking-wide">
+            <h3 class="kr-text-eyebrow-bold kr-text-dim-xs-55 tracking-wide">
               Shape of the tale
             </h3>
             <div class="grid gap-2 md:grid-cols-3">
@@ -320,7 +320,7 @@
           <div class="kr-panel-flat space-y-2 p-3">
             <label class="form-control w-full">
               <span
-                class="label-text mb-1 text-xs font-bold uppercase tracking-wide"
+                class="kr-text-eyebrow-bold label-text mb-1 text-xs tracking-wide"
               >
                 Extra story direction (optional)
               </span>
@@ -349,7 +349,7 @@
           <dl class="grid gap-3 md:grid-cols-2">
             <div class="kr-panel-flat p-3 md:col-span-2">
               <dt
-                class="text-[0.7rem] font-bold uppercase tracking-wide text-primary/70"
+                class="kr-text-eyebrow-bold text-[0.7rem] tracking-wide text-primary/70"
               >
                 {{ reviewTitle }}
               </dt>

--- a/components/conductor/voice-lab-page.vue
+++ b/components/conductor/voice-lab-page.vue
@@ -63,7 +63,7 @@
             :key="message.id"
             class="kr-text-dim-xs-70"
           >
-            <span class="font-bold uppercase">{{ message.role }}:</span>
+            <span class="kr-text-eyebrow-bold">{{ message.role }}:</span>
             {{ message.text }}
           </p>
         </div>

--- a/components/dreams/daily-digest-object-gallery.vue
+++ b/components/dreams/daily-digest-object-gallery.vue
@@ -49,7 +49,7 @@
                 v-if="!item.image"
                 class="absolute inset-0 flex items-center justify-center pt-8 text-center text-base-content/30"
               >
-                <span class="text-[0.58rem] font-bold uppercase tracking-wide">
+                <span class="kr-text-eyebrow-bold text-[0.58rem] tracking-wide">
                   Awaiting art
                 </span>
               </div>

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -140,7 +140,7 @@
             <label class="form-control">
               <span class="label py-1"
                 ><span
-                  class="label-text text-xs font-bold uppercase tracking-wide"
+                  class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
                   >Seed Title</span
                 ></span
               >
@@ -156,7 +156,7 @@
             <label class="form-control">
               <span class="label py-1"
                 ><span
-                  class="label-text text-xs font-bold uppercase tracking-wide"
+                  class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
                   >Save Type</span
                 ></span
               >
@@ -178,7 +178,7 @@
           <label class="form-control mt-3">
             <span class="label py-1"
               ><span
-                class="label-text text-xs font-bold uppercase tracking-wide"
+                class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
                 >Pitch</span
               ></span
             >
@@ -193,7 +193,7 @@
           <label class="form-control mt-3">
             <span class="label py-1"
               ><span
-                class="label-text text-xs font-bold uppercase tracking-wide"
+                class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
                 >Direction</span
               ></span
             >

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -323,7 +323,7 @@
               </div>
 
               <div class="min-w-0">
-                <p class="kr-text-dim-xs font-bold uppercase">
+                <p class="kr-text-eyebrow-bold kr-text-dim-xs">
                   Current Dream
                 </p>
 

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -75,7 +75,7 @@
               <label class="form-control">
                 <span class="label py-1">
                   <span
-                    class="label-text text-xs font-bold uppercase tracking-wide"
+                    class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
                     >Title</span
                   >
                 </span>
@@ -90,7 +90,7 @@
               <label class="form-control">
                 <span class="label py-1">
                   <span
-                    class="label-text text-xs font-bold uppercase tracking-wide"
+                    class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
                     >Type</span
                   >
                 </span>
@@ -113,7 +113,7 @@
               <label class="form-control">
                 <span class="label py-1">
                   <span
-                    class="label-text text-xs font-bold uppercase tracking-wide"
+                    class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
                     >Slug</span
                   >
                 </span>
@@ -140,7 +140,7 @@
             <label class="form-control">
               <span class="label py-1">
                 <span
-                  class="label-text text-xs font-bold uppercase tracking-wide"
+                  class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
                   >Dream Pitch</span
                 >
               </span>
@@ -154,7 +154,7 @@
             <label class="form-control mt-3">
               <span class="label py-1">
                 <span
-                  class="label-text text-xs font-bold uppercase tracking-wide"
+                  class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
                   >Description</span
                 >
               </span>
@@ -168,7 +168,7 @@
             <label class="form-control mt-3">
               <span class="label py-1">
                 <span
-                  class="label-text text-xs font-bold uppercase tracking-wide"
+                  class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
                   >Flavor Text</span
                 >
               </span>

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -40,7 +40,7 @@
     <section class="kr-panel-muted rounded-xl p-2.5">
       <div class="mb-2 flex items-center justify-between gap-2">
         <span
-          class="kr-text-dim-xs font-bold uppercase tracking-wide"
+          class="kr-text-eyebrow-bold kr-text-dim-xs tracking-wide"
         >
           Automate all {{ group.items.length }}
         </span>
@@ -118,7 +118,7 @@
       class="kr-panel-muted rounded-xl p-2.5"
     >
       <span
-        class="kr-text-dim-xs mb-2 block font-bold uppercase tracking-wide"
+        class="kr-text-eyebrow-bold kr-text-dim-xs mb-2 block tracking-wide"
       >
         Set a field on all {{ group.items.length }}
       </span>
@@ -177,7 +177,7 @@
     <!-- Per-item fine-tune -->
     <section class="kr-panel-muted rounded-xl p-2.5">
       <span
-        class="kr-text-dim-xs mb-2 block font-bold uppercase tracking-wide"
+        class="kr-text-eyebrow-bold kr-text-dim-xs mb-2 block tracking-wide"
       >
         Fine-tune individual items
       </span>

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -39,7 +39,7 @@
     <section class="kr-panel-flat rounded-xl p-2.5">
       <div class="mb-1.5 flex items-center gap-2">
         <Icon name="kind-icon:lightbulb" class="h-4 w-4 text-primary" />
-        <span class="text-xs font-bold uppercase tracking-wide">Pitch</span>
+        <span class="kr-text-eyebrow-bold text-xs tracking-wide">Pitch</span>
         <span class="badge badge-xs ml-auto" :class="badgeFor('PITCH')">
           {{ item.stages.PITCH.status }}
         </span>
@@ -112,7 +112,7 @@
     <section class="kr-panel-flat rounded-xl p-2.5">
       <div class="mb-1.5 flex items-center gap-2">
         <Icon name="kind-icon:list" class="h-4 w-4 text-primary" />
-        <span class="text-xs font-bold uppercase tracking-wide"
+        <span class="kr-text-eyebrow-bold text-xs tracking-wide"
           >Fields &amp; Prompts</span
         >
         <span
@@ -227,7 +227,7 @@
     <section class="kr-panel-flat rounded-xl p-2.5">
       <div class="mb-1.5 flex items-center gap-2">
         <Icon name="kind-icon:sparkles" class="h-4 w-4 text-primary" />
-        <span class="text-xs font-bold uppercase tracking-wide"
+        <span class="kr-text-eyebrow-bold text-xs tracking-wide"
           >Generate Assets</span
         >
         <span
@@ -359,7 +359,7 @@
     <section class="kr-panel-flat rounded-xl p-2.5">
       <div class="mb-1.5 flex items-center gap-2">
         <Icon name="kind-icon:check" class="h-4 w-4 text-primary" />
-        <span class="text-xs font-bold uppercase tracking-wide">Commit</span>
+        <span class="kr-text-eyebrow-bold text-xs tracking-wide">Commit</span>
         <span class="badge badge-xs ml-auto" :class="badgeFor('COMMIT')">
           {{ item.stages.COMMIT.status }}
         </span>

--- a/components/narrative/kr-chat-window.vue
+++ b/components/narrative/kr-chat-window.vue
@@ -49,7 +49,7 @@
     <template v-for="(turn, index) in turns" :key="turn.id">
       <div v-if="turn.dateLabel" class="flex justify-center py-1">
         <span
-          class="rounded-full border border-base-300 bg-base-200 px-3 py-1 text-[11px] font-bold uppercase tracking-wide text-base-content/60"
+          class="kr-text-eyebrow-bold rounded-full border border-base-300 bg-base-200 px-3 py-1 text-[11px] tracking-wide text-base-content/60"
         >
           {{ turn.dateLabel }}
         </span>

--- a/components/navigation/channel-tab-list.vue
+++ b/components/navigation/channel-tab-list.vue
@@ -74,7 +74,7 @@
                 </span>
                 <span
                   v-if="isAdminOnlyTab(channel, tab)"
-                  class="kr-badge-warning-xs shrink-0 font-bold uppercase"
+                  class="kr-text-eyebrow-bold kr-badge-warning-xs shrink-0"
                   title="Admin-only page"
                 >
                   Admin

--- a/components/navigation/navigation-trimmed.vue
+++ b/components/navigation/navigation-trimmed.vue
@@ -97,7 +97,7 @@
                 </span>
                 <span
                   v-if="isAdminOnlyTab(channel, tab)"
-                  class="kr-badge-warning-xs shrink-0 font-bold uppercase"
+                  class="kr-text-eyebrow-bold kr-badge-warning-xs shrink-0"
                   title="Admin-only page"
                 >
                   Admin

--- a/components/navigation/tutorial-flyer.vue
+++ b/components/navigation/tutorial-flyer.vue
@@ -156,7 +156,7 @@
               class="h-1.5 flex-1 rounded-full bg-primary/20"
             />
             <span
-              class="ml-1 shrink-0 text-[0.65rem] font-bold uppercase tracking-widest text-base-content/40"
+              class="kr-text-eyebrow-bold ml-1 shrink-0 text-[0.65rem] tracking-widest text-base-content/40"
             >
               {{ stepCount }} steps
             </span>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -248,7 +248,7 @@
               @submit.prevent="submitNewTodo"
             >
               <h4
-                class="kr-text-dim-xs font-bold uppercase tracking-wide"
+                class="kr-text-eyebrow-bold kr-text-dim-xs tracking-wide"
               >
                 New Task
               </h4>
@@ -610,7 +610,7 @@
             <!-- PROJECT TASK / COMMENT CREATION -->
             <div v-if="linkedProject" class="kr-panel-flat shrink-0 p-4">
               <h4
-                class="kr-text-dim-xs font-bold uppercase tracking-wide"
+                class="kr-text-eyebrow-bold kr-text-dim-xs tracking-wide"
               >
                 Add task / comment
               </h4>
@@ -672,7 +672,7 @@
                 <div class="flex flex-wrap items-center gap-2">
                   <Icon name="kind-icon:dream" class="size-4 text-primary" />
                   <h4
-                    class="kr-text-dim-xs-60 font-bold uppercase tracking-wide"
+                    class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide"
                   >
                     Project Profile
                   </h4>
@@ -820,7 +820,7 @@
                 />
                 <Icon name="kind-icon:document" class="size-4 text-info" />
                 <span
-                  class="kr-text-dim-xs-60 font-bold uppercase tracking-wide"
+                  class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide"
                   >Project Notes</span
                 >
                 <span class="ml-auto text-xs text-base-content/35">Conductor</span>
@@ -846,7 +846,7 @@
                   class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
                 />
                 <span
-                  class="kr-text-dim-xs-60 font-bold uppercase tracking-wide"
+                  class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide"
                   >Milestones</span
                 >
                 <span class="kr-badge-ghost-xs ml-auto">
@@ -904,7 +904,7 @@
                   class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
                 />
                 <span
-                  class="kr-text-dim-xs-60 font-bold uppercase tracking-wide"
+                  class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide"
                   >Roadmap</span
                 >
                 <span class="kr-badge-ghost-xs ml-auto">
@@ -1063,7 +1063,7 @@
               <div class="flex items-center gap-2">
                 <Icon name="kind-icon:check" class="size-4 text-primary" />
                 <h4
-                  class="kr-text-dim-xs font-bold uppercase tracking-wide"
+                  class="kr-text-eyebrow-bold kr-text-dim-xs tracking-wide"
                 >
                   Feature Wishlist
                 </h4>

--- a/components/pages/portos-page.vue
+++ b/components/pages/portos-page.vue
@@ -6,7 +6,7 @@
           <Icon name="kind-icon:server" class="size-6" />
         </div>
         <div class="min-w-0 flex-1">
-          <p class="text-xs font-bold uppercase tracking-wide text-accent/70">Portos</p>
+          <p class="kr-text-eyebrow-bold text-xs tracking-wide text-accent/70">Portos</p>
           <h2 class="text-2xl font-black leading-tight">Portos Server Setup</h2>
           <p class="kr-text-dim-sm-70 mt-1 leading-relaxed">
             This tab is reserved for connecting a Porto server address and saving the user/server pairing cleanly once the server entry flow is wired in.

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -28,7 +28,7 @@
 
       <div class="flex items-center gap-2">
         <span
-          class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-bold uppercase tracking-wide"
+          class="kr-text-eyebrow-bold inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs tracking-wide"
           :class="
             voice.connected
               ? 'bg-success/20 text-success'
@@ -55,7 +55,7 @@
     <!-- Relay endpoint -->
     <div class="flex flex-wrap items-end gap-3 kr-panel-tint-compact">
       <label class="flex-1">
-        <span class="kr-text-dim-xs-60 mb-1 block font-bold uppercase">
+        <span class="kr-text-eyebrow-bold kr-text-dim-xs-60 mb-1 block">
           Relay URL
         </span>
         <input
@@ -72,7 +72,7 @@
 
     <!-- Simulate an Echo utterance -->
     <div class="kr-panel-tint-compact">
-      <p class="kr-text-dim-xs-60 mb-2 font-bold uppercase">
+      <p class="kr-text-eyebrow-bold kr-text-dim-xs-60 mb-2">
         Speak to Serendipity (or simulate)
       </p>
       <div class="flex flex-wrap gap-2">
@@ -102,7 +102,7 @@
         class="flex min-h-48 flex-col rounded-xl border border-base-300 bg-base-100"
       >
         <div
-          class="kr-text-dim-xs-60 border-b border-base-300 px-3 py-2 font-bold uppercase"
+          class="kr-text-eyebrow-bold kr-text-dim-xs-60 border-b border-base-300 px-3 py-2"
         >
           Message feed
         </div>
@@ -133,7 +133,9 @@
       <!-- Live animation state -->
       <aside class="flex flex-col gap-3 kr-panel-tint-compact">
         <div>
-          <p class="kr-text-dim-xs-60 font-bold uppercase">Active animations</p>
+          <p class="kr-text-eyebrow-bold kr-text-dim-xs-60">
+            Active animations
+          </p>
           <p
             v-if="activeEffects.length === 0"
             class="mt-1 text-sm text-base-content/50"
@@ -157,7 +159,7 @@
         </div>
 
         <div class="border-t border-base-300 pt-2">
-          <p class="kr-text-dim-xs-60 font-bold uppercase">Theme</p>
+          <p class="kr-text-eyebrow-bold kr-text-dim-xs-60">Theme</p>
           <p class="mt-1 text-sm font-semibold">{{ currentTheme }}</p>
         </div>
 
@@ -177,7 +179,7 @@
 
     <!-- Art drafts (surfaced from voice; never generated or published here) -->
     <div v-if="voice.artRequests.length > 0" class="kr-panel-tint-compact">
-      <p class="kr-text-dim-xs-60 mb-2 font-bold uppercase">
+      <p class="kr-text-eyebrow-bold kr-text-dim-xs-60 mb-2">
         Art drafts from voice ({{ voice.artRequests.length }})
       </p>
       <ul class="space-y-2">

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -6,7 +6,7 @@
     >
       <div class="min-w-0">
         <p
-          class="text-[0.7rem] font-bold uppercase tracking-wide text-primary/70"
+          class="kr-text-eyebrow-bold text-[0.7rem] tracking-wide text-primary/70"
         >
           Story library
         </p>

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -489,7 +489,7 @@
                     {{ checkpoint.detail }}
                   </p>
                   <p
-                    class="mt-2 text-[0.65rem] font-bold uppercase tracking-wide text-base-content/35"
+                    class="kr-text-eyebrow-bold mt-2 text-[0.65rem] tracking-wide text-base-content/35"
                   >
                     {{ checkpoint.sourceKind.replace('-', ' ') }}
                   </p>
@@ -520,7 +520,7 @@
               <dl class="mt-4 space-y-3 text-sm">
                 <div>
                   <dt
-                    class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40"
+                    class="kr-text-eyebrow-bold text-[0.65rem] tracking-wide text-base-content/40"
                   >
                     Objective
                   </dt>
@@ -531,7 +531,7 @@
                 <div class="grid grid-cols-2 gap-3">
                   <div>
                     <dt
-                      class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40"
+                      class="kr-text-eyebrow-bold text-[0.65rem] tracking-wide text-base-content/40"
                     >
                       Tone
                     </dt>
@@ -539,7 +539,7 @@
                   </div>
                   <div>
                     <dt
-                      class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40"
+                      class="kr-text-eyebrow-bold text-[0.65rem] tracking-wide text-base-content/40"
                     >
                       Setting
                     </dt>
@@ -550,7 +550,7 @@
                 </div>
                 <div v-if="store.session.genre">
                   <dt
-                    class="text-[0.65rem] font-bold uppercase tracking-wide text-base-content/40"
+                    class="kr-text-eyebrow-bold text-[0.65rem] tracking-wide text-base-content/40"
                   >
                     Genre
                   </dt>

--- a/components/rewards/reward-card.vue
+++ b/components/rewards/reward-card.vue
@@ -77,26 +77,26 @@
           class="mx-0.5 mt-2.5 grid grid-cols-2 gap-2 kr-panel-flat p-3 text-xs"
         >
           <div>
-            <p class="font-bold uppercase text-base-content/45">ID</p>
+            <p class="kr-text-eyebrow-bold text-base-content/45">ID</p>
             <p class="truncate text-base-content/75">#{{ reward.id }}</p>
           </div>
 
           <div>
-            <p class="font-bold uppercase text-base-content/45">Rarity</p>
+            <p class="kr-text-eyebrow-bold text-base-content/45">Rarity</p>
             <p class="truncate text-base-content/75">
               {{ reward.rarity || 'COMMON' }}
             </p>
           </div>
 
           <div>
-            <p class="font-bold uppercase text-base-content/45">Collection</p>
+            <p class="kr-text-eyebrow-bold text-base-content/45">Collection</p>
             <p class="truncate text-base-content/75">
               {{ reward.collection || 'general' }}
             </p>
           </div>
 
           <div>
-            <p class="font-bold uppercase text-base-content/45">Image</p>
+            <p class="kr-text-eyebrow-bold text-base-content/45">Image</p>
             <p class="truncate text-base-content/75">
               {{ reward.artImageId ? `#${reward.artImageId}` : 'none' }}
             </p>

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -183,7 +183,7 @@
               <label class="form-control">
                 <span class="label py-1">
                   <span
-                    class="kr-text-dim-xs label-text font-bold uppercase tracking-wide"
+                    class="kr-text-eyebrow-bold kr-text-dim-xs label-text tracking-wide"
                   >
                     Customize the next move
                   </span>

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -210,7 +210,9 @@
               </div>
 
               <div class="min-w-0">
-                <p class="kr-text-dim-xs font-bold uppercase">Current Reward</p>
+                <p class="kr-text-eyebrow-bold kr-text-dim-xs">
+                  Current Reward
+                </p>
 
                 <h3 class="truncate text-base font-black text-base-content">
                   {{ selectedRewardTitle }}

--- a/components/ruler-hooked/ruler-hooked-fishing-encounter.vue
+++ b/components/ruler-hooked/ruler-hooked-fishing-encounter.vue
@@ -2,7 +2,7 @@
   <section class="rounded-2xl border border-primary/30 bg-base-100 p-4 shadow-sm" aria-labelledby="fishing-encounter-title">
     <div class="flex flex-wrap items-start justify-between gap-3">
       <div>
-        <p class="text-xs font-bold uppercase tracking-wide opacity-55">On the line</p>
+        <p class="kr-text-eyebrow-bold text-xs tracking-wide opacity-55">On the line</p>
         <h3 id="fishing-encounter-title" class="kr-text-black-xl">{{ encounter.fishName }}</h3>
         <p class="mt-1 text-xs opacity-65">{{ encounter.rarity }} · {{ encounter.affinity }} · {{ familyLabel }}</p>
       </div>

--- a/components/ruler-hooked/ruler-hooked-slots.vue
+++ b/components/ruler-hooked/ruler-hooked-slots.vue
@@ -3,7 +3,7 @@
      Reads and drives the store directly. -->
 <template>
   <div class="rounded-xl border border-base-300 bg-base-100 p-4">
-    <h3 class="mb-2 text-sm font-bold uppercase tracking-wide opacity-70">Save slots</h3>
+    <h3 class="kr-text-eyebrow-bold mb-2 text-sm tracking-wide opacity-70">Save slots</h3>
 
     <div v-if="store.slots.length" class="mb-3 flex flex-col gap-1">
       <div

--- a/components/scenarios/scenario-card.vue
+++ b/components/scenarios/scenario-card.vue
@@ -102,7 +102,7 @@
           class="mx-0.5 mt-2.5 kr-panel-flat rounded-xl p-2.5"
         >
           <p
-            class="text-[0.65rem] font-bold uppercase tracking-wider text-base-content/50"
+            class="kr-text-eyebrow-bold text-[0.65rem] tracking-wider text-base-content/50"
           >
             Inspirations
           </p>

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -64,7 +64,7 @@
           <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div class="flex flex-col gap-1.5">
               <label
-                class="kr-text-dim-xs font-bold uppercase tracking-widest"
+                class="kr-text-eyebrow-bold kr-text-dim-xs tracking-widest"
                 >Name *</label
               >
               <input
@@ -77,7 +77,7 @@
             </div>
             <div class="flex flex-col gap-1.5">
               <label
-                class="kr-text-dim-xs font-bold uppercase tracking-widest"
+                class="kr-text-eyebrow-bold kr-text-dim-xs tracking-widest"
               >
                 Voice / Notes
               </label>
@@ -145,7 +145,7 @@
           <div class="flex flex-col gap-1.5">
             <div class="flex items-center justify-between">
               <label
-                class="kr-text-dim-xs font-bold uppercase tracking-widest"
+                class="kr-text-eyebrow-bold kr-text-dim-xs tracking-widest"
                 >Stage Prompt</label
               >
               <button
@@ -176,7 +176,7 @@
           <div class="flex flex-col gap-2">
             <div class="flex items-center justify-between">
               <label
-                class="kr-text-dim-xs font-bold uppercase tracking-widest"
+                class="kr-text-eyebrow-bold kr-text-dim-xs tracking-widest"
                 >Avatar Image</label
               >
               <button

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -89,7 +89,7 @@
         class="kr-pane-scroll flex flex-col border-r border-base-300 bg-base-100/60 backdrop-blur-sm p-4 gap-3"
       >
         <p
-          class="kr-text-dim-xs-40 font-bold uppercase tracking-widest"
+          class="kr-text-eyebrow-bold kr-text-dim-xs-40 tracking-widest"
         >
           Show Status
         </p>
@@ -128,7 +128,7 @@
         <!-- Cast status -->
         <div v-if="store.selectedStage" class="flex flex-col gap-1.5">
           <p
-            class="kr-text-dim-xs-40 font-bold uppercase tracking-widest"
+            class="kr-text-eyebrow-bold kr-text-dim-xs-40 tracking-widest"
           >
             Cast
           </p>
@@ -185,7 +185,7 @@
         <!-- Turn progress -->
         <div v-if="store.transcript.length" class="flex flex-col gap-1.5">
           <p
-            class="kr-text-dim-xs-40 font-bold uppercase tracking-widest"
+            class="kr-text-eyebrow-bold kr-text-dim-xs-40 tracking-widest"
           >
             Progress
           </p>
@@ -513,7 +513,7 @@
             <!-- Show title -->
             <div class="flex flex-col gap-1.5">
               <label
-                class="kr-text-dim-xs font-bold uppercase tracking-widest"
+                class="kr-text-eyebrow-bold kr-text-dim-xs tracking-widest"
                 >Show Title</label
               >
               <input
@@ -528,7 +528,7 @@
             <!-- Topic -->
             <div class="flex flex-col gap-1.5">
               <label
-                class="kr-text-dim-xs font-bold uppercase tracking-widest"
+                class="kr-text-eyebrow-bold kr-text-dim-xs tracking-widest"
                 >Topic / Premise</label
               >
               <input
@@ -543,7 +543,7 @@
             <!-- Custom opening -->
             <div class="flex flex-col gap-1.5 sm:col-span-2">
               <label
-                class="kr-text-dim-xs font-bold uppercase tracking-widest"
+                class="kr-text-eyebrow-bold kr-text-dim-xs tracking-widest"
                 >Custom Opening Cue</label
               >
               <input
@@ -560,7 +560,7 @@
             <!-- Turns -->
             <div class="flex flex-col gap-2">
               <label
-                class="kr-text-dim-xs font-bold uppercase tracking-widest"
+                class="kr-text-eyebrow-bold kr-text-dim-xs tracking-widest"
                 >Turns ({{ store.maxTurns }})</label
               >
               <input
@@ -580,7 +580,7 @@
             <!-- Delay -->
             <div class="flex flex-col gap-2">
               <label
-                class="kr-text-dim-xs font-bold uppercase tracking-widest"
+                class="kr-text-eyebrow-bold kr-text-dim-xs tracking-widest"
                 >Delay between turns ({{ store.turnDelayMs }}ms)</label
               >
               <input
@@ -600,7 +600,7 @@
             <!-- Server -->
             <div class="flex flex-col gap-1.5">
               <label
-                class="kr-text-dim-xs font-bold uppercase tracking-widest"
+                class="kr-text-eyebrow-bold kr-text-dim-xs tracking-widest"
                 >Text Server</label
               >
               <select
@@ -622,7 +622,7 @@
             <!-- Model -->
             <div class="flex flex-col gap-1.5">
               <label
-                class="kr-text-dim-xs font-bold uppercase tracking-widest"
+                class="kr-text-eyebrow-bold kr-text-dim-xs tracking-widest"
                 >Model</label
               >
               <input

--- a/components/storybook/storybook-state-panel.vue
+++ b/components/storybook/storybook-state-panel.vue
@@ -13,7 +13,7 @@
 
     <div class="mt-3 grid gap-3 lg:grid-cols-3">
       <section class="kr-panel-flat p-3">
-        <h3 class="kr-text-dim-xs-55 font-bold uppercase tracking-wide">
+        <h3 class="kr-text-eyebrow-bold kr-text-dim-xs-55 tracking-wide">
           Inventory
         </h3>
         <div v-if="session.inventory.length" class="mt-2 space-y-2">
@@ -57,7 +57,7 @@
       </section>
 
       <section class="kr-panel-flat p-3">
-        <h3 class="kr-text-dim-xs-55 font-bold uppercase tracking-wide">
+        <h3 class="kr-text-eyebrow-bold kr-text-dim-xs-55 tracking-wide">
           Consequences
         </h3>
         <ol v-if="recentConsequences.length" class="mt-2 space-y-2">
@@ -84,7 +84,7 @@
       </section>
 
       <section class="kr-panel-flat p-3">
-        <h3 class="kr-text-dim-xs-55 font-bold uppercase tracking-wide">
+        <h3 class="kr-text-eyebrow-bold kr-text-dim-xs-55 tracking-wide">
           Branch path
         </h3>
         <ol v-if="recentBranches.length" class="mt-2 space-y-2">

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -6,7 +6,7 @@
     <header class="flex shrink-0 flex-col gap-3">
       <div class="flex items-start justify-between gap-3">
         <div v-if="showHeader" class="flex flex-col gap-1">
-          <p class="text-xs font-bold uppercase tracking-wide text-primary">
+          <p class="kr-text-eyebrow-bold text-xs tracking-wide text-primary">
             Message Timeline
           </p>
           <h2 class="text-2xl font-black text-base-content">Chats</h2>

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -182,7 +182,7 @@
 
         <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
           <div class="kr-panel-muted-md">
-            <p class="kr-text-dim-xs-45 font-bold uppercase tracking-wide">
+            <p class="kr-text-eyebrow-bold kr-text-dim-xs-45 tracking-wide">
               Sections
             </p>
             <p class="mt-1 text-3xl font-black text-primary">
@@ -191,7 +191,7 @@
           </div>
 
           <div class="kr-panel-muted-md">
-            <p class="kr-text-dim-xs-45 font-bold uppercase tracking-wide">
+            <p class="kr-text-eyebrow-bold kr-text-dim-xs-45 tracking-wide">
               Groups
             </p>
             <p class="mt-1 text-3xl font-black text-secondary">
@@ -200,7 +200,7 @@
           </div>
 
           <div class="kr-panel-muted-md">
-            <p class="kr-text-dim-xs-45 font-bold uppercase tracking-wide">
+            <p class="kr-text-eyebrow-bold kr-text-dim-xs-45 tracking-wide">
               Saved colors
             </p>
             <p class="mt-1 text-3xl font-black text-accent">
@@ -225,7 +225,7 @@
             class="mb-3 rounded-2xl border border-primary/30 bg-primary/10 p-3"
           >
             <p
-              class="text-xs font-bold uppercase tracking-wide text-primary/70"
+              class="kr-text-eyebrow-bold text-xs tracking-wide text-primary/70"
             >
               Selected section
             </p>

--- a/components/wonderlab/reactable-card.vue
+++ b/components/wonderlab/reactable-card.vue
@@ -56,7 +56,7 @@
       >
         <div class="mb-2 flex items-center justify-between gap-2">
           <p
-            class="kr-text-dim-xs-45 truncate font-bold uppercase tracking-wide"
+            class="kr-text-eyebrow-bold kr-text-dim-xs-45 truncate tracking-wide"
           >
             React
           </p>

--- a/components/wonderlab/reaction-card.vue
+++ b/components/wonderlab/reaction-card.vue
@@ -10,7 +10,7 @@
     >
       <div class="min-w-0">
         <p
-          class="kr-text-dim-xs-45 font-bold uppercase tracking-wide"
+          class="kr-text-eyebrow-bold kr-text-dim-xs-45 tracking-wide"
         >
           Reaction
         </p>

--- a/pages/play/aquarium/browse/[username]/[slug].vue
+++ b/pages/play/aquarium/browse/[username]/[slug].vue
@@ -76,7 +76,7 @@
             </div>
           </div>
           <p
-            class="kr-text-dim-xs-45 mt-4 font-bold uppercase tracking-wide"
+            class="kr-text-eyebrow-bold kr-text-dim-xs-45 mt-4 tracking-wide"
           >
             Read-only -- visiting doesn't feed, clean, or change anything here.
           </p>

--- a/utils/scripts/codemods/kr_text_eyebrow_bold_codemod.py
+++ b/utils/scripts/codemods/kr_text_eyebrow_bold_codemod.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `font-bold uppercase` eyebrow/label text to
+`kr-text-eyebrow-bold`.
+
+Sibling of `kr-text-eyebrow` (interface-vision t-104 slice 168) -- same
+eyebrow/label-text usage (`bot-card.vue`, `bot-chat.vue`,
+`model-builder-item-panel.vue`, etc.) but `font-bold` instead of
+`font-black`, so it is named as a weight sibling rather than folded into
+the existing primitive. A fresh full-repo class-frequency survey outside
+the now-closed `kr-text-black-*`/`kr-text-dim-*`/`kr-text-eyebrow` families
+found `font-bold uppercase` at 127 subset-match occurrences across 44
+files -- the next largest bounded pattern surfaced. `tracking-wide` rides
+along on some call sites (as it did for `kr-text-eyebrow`) but is left as
+a caller-supplied extra token rather than folded into the base set. Only
+the exact `font-bold uppercase` shape is touched, and only in static
+`class="..."` attributes -- never `:class`/`v-bind:class` bindings,
+regardless of the base tokens' order in the source. A source that already
+carries `kr-text-eyebrow-bold`, or is missing either base token, is left
+untouched. Extra tokens beyond the base set are preserved verbatim after
+the primitive class, matching the established subset-match convention --
+pass --exact-only to restrict a slice to sources with no extra tokens at
+all, the safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-eyebrow-bold"
+BASE_TOKENS = {"font-bold", "uppercase"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-eyebrow-bold {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (slice 168, kind: software)

### What changed / what I produced
- Added `.kr-text-eyebrow-bold` (`font-bold uppercase`) to `assets/css/tailwind.css`, a weight sibling of the existing `.kr-text-eyebrow` (`font-black uppercase`) primitive.
- Added `utils/scripts/codemods/kr_text_eyebrow_bold_codemod.py`, following the established subset-match convention (`--write`, `--exact-only`) used by every prior `kr-text-*` codemod.
- Migrated all 127 subset-match occurrences of `font-bold uppercase` across 44 files to `kr-text-eyebrow-bold`, preserving any extra caller-supplied tokens (e.g. `tracking-wide`) after the primitive, exactly like `kr-text-eyebrow`.
- A fresh full-repo class-frequency survey outside the now-closed `kr-text-black-*`/`kr-text-dim-*`/`kr-text-eyebrow` families found this shape as the next-largest bounded pattern.

### How I verified
- `npm run test` (vue-tsc --noEmit): clean, no errors.
- `npm run lint:js`: 333 problems (327 errors, 6 warnings) — identical before and after via `git stash` comparison. No new fallout.
- `npm run test:lint-ratchet`: 333 problems / -59, holds at the established baseline.
- `npm run test:layout-contract`: holds — same pre-existing -2 ratchet opportunity in `narrative-ingredient-multi-picker.vue`, unrelated and left untouched.
- `npm run lint:prettier`: baseline is 1148/1152 warn-files pre-existing; my changes introduced 4 files needing reformatting (line-length wraps from the longer combined class string) — fixed with a targeted `prettier --write` on just those 4 files, confirmed back to the exact pre-existing baseline byte-for-byte via `git stash` diff.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Slice 169 should run a fresh full-repo class-frequency survey outside the now-covered `kr-text-black-*`/`kr-text-dim-*`/`kr-text-eyebrow`/`kr-text-eyebrow-bold` families to find the next largest bounded hand-rolled pattern (candidates spotted during this slice's survey but not yet mined: `font-bold text-xs`/`font-bold text-sm` label pairs, and `label-text text-xs` form-label pairs).

### Notes for reviewer
Recurring task — this PR is one slice of the ongoing interface-vision/t-104 umbrella. The conductor roadmap task will be re-armed to `ready` for the next slice after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjMR5SYiw9tYfnJzEAeeNp


---
_Generated by [Claude Code](https://claude.ai/code/session_01FjMR5SYiw9tYfnJzEAeeNp)_