### PR TITLE
refactor(ui): add kr-text-bold-sm for font-bold text-sm (slice 169)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1850,6 +1850,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply font-bold uppercase;
   }
 
+  /* `font-bold text-sm` label/heading-emphasis text (interface-vision t-104
+   * slice 169) -- first of a new `kr-text-bold-*` family, weight sibling in
+   * spirit to `kr-text-black-*` but for `font-bold` instead of `font-black`
+   * (the same relationship `kr-text-eyebrow-bold` has to `kr-text-eyebrow`).
+   * A fresh full-repo class-frequency survey outside the now-closed
+   * `kr-text-black-*`/`kr-text-dim-*`/`kr-text-eyebrow`/`kr-text-eyebrow-bold`
+   * families found this shape at 90 subset-match occurrences across 57
+   * files, the largest bounded pattern surfaced this slice (`font-bold
+   * text-xs`, 84 occurrences, and `label-text text-xs font-bold`, 25
+   * occurrences, are left for future slices). */
+  .kr-text-bold-sm {
+    @apply font-bold text-sm;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -4,7 +4,7 @@
     <div class="flex items-center gap-2">
       <Icon name="kind-icon:tag" class="size-4 text-secondary" />
       <div class="min-w-0 flex-1">
-        <h3 class="text-sm font-bold">{{ label }}</h3>
+        <h3 class="kr-text-bold-sm">{{ label }}</h3>
         <p v-if="!compact" class="kr-text-dim-xs">
           Canonical creative direction recorded on the ArtJob and finished
           image.

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -311,7 +311,7 @@
 
             <details class="mt-3 rounded-xl border border-base-300 bg-base-100">
               <summary
-                class="flex cursor-pointer list-none items-center justify-between px-3 py-2 text-sm font-bold"
+                class="kr-text-bold-sm flex cursor-pointer list-none items-center justify-between px-3 py-2"
               >
                 <span>Prompt Text</span>
                 <span class="kr-text-dim-xs font-normal"

--- a/components/art/art-lora-picker.vue
+++ b/components/art/art-lora-picker.vue
@@ -3,7 +3,7 @@
   <section class="space-y-3 kr-panel-flat p-3">
     <div class="flex flex-wrap items-start justify-between gap-2">
       <div class="min-w-0">
-        <h3 class="flex items-center gap-2 text-sm font-bold">
+        <h3 class="kr-text-bold-sm flex items-center gap-2">
           <Icon name="kind-icon:sparkles" class="size-4 text-secondary" />
           LoRAs <span class="font-normal opacity-50">(optional)</span>
         </h3>

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -338,7 +338,7 @@
         </Transition>
 
         <div class="flex min-w-0 flex-col justify-center gap-1">
-          <p class="truncate text-sm font-bold text-base-content">
+          <p class="kr-text-bold-sm truncate text-base-content">
             {{
               selectedSourceImage?.fileName ||
               (selectedSourceImage

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -900,7 +900,7 @@ onMounted(async () => {
             </div>
 
             <div v-if="endpointDef.needsSize" class="flex flex-col gap-3">
-              <div class="text-sm font-bold">Size</div>
+              <div class="kr-text-bold-sm">Size</div>
 
               <div class="grid gap-3 md:grid-cols-2">
                 <label class="form-control">
@@ -955,7 +955,7 @@ onMounted(async () => {
             </div>
 
             <div v-if="endpointDef.needsNegative" class="flex flex-col gap-2">
-              <div class="text-sm font-bold">Negative Prompt</div>
+              <div class="kr-text-bold-sm">Negative Prompt</div>
               <textarea
                 v-model="negativePrompt"
                 rows="3"
@@ -1038,7 +1038,7 @@ onMounted(async () => {
               </div>
 
               <label class="form-control">
-                <span class="mb-2 text-sm font-bold">Extra Prompt Notes</span>
+                <span class="kr-text-bold-sm mb-2">Extra Prompt Notes</span>
                 <textarea
                   v-model="extraPrompt"
                   rows="6"
@@ -1092,7 +1092,7 @@ onMounted(async () => {
 
               <div class="flex flex-col gap-4">
                 <label class="form-control">
-                  <span class="mb-2 text-sm font-bold">Artist Style</span>
+                  <span class="kr-text-bold-sm mb-2">Artist Style</span>
                   <select
                     v-model="selectedStyle"
                     class="select select-bordered rounded-2xl bg-base-100"
@@ -1108,7 +1108,7 @@ onMounted(async () => {
                 </label>
 
                 <label class="form-control">
-                  <span class="mb-2 text-sm font-bold">Extra Prompt Notes</span>
+                  <span class="kr-text-bold-sm mb-2">Extra Prompt Notes</span>
                   <textarea
                     v-model="extraPrompt"
                     rows="5"
@@ -1177,7 +1177,7 @@ onMounted(async () => {
 
             <div class="grid gap-4 lg:grid-cols-2">
               <div class="kr-panel-flat p-3">
-                <div class="mb-2 text-sm font-bold">
+                <div class="kr-text-bold-sm mb-2">
                   {{ selectedAnimalADef.label }}
                 </div>
                 <img
@@ -1188,7 +1188,7 @@ onMounted(async () => {
               </div>
 
               <div class="kr-panel-flat p-3">
-                <div class="mb-2 text-sm font-bold">
+                <div class="kr-text-bold-sm mb-2">
                   {{ selectedAnimalBDef.label }}
                 </div>
                 <img
@@ -1200,7 +1200,7 @@ onMounted(async () => {
             </div>
 
             <label class="form-control">
-              <span class="mb-2 text-sm font-bold">Extra Prompt Notes</span>
+              <span class="kr-text-bold-sm mb-2">Extra Prompt Notes</span>
               <textarea
                 v-model="extraPrompt"
                 rows="5"

--- a/components/art/hair-studio-manager.vue
+++ b/components/art/hair-studio-manager.vue
@@ -15,7 +15,7 @@
       </div>
       <span
         v-if="stylist.isBusy"
-        class="flex items-center gap-2 text-sm font-bold text-primary"
+        class="kr-text-bold-sm flex items-center gap-2 text-primary"
       >
         <span class="kr-spinner-sm" />
         styling

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -45,7 +45,7 @@
           </div>
 
           <div class="flex min-w-44 flex-1 flex-col">
-            <span class="truncate text-sm font-bold">{{ customer.name }}</span>
+            <span class="kr-text-bold-sm truncate">{{ customer.name }}</span>
             <span class="kr-text-dim-xs truncate">
               {{ customer.email || 'no email' }} ·
               {{ superkate.appointmentsForCustomer(customer.id).length }} appointments ·

--- a/components/art/stylist-history.vue
+++ b/components/art/stylist-history.vue
@@ -45,7 +45,7 @@
       >
         <div class="flex flex-wrap items-center gap-2">
           <div class="flex min-w-0 flex-1 flex-col">
-            <span class="truncate text-sm font-bold">{{ appointment.clientName }}</span>
+            <span class="kr-text-bold-sm truncate">{{ appointment.clientName }}</span>
             <span class="kr-text-dim-xs">
               {{ appointment.date }} · {{ formatCents(appointment.hourlyRateCents) }}/hr ×
               {{ formatMinutes(appointment.minutes) }} +

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -156,7 +156,7 @@
       <label class="flex items-start gap-2">
         <input v-model="changeColor" type="checkbox" class="kr-checkbox-primary-sm mt-1" />
         <div class="flex flex-1 flex-col gap-1">
-          <span class="text-sm font-bold">Change color</span>
+          <span class="kr-text-bold-sm">Change color</span>
           <input
             v-model="colorValue"
             :disabled="!changeColor"
@@ -170,7 +170,7 @@
       <label class="flex items-start gap-2">
         <input v-model="changeStyle" type="checkbox" class="kr-checkbox-primary-sm mt-1" />
         <div class="flex flex-1 flex-col gap-1">
-          <span class="text-sm font-bold">Change style</span>
+          <span class="kr-text-bold-sm">Change style</span>
           <input
             v-model="styleValue"
             :disabled="!changeStyle"
@@ -184,7 +184,7 @@
       <label class="flex items-start gap-2">
         <input v-model="enhanceImage" type="checkbox" class="kr-checkbox-primary-sm mt-1" />
         <div class="flex flex-1 flex-col gap-1">
-          <span class="text-sm font-bold">Improve the overall image</span>
+          <span class="kr-text-bold-sm">Improve the overall image</span>
           <span class="kr-text-dim-xs">Cleaner lighting, sharper detail — face and identity kept.</span>
         </div>
       </label>

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -184,7 +184,7 @@
             <div
               class="flex items-center justify-between gap-3 kr-panel-muted-sm"
             >
-              <span class="text-sm font-bold">Keep avatar</span>
+              <span class="kr-text-bold-sm">Keep avatar</span>
 
               <input
                 v-model="keepField.avatarImage"

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -229,7 +229,7 @@
           <label class="form-control">
             <div class="mb-1 flex items-center justify-between">
               <span class="kr-label-bold">Temperature</span>
-              <span class="font-mono text-sm font-bold text-primary">
+              <span class="kr-text-bold-sm font-mono text-primary">
                 {{ temperature.toFixed(1) }}
               </span>
             </div>

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -154,7 +154,7 @@
         class="mt-4 rounded-2xl border border-base-content/10 bg-base-200/45 p-3"
         data-testid="brainstorm-response-mix"
       >
-        <summary class="cursor-pointer select-none text-sm font-bold text-base-content/75">
+        <summary class="kr-text-bold-sm cursor-pointer select-none text-base-content/75">
           Response mix
           <span class="ml-2 font-normal text-base-content/45">{{ responseMixSummary }}</span>
         </summary>
@@ -256,7 +256,7 @@
       </details>
 
       <details class="mt-4 rounded-2xl border border-base-content/10 bg-base-200/45 p-3">
-        <summary class="cursor-pointer select-none text-sm font-bold text-base-content/75">
+        <summary class="kr-text-bold-sm cursor-pointer select-none text-base-content/75">
           Add constraints or examples
         </summary>
         <div class="mt-4 grid grid-cols-[repeat(auto-fit,minmax(min(100%,18rem),1fr))] gap-4">
@@ -293,7 +293,7 @@
         class="mt-4 rounded-2xl border border-base-content/10 bg-base-200/45 p-3"
         data-testid="brainstorm-source"
       >
-        <summary class="cursor-pointer select-none text-sm font-bold text-base-content/75">
+        <summary class="kr-text-bold-sm cursor-pointer select-none text-base-content/75">
           Ground it in a Kind Robots object
           <span v-if="source" class="ml-2 font-normal text-success">linked</span>
         </summary>
@@ -414,7 +414,7 @@
         class="mt-4 rounded-2xl border border-base-content/10 bg-base-200/45 p-3"
         data-testid="brainstorm-saved-work"
       >
-        <summary class="cursor-pointer select-none text-sm font-bold text-base-content/75">
+        <summary class="kr-text-bold-sm cursor-pointer select-none text-base-content/75">
           Saved work
           <span v-if="savedSessionId" class="ml-2 font-normal text-success">linked</span>
         </summary>
@@ -517,7 +517,7 @@
                 >
                   <span class="min-w-0">
                     <span
-                      class="block truncate text-sm font-bold text-base-content"
+                      class="kr-text-bold-sm block truncate text-base-content"
                     >
                       {{ saved.name }}
                     </span>
@@ -585,7 +585,7 @@
       <summary
         class="flex cursor-pointer select-none flex-wrap items-center justify-between gap-2"
       >
-        <span class="text-sm font-bold text-base-content/75">
+        <span class="kr-text-bold-sm text-base-content/75">
           Kept ideas
           <span class="ml-1 font-normal text-base-content/45">
             {{ selectedKeptCandidates.length }}/{{ allKeptCandidates.length }}
@@ -611,7 +611,7 @@
             @change="toggleKeptSelection(candidate.id)"
           />
           <span class="min-w-0 flex-1">
-            <span class="block truncate text-sm font-bold text-base-content">{{
+            <span class="kr-text-bold-sm block truncate text-base-content">{{
               candidate.title
             }}</span>
             <span class="kr-text-dim-xs-55 line-clamp-2 leading-5">{{
@@ -678,7 +678,7 @@
           {{ keptCandidates.length }} kept · {{ rejectedCandidates.length }} rejected
         </p>
       </div>
-      <p v-if="isGenerating && generationTargetId" class="text-sm font-bold text-secondary">
+      <p v-if="isGenerating && generationTargetId" class="kr-text-bold-sm text-secondary">
         Working on one idea without touching the others…
       </p>
     </div>

--- a/components/builder/builder-card.vue
+++ b/components/builder/builder-card.vue
@@ -62,7 +62,7 @@
       </div>
 
       <div class="min-h-0 flex-1 space-y-1.5 xl:hidden">
-        <p class="line-clamp-1 text-sm font-bold leading-snug text-secondary">
+        <p class="kr-text-bold-sm line-clamp-1 leading-snug text-secondary">
           {{ card.tagline }}
         </p>
 

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -244,9 +244,7 @@
             </div>
 
             <details class="mb-3 kr-panel-muted-sm">
-              <summary
-                class="cursor-pointer text-sm font-bold text-base-content"
-              >
+              <summary class="kr-text-bold-sm cursor-pointer text-base-content">
                 Getting To Know You Questions
               </summary>
 

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -4,7 +4,7 @@
     <div class="flex flex-wrap items-center gap-2">
       <Icon name="kind-icon:tag" class="size-4 text-secondary" />
       <div class="min-w-0 flex-1">
-        <h3 class="text-sm font-bold">Character Facets</h3>
+        <h3 class="kr-text-bold-sm">Character Facets</h3>
         <p class="kr-text-dim-xs">
           Species, archetype, quirks, and other reusable traits that shape
           this character independently of their name.

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -72,7 +72,7 @@
             </div>
             <div class="flex items-center justify-between gap-2">
               <span
-                class="text-sm font-bold text-base-content group-hover:text-primary"
+                class="kr-text-bold-sm text-base-content group-hover:text-primary"
               >
                 {{ pageRef.title }}
               </span>

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -130,7 +130,7 @@
               >
                 {{ item.type }}
               </span>
-              <span class="truncate text-sm font-bold text-base-content">
+              <span class="kr-text-bold-sm truncate text-base-content">
                 {{ item.draftPayload?.title || item.id }}
               </span>
               <span

--- a/components/conductor/packmaker-pack-editor.vue
+++ b/components/conductor/packmaker-pack-editor.vue
@@ -120,7 +120,7 @@
           <span class="kr-badge-ghost-xs rounded-lg">{{
             item.type
           }}</span>
-          <span class="text-sm font-bold">{{
+          <span class="kr-text-bold-sm">{{
             item.draftPayload.title || item.id || `item ${index + 1}`
           }}</span>
           <button

--- a/components/content-visibility-controls.vue
+++ b/components/content-visibility-controls.vue
@@ -2,7 +2,7 @@
   <section class="space-y-2 kr-panel-flat p-3">
     <div class="flex flex-wrap items-start justify-between gap-2">
       <div>
-        <h3 class="text-sm font-bold">Content visibility</h3>
+        <h3 class="kr-text-bold-sm">Content visibility</h3>
         <p class="kr-text-dim-xs-55 mt-0.5">
           Mature work defaults private; general-audience work defaults public.
           You can override privacy after choosing maturity.

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -89,7 +89,7 @@
       </div>
 
       <div class="flex flex-wrap items-center justify-between gap-2">
-        <div class="flex items-center gap-3 text-sm font-bold">
+        <div class="kr-text-bold-sm flex items-center gap-3">
           <span class="flex items-center gap-1">
             <Icon name="kind-icon:coin" class="size-4 text-warning" />
             {{ tankStore.coins }}
@@ -211,7 +211,7 @@
           >
             <div class="flex items-start justify-between gap-2">
               <div>
-                <p class="text-sm font-bold">{{ entry.Monster.name }}</p>
+                <p class="kr-text-bold-sm">{{ entry.Monster.name }}</p>
                 <p class="mt-0.5 text-xs italic opacity-70">
                   {{ entry.Monster.species || entry.Monster.behavior || '—' }}
                 </p>
@@ -348,7 +348,7 @@
               placeholder-icon="kind-icon:fish"
             />
             <div class="min-w-0 flex-1">
-              <p class="truncate text-sm font-bold">{{ entry.name }}</p>
+              <p class="kr-text-bold-sm truncate">{{ entry.name }}</p>
               <!-- Deliberately never the field note here -- the server
                    doesn't even send it for unowned species
                    (cthulhuquarium/t-012). It reveals in the dialog below,
@@ -429,7 +429,7 @@
                 "
               />
               <div class="min-w-0 flex-1">
-                <p class="truncate text-sm font-bold">{{ entry.name }}</p>
+                <p class="kr-text-bold-sm truncate">{{ entry.name }}</p>
                 <p class="mt-0.5 line-clamp-2 text-xs italic opacity-70">
                   {{
                     entry.collected
@@ -506,7 +506,7 @@
               :class="{ 'border-primary/60': entry.equipped }"
             >
               <div class="flex items-start justify-between gap-2">
-                <p class="text-sm font-bold">{{ entry.title }}</p>
+                <p class="kr-text-bold-sm">{{ entry.title }}</p>
                 <span
                   v-if="entry.equipped"
                   class="kr-badge-primary-xs shrink-0"
@@ -587,7 +587,7 @@
               }"
             >
               <div class="flex items-start justify-between gap-2">
-                <p class="text-sm font-bold">
+                <p class="kr-text-bold-sm">
                   <span class="mr-1">{{ entry.icon }}</span
                   >{{ entry.title }}
                 </p>
@@ -658,7 +658,7 @@
                 EGG_ICON
               }}</span>
               <div class="min-w-0 flex-1">
-                <p class="truncate text-sm font-bold">
+                <p class="kr-text-bold-sm truncate">
                   {{ egg.rarity.charAt(0)
                   }}{{ egg.rarity.slice(1).toLowerCase() }}
                   Egg
@@ -697,7 +697,7 @@
                 entry.icon
               }}</span>
               <div class="min-w-0 flex-1">
-                <p class="truncate text-sm font-bold">
+                <p class="kr-text-bold-sm truncate">
                   {{ entry.title }}
                   <span class="font-normal opacity-60"
                     >(size {{ entry.size }})</span
@@ -744,7 +744,7 @@
         />
         <div class="min-w-0 flex-1">
           <div class="flex items-start justify-between gap-2">
-            <p class="text-sm font-bold">{{ tankStore.finaleConfig.title }}</p>
+            <p class="kr-text-bold-sm">{{ tankStore.finaleConfig.title }}</p>
             <span
               v-if="tankStore.finaleTriggered"
               class="kr-badge-primary-xs shrink-0"

--- a/components/curation/coloring-book-curation.vue
+++ b/components/curation/coloring-book-curation.vue
@@ -32,7 +32,7 @@
       </label>
 
       <label
-        class="flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 px-3 py-2 text-sm font-bold"
+        class="kr-text-bold-sm flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 px-3 py-2"
       >
         <input
           v-model="hideFinal"

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -12,7 +12,7 @@
       </label>
 
       <label
-        class="flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 px-3 py-2 text-sm font-bold"
+        class="kr-text-bold-sm flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 px-3 py-2"
       >
         <input
           v-model="hideSettled"

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -101,7 +101,7 @@
         </label>
 
         <label
-          class="mt-auto flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 px-3 py-2 text-sm font-bold"
+          class="kr-text-bold-sm mt-auto flex cursor-pointer items-center gap-2 rounded-xl border border-base-300 px-3 py-2"
         >
           <input
             v-model="overrideOnly"

--- a/components/dreams/daily-digest-browser.vue
+++ b/components/dreams/daily-digest-browser.vue
@@ -84,7 +84,7 @@
 
             <p
               v-if="activeDream.PitchSheet?.subtitle"
-              class="mb-3 text-sm font-bold leading-relaxed text-primary"
+              class="kr-text-bold-sm mb-3 leading-relaxed text-primary"
             >
               {{ activeDream.PitchSheet.subtitle }}
             </p>

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -32,7 +32,7 @@
             class="absolute inset-0 flex flex-col items-center justify-center gap-2 p-6 text-center text-base-content/40"
           >
             <Icon name="kind-icon:image" class="size-12 opacity-40" />
-            <p class="text-sm font-bold">
+            <p class="kr-text-bold-sm">
               No {{ selectedSlot.label.toLowerCase() }} is attached yet.
             </p>
           </div>
@@ -140,7 +140,7 @@
             :disabled="submitting"
           />
           <span>
-            <span class="block text-sm font-bold">Keep the current version as inspiration</span>
+            <span class="kr-text-bold-sm block">Keep the current version as inspiration</span>
             <span class="kr-text-dim-xs-45 block leading-relaxed">
               Preserve the previous image in object history before the replacement attaches.
             </span>

--- a/components/dreams/dream-pitch-sheet.vue
+++ b/components/dreams/dream-pitch-sheet.vue
@@ -74,7 +74,7 @@
           </h2>
           <p
             v-if="subtitle"
-            class="mt-2 line-clamp-2 text-sm font-bold leading-snug text-(--sheet-muted) sm:text-base"
+            class="kr-text-bold-sm mt-2 line-clamp-2 leading-snug text-(--sheet-muted) sm:text-base"
           >
             {{ subtitle }}
           </p>

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -4,7 +4,7 @@
     <div class="flex flex-wrap items-center gap-2">
       <Icon name="kind-icon:tag" class="size-4 text-secondary" />
       <div class="min-w-0 flex-1">
-        <h3 class="text-sm font-bold">{{ label }}</h3>
+        <h3 class="kr-text-bold-sm">{{ label }}</h3>
         <p class="kr-text-dim-xs">
           Reusable creative building blocks shared by Characters, Bots, Dreams,
           Rewards, Scenarios, and art. Aliases resolve to one canonical Facet.

--- a/components/facets/facet-profile-editor.vue
+++ b/components/facets/facet-profile-editor.vue
@@ -112,7 +112,7 @@
       <div class="mb-3 flex items-center gap-2">
         <Icon name="kind-icon:palette" class="size-4 text-accent" />
         <div>
-          <h3 class="text-sm font-bold">Curated artwork</h3>
+          <h3 class="kr-text-bold-sm">Curated artwork</h3>
           <p class="kr-text-dim-xs">
             Preserve primary, portrait/card, and hero/wide roles separately.
           </p>

--- a/components/home/home-dream-hero.vue
+++ b/components/home/home-dream-hero.vue
@@ -315,7 +315,7 @@
         -->
           <div class="min-w-0 shrink-0 px-2 py-1.5">
             <p
-              class="line-clamp-2 text-sm font-bold leading-tight group-hover:text-primary"
+              class="kr-text-bold-sm line-clamp-2 leading-tight group-hover:text-primary"
             >
               {{ member.title }}
             </p>

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -72,7 +72,7 @@
       </div>
       <div class="min-w-0 flex-1">
         <div class="flex items-center gap-1.5">
-          <span class="truncate text-sm font-bold text-base-content">
+          <span class="kr-text-bold-sm truncate text-base-content">
             {{ run?.sourceLabel }}
           </span>
           <span class="kr-badge-ghost-xs">{{ run?.sourceType }}</span>

--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -90,7 +90,7 @@
 
         <div class="min-w-0 flex-1">
           <div class="flex items-center gap-1.5">
-            <span class="truncate text-sm font-bold text-base-content">
+            <span class="kr-text-bold-sm truncate text-base-content">
               {{ output.label }}
             </span>
             <span class="kr-badge-ghost-xs">{{

--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -73,7 +73,7 @@
 
           <div class="min-w-0 flex-1">
             <div class="flex items-center gap-1.5">
-              <span class="truncate text-sm font-bold text-base-content">
+              <span class="kr-text-bold-sm truncate text-base-content">
                 {{ run.sourceLabel || `#${run.sourceId}` }}
               </span>
               <span class="kr-badge-ghost-xs">{{

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -183,7 +183,7 @@
           </div>
 
           <div class="min-w-0 flex-1">
-            <span class="block truncate text-sm font-bold text-base-content">
+            <span class="kr-text-bold-sm block truncate text-base-content">
               {{ store.sourceLabel(record) }}
             </span>
             <span
@@ -236,7 +236,7 @@
               class="h-4 w-4 text-base-content/30"
             />
           </div>
-          <span class="shrink-0 truncate text-sm font-bold text-base-content">
+          <span class="kr-text-bold-sm shrink-0 truncate text-base-content">
             {{ store.sourceLabel(record) }}
           </span>
           <span

--- a/components/narrative/kr-choice-list.vue
+++ b/components/narrative/kr-choice-list.vue
@@ -55,7 +55,7 @@
            the buttons sit inline as quick topics. -->
       <span
         v-if="layout === 'stack' && showIndex"
-        class="grid size-7 shrink-0 place-items-center rounded-full bg-primary/12 text-sm font-bold text-primary"
+        class="kr-text-bold-sm grid size-7 shrink-0 place-items-center rounded-full bg-primary/12 text-primary"
         aria-hidden="true"
       >
         {{ index + 1 }}

--- a/components/narrative/narrative-art-status.vue
+++ b/components/narrative/narrative-art-status.vue
@@ -38,7 +38,7 @@
       class="flex min-h-24 flex-wrap items-center justify-between gap-3 bg-error/5 p-4"
     >
       <div class="min-w-0 flex-1">
-        <p class="text-sm font-bold text-error">
+        <p class="kr-text-bold-sm text-error">
           {{ art.status === 'cancelled' ? 'Illustration cancelled' : 'Illustration paused' }}
         </p>
         <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">

--- a/components/navigation/maturity-toggle.vue
+++ b/components/navigation/maturity-toggle.vue
@@ -25,7 +25,7 @@
           </span>
 
           <span class="min-w-0">
-            <span class="block text-sm font-bold text-base-content">
+            <span class="kr-text-bold-sm block text-base-content">
               {{ label }}
             </span>
             <span class="kr-text-dim-xs-55 block">

--- a/components/pages/memory-dungeon.vue
+++ b/components/pages/memory-dungeon.vue
@@ -510,7 +510,7 @@
         class="absolute bottom-10 left-2 right-2 z-40 max-h-[min(45dvh,20rem)] overflow-y-auto rounded-2xl border border-base-content/15 bg-base-100/95 px-4 py-3 shadow-2xl backdrop-blur-md sm:left-auto sm:w-96"
       >
         <div class="mb-2 flex items-center justify-between gap-2">
-          <h2 class="text-sm font-bold">🏆 Global Leaderboard</h2>
+          <h2 class="kr-text-bold-sm">🏆 Global Leaderboard</h2>
           <button
             type="button"
             class="kr-btn-ghost-xs-lg"

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -248,7 +248,7 @@
                       >
                         Setting
                       </span>
-                      <span class="block truncate text-sm font-bold">
+                      <span class="kr-text-bold-sm block truncate">
                         {{ selectedLocationLabel }}
                       </span>
                     </span>
@@ -292,7 +292,7 @@
                       >
                         Genre, mood, and style
                       </span>
-                      <span class="block truncate text-sm font-bold">
+                      <span class="kr-text-bold-sm block truncate">
                         {{ selectedGrammarLabel }}
                       </span>
                     </span>

--- a/components/projects/project-placement-manager.vue
+++ b/components/projects/project-placement-manager.vue
@@ -72,7 +72,7 @@
 
           <div class="flex flex-wrap items-center gap-2">
             <label
-              class="flex cursor-pointer items-center gap-2 kr-panel-muted-compact-row text-sm font-bold"
+              class="kr-text-bold-sm flex cursor-pointer items-center gap-2 kr-panel-muted-compact-row"
             >
               <input
                 v-model="overwriteLiveUrl"

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -440,7 +440,7 @@ onMounted(async () => {
     </header>
 
     <div v-if="showAddChoice" class="flex flex-col gap-3 kr-panel-flat p-4">
-      <p class="text-sm font-bold">What are you adding?</p>
+      <p class="kr-text-bold-sm">What are you adding?</p>
       <div class="flex flex-wrap gap-2">
         <button
           type="button"

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -4,7 +4,7 @@
     <div class="flex flex-wrap items-center gap-2">
       <Icon name="kind-icon:tag" class="size-4 text-secondary" />
       <div class="min-w-0 flex-1">
-        <h3 class="text-sm font-bold">Reward Facets</h3>
+        <h3 class="kr-text-bold-sm">Reward Facets</h3>
         <p class="kr-text-dim-xs">
           Materials, colors, themes, and other reusable traits that shape the
           object independently of its name.

--- a/components/ruler-hooked/ruler-hooked-game.vue
+++ b/components/ruler-hooked/ruler-hooked-game.vue
@@ -16,7 +16,7 @@
 
         <div class="flex items-center justify-between gap-3">
           <div>
-            <p class="text-sm font-bold">{{ store.save.ruler.honorific }} {{ store.save.ruler.name }}</p>
+            <p class="kr-text-bold-sm">{{ store.save.ruler.honorific }} {{ store.save.ruler.name }}</p>
             <p class="text-xs opacity-60">Turn {{ store.save.turnCount }} · {{ store.save.status.toLowerCase() }} · {{ store.save.counters.fishCaught ?? 0 }} fish</p>
           </div>
           <button
@@ -60,7 +60,7 @@
         />
 
         <div v-if="store.pendingEnding" class="rounded-xl border border-accent bg-accent/10 p-4">
-          <p class="text-sm font-bold">An ending is within reach:</p>
+          <p class="kr-text-bold-sm">An ending is within reach:</p>
           <p class="mt-1 text-lg font-bold">{{ endingTitle }}</p>
           <p v-if="endingBody" class="text-sm opacity-80">{{ endingBody }}</p>
           <div class="mt-3 flex gap-2">

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -336,7 +336,7 @@
                 v-if="userStore.isAdmin"
                 class="label cursor-pointer gap-2 rounded-xl border border-base-300 bg-base-200 px-3 py-1.5"
               >
-                <span class="label-text text-sm font-bold">Mature</span>
+                <span class="kr-text-bold-sm label-text">Mature</span>
 
                 <input
                   v-model="showMature"

--- a/components/screenfx/animation-layer.vue
+++ b/components/screenfx/animation-layer.vue
@@ -22,7 +22,7 @@
         aria-live="polite"
       >
         <div
-          class="pointer-events-auto flex max-w-full items-center gap-3 rounded-2xl px-4 py-3 text-sm font-bold text-base-content shadow-xl backdrop-blur-md"
+          class="kr-text-bold-sm pointer-events-auto flex max-w-full items-center gap-3 rounded-2xl px-4 py-3 text-base-content shadow-xl backdrop-blur-md"
         >
           <span class="loading loading-spinner loading-sm text-primary" />
 

--- a/components/servers/checkpoint-gallery.vue
+++ b/components/servers/checkpoint-gallery.vue
@@ -21,7 +21,7 @@
       class="flex shrink-0 items-center justify-between gap-2 kr-panel-muted-row"
     >
       <div class="min-w-0">
-        <h2 class="truncate text-sm font-bold text-base-content">
+        <h2 class="kr-text-bold-sm truncate text-base-content">
           {{ title }}
         </h2>
         <!-- Orientation text, not instruction: it costs a whole row on the

--- a/components/servers/server-gallery.vue
+++ b/components/servers/server-gallery.vue
@@ -12,7 +12,7 @@
       class="flex shrink-0 items-center justify-between gap-2 kr-panel-muted-row"
     >
       <div class="min-w-0">
-        <h2 class="truncate text-sm font-bold text-base-content">
+        <h2 class="kr-text-bold-sm truncate text-base-content">
           {{ resolvedTitle }}
         </h2>
         <p class="kr-text-dim-xs-60 hidden truncate md:block">

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -70,7 +70,7 @@
       >
         <div class="flex items-start justify-between gap-3">
           <div class="min-w-0">
-            <p class="truncate text-sm font-bold">{{ credential.label }}</p>
+            <p class="kr-text-bold-sm truncate">{{ credential.label }}</p>
             <p class="kr-text-dim-xs-55 truncate">
               {{ botLabel(credential.botId) }} · {{ credential.keyPrefix }}…
             </p>

--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -153,7 +153,7 @@
             class="flex flex-1 flex-col items-center justify-center gap-2 text-center text-base-content/55"
           >
             <Icon name="kind-icon:gallery" class="h-10 w-10 text-primary/60" />
-            <p class="text-sm font-bold text-base-content">No images here yet.</p>
+            <p class="kr-text-bold-sm text-base-content">No images here yet.</p>
             <p class="text-xs">Try the Upload or Generate tab to make your first one.</p>
           </div>
 

--- a/components/user/login-page.vue
+++ b/components/user/login-page.vue
@@ -17,13 +17,13 @@
       />
 
       <div
-        class="pointer-events-none absolute left-4 top-5 hidden rounded-full border border-white/30 bg-white/20 px-4 py-2 text-sm font-bold text-white shadow-xl backdrop-blur-md sm:block"
+        class="kr-text-bold-sm pointer-events-none absolute left-4 top-5 hidden rounded-full border border-white/30 bg-white/20 px-4 py-2 text-white shadow-xl backdrop-blur-md sm:block"
       >
         ✨ empathy.exe loaded
       </div>
 
       <div
-        class="pointer-events-none absolute bottom-5 right-4 hidden rounded-full border border-white/30 bg-white/20 px-4 py-2 text-sm font-bold text-white shadow-xl backdrop-blur-md md:block"
+        class="kr-text-bold-sm pointer-events-none absolute bottom-5 right-4 hidden rounded-full border border-white/30 bg-white/20 px-4 py-2 text-white shadow-xl backdrop-blur-md md:block"
       >
         🦋 tiny robot sanctuary
       </div>
@@ -71,7 +71,7 @@
           class="mb-5 flex flex-col items-center gap-3 rounded-2xl border border-info/30 bg-info/10 px-4 py-6 text-info"
         >
           <Icon name="kind-icon:bubble-loading" class="text-3xl animate-spin" />
-          <span class="text-sm font-bold tracking-wide">
+          <span class="kr-text-bold-sm tracking-wide">
             Authenticating the human...
           </span>
         </div>

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -180,7 +180,7 @@
 
                   <p class="mt-2 text-2xl font-black text-secondary">
                     {{ manaStore.balance }}
-                    <span class="text-sm font-bold text-base-content/45">
+                    <span class="kr-text-bold-sm text-base-content/45">
                       / {{ manaStore.cap }}
                     </span>
                   </p>

--- a/components/user/user-galleries.vue
+++ b/components/user/user-galleries.vue
@@ -87,7 +87,7 @@
             class="mt-3 kr-panel-muted-sm"
           >
             <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
-              <p class="text-sm font-bold">Inline {{ section.label }} preview</p>
+              <p class="kr-text-bold-sm">Inline {{ section.label }} preview</p>
               <div class="join">
                 <button
                   type="button"

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -123,7 +123,7 @@
           </div>
 
           <div class="flex flex-wrap items-center gap-2 kr-panel-divider">
-            <span class="text-sm font-bold"
+            <span class="kr-text-bold-sm"
               >{{ triageStore.selectedCount }} selected</span
             >
             <button
@@ -307,7 +307,7 @@
             >
               Previous
             </button>
-            <span class="text-sm font-bold"
+            <span class="kr-text-bold-sm"
               >Page {{ safePage }} / {{ totalPages }}</span
             >
             <button

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -95,7 +95,7 @@
                     :disabled="store.loading || store.queueing"
                     @change="onDurationChange"
                   />
-                  <span class="join-item grid place-items-center border border-base-300 bg-base-200 px-3 text-sm font-bold">sec</span>
+                  <span class="kr-text-bold-sm join-item grid place-items-center border border-base-300 bg-base-200 px-3">sec</span>
                 </div>
               </label>
             </div>

--- a/pages/play/aquarium/browse/[username]/[slug].vue
+++ b/pages/play/aquarium/browse/[username]/[slug].vue
@@ -26,7 +26,7 @@
       >
         <div class="text-center">
           <span class="loading loading-ring loading-lg text-primary" />
-          <p class="mt-3 text-sm font-bold text-base-content/55">
+          <p class="kr-text-bold-sm mt-3 text-base-content/55">
             Peering into the tank…
           </p>
         </div>
@@ -122,7 +122,7 @@
               placeholder-icon="kind-icon:fish"
             />
             <div class="min-w-0">
-              <p class="truncate text-sm font-bold">
+              <p class="kr-text-bold-sm truncate">
                 {{ entry.nickname || entry.Monster.name }}
               </p>
               <p class="truncate text-xs italic opacity-60">

--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -33,7 +33,7 @@
       >
         <div class="text-center">
           <span class="loading loading-ring loading-lg text-primary" />
-          <p class="mt-3 text-sm font-bold text-base-content/55">
+          <p class="kr-text-bold-sm mt-3 text-base-content/55">
             Finding public tanks…
           </p>
         </div>

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -33,7 +33,7 @@
       >
         <div class="text-center">
           <span class="loading loading-ring loading-lg text-primary" />
-          <p class="mt-3 text-sm font-bold text-base-content/55">
+          <p class="kr-text-bold-sm mt-3 text-base-content/55">
             Tallying specimens…
           </p>
         </div>
@@ -89,7 +89,7 @@
                 class="size-4 text-primary/60"
               />
             </div>
-            <p class="min-w-0 flex-1 truncate text-sm font-bold">
+            <p class="kr-text-bold-sm min-w-0 flex-1 truncate">
               @{{ entry.username }}
             </p>
             <p class="kr-text-black-sm shrink-0 text-primary">

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -23,7 +23,7 @@
       >
         <div class="text-center">
           <span class="loading loading-ring loading-lg text-primary" />
-          <p class="mt-3 text-sm font-bold text-base-content/55">
+          <p class="kr-text-bold-sm mt-3 text-base-content/55">
             Building the matchup…
           </p>
         </div>

--- a/utils/scripts/codemods/kr_text_bold_sm_codemod.py
+++ b/utils/scripts/codemods/kr_text_bold_sm_codemod.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `font-bold text-sm` label/heading text to
+`kr-text-bold-sm`.
+
+First of a new `kr-text-bold-*` family (interface-vision t-104 slice 169) --
+weight sibling in spirit to `kr-text-black-*` (font-black) but for
+`font-bold`, the same relationship `kr-text-eyebrow-bold` has to
+`kr-text-eyebrow`. A fresh full-repo class-frequency survey outside the
+now-closed `kr-text-black-*`/`kr-text-dim-*`/`kr-text-eyebrow`/
+`kr-text-eyebrow-bold` families found `font-bold text-sm` at 90
+subset-match occurrences across 57 files -- the largest bounded pattern
+surfaced this slice (ahead of `font-bold text-xs`, 84 occurrences across 35
+files, and `label-text text-xs font-bold`, 25 occurrences across 4 files,
+both left for future slices).
+
+Dry-run by default, --write to update matching Vue files in place. Only the
+exact `font-bold text-sm` shape is touched, and only in static
+`class="..."` attributes -- never `:class`/`v-bind:class` bindings, and
+regardless of the base tokens' order in the source. A source that already
+carries `kr-text-bold-sm`, or is missing either base token, is left
+untouched. Extra tokens beyond the base set are preserved verbatim after
+the primitive class, matching the kr-badge-*/kr-spinner-*/kr-label-bold/
+kr-text-dim-*/kr-text-black-*/kr-text-eyebrow-* codemods' subset-match
+convention -- pass --exact-only to restrict a slice to sources with no
+extra tokens at all, the safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-bold-sm"
+BASE_TOKENS = {"font-bold", "text-sm"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-bold-sm {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 169: shared kr-* component/composition-rule consistency umbrella (recurring). (kind: software)

### What changed / what I produced
- Added `.kr-text-bold-sm` (`assets/css/tailwind.css`) — `@apply font-bold text-sm;`. First of a new `kr-text-bold-*` family, weight sibling in spirit to `kr-text-black-*` but for `font-bold` instead of `font-black` (same relationship `kr-text-eyebrow-bold` has to `kr-text-eyebrow`).
- Added `utils/scripts/codemods/kr_text_bold_sm_codemod.py` (dry-run by default, `--write` to apply) following the established subset-match convention used by every prior `kr-*` codemod in this series.
- Migrated all 90 subset-match occurrences of hand-rolled `font-bold text-sm` across 57 files to `kr-text-bold-sm`, preserving any extra utility tokens verbatim. No geometry or behavior change — purely a class-name consolidation.

A fresh full-repo class-frequency survey (outside the now-closed `kr-text-black-*`/`kr-text-dim-*`/`kr-text-eyebrow`/`kr-text-eyebrow-bold` families) found `font-bold text-sm` as the largest bounded pattern this slice (90 occurrences/57 files), ahead of `font-bold text-xs` (84/35) and `label-text text-xs font-bold` (25/4, already flagged as a future-slice candidate in `kr_label_bold_codemod.py`'s own docstring). Both left for future slices.

### How I verified
- `npm run test` (vue-tsc --noEmit): clean, no errors.
- `npm run lint:js`: 333 problems (327 errors, 6 warnings) — identical before/after via `git stash` (confirmed none are in touched files).
- `npm run test:layout-contract`: holds, no new violations (same unrelated -2 ratchet opportunity in `narrative-ingredient-multi-picker.vue`, left untouched, out of scope).
- `npm run lint:prettier`: found 1 genuinely new fallout file (`components/characters/character-chat.vue`, a `text-sm font-bold` → `kr-text-bold-sm` class string that now fits prettier's line-length differently) via `git stash` diff of flagged-file lists; fixed with a targeted `npx prettier --write` on just that file, landing back at the exact pre-existing baseline (1148 files) byte-for-byte.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Slice 170 should run a fresh full-repo class-frequency survey outside the now-covered `kr-text-black-*`/`kr-text-dim-*`/`kr-text-eyebrow`/`kr-text-eyebrow-bold`/`kr-text-bold-sm` families. Two candidates already surveyed but not yet mined: `font-bold text-xs` (84 occurrences, 35 files, natural next sibling in the new `kr-text-bold-*` family) and `label-text text-xs font-bold` (25 occurrences, 4 files, previously flagged in `kr_label_bold_codemod.py`'s own docstring as its own bounded family for a future slice).

### Notes for reviewer
Conductor task `interface-vision/t-104` claimed via `claim_task.py` at session start; will close out (`review` → `done`, re-arming the recurring umbrella) via `close_task.py` once this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETHX6hM3fp7qjTyxML1Tqc

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETHX6hM3fp7qjTyxML1Tqc)_