### PR TITLE
refactor(ui): drop dead label-text token from kr-text-bold-xs (slice 171)

### DIFF
--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -217,9 +217,7 @@
             <div class="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-4">
               <label class="form-control">
                 <span class="label py-1"
-                  ><span class="kr-text-bold-xs label-text"
-                    >Designer</span
-                  ></span
+                  ><span class="kr-text-bold-xs">Designer</span></span
                 >
                 <input
                   v-model="editForm.designer"
@@ -231,7 +229,7 @@
 
               <label class="form-control">
                 <span class="label py-1"
-                  ><span class="kr-text-bold-xs label-text">Sampler</span></span
+                  ><span class="kr-text-bold-xs">Sampler</span></span
                 >
                 <input
                   v-model="editForm.sampler"
@@ -242,9 +240,7 @@
 
               <label class="form-control">
                 <span class="label py-1"
-                  ><span class="kr-text-bold-xs label-text"
-                    >Checkpoint</span
-                  ></span
+                  ><span class="kr-text-bold-xs">Checkpoint</span></span
                 >
                 <input
                   v-model="editForm.checkpoint"
@@ -255,7 +251,7 @@
 
               <label class="form-control">
                 <span class="label py-1"
-                  ><span class="kr-text-bold-xs label-text">Steps</span></span
+                  ><span class="kr-text-bold-xs">Steps</span></span
                 >
                 <input
                   v-model.number="editForm.steps"
@@ -267,7 +263,7 @@
 
               <label class="form-control">
                 <span class="label py-1"
-                  ><span class="kr-text-bold-xs label-text">Seed</span></span
+                  ><span class="kr-text-bold-xs">Seed</span></span
                 >
                 <input
                   v-model.number="editForm.seed"
@@ -278,7 +274,7 @@
 
               <label class="form-control">
                 <span class="label py-1"
-                  ><span class="kr-text-bold-xs label-text">CFG</span></span
+                  ><span class="kr-text-bold-xs">CFG</span></span
                 >
                 <input
                   v-model.number="editForm.cfg"
@@ -289,7 +285,7 @@
               </label>
 
               <label class="kr-toggle-row-plain">
-                <span class="kr-text-bold-xs label-text">Public</span>
+                <span class="kr-text-bold-xs">Public</span>
                 <input
                   v-model="editForm.isPublic"
                   type="checkbox"
@@ -298,7 +294,7 @@
               </label>
 
               <label class="kr-toggle-row-plain">
-                <span class="kr-text-bold-xs label-text">Mature</span>
+                <span class="kr-text-bold-xs">Mature</span>
                 <input
                   v-model="editForm.isMature"
                   type="checkbox"
@@ -319,9 +315,7 @@
               <div class="grid gap-2 p-3">
                 <label class="form-control">
                   <span class="label py-1"
-                    ><span class="kr-text-bold-xs label-text"
-                      >Prompt</span
-                    ></span
+                    ><span class="kr-text-bold-xs">Prompt</span></span
                   >
                   <textarea
                     v-model="editForm.promptString"
@@ -331,9 +325,7 @@
                 </label>
                 <label class="form-control">
                   <span class="label py-1"
-                    ><span class="kr-text-bold-xs label-text"
-                      >Negative Prompt</span
-                    ></span
+                    ><span class="kr-text-bold-xs">Negative Prompt</span></span
                   >
                   <textarea
                     v-model="editForm.negativePrompt"

--- a/components/conductor/packmaker-pack-editor.vue
+++ b/components/conductor/packmaker-pack-editor.vue
@@ -58,7 +58,7 @@
     <!-- Pack fields -->
     <div class="grid gap-2 sm:grid-cols-2">
       <label class="form-control">
-        <span class="kr-text-bold-xs label-text">Title</span>
+        <span class="kr-text-bold-xs">Title</span>
         <input
           v-model="draft.title"
           type="text"
@@ -67,7 +67,7 @@
         />
       </label>
       <label class="form-control">
-        <span class="kr-text-bold-xs label-text">Id (slug)</span>
+        <span class="kr-text-bold-xs">Id (slug)</span>
         <input
           v-model="draft.id"
           type="text"
@@ -77,7 +77,7 @@
         />
       </label>
       <label class="form-control sm:col-span-2">
-        <span class="kr-text-bold-xs label-text">Description</span>
+        <span class="kr-text-bold-xs">Description</span>
         <textarea
           v-model="draft.description"
           rows="2"
@@ -85,7 +85,7 @@
         />
       </label>
       <label class="form-control">
-        <span class="kr-text-bold-xs label-text">Price hook</span>
+        <span class="kr-text-bold-xs">Price hook</span>
         <select
           v-model="draft.price.hook"
           class="select select-bordered select-sm"
@@ -133,7 +133,7 @@
         </summary>
         <div class="grid gap-2 p-3 pt-1 sm:grid-cols-2">
           <label class="form-control">
-            <span class="kr-text-bold-xs label-text">Type</span>
+            <span class="kr-text-bold-xs">Type</span>
             <select
               v-model="item.type"
               class="select select-bordered select-sm"
@@ -146,7 +146,7 @@
             </select>
           </label>
           <label class="form-control">
-            <span class="kr-text-bold-xs label-text">Shape</span>
+            <span class="kr-text-bold-xs">Shape</span>
             <select
               v-model="item.itemShape"
               class="select select-bordered select-sm"
@@ -161,7 +161,7 @@
             </select>
           </label>
           <label class="form-control sm:col-span-2">
-            <span class="kr-text-bold-xs label-text">Title</span>
+            <span class="kr-text-bold-xs">Title</span>
             <input
               v-model="item.draftPayload.title"
               type="text"
@@ -170,7 +170,7 @@
             />
           </label>
           <label class="form-control sm:col-span-2">
-            <span class="kr-text-bold-xs label-text">Description</span>
+            <span class="kr-text-bold-xs">Description</span>
             <textarea
               v-model="item.draftPayload.description"
               rows="2"
@@ -178,7 +178,7 @@
             />
           </label>
           <label class="form-control sm:col-span-2">
-            <span class="kr-text-bold-xs label-text">Art prompt</span>
+            <span class="kr-text-bold-xs">Art prompt</span>
             <textarea
               v-model="item.draftPayload.artPrompt"
               rows="2"
@@ -186,7 +186,7 @@
             />
           </label>
           <label class="form-control sm:col-span-2">
-            <span class="kr-text-bold-xs label-text"
+            <span class="kr-text-bold-xs"
               >Text generation prompt</span
             >
             <textarea

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -308,7 +308,7 @@
                   class="form-control mt-2"
                 >
                   <span class="label"
-                    ><span class="kr-text-bold-xs label-text"
+                    ><span class="kr-text-bold-xs"
                       >Rejection feedback</span
                     ></span
                   >
@@ -401,7 +401,7 @@
           <div class="grid gap-3">
             <label class="form-control">
               <span class="label"
-                ><span class="kr-text-bold-xs label-text"
+                ><span class="kr-text-bold-xs"
                   >Requests</span
                 ></span
               >
@@ -415,7 +415,7 @@
             </label>
             <label class="form-control">
               <span class="label"
-                ><span class="kr-text-bold-xs label-text"
+                ><span class="kr-text-bold-xs"
                   >Max Tokens</span
                 ></span
               >

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -159,7 +159,7 @@
       />
 
       <label class="form-control w-full">
-        <span class="kr-text-bold-xs label-text mb-1">Bot identity</span>
+        <span class="kr-text-bold-xs mb-1">Bot identity</span>
         <select
           v-model.number="newBotId"
           class="kr-select-sm w-full bg-base-200"
@@ -200,7 +200,7 @@
       </fieldset>
 
       <label class="form-control w-full">
-        <span class="kr-text-bold-xs label-text mb-1">Expiry</span>
+        <span class="kr-text-bold-xs mb-1">Expiry</span>
         <select
           v-model="expiryChoice"
           class="kr-select-sm w-full bg-base-200"

--- a/utils/scripts/codemods/kr_text_bold_xs_label_cleanup_codemod.py
+++ b/utils/scripts/codemods/kr_text_bold_xs_label_cleanup_codemod.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Drop the dead `label-text` token trailing an already-migrated
+`kr-text-bold-xs` class.
+
+Follow-up to `kr_text_bold_xs_codemod.py` (interface-vision t-104 slice
+171). That codemod's own docstring expected `label-text text-xs font-bold`
+(25 occurrences, 4 files -- previously flagged in `kr_label_bold_codemod.py`'s
+docstring as its own bounded family) to be "still left for" a future slice,
+but its subset-match convention -- `BASE_TOKENS = {"font-bold", "text-xs"}`,
+order-independent, extra tokens preserved -- means slice 170 actually
+absorbed those exact 25 occurrences already: `label-text text-xs font-bold`
+contains `font-bold`/`text-xs` as a subset, so it became `kr-text-bold-xs
+label-text` (or `kr-text-bold-xs label-text mb-1`), with the inert
+`label-text` token carried along verbatim as an "extra" token rather than
+recognized as the dead markup it is.
+
+`label-text` is confirmed dead under daisyUI 5 -- no `.label-text` CSS rule
+exists anywhere in this repo's `assets/` or in daisyui's own dist CSS (see
+`kr_label_bold_codemod.py`'s docstring, which established this same fact
+when it dropped the identical token from the unsized `label-text font-bold`
+family). Dropping it here is the same pure no-op: the `font-bold text-xs`
+visual contract is already fully carried by `.kr-text-bold-xs`.
+
+Deliberately scoped to only the `kr-text-bold-xs label-text` shape (the
+exact family flagged above), not a full-repo dead-`label-text` sweep --
+~99 other `label-text` occurrences remain (paired with `kr-text-eyebrow`,
+`kr-text-eyebrow-bold`, `kr-text-dim-xs-*`, or no kr-* primitive at all)
+that this slice has not surveyed. Left for a future slice, same convention
+as every other bounded family in this series.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+static `class="..."` attributes are touched, never `:class`/`v-bind:class`
+bindings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-bold-xs"
+DEAD_TOKEN = "label-text"
+
+
+def migrate_classes(classes: str) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE not in tokens or DEAD_TOKEN not in tokens:
+        return None
+    remaining = [token for token in tokens if token != DEAD_TOKEN]
+    return " ".join(remaining)
+
+
+def migrate_text(text: str) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1))
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-bold-xs dead-label-text {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring umbrella, slice 171)

### What changed / what I produced
- Slice 170's `kr_text_bold_xs_codemod.py` migrated `font-bold text-xs` to `.kr-text-bold-xs` using its established subset-match convention (order-independent, extra tokens preserved). That convention also matched `label-text text-xs font-bold` (a subset of `font-bold`+`text-xs`), which the codemod's own docstring expected to be "still left for" this slice — instead it was already absorbed, leaving a dead trailing `label-text` token: `kr-text-bold-xs label-text` (23 occurrences) / `kr-text-bold-xs label-text mb-1` (2 occurrences), 25 total across 4 files.
- `label-text` is confirmed dead markup under daisyUI 5 — no `.label-text` CSS rule exists anywhere in this repo's `assets/` or in daisyui's own dist CSS (same fact `kr_label_bold_codemod.py` established when it dropped the identical token from the unsized `label-text font-bold` family).
- Added `utils/scripts/codemods/kr_text_bold_xs_label_cleanup_codemod.py` (dry-run by default, `--write` to apply) and ran it across the codebase: 25 occurrences migrated across 4 files (`components/art/art-interact.vue`, `components/conductor/packmaker-pack-editor.vue`, `components/dreams/dream-brainstorm.vue`, `components/user/agent-credentials-panel.vue`).
- Pure no-op visually — removes an inert class token, no CSS rule lost.

### How I verified
- `npm run test` (vue-tsc --noEmit): clean.
- `npm run lint:js`: 333/327/6 identical to pre-existing baseline (confirmed via `git stash`).
- `npm run test:layout-contract`: holds (same pre-existing unrelated -2 ratchet opportunity in `narrative-ingredient-multi-picker.vue`, left untouched, out of scope).
- `npm run test:lint-ratchet`: holds at 333/-59.
- `npx prettier --check` on the 4 touched files: only `art-interact.vue` was genuinely new fallout (confirmed via `git stash` diff against baseline — the other 3 files were already unformatted on `main` before this change). Targeted `--write` on just that file landed it clean without touching the pre-existing baseline noise in the other 3.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
~99 other `label-text` occurrences remain in the codebase, paired with `kr-text-eyebrow`, `kr-text-eyebrow-bold`, `kr-text-dim-xs-*`, or no kr-* primitive at all (`label-text text-xs`, `label-text text-xs font-semibold`, `label-text mb-1 text-xs font-semibold`, etc.). A future slice should survey and bound these into their own families the same way this one did, rather than a blanket dead-token sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9yPvb9bkmKafXfjT5iUYt

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9yPvb9bkmKafXfjT5iUYt)_