### PR TITLE
refactor(ui): drop dead label-text token from six more kr-* primitives (slice 172)

### DIFF
--- a/components/art/generate-button.vue
+++ b/components/art/generate-button.vue
@@ -12,7 +12,7 @@
     >
       <label class="form-control w-full">
         <div class="label py-1">
-          <span class="kr-text-eyebrow label-text text-xs tracking-wide">
+          <span class="kr-text-eyebrow text-xs tracking-wide">
             Image Server
           </span>
         </div>

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -345,7 +345,7 @@
         <div class="mt-4 grid grid-cols-[auto_minmax(0,1fr)_auto] items-end gap-2">
           <label class="form-control">
             <span class="label py-1"
-              ><span class="kr-text-eyebrow-bold kr-text-dim-xs-55 label-text tracking-[0.12em]"
+              ><span class="kr-text-eyebrow-bold kr-text-dim-xs-55 tracking-[0.12em]"
                 >Type</span
               ></span
             >
@@ -361,7 +361,7 @@
           </label>
           <label class="form-control">
             <span class="label py-1"
-              ><span class="kr-text-eyebrow-bold kr-text-dim-xs-55 label-text tracking-[0.12em]"
+              ><span class="kr-text-eyebrow-bold kr-text-dim-xs-55 tracking-[0.12em]"
                 >Search</span
               ></span
             >

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -178,7 +178,7 @@
           <div class="kr-panel-tint-sm">
             <label class="form-control">
               <div class="label py-1">
-                <span class="kr-text-eyebrow label-text text-xs tracking-wide">
+                <span class="kr-text-eyebrow text-xs tracking-wide">
                   Adopt an existing set-local cover file
                 </span>
               </div>

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -137,9 +137,7 @@
                across screens. -->
           <div class="kr-panel-flat space-y-3 p-3">
             <label class="form-control w-full">
-              <span
-                class="kr-text-eyebrow-bold label-text mb-1 text-xs tracking-wide"
-              >
+              <span class="kr-text-eyebrow-bold mb-1 text-xs tracking-wide">
                 Working title (optional)
               </span>
               <input
@@ -151,9 +149,7 @@
             </label>
 
             <label class="form-control w-full">
-              <span
-                class="kr-text-eyebrow-bold label-text mb-1 text-xs tracking-wide"
-              >
+              <span class="kr-text-eyebrow-bold mb-1 text-xs tracking-wide">
                 Premise
               </span>
               <textarea
@@ -319,9 +315,7 @@
 
           <div class="kr-panel-flat space-y-2 p-3">
             <label class="form-control w-full">
-              <span
-                class="kr-text-eyebrow-bold label-text mb-1 text-xs tracking-wide"
-              >
+              <span class="kr-text-eyebrow-bold mb-1 text-xs tracking-wide">
                 Extra story direction (optional)
               </span>
               <textarea

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -140,7 +140,7 @@
             <label class="form-control">
               <span class="label py-1"
                 ><span
-                  class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
+                  class="kr-text-eyebrow-bold text-xs tracking-wide"
                   >Seed Title</span
                 ></span
               >
@@ -156,7 +156,7 @@
             <label class="form-control">
               <span class="label py-1"
                 ><span
-                  class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
+                  class="kr-text-eyebrow-bold text-xs tracking-wide"
                   >Save Type</span
                 ></span
               >
@@ -178,7 +178,7 @@
           <label class="form-control mt-3">
             <span class="label py-1"
               ><span
-                class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
+                class="kr-text-eyebrow-bold text-xs tracking-wide"
                 >Pitch</span
               ></span
             >
@@ -193,7 +193,7 @@
           <label class="form-control mt-3">
             <span class="label py-1"
               ><span
-                class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
+                class="kr-text-eyebrow-bold text-xs tracking-wide"
                 >Direction</span
               ></span
             >

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -75,7 +75,7 @@
               <label class="form-control">
                 <span class="label py-1">
                   <span
-                    class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
+                    class="kr-text-eyebrow-bold text-xs tracking-wide"
                     >Title</span
                   >
                 </span>
@@ -90,7 +90,7 @@
               <label class="form-control">
                 <span class="label py-1">
                   <span
-                    class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
+                    class="kr-text-eyebrow-bold text-xs tracking-wide"
                     >Type</span
                   >
                 </span>
@@ -113,7 +113,7 @@
               <label class="form-control">
                 <span class="label py-1">
                   <span
-                    class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
+                    class="kr-text-eyebrow-bold text-xs tracking-wide"
                     >Slug</span
                   >
                 </span>
@@ -140,7 +140,7 @@
             <label class="form-control">
               <span class="label py-1">
                 <span
-                  class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
+                  class="kr-text-eyebrow-bold text-xs tracking-wide"
                   >Dream Pitch</span
                 >
               </span>
@@ -154,7 +154,7 @@
             <label class="form-control mt-3">
               <span class="label py-1">
                 <span
-                  class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
+                  class="kr-text-eyebrow-bold text-xs tracking-wide"
                   >Description</span
                 >
               </span>
@@ -168,7 +168,7 @@
             <label class="form-control mt-3">
               <span class="label py-1">
                 <span
-                  class="kr-text-eyebrow-bold label-text text-xs tracking-wide"
+                  class="kr-text-eyebrow-bold text-xs tracking-wide"
                   >Flavor Text</span
                 >
               </span>

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -138,7 +138,7 @@
             <label class="form-control w-full">
               <div class="label py-1">
                 <span
-                  class="kr-text-eyebrow label-text text-[0.68rem] tracking-[0.12em] text-base-content/55"
+                  class="kr-text-eyebrow text-[0.68rem] tracking-[0.12em] text-base-content/55"
                 >
                   Project or task source
                   <span class="font-normal normal-case tracking-normal">(optional)</span>
@@ -322,7 +322,7 @@
                 <label class="form-control w-full">
                   <div class="label py-1">
                     <span
-                      class="kr-text-eyebrow label-text text-[0.68rem] tracking-[0.12em] text-base-content/55"
+                      class="kr-text-eyebrow text-[0.68rem] tracking-[0.12em] text-base-content/55"
                     >
                       Extra flavor
                       <span class="font-normal normal-case tracking-normal">(optional)</span>

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -183,7 +183,7 @@
               <label class="form-control">
                 <span class="label py-1">
                   <span
-                    class="kr-text-eyebrow-bold kr-text-dim-xs label-text tracking-wide"
+                    class="kr-text-eyebrow-bold kr-text-dim-xs tracking-wide"
                   >
                     Customize the next move
                   </span>

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -336,7 +336,7 @@
                 v-if="userStore.isAdmin"
                 class="label cursor-pointer gap-2 rounded-xl border border-base-300 bg-base-200 px-3 py-1.5"
               >
-                <span class="kr-text-bold-sm label-text">Mature</span>
+                <span class="kr-text-bold-sm">Mature</span>
 
                 <input
                   v-model="showMature"

--- a/components/screenfx/animation-selector.vue
+++ b/components/screenfx/animation-selector.vue
@@ -29,7 +29,7 @@
 
     <div class="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(0,1fr)_auto]">
       <label class="form-control min-w-0">
-        <span class="kr-text-dim-xs-70 label-text mb-1 font-black">
+        <span class="kr-text-dim-xs-70 mb-1 font-black">
           Startup animation
         </span>
 

--- a/utils/scripts/codemods/kr_dead_label_text_cleanup_codemod.py
+++ b/utils/scripts/codemods/kr_dead_label_text_cleanup_codemod.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Drop the dead `label-text` token from any class string that already
+carries a `kr-*` primitive.
+
+Generalizes `kr_text_bold_xs_label_cleanup_codemod.py` (interface-vision
+t-104 slice 171, which fixed this for `kr-text-bold-xs` specifically) after
+a fresh grep found the identical leftover-dead-token pattern behind six
+more `kr-*` primitives shipped in earlier slices: `kr-text-eyebrow`,
+`kr-text-eyebrow-bold`, `kr-text-dim-xs`, `kr-text-dim-xs-55`,
+`kr-text-dim-xs-70`, and `kr-text-bold-sm`. Each of those primitives'
+codemods used the same subset-match convention (order-independent, extra
+tokens preserved) as `kr_text_bold_xs_codemod.py`, so any of them run
+against a source that also had `label-text` in its class string carried
+that dead token along as an "extra" token rather than recognizing it as
+inert markup -- the exact mechanism slice 171 diagnosed and fixed for one
+primitive at a time. Rather than write a seventh single-primitive cleanup
+script, this one is scoped to the general shape: any class string with
+both `label-text` and at least one `kr-`-prefixed token.
+
+`label-text` is confirmed dead under daisyUI 5 -- no `.label-text` CSS rule
+exists anywhere in this repo's `assets/` or in daisyui's own dist CSS (see
+`kr_label_bold_codemod.py`'s docstring, which established this fact first).
+Dropping it wherever a `kr-*` primitive already carries the real styling is
+a pure no-op: no CSS rule lost, no `@apply` fallout, no test/lint file.
+
+Deliberately does NOT touch class strings with `label-text` but no `kr-*`
+primitive alongside it (e.g. the bare `label-text text-xs` family, 21
+occurrences, or `label-text text-xs font-semibold`, 15 occurrences) --
+those are real un-migrated hand-rolled patterns, not leftover dead tokens
+from an already-shipped primitive, and are left for a future slice's own
+survey and (if warranted) new primitive.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+static `class="..."` attributes are touched, never `:class`/`v-bind:class`
+bindings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+DEAD_TOKEN = "label-text"
+PRIMITIVE_PREFIX = "kr-"
+
+
+def migrate_classes(classes: str) -> str | None:
+    tokens = classes.split()
+    if DEAD_TOKEN not in tokens:
+        return None
+    if not any(token.startswith(PRIMITIVE_PREFIX) for token in tokens):
+        return None
+    remaining = [token for token in tokens if token != DEAD_TOKEN]
+    return " ".join(remaining)
+
+
+def migrate_text(text: str) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1))
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"dead-label-text {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring umbrella, slice 172)

### What changed / what I produced
- Slice 171 fixed the same "dead trailing `label-text` token" bug for `kr-text-bold-xs` specifically. A fresh grep for `label-text` co-occurring with any `kr-*` primitive found the identical pattern behind six more primitives shipped in earlier slices: `kr-text-eyebrow` (3 occurrences), `kr-text-eyebrow-bold` (17 across several combos), `kr-text-dim-xs` (1), `kr-text-dim-xs-55` (2), `kr-text-dim-xs-70` (1), `kr-text-bold-sm` (1) — 22 total across 10 files. Each was absorbed by its own subset-match codemod (order-independent, extra tokens preserved), which correctly captured the primitive's real styling but preserved `label-text` as a harmless-looking "extra" token instead of recognizing it as the dead markup `kr_label_bold_codemod.py` already established it is.
- Added `utils/scripts/codemods/kr_dead_label_text_cleanup_codemod.py`, generalized (rather than writing a 7th single-primitive script): drops `label-text` from any class string that already carries at least one `kr-`-prefixed token. Ran it (`--write`) across the codebase: 22 occurrences migrated across 10 files.
- Pure no-op visually — removes an inert class token, no CSS rule lost.
- Deliberately still leaves the bare `label-text text-xs` (21 occurrences) and `label-text text-xs font-semibold` (15 occurrences) families alone — those are real un-migrated hand-rolled patterns without an existing `kr-*` primitive, not leftover dead tokens, and are a future slice's own survey.

### How I verified
- `npm run test` (vue-tsc --noEmit): clean.
- `npm run lint:js`: 333/327/6 identical to pre-existing baseline (confirmed via `git stash`).
- `npm run test:layout-contract`: holds (same pre-existing unrelated -2 ratchet opportunity in `narrative-ingredient-multi-picker.vue`, left untouched, out of scope).
- `npm run test:lint-ratchet`: holds at 333/-59.
- `npx prettier --check` on the 10 touched files: only `storybook-page.vue` was genuinely new fallout (confirmed via `git stash` diff against baseline — the other files' flagged state was already present on `main`). Targeted `--write` on just that file landed it back at the exact pre-existing baseline set (same 7 files flagged before and after).

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
The bare `label-text text-xs` (21 occurrences) and `label-text text-xs font-semibold` (15 occurrences) families are the next slice's real target — no existing `kr-*` primitive covers them yet, so they'd need either a new primitive or a decision that `text-xs`/`text-xs font-semibold` alone don't warrant one (in which case just drop the dead `label-text` token and leave the bare Tailwind utilities as-is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9yPvb9bkmKafXfjT5iUYt

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9yPvb9bkmKafXfjT5iUYt)_