### PR TITLE
refactor(ui): add kr-label-xs and kr-label-xs-semibold, drop dead label-text token (slice 173)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1872,6 +1872,39 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply font-bold text-xs;
   }
 
+  /* Sibling of `.kr-label-bold` (`label-text font-bold`) for the plain,
+   * weightless form-label caption -- `label-text text-xs`, with the dead
+   * `label-text` token dropped the same way `.kr-label-bold` already drops
+   * it (`label-text` carries no CSS rule anywhere in this repo's `assets/`
+   * or in daisyui's dist CSS -- see `kr_label_bold_codemod.py`'s docstring)
+   * (interface-vision t-104 slice 173) -- previously hand-rolled
+   * identically in 21 occurrences across 4 files (facet-profile-editor.vue,
+   * conductor-project-gallery-page.vue, mission-accrual-page.vue,
+   * ruler-hooked-slots.vue), the bare-size sibling of `label-text text-xs
+   * font-bold` (migrated in slice 171 by reuse of the already-shipped
+   * `.kr-text-bold-xs`) and `label-text text-xs font-semibold` (this same
+   * slice's other target, named `.kr-label-xs-semibold` below) surveyed
+   * together since `kr_label_bold_codemod.py`'s own docstring first flagged
+   * this family in slice 151/152. */
+  .kr-label-xs {
+    @apply text-xs;
+  }
+
+  /* Sibling of `.kr-label-xs` carrying the extra `font-semibold` weight --
+   * `label-text text-xs font-semibold`, dead `label-text` token dropped
+   * the same way (interface-vision t-104 slice 173) -- previously
+   * hand-rolled in 29 subset-match occurrences across 5 files (15 exact,
+   * 14 carrying an additional `mb-1` in image-upload.vue/davinci-page.vue,
+   * preserved verbatim as an extra token). Kept as its own named family
+   * rather than folded into `.kr-label-xs` plus a preserved `font-semibold`
+   * extra, matching this codebase's established convention of naming each
+   * distinct compound weight/size shape separately (`kr-text-dim-xs-45`
+   * vs. `-55` vs. `-60`, `kr-text-bold-sm` vs. `kr-text-bold-xs`, etc.)
+   * rather than treating a real style token as generic pass-through. */
+  .kr-label-xs-semibold {
+    @apply text-xs font-semibold;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -511,9 +511,7 @@
               class="toggle toggle-primary toggle-xs"
               :disabled="isGenerating"
             />
-            <span class="label-text text-xs font-semibold">
-              Inherit negative prompt
-            </span>
+            <span class="kr-label-xs-semibold"> Inherit negative prompt </span>
           </label>
           <label class="kr-toggle-row-xs">
             <input
@@ -522,7 +520,7 @@
               class="toggle toggle-success toggle-xs"
               :disabled="isGenerating"
             />
-            <span class="label-text text-xs font-semibold">Public</span>
+            <span class="kr-label-xs-semibold">Public</span>
           </label>
         </div>
       </div>

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -151,9 +151,7 @@
 
           <div class="grid gap-3 md:grid-cols-2">
             <label class="form-control">
-              <span class="label-text mb-1 text-xs font-semibold"
-                >Designer</span
-              >
+              <span class="kr-label-xs-semibold mb-1">Designer</span>
               <input
                 v-model.trim="imageForm.designer"
                 type="text"
@@ -164,7 +162,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text mb-1 text-xs font-semibold">Genres</span>
+              <span class="kr-label-xs-semibold mb-1">Genres</span>
               <input
                 v-model.trim="imageForm.genres"
                 type="text"
@@ -175,7 +173,7 @@
             </label>
 
             <label class="form-control md:col-span-2">
-              <span class="label-text mb-1 text-xs font-semibold">Prompt</span>
+              <span class="kr-label-xs-semibold mb-1">Prompt</span>
               <textarea
                 v-model.trim="imageForm.promptString"
                 class="textarea textarea-bordered min-h-24"
@@ -185,9 +183,7 @@
             </label>
 
             <label class="form-control md:col-span-2">
-              <span class="label-text mb-1 text-xs font-semibold"
-                >Negative Prompt</span
-              >
+              <span class="kr-label-xs-semibold mb-1">Negative Prompt</span>
               <textarea
                 v-model.trim="imageForm.negativePrompt"
                 class="textarea textarea-bordered min-h-16"
@@ -197,9 +193,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text mb-1 text-xs font-semibold"
-                >Checkpoint</span
-              >
+              <span class="kr-label-xs-semibold mb-1">Checkpoint</span>
               <input
                 v-model.trim="imageForm.checkpoint"
                 type="text"
@@ -210,7 +204,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text mb-1 text-xs font-semibold">Sampler</span>
+              <span class="kr-label-xs-semibold mb-1">Sampler</span>
               <input
                 v-model.trim="imageForm.sampler"
                 type="text"
@@ -221,7 +215,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text mb-1 text-xs font-semibold">Seed</span>
+              <span class="kr-label-xs-semibold mb-1">Seed</span>
               <input
                 v-model.number="imageForm.seed"
                 type="number"
@@ -231,7 +225,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text mb-1 text-xs font-semibold">Steps</span>
+              <span class="kr-label-xs-semibold mb-1">Steps</span>
               <input
                 v-model.number="imageForm.steps"
                 type="number"
@@ -242,7 +236,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text mb-1 text-xs font-semibold">CFG</span>
+              <span class="kr-label-xs-semibold mb-1">CFG</span>
               <input
                 v-model.number="imageForm.cfg"
                 type="number"
@@ -253,7 +247,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text mb-1 text-xs font-semibold">Rarity</span>
+              <span class="kr-label-xs-semibold mb-1">Rarity</span>
               <input
                 v-model.number="imageForm.rarity"
                 type="number"
@@ -264,9 +258,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text mb-1 text-xs font-semibold"
-                >Server name</span
-              >
+              <span class="kr-label-xs-semibold mb-1">Server name</span>
               <input
                 v-model.trim="imageForm.serverName"
                 type="text"
@@ -277,9 +269,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label-text mb-1 text-xs font-semibold"
-                >Server URL</span
-              >
+              <span class="kr-label-xs-semibold mb-1">Server URL</span>
               <input
                 v-model.trim="imageForm.serverUrl"
                 type="text"
@@ -299,7 +289,7 @@
                 class="toggle toggle-primary toggle-xs"
                 :disabled="isUploading"
               />
-              <span class="label-text text-xs font-semibold">CFG + 0.5</span>
+              <span class="kr-label-xs-semibold">CFG + 0.5</span>
             </label>
             <label class="kr-toggle-row-compact">
               <input
@@ -308,7 +298,7 @@
                 class="toggle toggle-success toggle-xs"
                 :disabled="isUploading"
               />
-              <span class="label-text text-xs font-semibold">Public</span>
+              <span class="kr-label-xs-semibold">Public</span>
             </label>
             <label class="kr-toggle-row-compact">
               <input
@@ -317,7 +307,7 @@
                 class="toggle toggle-warning toggle-xs"
                 :disabled="isUploading"
               />
-              <span class="label-text text-xs font-semibold">Mature</span>
+              <span class="kr-label-xs-semibold">Mature</span>
             </label>
           </div>
         </div>

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -85,7 +85,7 @@
               into one of many possible endings.
             </p>
             <label class="form-control w-full max-w-sm">
-              <span class="label-text mb-1 text-xs font-semibold"
+              <span class="kr-label-xs-semibold mb-1"
                 >Protagonist name (optional)</span
               >
               <input
@@ -97,9 +97,7 @@
               />
             </label>
             <label class="form-control w-full max-w-sm">
-              <span class="label-text mb-1 text-xs font-semibold"
-                >Genre (optional)</span
-              >
+              <span class="kr-label-xs-semibold mb-1">Genre (optional)</span>
               <input
                 v-model="genre"
                 type="text"

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -159,7 +159,7 @@
           <div class="project-profile-fields grid gap-2 p-3">
             <div class="form-control min-w-0">
               <label class="label py-0.5">
-                <span class="label-text text-xs font-semibold">Goal</span>
+                <span class="kr-label-xs-semibold">Goal</span>
               </label>
               <textarea
                 class="textarea textarea-bordered min-h-16 w-full rounded-xl text-sm leading-relaxed"
@@ -172,9 +172,7 @@
             </div>
             <div class="form-control min-w-0">
               <label class="label py-0.5">
-                <span class="label-text text-xs font-semibold"
-                  >Description</span
-                >
+                <span class="kr-label-xs-semibold">Description</span>
               </label>
               <textarea
                 class="textarea textarea-bordered min-h-16 w-full rounded-xl text-sm leading-relaxed"
@@ -187,7 +185,7 @@
             </div>
             <div class="form-control min-w-0">
               <label class="label py-0.5">
-                <span class="label-text text-xs font-semibold">Live URL</span>
+                <span class="kr-label-xs-semibold">Live URL</span>
               </label>
               <input
                 type="url"
@@ -200,7 +198,7 @@
             </div>
             <div class="form-control min-w-0">
               <label class="label py-0.5">
-                <span class="label-text text-xs font-semibold">Repo URL</span>
+                <span class="kr-label-xs-semibold">Repo URL</span>
               </label>
               <input
                 type="url"
@@ -214,7 +212,7 @@
             <template v-if="userStore.isAdmin">
               <div class="form-control min-w-0">
                 <label class="label py-0.5">
-                  <span class="label-text text-xs font-semibold">Status</span>
+                  <span class="kr-label-xs-semibold">Status</span>
                 </label>
                 <select
                   class="kr-select-sm w-full text-sm"
@@ -235,7 +233,7 @@
               </div>
               <div class="form-control min-w-0">
                 <label class="label py-0.5">
-                  <span class="label-text text-xs font-semibold">Priority</span>
+                  <span class="kr-label-xs-semibold">Priority</span>
                 </label>
                 <select
                   class="kr-select-sm w-full text-sm"

--- a/components/facets/facet-profile-editor.vue
+++ b/components/facets/facet-profile-editor.vue
@@ -3,7 +3,7 @@
   <div class="space-y-4">
     <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
       <label class="form-control xl:col-span-2">
-        <span class="label-text text-xs">Canonical title</span>
+        <span class="kr-label-xs">Canonical title</span>
         <input
           v-model="form.title"
           type="text"
@@ -12,7 +12,7 @@
         />
       </label>
       <label class="form-control">
-        <span class="label-text text-xs">Canonical value</span>
+        <span class="kr-label-xs">Canonical value</span>
         <input
           v-model="form.canonicalValue"
           type="text"
@@ -21,7 +21,7 @@
         />
       </label>
       <label class="form-control">
-        <span class="label-text text-xs">Taxonomy</span>
+        <span class="kr-label-xs">Taxonomy</span>
         <select v-model="form.taxonomy" class="kr-select-sm">
           <option
             v-for="taxonomy in FACET_TAXONOMIES"
@@ -33,7 +33,7 @@
         </select>
       </label>
       <label class="form-control sm:col-span-2 xl:col-span-4">
-        <span class="label-text text-xs">Aliases</span>
+        <span class="kr-label-xs">Aliases</span>
         <input
           v-model="form.aliases"
           type="text"
@@ -42,7 +42,7 @@
         />
       </label>
       <label class="form-control">
-        <span class="label-text text-xs">Group key</span>
+        <span class="kr-label-xs">Group key</span>
         <input
           v-model="form.groupKey"
           type="text"
@@ -51,7 +51,7 @@
         />
       </label>
       <label class="form-control">
-        <span class="label-text text-xs">Group label</span>
+        <span class="kr-label-xs">Group label</span>
         <input
           v-model="form.groupLabel"
           type="text"
@@ -60,7 +60,7 @@
         />
       </label>
       <label class="form-control">
-        <span class="label-text text-xs">Sort order</span>
+        <span class="kr-label-xs">Sort order</span>
         <input
           v-model.number="form.sortOrder"
           type="number"
@@ -69,7 +69,7 @@
         />
       </label>
       <label class="form-control">
-        <span class="label-text text-xs">Source rank</span>
+        <span class="kr-label-xs">Source rank</span>
         <input
           v-model.number="form.sourceRank"
           type="number"
@@ -79,7 +79,7 @@
         />
       </label>
       <label class="form-control">
-        <span class="label-text text-xs">Random weight</span>
+        <span class="kr-label-xs">Random weight</span>
         <input
           v-model.number="form.randomWeight"
           type="number"
@@ -89,7 +89,7 @@
         />
       </label>
       <label class="form-control sm:col-span-2 xl:col-span-3">
-        <span class="label-text text-xs">Description</span>
+        <span class="kr-label-xs">Description</span>
         <textarea
           v-model="form.description"
           class="textarea textarea-bordered min-h-24 rounded-xl"
@@ -97,9 +97,7 @@
         />
       </label>
       <label class="form-control sm:col-span-2 xl:col-span-4">
-        <span class="label-text text-xs"
-          >Structured metadata (JSON object)</span
-        >
+        <span class="kr-label-xs">Structured metadata (JSON object)</span>
         <textarea
           v-model="form.metadata"
           class="textarea textarea-bordered min-h-28 rounded-xl font-mono text-xs"
@@ -136,7 +134,7 @@
         </div>
         <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
           <label class="form-control">
-            <span class="label-text text-xs">Primary image path</span>
+            <span class="kr-label-xs">Primary image path</span>
             <input
               v-model="form.imagePath"
               type="text"
@@ -145,7 +143,7 @@
             />
           </label>
           <label class="form-control sm:col-span-2 xl:col-span-3">
-            <span class="label-text text-xs">Art prompt</span>
+            <span class="kr-label-xs">Art prompt</span>
             <textarea
               v-model="form.artPrompt"
               class="textarea textarea-bordered min-h-24 rounded-xl"

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -682,7 +682,7 @@
                 </div>
                 <div class="form-control">
                   <label class="label py-0.5"
-                    ><span class="label-text text-xs font-semibold"
+                    ><span class="kr-label-xs-semibold"
                       >Goal — what does 100% look like?</span
                     ></label
                   >
@@ -697,7 +697,7 @@
                 </div>
                 <div class="form-control">
                   <label class="label py-0.5"
-                    ><span class="label-text text-xs font-semibold"
+                    ><span class="kr-label-xs-semibold"
                       >Description</span
                     ></label
                   >
@@ -713,7 +713,7 @@
                 <div class="grid gap-3 sm:grid-cols-2">
                   <div class="form-control">
                     <label class="label py-0.5"
-                      ><span class="label-text text-xs font-semibold"
+                      ><span class="kr-label-xs-semibold"
                         >Live URL</span
                       ></label
                     >
@@ -728,7 +728,7 @@
                   </div>
                   <div class="form-control">
                     <label class="label py-0.5"
-                      ><span class="label-text text-xs font-semibold"
+                      ><span class="kr-label-xs-semibold"
                         >Repo URL</span
                       ></label
                     >

--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -24,7 +24,7 @@
       <div class="space-y-3 p-3">
         <div class="grid gap-3 sm:grid-cols-2">
           <label class="form-control sm:col-span-2">
-            <span class="label-text text-xs">Title</span>
+            <span class="kr-label-xs">Title</span>
             <input
               v-model="createForm.title"
               type="text"
@@ -34,7 +34,7 @@
             />
           </label>
           <label class="form-control sm:col-span-2">
-            <span class="label-text text-xs">
+            <span class="kr-label-xs">
               Slug
               <span class="opacity-60">(project URL and Conductor key)</span>
             </span>
@@ -57,7 +57,7 @@
             </span>
           </label>
           <label class="form-control sm:col-span-2">
-            <span class="label-text text-xs">Description</span>
+            <span class="kr-label-xs">Description</span>
             <textarea
               v-model="createForm.description"
               class="textarea textarea-bordered min-h-20 rounded-xl"

--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -138,7 +138,7 @@
             @submit.prevent="submit"
           >
             <label class="form-control sm:col-span-1">
-              <span class="label-text text-xs">Amount (USD)</span>
+              <span class="kr-label-xs">Amount (USD)</span>
               <input
                 v-model="form.amountUsd"
                 type="number"
@@ -150,7 +150,7 @@
               />
             </label>
             <label class="form-control sm:col-span-2">
-              <span class="label-text text-xs">Note</span>
+              <span class="kr-label-xs">Note</span>
               <input
                 v-model="form.note"
                 type="text"
@@ -160,7 +160,7 @@
               />
             </label>
             <label class="form-control sm:col-span-1">
-              <span class="label-text text-xs">Reference (optional)</span>
+              <span class="kr-label-xs">Reference (optional)</span>
               <input
                 v-model="form.reference"
                 type="text"

--- a/components/ruler-hooked/ruler-hooked-slots.vue
+++ b/components/ruler-hooked/ruler-hooked-slots.vue
@@ -25,11 +25,11 @@
     <div class="flex flex-col gap-2">
       <div class="flex flex-wrap items-end gap-2">
         <label class="form-control">
-          <span class="label-text text-xs">Ruler name</span>
+          <span class="kr-label-xs">Ruler name</span>
           <input v-model="rulerName" type="text" placeholder="Mo" class="input input-bordered input-sm w-28" />
         </label>
         <label class="form-control">
-          <span class="label-text text-xs">Title</span>
+          <span class="kr-label-xs">Title</span>
           <input
             v-model="honorific"
             type="text"

--- a/utils/scripts/codemods/kr_label_xs_codemod.py
+++ b/utils/scripts/codemods/kr_label_xs_codemod.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `label-text text-xs` form-label captions to
+`kr-label-xs`.
+
+Sibling of `kr_label_bold_codemod.py` (`label-text font-bold` ->
+`kr-label-bold`), but for the plain, weightless size variant -- the base
+`label-text` token is dropped in the migrated output because it is
+confirmed dead CSS in this repo (no `.label-text` rule exists anywhere in
+`assets/` or in daisyui's own dist CSS; see `kr_label_bold_codemod.py`'s
+docstring, which established this fact first). A fresh survey outside the
+now-closed `kr-text-bold-*`/`kr-text-black-*`/`kr-text-dim-*`/
+`kr-text-eyebrow-*` families found `label-text text-xs` (with no
+`font-semibold` alongside -- that combination is its own sibling family,
+see `kr_label_xs_semibold_codemod.py`) at 21 exact-match occurrences across
+4 files this slice (interface-vision t-104 slice 173), previously flagged
+in `kr_label_bold_codemod.py`'s own docstring back in slice 151/152 as a
+bounded family for a future slice.
+
+Dry-run by default, --write to update matching Vue files in place. Only the
+exact `label-text text-xs` base pair is touched (a class string that also
+carries `font-semibold` is left for `kr_label_xs_semibold_codemod.py`), and
+only in static `class="..."` attributes -- never `:class`/`v-bind:class`
+bindings, regardless of the base tokens' order in the source. A source that
+already carries `kr-label-xs`, or is missing either base token, is left
+untouched. Extra tokens beyond the base set are preserved verbatim after
+the primitive class, matching the kr-badge-*/kr-spinner-*/kr-label-bold/
+kr-text-dim-*/kr-text-black-*/kr-text-eyebrow-*/kr-text-bold-* codemods'
+subset-match convention -- pass --exact-only to restrict a slice to
+sources with no extra tokens at all, the safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-label-xs"
+BASE_TOKENS = {"label-text", "text-xs"}
+EXCLUDE_TOKENS = {"font-semibold"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    token_set = set(tokens)
+    if PRIMITIVE in token_set or not BASE_TOKENS.issubset(token_set):
+        return None
+    if token_set & EXCLUDE_TOKENS:
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-label-xs {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/scripts/codemods/kr_label_xs_semibold_codemod.py
+++ b/utils/scripts/codemods/kr_label_xs_semibold_codemod.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `label-text text-xs font-semibold` form-label
+captions to `kr-label-xs-semibold`.
+
+Sibling of `kr_label_xs_codemod.py` (`label-text text-xs` -> `kr-label-xs`),
+carrying the extra `font-semibold` weight -- kept as its own named family
+rather than folded into `kr-label-xs` plus a preserved `font-semibold`
+extra, matching this codebase's established convention of naming each
+distinct compound weight/size shape separately (`kr-text-dim-xs-45` vs.
+`-55` vs. `-60`, `kr-text-bold-sm` vs. `kr-text-bold-xs`, etc.) rather than
+treating a real style token as generic pass-through. The base `label-text`
+token is dropped in the migrated output because it is confirmed dead CSS
+in this repo (no `.label-text` rule exists anywhere in `assets/` or in
+daisyui's own dist CSS; see `kr_label_bold_codemod.py`'s docstring, which
+established this fact first). A fresh survey found this shape at 29
+subset-match occurrences across 5 files this slice (interface-vision t-104
+slice 173; 15 exact, 14 carrying an additional `mb-1` in
+image-upload.vue/davinci-page.vue), previously flagged in
+`kr_label_bold_codemod.py`'s own docstring back in slice 151/152 as a
+bounded family for a future slice.
+
+Dry-run by default, --write to update matching Vue files in place. Only the
+exact `label-text text-xs font-semibold` base set is touched, and only in
+static `class="..."` attributes -- never `:class`/`v-bind:class` bindings,
+regardless of the base tokens' order in the source. A source that already
+carries `kr-label-xs-semibold`, or is missing any one base token, is left
+untouched. Extra tokens beyond the base set are preserved verbatim after
+the primitive class, matching the kr-badge-*/kr-spinner-*/kr-label-bold/
+kr-label-xs/kr-text-dim-*/kr-text-black-*/kr-text-eyebrow-*/kr-text-bold-*
+codemods' subset-match convention -- pass --exact-only to restrict a slice
+to sources with no extra tokens at all, the safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-label-xs-semibold"
+BASE_TOKENS = {"label-text", "text-xs", "font-semibold"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    token_set = set(tokens)
+    if PRIMITIVE in token_set or not BASE_TOKENS.issubset(token_set):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-label-xs-semibold {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104 (slice 173): Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Added two new `kr-*` text primitives to `assets/css/tailwind.css`, siblings of the existing `.kr-label-bold`:
  - `.kr-label-xs { @apply text-xs; }`
  - `.kr-label-xs-semibold { @apply text-xs font-semibold; }`
- Both drop the dead `label-text` token in the migrated markup (confirmed dead CSS — no `.label-text` rule exists anywhere in this repo's `assets/` or in daisyui's own dist CSS, per `kr_label_bold_codemod.py`'s docstring).
- New `utils/scripts/codemods/kr_label_xs_codemod.py` and `kr_label_xs_semibold_codemod.py`, same dry-run-by-default/`--write`/subset-match/`--exact-only` convention as the rest of the `kr-badge-*`/`kr-spinner-*`/`kr-text-*`/`kr-label-*` codemod family.
- Migrated all 21 `label-text text-xs` occurrences (4 files) to `kr-label-xs`, and all 29 subset-match `label-text text-xs font-semibold` occurrences (5 files, 15 exact + 14 carrying an extra `mb-1` preserved verbatim) to `kr-label-xs-semibold`.
- No geometry or behavior change — pure class-name substitution plus one dead-token removal.

### How I verified
- `vue-tsc --noEmit` (via `npm run test`): clean.
- `eslint .`: 333 problems (327 errors, 6 warnings) — byte-identical to the documented baseline, 0 new issues.
- `test:lint-ratchet`: holds at 333/-59, no rule regressed.
- `test:layout-contract`: holds — the pre-existing, unrelated `-2` ratchet opportunity in `narrative-ingredient-multi-picker.vue` is still there, left untouched (out of scope for this slice).
- `prettier --check` on all touched files: flagged 5 genuinely new fallout files (`facet-profile-editor.vue`, `art-styler.vue`, `image-upload.vue`, `davinci-page.vue`, `project-detail.vue`) after class-shortening collapsed some multi-line tags — targeted `--write` landed those back at clean. The other 4 touched files (`conductor-project-gallery-page.vue`, `ruler-hooked-slots.vue`, `conductor-page.vue`, `tailwind.css`) were already unformatted on `main` before this change — confirmed via `git stash` against the pre-change baseline, left untouched per established convention.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
This closes out every `label-text`/`kr-*`-adjacent family flagged since slice 151/152. The remaining bare `label-text` occurrences in the repo (13 files: `label-text` alone, `label-text-alt`, `label-text text-sm`, `label-text text-smart-caption font-bold`, `label-text flex items-center gap-1.5 text-base font-bold text-primary`, etc.) are each too small/varied to be a single bounded family on their own — a fresh full-repo class-frequency survey outside the now-closed `kr-text-*`/`kr-label-*` families is the right next step for slice 174, rather than assuming these leftovers share one shape.

### Notes for reviewer
Recurring task — will return `interface-vision/t-104` to `status: ready` in conductor after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTwjutoBMYEUs4P8JX3mhp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTwjutoBMYEUs4P8JX3mhp)_