### PR TITLE
fix(scene-animator): mount the production source tree

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,7 +106,7 @@ GITHUB_TOKEN=your_github_token_here
 # AppMaker GitHub App (appmaker/t-007/t-008, see GITHUB-APP-DESIGN.md)
 APPMAKER_GH_APP_ID=your_appmaker_github_app_id_here
 APPMAKER_GH_APP_KEY=your_appmaker_github_app_private_key_here
-APPMAKER_GH_WEBHOOK_SECRET=your_appmaker_github_app_webhook_secret_here
+APPMAKER_GH_WEBHOOK_SECRET=your_appmaker_github_webhook_secret_here
 
 GOOGLE_ID=your_google_oauth_client_id_here
 GOOGLE_SECRET=your_google_oauth_client_secret_here

--- a/.env.example
+++ b/.env.example
@@ -106,7 +106,7 @@ GITHUB_TOKEN=your_github_token_here
 # AppMaker GitHub App (appmaker/t-007/t-008, see GITHUB-APP-DESIGN.md)
 APPMAKER_GH_APP_ID=your_appmaker_github_app_id_here
 APPMAKER_GH_APP_KEY=your_appmaker_github_app_private_key_here
-APPMAKER_GH_WEBHOOK_SECRET=your_appmaker_github_webhook_secret_here
+APPMAKER_GH_WEBHOOK_SECRET=your_appmaker_github_app_webhook_secret_here
 
 GOOGLE_ID=your_google_oauth_client_id_here
 GOOGLE_SECRET=your_google_oauth_client_secret_here
@@ -137,3 +137,4 @@ APP_BASE_URL=https://kindrobots.org
 # KIND_ROBOTS_IMAGE=ghcr.io/silasfelinus/kind_robots:latest
 # KIND_ROBOTS_PORT=3009
 # KIND_ROBOTS_MEDIA_PATH=/mnt/user/pc/kindrobots/images
+# KIND_ROBOTS_ANIMATE_PATH=/mnt/user/pc/kindrobots/animate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,9 +67,11 @@ services:
       NITRO_HOST: 0.0.0.0
       NITRO_PORT: 3000
       IMAGES_PATH: /app/.output/public/images
+      ANIMATE_PATH: /app/animate
     volumes:
       - ${KIND_ROBOTS_ENV_FILE:-./.env}:/config/kind-robots.env:ro
       - ${KIND_ROBOTS_MEDIA_PATH:-/mnt/user/pc/kindrobots/images}:/app/.output/public/images:rw
+      - ${KIND_ROBOTS_ANIMATE_PATH:-/mnt/user/pc/kindrobots/animate}:/app/animate:ro
     networks:
       - cafepurr
 

--- a/docs/scene-animator.md
+++ b/docs/scene-animator.md
@@ -34,7 +34,22 @@ Production target:
     shot-01.jpg
 ```
 
-Set the source root explicitly when the application can see that path:
+The production container contract maps that host tree read-only to
+`/app/animate` and sets `ANIMATE_PATH=/app/animate`. `docker-compose.yml`
+expresses the mapping directly:
+
+```text
+host:      /mnt/user/pc/kindrobots/animate
+container: /app/animate
+mode:      read-only
+```
+
+The host path can be overridden for Compose deployments with
+`KIND_ROBOTS_ANIMATE_PATH`; the container path stays `/app/animate` so the
+application and deployment agree on one stable location.
+
+For a non-container process that can see the host filesystem directly, set the
+source root explicitly:
 
 ```dotenv
 ANIMATE_PATH=/mnt/user/pc/kindrobots/animate
@@ -70,9 +85,24 @@ as `rootAvailable` in its response, so a misconfigured or not-yet-mounted
 root surfaces as a clear message in the admin UI instead of an opaque request
 failure.
 
-The application/container still needs read access to the chosen source root.
-Adding or changing a production bind mount is an operator deployment step; the
-code does not attempt to alter container configuration itself.
+On Alexandria, Kind Robots is recreated from the saved Unraid DockerMan
+template rather than from `docker-compose.yml`. That template therefore needs
+the same read-only path mapping before Scene Animator can work:
+
+```text
+Host Path:      /mnt/user/pc/kindrobots/animate
+Container Path: /app/animate
+Access Mode:    Read Only
+```
+
+After the template is updated and the container is recreated through the
+normal guarded deployment path, `/api/scene-animator/health` should report
+`root: /app/animate`, `source: ANIMATE_PATH` (when the template supplies that
+environment value) or the fallback source, and `available: true`.
+
+The application never mutates source stills, and the production mount should
+remain read-only. The code does not rewrite Unraid's saved DockerMan template;
+that host configuration is intentionally an operator-owned deployment step.
 
 ## Automatic motion prompt
 

--- a/utils/scripts/verifySceneAnimatorDeploymentContract.ts
+++ b/utils/scripts/verifySceneAnimatorDeploymentContract.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const compose = readFileSync(resolve('docker-compose.yml'), 'utf8')
+
+assert.match(
+  compose,
+  /^\s*ANIMATE_PATH:\s*\/app\/animate\s*$/m,
+  'kind-robots service must set ANIMATE_PATH=/app/animate',
+)
+
+assert.match(
+  compose,
+  /^\s*- \$\{KIND_ROBOTS_ANIMATE_PATH:-\/mnt\/user\/pc\/kindrobots\/animate\}:\/app\/animate:ro\s*$/m,
+  'kind-robots service must bind the dedicated host animate tree to /app/animate read-only',
+)
+
+assert.doesNotMatch(
+  compose,
+  /kindrobots\/animate[^\n]*:\/app\/animate:rw/,
+  'Scene Animator source media must not be mounted read-write',
+)
+
+console.log('Scene Animator deployment contract verified: /app/animate is a dedicated read-only mount.')


### PR DESCRIPTION
### Task
scene-animator/t-005: repair the failed production acceptance test (`Scene Animator source root is unavailable: /app/animate`)  (kind: software)

### What changed / what I produced
- Root-caused the failure to deployment wiring, not the folder picker or video queue: Scene Animator already resolves `/app/animate`, but the container definition mounted only the public image tree.
- Added the dedicated host source tree `${KIND_ROBOTS_ANIMATE_PATH:-/mnt/user/pc/kindrobots/animate}` as a read-only `/app/animate` bind and explicitly sets `ANIMATE_PATH=/app/animate` in `docker-compose.yml`.
- Documented the host override in `.env.example`.
- Updated `docs/scene-animator.md` with the exact Docker/Unraid source mapping and the Alexandria DockerMan-template requirement.
- Added `utils/scripts/verifySceneAnimatorDeploymentContract.ts` to pin the path + read-only mount contract.

### How I verified
- Compared the branch to current `main`: exactly four files changed, all within the Scene Animator deployment/docs contract; no app/runtime logic or schema changes.
- Re-read the live Scene Animator root resolver and health test: `/app/animate` is already the runtime fallback used in the reported error, so the missing bind is the direct failure point.
- GitHub CI is the executable verification path for this connector-only session; I will inspect the exact-head runs and only merge after they complete successfully.

### Stakes
reversible

### Flags for Reviewer
- Alexandria production is recreated from its saved Unraid DockerMan template, not from `docker-compose.yml`. This PR makes the repository deployment contract correct, but the **live** container cannot see the source tree until the saved template receives the equivalent read-only host mapping `/mnt/user/pc/kindrobots/animate` → `/app/animate`. That is the remaining physical-host gate and should not be mistaken for an app-code regression if the PR is merged before the template is updated.

### Kaizen suggestion
Wire the Scene Animator deployment-contract verifier into the shared Contract Tests job so a future removal of the `/app/animate` bind fails CI immediately.

### Notes for reviewer
No database migration, no source-media mutation, and no production deploy is performed by this PR.