### PR TITLE
refactor(ui): add kr-text-black-xs, close out kr-text-black-* family (slice 174)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1819,12 +1819,24 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply font-black text-xl;
   }
 
-  /* Third and final sibling in the `kr-text-black-*` family -- `font-black
+  /* Third sibling in the `kr-text-black-*` family -- `font-black
    * text-sm` (interface-vision t-104 slice 166) -- 108 subset-match
-   * occurrences across 70 files. Closes out the family entirely (`-lg`,
-   * `-xl`, `-sm` all now named), same convention as `.kr-text-dim-*`. */
+   * occurrences across 70 files. */
   .kr-text-black-sm {
     @apply font-black text-sm;
+  }
+
+  /* Fourth and final sibling in the `kr-text-black-*` family -- `font-black
+   * text-xs` (interface-vision t-104 slice 174) -- a fresh full-repo
+   * class-frequency survey once the `label-text`/`kr-label-*` families
+   * closed out (slice 173) found this shape still unnamed at 56
+   * subset-match occurrences across 27 files. Slice 166 called the family
+   * closed at `-lg`/`-xl`/`-sm`, but that was simply the set surveyed at
+   * the time, not a deliberate exclusion of `-xs`. Closes out the family
+   * entirely now (`-lg`, `-xl`, `-sm`, `-xs` all named), same convention as
+   * `.kr-text-dim-*`. */
+  .kr-text-black-xs {
+    @apply font-black text-xs;
   }
 
   /* `font-black uppercase` eyebrow/label text (interface-vision t-104 slice

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -204,7 +204,7 @@
               class="flex items-start gap-3 rounded-2xl border border-base-300 bg-base-200/45 p-3"
             >
               <span
-                class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-black text-primary"
+                class="kr-text-black-xs flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary"
               >
                 {{ index + 1 }}
               </span>

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -52,7 +52,7 @@
           </div>
           <div class="absolute inset-0 bg-linear-to-t from-base-content/65 via-transparent to-transparent" />
           <p
-            class="absolute inset-x-2 bottom-2 line-clamp-2 text-xs font-black leading-tight text-base-100 drop-shadow"
+            class="kr-text-black-xs absolute inset-x-2 bottom-2 line-clamp-2 leading-tight text-base-100 drop-shadow"
           >
             {{ style.name }}
           </p>

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -21,7 +21,7 @@
     <div class="flex flex-col gap-2 kr-panel-compact">
       <div class="flex items-center gap-2">
         <Icon name="kind-icon:image" class="h-4 w-4 text-primary" />
-        <span class="text-xs font-black text-base-content">Source Image</span>
+        <span class="kr-text-black-xs text-base-content">Source Image</span>
         <div class="flex-1" />
         <div
           class="flex overflow-hidden rounded-lg border border-base-300 text-xs"
@@ -476,7 +476,7 @@
       >
         <div class="flex items-center gap-1.5">
           <Icon name="kind-icon:edit" class="h-4 w-4 text-primary" />
-          <span class="text-xs font-black text-base-content">Prompt</span>
+          <span class="kr-text-black-xs text-base-content">Prompt</span>
           <span class="kr-text-dim-xs-40 ml-auto">
             {{
               selectedStyle?.loraPath

--- a/components/art/stylist-calculator.vue
+++ b/components/art/stylist-calculator.vue
@@ -13,7 +13,7 @@
 
     <div class="grid gap-3 sm:grid-cols-2">
       <label class="flex flex-col gap-1">
-        <span class="text-xs font-black text-base-content">Client</span>
+        <span class="kr-text-black-xs text-base-content">Client</span>
         <input
           v-model="clientName"
           type="text"
@@ -31,12 +31,12 @@
       </label>
 
       <label class="flex flex-col gap-1">
-        <span class="text-xs font-black text-base-content">Date</span>
+        <span class="kr-text-black-xs text-base-content">Date</span>
         <input v-model="date" type="date" class="input input-sm input-bordered w-full" />
       </label>
 
       <label class="flex flex-col gap-1">
-        <span class="text-xs font-black text-base-content">Hourly rate ($)</span>
+        <span class="kr-text-black-xs text-base-content">Hourly rate ($)</span>
         <input
           v-model.number="hourlyRate"
           type="number"
@@ -47,7 +47,7 @@
       </label>
 
       <label class="flex flex-col gap-1">
-        <span class="text-xs font-black text-base-content">Product cost ($, optional)</span>
+        <span class="kr-text-black-xs text-base-content">Product cost ($, optional)</span>
         <input
           v-model.number="productCost"
           type="number"
@@ -60,7 +60,7 @@
 
     <!-- Time spent -->
     <div class="flex flex-col gap-2 kr-panel-compact">
-      <span class="text-xs font-black text-base-content">Time spent</span>
+      <span class="kr-text-black-xs text-base-content">Time spent</span>
       <div class="flex flex-wrap gap-1">
         <button
           v-for="chip in TIME_CHIPS"
@@ -121,7 +121,7 @@
       v-if="savedAppointment"
       class="flex flex-col gap-2 rounded-xl border border-success/40 bg-success/5 p-3"
     >
-      <span class="text-xs font-black text-success">Saved! Receipt preview</span>
+      <span class="kr-text-black-xs text-success">Saved! Receipt preview</span>
       <pre class="whitespace-pre-wrap rounded-lg bg-base-100 p-2 text-xs">{{
         superkate.receiptText(savedAppointment)
       }}</pre>

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -9,11 +9,11 @@
 
     <form class="flex flex-wrap items-end gap-2 kr-panel-compact" @submit.prevent="save">
       <label class="flex min-w-40 flex-1 flex-col gap-1">
-        <span class="text-xs font-black">Name</span>
+        <span class="kr-text-black-xs">Name</span>
         <input v-model="name" type="text" placeholder="Client name" class="input input-sm input-bordered w-full" />
       </label>
       <label class="flex min-w-40 flex-1 flex-col gap-1">
-        <span class="text-xs font-black">Email (optional)</span>
+        <span class="kr-text-black-xs">Email (optional)</span>
         <input v-model="email" type="email" placeholder="For receipt prefill" class="input input-sm input-bordered w-full" />
       </label>
       <button type="submit" class="kr-btn-primary-plain" :disabled="!name.trim()">

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -30,7 +30,7 @@
     <!-- Client -->
     <div class="kr-panel-compact">
       <label class="flex flex-col gap-1">
-        <span class="text-xs font-black text-base-content">Client</span>
+        <span class="kr-text-black-xs text-base-content">Client</span>
         <input
           v-model="clientName"
           type="text"
@@ -52,7 +52,7 @@
     <div class="flex flex-col gap-2 kr-panel-compact">
       <div class="flex items-center gap-2">
         <Icon name="kind-icon:image" class="h-4 w-4 text-primary" />
-        <span class="text-xs font-black text-base-content">Client Photo</span>
+        <span class="kr-text-black-xs text-base-content">Client Photo</span>
         <div class="flex-1" />
         <div class="flex overflow-hidden rounded-lg border border-base-300 text-xs">
           <button
@@ -151,7 +151,7 @@
 
     <!-- What to change -->
     <div class="flex flex-col gap-3 kr-panel-compact">
-      <span class="text-xs font-black text-base-content">What are we changing?</span>
+      <span class="kr-text-black-xs text-base-content">What are we changing?</span>
 
       <label class="flex items-start gap-2">
         <input v-model="changeColor" type="checkbox" class="kr-checkbox-primary-sm mt-1" />
@@ -207,7 +207,7 @@
     <!-- How much to keep them looking like themselves -->
     <div class="flex flex-col gap-2 kr-panel-compact">
       <div class="flex items-center justify-between">
-        <span class="text-xs font-black text-base-content">How much should it still look like them?</span>
+        <span class="kr-text-black-xs text-base-content">How much should it still look like them?</span>
         <span class="kr-text-bold-xs text-primary">{{ preserveLabel }}</span>
       </div>
       <input
@@ -293,7 +293,7 @@
 
     <!-- This session's jobs -->
     <div v-if="visibleJobs.length" class="flex flex-col gap-2">
-      <span class="text-xs font-black text-base-content">
+      <span class="kr-text-black-xs text-base-content">
         {{ clientName.trim() ? `Styling ${clientName.trim()}` : 'This session' }}
       </span>
       <p
@@ -378,7 +378,7 @@
     <!-- Durable per-client history -->
     <div class="flex flex-col gap-2">
       <div class="flex items-center gap-2">
-        <span class="text-xs font-black text-base-content">
+        <span class="kr-text-black-xs text-base-content">
           {{ clientName.trim() ? `Past looks for ${clientName.trim()}` : 'Past looks' }}
         </span>
         <span v-if="stylist.isLoadingHistory" class="loading loading-spinner loading-xs text-primary" />

--- a/components/art/stylist-settings.vue
+++ b/components/art/stylist-settings.vue
@@ -13,7 +13,7 @@
 
     <div class="grid gap-3 sm:grid-cols-2">
       <label class="flex flex-col gap-1 sm:col-span-2">
-        <span class="text-xs font-black text-base-content">Salon name</span>
+        <span class="kr-text-black-xs text-base-content">Salon name</span>
         <input
           v-model="salonName"
           type="text"
@@ -23,7 +23,7 @@
       </label>
 
       <label class="flex flex-col gap-1">
-        <span class="text-xs font-black text-base-content">Booking / contact link</span>
+        <span class="kr-text-black-xs text-base-content">Booking / contact link</span>
         <input
           v-model="bookingLink"
           type="text"
@@ -34,7 +34,7 @@
       </label>
 
       <label class="flex flex-col gap-1">
-        <span class="text-xs font-black text-base-content">Reply contact</span>
+        <span class="kr-text-black-xs text-base-content">Reply contact</span>
         <input
           v-model="replyContact"
           type="text"
@@ -46,7 +46,7 @@
     </div>
 
     <div class="flex flex-col gap-1 kr-panel-compact">
-      <span class="text-xs font-black text-base-content">Receipt preview</span>
+      <span class="kr-text-black-xs text-base-content">Receipt preview</span>
       <pre class="kr-text-dim-xs-70 whitespace-pre-wrap">{{ preview }}</pre>
     </div>
 

--- a/components/brainstorm/brainstorm-candidate-card.vue
+++ b/components/brainstorm/brainstorm-candidate-card.vue
@@ -250,7 +250,7 @@
           </div>
           <p
             v-if="entry.revision.title"
-            class="mt-2 text-xs font-black text-base-content/75"
+            class="kr-text-black-xs mt-2 text-base-content/75"
           >
             {{ entry.revision.title }}
           </p>

--- a/components/characters/character-card.vue
+++ b/components/characters/character-card.vue
@@ -101,7 +101,7 @@
               {{ stat.label }}
             </div>
 
-            <div class="truncate text-xs font-black text-primary">
+            <div class="kr-text-black-xs truncate text-primary">
               {{ stat.value }}
             </div>
           </div>

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -233,7 +233,7 @@
             :alt="`${book.title} archived cover revision`"
             class="aspect-[2/3] w-full rounded-xl bg-base-100 object-contain"
           />
-          <p class="text-xs font-black">{{ revision.previousStatus || 'Archived revision' }}</p>
+          <p class="kr-text-black-xs">{{ revision.previousStatus || 'Archived revision' }}</p>
           <p class="kr-text-dim-xs-45">
             {{ formatDate(revision.requestedAt) }}
           </p>

--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -221,7 +221,7 @@
                     >
                       Current leader
                     </p>
-                    <p class="truncate text-xs font-black">
+                    <p class="kr-text-black-xs truncate">
                       {{ leaderLabel(challenge.slug) }}
                     </p>
                   </div>

--- a/components/conductor/davinci-page.vue
+++ b/components/conductor/davinci-page.vue
@@ -178,7 +178,7 @@
                   {{ DIMENSION_LABELS[dim] }}
                 </span>
                 <span
-                  class="text-xs font-black"
+                  class="kr-text-black-xs"
                   :class="dimensionValueClass(statMap[dim] ?? 0)"
                   >{{ statMap[dim] ?? 0 }}</span
                 >

--- a/components/curation/coloring-book-curation.vue
+++ b/components/curation/coloring-book-curation.vue
@@ -206,7 +206,7 @@
           </div>
 
           <label class="form-control gap-1">
-            <span class="text-xs font-black">Pitch / art prompt</span>
+            <span class="kr-text-black-xs">Pitch / art prompt</span>
             <textarea
               v-model="drafts[proposal.id]"
               class="textarea textarea-bordered min-h-28 rounded-xl text-sm leading-5"

--- a/components/curation/cthulhuquarium-curation.vue
+++ b/components/curation/cthulhuquarium-curation.vue
@@ -143,7 +143,7 @@
 
           <label class="form-control gap-1">
             <span
-              class="flex items-center justify-between gap-2 text-xs font-black"
+              class="kr-text-black-xs flex items-center justify-between gap-2"
             >
               Art prompt
               <span
@@ -184,7 +184,7 @@
             v-if="fish.curation.inspirations.length"
             class="kr-panel-compact"
           >
-            <summary class="cursor-pointer text-xs font-black">
+            <summary class="kr-text-black-xs cursor-pointer">
               All inspiration art
             </summary>
             <div class="mt-3 flex gap-2 overflow-x-auto pb-1">
@@ -213,7 +213,7 @@
           <div class="kr-panel-compact">
             <div class="flex flex-wrap gap-3">
               <label class="form-control min-w-52 flex-1 gap-1">
-                <span class="text-xs font-black">Render preset</span>
+                <span class="kr-text-black-xs">Render preset</span>
                 <select v-model="draft.presetId" class="kr-select-sm">
                   <option
                     v-for="preset in presets"
@@ -231,7 +231,7 @@
               </label>
 
               <label class="form-control min-w-52 flex-1 gap-1">
-                <span class="text-xs font-black">Starting point</span>
+                <span class="kr-text-black-xs">Starting point</span>
                 <select v-model="draft.sourceMode" class="kr-select-sm">
                   <option value="fresh">Fresh composition</option>
                   <option value="existing">Existing candidate art</option>
@@ -246,7 +246,7 @@
               "
               class="form-control mt-3 gap-1"
             >
-              <span class="text-xs font-black">SDXL checkpoint</span>
+              <span class="kr-text-black-xs">SDXL checkpoint</span>
               <select v-model="draft.checkpoint" class="kr-select-sm">
                 <option value="">Choose checkpoint</option>
                 <option
@@ -263,7 +263,7 @@
               v-if="draft.sourceMode === 'existing'"
               class="form-control mt-3 gap-1"
             >
-              <span class="text-xs font-black">Source ArtImage</span>
+              <span class="kr-text-black-xs">Source ArtImage</span>
               <select v-model.number="draft.sourceImageId" class="kr-select-sm">
                 <option :value="0">Choose candidate</option>
                 <option

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -326,7 +326,7 @@
             v-if="selectedRow.overriddenFields.length"
             class="flex flex-wrap gap-1"
           >
-            <span class="mr-1 text-xs font-black">Overridden:</span>
+            <span class="kr-text-black-xs mr-1">Overridden:</span>
             <span
               v-for="field in selectedRow.overriddenFields"
               :key="field"
@@ -337,7 +337,7 @@
           </div>
 
           <label class="form-control gap-1">
-            <span class="text-xs font-black">Traditional form</span>
+            <span class="kr-text-black-xs">Traditional form</span>
             <input
               v-model="draft.traditional"
               class="kr-input-sm"
@@ -347,7 +347,7 @@
 
           <label class="form-control gap-1">
             <span
-              class="flex items-center justify-between gap-2 text-xs font-black"
+              class="kr-text-black-xs flex items-center justify-between gap-2"
             >
               Pinyin
               <span
@@ -364,7 +364,7 @@
 
           <label class="form-control gap-1">
             <span
-              class="flex items-center justify-between gap-2 text-xs font-black"
+              class="kr-text-black-xs flex items-center justify-between gap-2"
             >
               Primary meaning
               <span
@@ -377,7 +377,7 @@
           </label>
 
           <label class="form-control gap-1">
-            <span class="text-xs font-black">Meanings / senses</span>
+            <span class="kr-text-black-xs">Meanings / senses</span>
             <textarea
               v-model="draft.meaningsText"
               class="textarea textarea-bordered min-h-28 rounded-xl text-sm leading-5"
@@ -390,7 +390,7 @@
           </label>
 
           <label class="form-control gap-1">
-            <span class="text-xs font-black">Topical categories</span>
+            <span class="kr-text-black-xs">Topical categories</span>
             <input
               v-model="draft.categoriesText"
               class="kr-input-sm"
@@ -403,7 +403,7 @@
           </label>
 
           <label class="form-control gap-1">
-            <span class="text-xs font-black">Usage note</span>
+            <span class="kr-text-black-xs">Usage note</span>
             <textarea
               v-model="draft.usageNote"
               class="textarea textarea-bordered min-h-20 rounded-xl text-sm leading-5"
@@ -412,7 +412,7 @@
           </label>
 
           <label class="form-control gap-1">
-            <span class="text-xs font-black">Change note</span>
+            <span class="kr-text-black-xs">Change note</span>
             <textarea
               v-model="draft.note"
               class="textarea textarea-bordered min-h-16 rounded-xl text-sm leading-5"
@@ -453,7 +453,7 @@
           </div>
 
           <details v-if="selectedRow.changes.length" class="kr-panel-compact">
-            <summary class="cursor-pointer text-xs font-black">
+            <summary class="kr-text-black-xs cursor-pointer">
               Audit history · {{ selectedRow.changes.length }} recent change{{
                 selectedRow.changes.length === 1 ? '' : 's'
               }}

--- a/components/home/home-page.vue
+++ b/components/home/home-page.vue
@@ -270,7 +270,7 @@
 
                 <div class="min-w-0 flex-1">
                   <p
-                    class="truncate text-xs font-black leading-tight group-hover:text-primary"
+                    class="kr-text-black-xs truncate leading-tight group-hover:text-primary"
                     :title="project.title"
                   >
                     {{ project.title }}

--- a/components/narrative/narrative-cast-card.vue
+++ b/components/narrative/narrative-cast-card.vue
@@ -38,7 +38,7 @@
         type="button"
         tabindex="-1"
         aria-hidden="true"
-        class="absolute right-2 top-2 z-10 cursor-grab touch-none rounded-lg bg-base-100/90 px-2 py-1 text-xs font-black shadow active:cursor-grabbing"
+        class="kr-text-black-xs absolute right-2 top-2 z-10 cursor-grab touch-none rounded-lg bg-base-100/90 px-2 py-1 shadow active:cursor-grabbing"
         title="Drag to a part"
         @pointerdown="startPointerDrag"
         @pointermove="movePointerDrag"
@@ -62,7 +62,7 @@
       </span>
 
       <span
-        class="absolute inset-x-0 bottom-0 truncate bg-linear-to-t from-base-100 to-transparent px-2 pb-1.5 pt-6 text-xs font-black"
+        class="kr-text-black-xs absolute inset-x-0 bottom-0 truncate bg-linear-to-t from-base-100 to-transparent px-2 pb-1.5 pt-6"
       >
         {{ member.title }}
       </span>

--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -172,7 +172,7 @@
             />
 
             <span class="min-w-0 flex-1">
-              <span class="block truncate text-xs font-black">
+              <span class="kr-text-black-xs block truncate">
                 {{ account.label || account.username }}
               </span>
 

--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -135,7 +135,7 @@
           class="rounded-lg border border-error/20 bg-base-100 p-3 text-left hover:border-error"
           @click="openSlug(task.projectSlug)"
         >
-          <p class="text-xs font-black text-error">
+          <p class="kr-text-black-xs text-error">
             {{ task.projectTitle }} · {{ task.id }}
           </p>
           <p class="text-sm font-semibold">{{ task.title }}</p>

--- a/components/pages/memory-dungeon.vue
+++ b/components/pages/memory-dungeon.vue
@@ -30,7 +30,7 @@
               ❤️
             </span>
           </div>
-          <div class="text-xs font-black sm:hidden">❤️ {{ lives }}</div>
+          <div class="kr-text-black-xs sm:hidden">❤️ {{ lives }}</div>
           <div class="mt-0.5 text-[10px] text-base-content/50">
             HP {{ lives }}/{{ maxLives }}
           </div>

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -476,7 +476,7 @@
                 class="taskmaster-checkpoint relative flex items-start gap-3 rounded-2xl border border-base-300/85 bg-base-100/90 p-3 shadow-sm backdrop-blur"
               >
                 <span
-                  class="relative z-10 flex size-9 shrink-0 items-center justify-center rounded-full bg-secondary text-xs font-black text-secondary-content shadow-md"
+                  class="kr-text-black-xs relative z-10 flex size-9 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-content shadow-md"
                 >
                   {{ index + 1 }}
                 </span>

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -106,7 +106,7 @@
             class="h-20 w-full object-cover opacity-80"
           />
           <div class="p-2.5">
-            <p class="text-xs font-black text-base-content">
+            <p class="kr-text-black-xs text-base-content">
               {{ store.selectedStage.label }}
             </p>
             <p class="kr-text-dim-xs mt-0.5 line-clamp-2">

--- a/components/storybook/storybook-state-panel.vue
+++ b/components/storybook/storybook-state-panel.vue
@@ -39,7 +39,7 @@
               />
             </span>
             <span class="min-w-0 flex-1">
-              <span class="block truncate text-xs font-black">
+              <span class="kr-text-black-xs block truncate">
                 {{ item.ingredient.title }}
               </span>
               <span

--- a/components/taskmaster/taskmaster-quest-stepper.vue
+++ b/components/taskmaster/taskmaster-quest-stepper.vue
@@ -11,7 +11,7 @@
       :aria-current="step.key === active ? 'step' : undefined"
     >
       <span
-        class="flex size-7 shrink-0 items-center justify-center rounded-full border text-xs font-black shadow-sm"
+        class="kr-text-black-xs flex size-7 shrink-0 items-center justify-center rounded-full border shadow-sm"
         :class="
           step.key === active
             ? 'border-secondary bg-secondary text-secondary-content'

--- a/components/themes/theme-gallery.vue
+++ b/components/themes/theme-gallery.vue
@@ -74,7 +74,7 @@
 
           <span
             v-if="activeThemeName"
-            class="inline-flex max-w-44 items-center gap-1.5 truncate rounded-full border border-accent/40 bg-accent/10 px-2.5 py-1 text-xs font-black text-accent"
+            class="kr-text-black-xs inline-flex max-w-44 items-center gap-1.5 truncate rounded-full border border-accent/40 bg-accent/10 px-2.5 py-1 text-accent"
           >
             <Icon name="kind-icon:check" class="h-3.5 w-3.5 shrink-0" />
             <span class="truncate">{{ activeThemeName }}</span>

--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -58,7 +58,7 @@
       >
         <div class="flex items-start gap-2">
           <span
-            class="flex size-6 shrink-0 items-center justify-center rounded-lg bg-accent text-xs font-black text-accent-content"
+            class="kr-text-black-xs flex size-6 shrink-0 items-center justify-center rounded-lg bg-accent text-accent-content"
           >
             {{ index + 1 }}
           </span>

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -70,7 +70,7 @@
             class="flex items-center gap-3 kr-panel-flat p-3 shadow-sm"
           >
             <span
-              class="grid size-8 shrink-0 place-items-center rounded-full bg-base-200 text-xs font-black"
+              class="kr-text-black-xs grid size-8 shrink-0 place-items-center rounded-full bg-base-200"
             >
               {{ entry.rank }}
             </span>

--- a/utils/scripts/codemods/kr_text_black_xs_codemod.py
+++ b/utils/scripts/codemods/kr_text_black_xs_codemod.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `font-black text-xs` heading-emphasis text to
+`kr-text-black-xs`.
+
+Fourth sibling of kr_text_black_lg_codemod.py / kr_text_black_xl_codemod.py /
+kr_text_black_sm_codemod.py -- a fresh full-repo class-frequency survey after
+slice 173 closed out the `label-text`/`kr-label-*` families found this shape
+still unnamed at 56 subset-match occurrences across 27 files (interface-vision
+t-104 slice 174). The `kr-text-black-*` family's own docstring called itself
+closed at `-lg`/`-xl`/`-sm` (slice 166) because those were the sizes surveyed
+at the time; `-xs` simply hadn't been counted yet, not deliberately excluded --
+same situation `kr_label_xs_codemod.py` found for the `label-text` family.
+
+Dry-run by default, --write to update matching Vue files in place. Only the
+exact `font-black text-xs` shape is touched, and only in static
+`class="..."` attributes -- never `:class`/`v-bind:class` bindings, and
+regardless of the base tokens' order in the source. A source that already
+carries `kr-text-black-xs`, or is missing either base token, is left
+untouched. Extra tokens beyond the base set are preserved verbatim after the
+primitive class, matching the kr-badge-*/kr-spinner-*/kr-label-bold/
+kr-text-dim-*/kr-text-black-{lg,xl,sm} codemods' subset-match convention --
+pass --exact-only to restrict a slice to sources with no extra tokens at
+all, the safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-black-xs"
+BASE_TOKENS = {"font-black", "text-xs"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-black-xs {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 174 (kind: software, recurring consistency umbrella)

### What changed / what I produced
- Added `.kr-text-black-xs { @apply font-black text-xs; }` to `assets/css/tailwind.css`, the fourth and final sibling in the `kr-text-black-*` family (`-lg`, `-xl`, `-sm` already existed from slices 164-166).
- Added `utils/scripts/codemods/kr_text_black_xs_codemod.py`, same dry-run/`--write`/`--exact-only`/subset-match convention as every prior codemod in the family.
- Migrated all 56 subset-match occurrences of hand-rolled `font-black text-xs` across 27 files to `kr-text-black-xs`, preserving extra tokens verbatim. No geometry or behavior change — pure class-string substitution.

### How I verified
- `vue-tsc --noEmit`: clean.
- `eslint .`: 333 problems (327 errors, 6 warnings) — identical to documented baseline.
- `npm run test:layout-contract`: holds, no new violations (same pre-existing -2 ratchet opportunity in `narrative-ingredient-multi-picker.vue`, left untouched — out of scope for this slice).
- `npm run test:lint-ratchet`: holds at 333/-59.
- `prettier --check` on all 28 changed files: flagged 18, every one confirmed pre-existing baseline drift via `git stash` before/after — none newly introduced by this change.

### Stakes
reversible

### Flags for Reviewer
- Slice 166's own docstring called the `kr-text-black-*` family "closed" at `-lg`/`-xl`/`-sm` — that was the set surveyed at the time, not a deliberate exclusion of `-xs`. This slice's fresh full-repo survey (per slice 173's kaizen note) found `-xs` was simply never counted.

### Kaizen suggestion
A fresh full-repo class-frequency survey outside all now-closed `kr-text-*`/`kr-label-*` families is still the next open item — the remaining bare `label-text` occurrences (13 files, varied shapes) and generic layout-utility combos (`flex items-center gap-2` etc.) surveyed this slice are each too small/varied or too generic (layout composition, not a duplicated component "shape") to be a single bounded family.

### Notes for reviewer
Conductor task interface-vision/t-104 claimed this slice; roadmap close-out follows in a separate conductor PR after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WjJqUsRV5r6xaBjf4FELV

---
_Generated by [Claude Code](https://claude.ai/code/session_012WjJqUsRV5r6xaBjf4FELV)_