### PR TITLE
feat(interface-vision): add kr-text-black-2xl primitive, migrate 72 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1839,6 +1839,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply font-black text-xs;
   }
 
+  /* Fifth sibling in the `kr-text-black-*` family -- `font-black text-2xl`
+   * (interface-vision t-104 slice 175). Slice 174 called the family closed
+   * at `-lg`/`-xl`/`-sm`/`-xs`, the same "closed at the sizes surveyed, not
+   * a deliberate exclusion" situation that reopened it for `-xs` one slice
+   * earlier: a fresh full-repo class-frequency survey after slice 174
+   * found `-2xl` unnamed at 72 subset-match occurrences across roughly 50
+   * files, mostly page-header titles (the icon-badge + title/subtitle
+   * pattern t-105's page-polish slices established elsewhere). Same
+   * subset-match/--exact-only codemod convention as every other
+   * `kr-text-black-*`/`kr-text-dim-*` sibling. */
+  .kr-text-black-2xl {
+    @apply font-black text-2xl;
+  }
+
   /* `font-black uppercase` eyebrow/label text (interface-vision t-104 slice
    * 167) -- a fresh full-repo class-frequency survey once both the
    * `kr-text-black-*` and `kr-text-dim-*` families closed out found this

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -116,7 +116,7 @@
     >
       <div class="flex min-w-0 flex-col gap-2">
         <div class="flex flex-wrap items-center gap-2">
-          <h3 class="text-2xl font-black text-base-content">{{ lesson.name }}</h3>
+          <h3 class="kr-text-black-2xl text-base-content">{{ lesson.name }}</h3>
           <span class="kr-badge-primary-sm font-bold">{{ lesson.era }}</span>
           <span class="kr-badge-ghost-sm">{{ lesson.region }}</span>
         </div>
@@ -280,7 +280,7 @@
               <Icon name="kind-icon:flask" class="h-4 w-4" />
               Try it
             </p>
-            <h4 class="mt-2 text-2xl font-black leading-tight text-base-content">
+            <h4 class="kr-text-black-2xl mt-2 leading-tight text-base-content">
               Turn the lesson into an image
             </h4>
           </div>

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -9,7 +9,7 @@
           <Icon name="kind-icon:palette" class="h-4 w-4" aria-hidden="true" />
           Browse the collection
         </p>
-        <h2 class="mt-2 text-2xl font-black text-base-content sm:text-3xl">Style Gallery</h2>
+        <h2 class="kr-text-black-2xl mt-2 text-base-content sm:text-3xl">Style Gallery</h2>
         <p class="mt-1 text-sm leading-relaxed text-base-content/65">
           Start with the image. Open whatever catches your eye, learn how to recognize it, then remix your own source in that visual language.
         </p>

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -12,7 +12,7 @@
           </span>
         </div>
         <div class="max-w-2xl">
-          <h2 class="text-2xl font-black leading-tight text-base-content sm:text-3xl">
+          <h2 class="kr-text-black-2xl leading-tight text-base-content sm:text-3xl">
             The Art History Timeline
           </h2>
           <p class="kr-text-dim-sm-70 mt-2 leading-relaxed sm:text-base">

--- a/components/achievements/achievement-popup.vue
+++ b/components/achievements/achievement-popup.vue
@@ -32,7 +32,7 @@
         </span>
         <h2
           id="achievement-popup"
-          class="mt-3 text-2xl font-black text-white drop-shadow"
+          class="kr-text-black-2xl mt-3 text-white drop-shadow"
         >
           Achievement Unlocked!
         </h2>

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -14,7 +14,7 @@
               <Icon name="kind-icon:paintbrush" class="h-6 w-6 text-primary" />
             </span>
             <div class="min-w-0">
-              <h1 class="text-2xl font-black text-primary">Image Generator</h1>
+              <h1 class="kr-text-black-2xl text-primary">Image Generator</h1>
               <p class="kr-text-dim-sm mt-0.5">
                 Recipe → prompt → pixels. Everything here renders on ComfyUI.
               </p>

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -74,7 +74,7 @@
           >
             {{ status }}
           </div>
-          <div class="mt-1 text-2xl font-black">{{ statusCount(status) }}</div>
+          <div class="kr-text-black-2xl mt-1">{{ statusCount(status) }}</div>
         </div>
       </div>
 

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -6,7 +6,7 @@
           <Icon name="kind-icon:server" class="h-7 w-7" />
         </span>
         <div>
-          <p class="text-2xl font-black tracking-tight">Build Bench</p>
+          <p class="kr-text-black-2xl tracking-tight">Build Bench</p>
           <p class="kr-text-dim-sm">
             Two builds enter, you decide. Clone one side, change a single knob,
             render both, pick the winner.

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -61,7 +61,7 @@
           />
 
           <div class="min-w-0 flex-1 text-center sm:text-left">
-            <h2 class="truncate text-2xl font-black text-base-content">
+            <h2 class="kr-text-black-2xl truncate text-base-content">
               {{ selectedBotName }}
             </h2>
 

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -26,7 +26,7 @@
             <span v-else aria-hidden="true">🧠</span>
             Brainstorm
           </div>
-          <h2 class="text-2xl font-black tracking-tight text-base-content sm:text-3xl">
+          <h2 class="kr-text-black-2xl tracking-tight text-base-content sm:text-3xl">
             What are we trying to invent?
           </h2>
           <p class="mt-2 max-w-3xl text-sm leading-6 text-base-content/65">

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -12,7 +12,7 @@
             {{ book.title }}
           </span>
         </div>
-        <h3 class="mt-2 text-2xl font-black">Canonical cover production</h3>
+        <h3 class="kr-text-black-2xl mt-2">Canonical cover production</h3>
         <p class="mt-1 max-w-3xl text-sm text-base-content/55">
           Generate, revise, adopt, accept, and finalize the portrait source illustration.
           Title typography, spine, back cover, barcode space, bleed, and printer template

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -15,7 +15,7 @@
             Initial canonical refresh pending
           </span>
         </div>
-        <h3 class="mt-2 text-2xl font-black">Publishing readiness</h3>
+        <h3 class="kr-text-black-2xl mt-2">Publishing readiness</h3>
         <p class="mt-1 max-w-3xl text-sm text-base-content/55">
           Source art, physical layout decisions, and export files are tracked as separate
           gates. A finished illustration is not secretly a paperback wearing sunglasses.

--- a/components/coloring/coloring-book-readiness.vue
+++ b/components/coloring/coloring-book-readiness.vue
@@ -4,7 +4,7 @@
       <div>
         <div class="flex items-center gap-2">
           <icon name="kind-icon:check" class="size-6 text-success" />
-          <h3 class="text-2xl font-black">Book readiness</h3>
+          <h3 class="kr-text-black-2xl">Book readiness</h3>
         </div>
         <p class="mt-1 max-w-3xl text-sm text-base-content/55">
           Every interior page gets one explicit next action. Covers remain separate

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -6,7 +6,7 @@
       <div>
         <div class="flex items-center gap-2">
           <icon name="kind-icon:book" class="size-6 text-primary" />
-          <h3 class="text-2xl font-black">Coloring Book Production Studio</h3>
+          <h3 class="kr-text-black-2xl">Coloring Book Production Studio</h3>
         </div>
         <p class="kr-text-dim-sm mt-1 max-w-3xl">
           Three canonical books, 108 proposal slots, real Conductor prompts,
@@ -145,7 +145,7 @@
               >
                 {{ book.slug }}
               </p>
-              <h4 class="text-2xl font-black">{{ book.title }}</h4>
+              <h4 class="kr-text-black-2xl">{{ book.title }}</h4>
             </div>
             <span class="badge badge-primary rounded-2xl">
               {{ book.counts.total }}/{{ book.targetProposals }}
@@ -310,7 +310,7 @@
                 {{ studio.selectedProposal.slot }} ·
                 {{ studio.selectedProposal.id }}
               </p>
-              <h4 class="text-2xl font-black">
+              <h4 class="kr-text-black-2xl">
                 {{ studio.selectedProposal.title }}
               </h4>
             </div>

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -15,7 +15,7 @@
         <Icon name="kind-icon:book" class="size-6" />
       </div>
       <div class="min-w-0 flex-1 basis-full sm:basis-auto">
-        <p class="text-2xl font-black leading-tight">
+        <p class="kr-text-black-2xl leading-tight">
           Build a world, then step inside it
         </p>
         <p class="mt-1 max-w-3xl text-sm leading-relaxed text-base-content/65">

--- a/components/curation/mandarin-curation.vue
+++ b/components/curation/mandarin-curation.vue
@@ -178,7 +178,7 @@
               >
                 <td>
                   <div class="flex items-center gap-2">
-                    <span class="text-2xl font-black">{{
+                    <span class="kr-text-black-2xl">{{
                       row.effective.simplified
                     }}</span>
                     <span

--- a/components/dreams/daily-digest-browser.vue
+++ b/components/dreams/daily-digest-browser.vue
@@ -67,7 +67,7 @@
                   : 'The archive is waking up'
               }}
             </p>
-            <h2 class="mt-1 text-2xl font-black leading-tight sm:text-3xl">
+            <h2 class="kr-text-black-2xl mt-1 leading-tight sm:text-3xl">
               {{ activeDream?.title || 'Fresh worlds will gather here' }}
             </h2>
           </div>

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -10,7 +10,7 @@
         <div class="min-w-0">
           <div class="flex flex-wrap items-center gap-2">
             <Icon name="kind-icon:sparkles" class="h-7 w-7 text-primary" />
-            <h1 class="text-2xl font-black text-primary">Brainstorm</h1>
+            <h1 class="kr-text-black-2xl text-primary">Brainstorm</h1>
             <span class="badge badge-info rounded-xl">Dream Riffs</span>
           </div>
           <p class="mt-1 max-w-4xl text-sm text-base-content/65">

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -10,7 +10,7 @@
         <div class="min-w-0">
           <div class="flex flex-wrap items-center gap-2">
             <Icon name="kind-icon:dream" class="h-7 w-7 text-primary" />
-            <h1 class="text-2xl font-black text-primary">Dreammaker</h1>
+            <h1 class="kr-text-black-2xl text-primary">Dreammaker</h1>
             <span
               v-if="dreamStore.dreamForm.id"
               class="badge badge-outline rounded-xl"

--- a/components/dreams/dream-pitch-sheet.vue
+++ b/components/dreams/dream-pitch-sheet.vue
@@ -68,7 +68,7 @@
       <section class="sheet-copy-panel min-w-0 lg:row-span-2">
         <div class="sheet-title-frame">
           <h2
-            class="line-clamp-2 text-2xl font-black leading-none text-(--sheet-ink) sm:text-4xl"
+            class="kr-text-black-2xl line-clamp-2 leading-none text-(--sheet-ink) sm:text-4xl"
           >
             {{ title }}
           </h2>

--- a/components/giftshop/checkout-cancel.vue
+++ b/components/giftshop/checkout-cancel.vue
@@ -24,7 +24,7 @@
         <div class="kr-text-eyebrow kr-text-dim-xs tracking-widest">
           Cart preserved
         </div>
-        <div class="text-2xl font-black text-primary">
+        <div class="kr-text-black-2xl text-primary">
           {{ cartStore.totalItems }} item{{ cartStore.totalItems === 1 ? '' : 's' }} ·
           ${{ cartStore.formattedTotalPrice }}
         </div>

--- a/components/giftshop/checkout-success.vue
+++ b/components/giftshop/checkout-success.vue
@@ -24,7 +24,7 @@
         <div class="kr-text-eyebrow kr-text-dim-xs tracking-widest">
           Confirmed total
         </div>
-        <div class="text-2xl font-black text-primary">
+        <div class="kr-text-black-2xl text-primary">
           {{ verifiedAmount }}
         </div>
       </div>

--- a/components/giftshop/giftshop-interact.vue
+++ b/components/giftshop/giftshop-interact.vue
@@ -10,7 +10,7 @@
             <div class="flex flex-wrap items-center gap-2">
               <Icon name="kind-icon:gift" class="h-7 w-7 text-primary" />
 
-              <h3 class="text-2xl font-black text-primary sm:text-3xl">
+              <h3 class="kr-text-black-2xl text-primary sm:text-3xl">
                 Swarm Giftshop
               </h3>
 

--- a/components/giftshop/giftshop-manager.vue
+++ b/components/giftshop/giftshop-manager.vue
@@ -85,7 +85,7 @@
             <Icon name="kind-icon:forum" class="h-12 w-12 text-primary" />
 
             <div class="max-w-xl space-y-2">
-              <h2 class="text-2xl font-black text-base-content">
+              <h2 class="kr-text-black-2xl text-base-content">
                 Giftshop Forum
               </h2>
 

--- a/components/giftshop/shopping-cart.vue
+++ b/components/giftshop/shopping-cart.vue
@@ -3,7 +3,7 @@
   <section class="kr-container max-w-5xl space-y-6 p-4 sm:p-6">
     <div class="flex flex-wrap items-center justify-between gap-3">
       <div>
-        <h1 class="flex items-center gap-2 text-2xl font-black text-primary">
+        <h1 class="kr-text-black-2xl flex items-center gap-2 text-primary">
           <Icon name="kind-icon:cart" class="h-7 w-7" />
           Your Cart
         </h1>

--- a/components/home/home-account-links.vue
+++ b/components/home/home-account-links.vue
@@ -7,7 +7,7 @@
         <Icon name="kind-icon:users" class="h-6 w-6" />
       </span>
       <div>
-        <h1 class="text-2xl font-black">Connect</h1>
+        <h1 class="kr-text-black-2xl">Connect</h1>
         <p class="kr-text-dim-sm mt-1">
           Account settings, the newsfeed, and your people now share one Home doorway.
         </p>

--- a/components/navigation/tutorial-flyer.vue
+++ b/components/navigation/tutorial-flyer.vue
@@ -131,7 +131,7 @@
               </p>
 
               <h2
-                class="mt-2.5 text-2xl font-black leading-[1.1] tracking-tight text-base-content sm:text-3xl"
+                class="kr-text-black-2xl mt-2.5 leading-[1.1] tracking-tight text-base-content sm:text-3xl"
               >
                 {{ config.title }}
               </h2>

--- a/components/navigation/workspace-sheet.vue
+++ b/components/navigation/workspace-sheet.vue
@@ -155,7 +155,7 @@
 
               <div class="min-w-0 flex-1">
                 <p
-                  class="truncate text-2xl font-black leading-none tracking-tight text-base-content drop-shadow-sm"
+                  class="kr-text-black-2xl truncate leading-none tracking-tight text-base-content drop-shadow-sm"
                 >
                   {{ card.label }}
                 </p>

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -9,7 +9,7 @@
           <Icon name="kind-icon:toolbox" class="h-7 w-7" />
         </span>
         <div>
-          <p class="text-2xl font-black tracking-tight">AppMaker</p>
+          <p class="kr-text-black-2xl tracking-tight">AppMaker</p>
           <p class="kr-text-dim-sm">
             The app factory — every app is a workspace folder, a project
             roadmap, and a Dream sharing one slug.

--- a/components/pages/click-leaderboard.vue
+++ b/components/pages/click-leaderboard.vue
@@ -7,7 +7,7 @@
           <Icon name="kind-icon:trophy" class="h-7 w-7" />
         </span>
         <div>
-          <p class="text-2xl font-black tracking-tight">Global Leaderboard</p>
+          <p class="kr-text-black-2xl tracking-tight">Global Leaderboard</p>
           <p class="kr-text-dim-sm">
             The highest click records ever recorded, ranked best to worst.
           </p>

--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -9,7 +9,7 @@
         <Icon name="kind-icon:gallery" class="size-6" />
       </div>
       <div class="min-w-0 flex-1">
-        <h2 class="text-2xl font-black tracking-tight">Projects</h2>
+        <h2 class="kr-text-black-2xl tracking-tight">Projects</h2>
         <p class="kr-text-dim-sm">
           Browse every Conductor project, filter by status, or start a new
           one.

--- a/components/pages/creator-earnings-page.vue
+++ b/components/pages/creator-earnings-page.vue
@@ -5,7 +5,7 @@
         <Icon name="kind-icon:coin" class="h-7 w-7" />
       </span>
       <div>
-        <p class="text-2xl font-black tracking-tight">Creator Earnings</p>
+        <p class="kr-text-black-2xl tracking-tight">Creator Earnings</p>
         <p class="kr-text-dim-sm">
           What you've earned when someone spent tokens on something you made — a
           Bot, Character, Facet, Scenario, Pitch, Art, Pack, Reward, or Dream.

--- a/components/pages/giving-page.vue
+++ b/components/pages/giving-page.vue
@@ -98,7 +98,7 @@
     >
       <div class="mb-6 text-center">
         <Icon name="kind-icon:rocket" class="mx-auto h-8 w-8 text-primary" />
-        <h2 class="mt-2 text-2xl font-black text-base-content">
+        <h2 class="kr-text-black-2xl mt-2 text-base-content">
           Support Kind Robots Monthly
         </h2>
         <p class="kr-text-dim-sm-70 mx-auto mt-2 max-w-2xl">

--- a/components/pages/memory-dungeon.vue
+++ b/components/pages/memory-dungeon.vue
@@ -164,7 +164,7 @@
         class="pointer-events-none fixed left-1/2 top-1/3 z-100 min-w-55 -translate-x-1/2 rounded-3xl bg-linear-to-br from-yellow-400 via-orange-400 to-red-400 px-8 py-5 text-center text-black shadow-2xl"
       >
         <div class="mb-1 text-5xl drop-shadow">{{ award.icon }}</div>
-        <div class="text-2xl font-black leading-tight tracking-tight">
+        <div class="kr-text-black-2xl leading-tight tracking-tight">
           {{ award.title }}
         </div>
         <div class="mt-1 text-sm font-medium opacity-80">

--- a/components/pages/mermaids-page.vue
+++ b/components/pages/mermaids-page.vue
@@ -53,7 +53,7 @@
               <input
                 v-model="draft.heroTitle"
                 aria-label="Page title"
-                class="input input-bordered mb-3 w-full text-2xl font-black sm:text-3xl"
+                class="kr-text-black-2xl input input-bordered mb-3 w-full sm:text-3xl"
               />
               <textarea
                 v-model="draft.heroSubtitle"

--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -5,7 +5,7 @@
         <Icon name="kind-icon:hand-heart" class="h-7 w-7" />
       </span>
       <div>
-        <p class="text-2xl font-black tracking-tight">Mission Accrual</p>
+        <p class="kr-text-black-2xl tracking-tight">Mission Accrual</p>
         <p class="kr-text-dim-sm">
           How much mission share has accrued from the RevenueSplit ledger, how
           much has actually been remitted, and the outstanding balance still

--- a/components/pages/portos-page.vue
+++ b/components/pages/portos-page.vue
@@ -7,7 +7,7 @@
         </div>
         <div class="min-w-0 flex-1">
           <p class="kr-text-eyebrow-bold text-xs tracking-wide text-accent/70">Portos</p>
-          <h2 class="text-2xl font-black leading-tight">Portos Server Setup</h2>
+          <h2 class="kr-text-black-2xl leading-tight">Portos Server Setup</h2>
           <p class="kr-text-dim-sm-70 mt-1 leading-relaxed">
             This tab is reserved for connecting a Porto server address and saving the user/server pairing cleanly once the server entry flow is wired in.
           </p>

--- a/components/pages/privacy-page.vue
+++ b/components/pages/privacy-page.vue
@@ -7,7 +7,7 @@
         <Icon name="kind-icon:shield" class="h-7 w-7" />
       </span>
       <div>
-        <p class="text-2xl font-black tracking-tight">Privacy Policy</p>
+        <p class="kr-text-black-2xl tracking-tight">Privacy Policy</p>
         <p class="kr-text-dim-sm">Last updated: May 2026</p>
       </div>
     </header>

--- a/components/pages/rebel-button.vue
+++ b/components/pages/rebel-button.vue
@@ -6,7 +6,7 @@
         <Icon name="kind-icon:button" class="h-7 w-7" />
       </span>
       <div>
-        <p class="text-2xl font-black tracking-tight">Rebel Button</p>
+        <p class="kr-text-black-2xl tracking-tight">Rebel Button</p>
         <p class="kr-text-dim-sm">
           Do not press this button. (You're going to press it.)
         </p>

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -52,26 +52,12 @@
               class="menu dropdown-content z-20 mt-2 w-44 kr-panel-flat p-2 shadow-xl"
             >
               <li>
-                <button
-                  type="button"
-                  @click="
-                    downloadStory(undefined, 'markdown')
-                    closeExportMenu()
-                  "
-                >
+                <button type="button" @click="downloadStoryAsMarkdown">
                   Markdown
                 </button>
               </li>
               <li>
-                <button
-                  type="button"
-                  @click="
-                    downloadStory(undefined, 'json')
-                    closeExportMenu()
-                  "
-                >
-                  JSON
-                </button>
+                <button type="button" @click="downloadStoryAsJson">JSON</button>
               </li>
             </ul>
           </div>
@@ -321,6 +307,24 @@ function closeExportMenu(): void {
   if (typeof document === 'undefined') return
   const element = document.activeElement as HTMLElement | null
   element?.blur()
+}
+
+// Named wrappers for the export-menu items below instead of an inline
+// multi-statement @click: Prettier's canonical formatting for a
+// multi-statement inline handler is a semicolon-free, one-statement-per-line
+// block, which Vue's template expression compiler cannot parse (it looks
+// like a single expression, not a statement list) -- that's what broke the
+// production build after the storybook/davinci merge (#2549). A single
+// identifier handler sidesteps the ambiguity entirely and can't drift back
+// under a future --write.
+function downloadStoryAsMarkdown(): void {
+  downloadStory(undefined, 'markdown')
+  closeExportMenu()
+}
+
+function downloadStoryAsJson(): void {
+  downloadStory(undefined, 'json')
+  closeExportMenu()
 }
 
 function startNewStory(): void {

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -422,7 +422,7 @@
               >
                 Quest briefing
               </p>
-              <h2 class="mt-1 text-2xl font-black leading-tight sm:text-3xl">
+              <h2 class="kr-text-black-2xl mt-1 leading-tight sm:text-3xl">
                 Review the practical plan
               </h2>
               <p class="mt-2 max-w-xl text-sm leading-relaxed text-base-content/65">

--- a/components/pages/wallet-page.vue
+++ b/components/pages/wallet-page.vue
@@ -5,7 +5,7 @@
         <Icon name="kind-icon:money" class="h-7 w-7" />
       </span>
       <div>
-        <p class="text-2xl font-black tracking-tight">Wallet</p>
+        <p class="kr-text-black-2xl tracking-tight">Wallet</p>
         <p class="kr-text-dim-sm">
           Your karma and mana balance — earned by contributing, spent to
           create.

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -223,7 +223,7 @@
           class="kr-pane-scroll flex flex-col p-5 gap-4"
         >
           <div class="flex flex-col gap-1">
-            <h2 class="text-2xl font-black text-base-content">Pick a Stage</h2>
+            <h2 class="kr-text-black-2xl text-base-content">Pick a Stage</h2>
             <p class="kr-text-dim-sm">
               Choose the format. This determines the roles, rotation, and tone
               of the performance.
@@ -278,7 +278,7 @@
 
           <template v-else>
             <div class="flex flex-col gap-1">
-              <h2 class="text-2xl font-black text-base-content">
+              <h2 class="kr-text-black-2xl text-base-content">
                 Cast the Show
               </h2>
               <p class="kr-text-dim-sm">
@@ -501,7 +501,7 @@
           class="kr-pane-scroll flex flex-col p-5 gap-4"
         >
           <div class="flex flex-col gap-1">
-            <h2 class="text-2xl font-black text-base-content">
+            <h2 class="kr-text-black-2xl text-base-content">
               Configure the Show
             </h2>
             <p class="kr-text-dim-sm">
@@ -844,7 +844,7 @@
             class="mx-auto h-40 w-auto rounded-3xl object-cover opacity-70 shadow-xl"
           />
           <div class="max-w-sm">
-            <h2 class="text-2xl font-black text-base-content">
+            <h2 class="kr-text-black-2xl text-base-content">
               Cast the chaos.
             </h2>
             <p class="kr-text-dim-sm mt-2">

--- a/components/user/account-settings.vue
+++ b/components/user/account-settings.vue
@@ -7,7 +7,7 @@
 <template>
   <section class="kr-container max-w-3xl flex flex-col gap-6 p-4 sm:p-6">
     <header class="flex flex-col gap-1">
-      <h1 class="text-2xl font-black">Account &amp; Privacy</h1>
+      <h1 class="kr-text-black-2xl">Account &amp; Privacy</h1>
       <p class="kr-text-dim-sm-70">
         You're in control. Change what you share, who can reach you, and what
         lands in your inbox.

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -9,7 +9,7 @@
           <p class="kr-text-eyebrow-bold text-xs tracking-wide text-primary">
             Message Timeline
           </p>
-          <h2 class="text-2xl font-black text-base-content">Chats</h2>
+          <h2 class="kr-text-black-2xl text-base-content">Chats</h2>
           <p class="kr-text-dim-sm-70">
             Human, system, welcome, bot, and beautifully suspicious robot
             conversations.

--- a/components/user/forum-moderation-panel.vue
+++ b/components/user/forum-moderation-panel.vue
@@ -5,7 +5,7 @@
         <p class="kr-text-eyebrow text-xs tracking-widest text-primary">
           Forum moderation
         </p>
-        <p class="mt-1 text-2xl font-black">Health-claim escalation queue</p>
+        <p class="kr-text-black-2xl mt-1">Health-claim escalation queue</p>
         <p class="kr-text-dim-sm mt-1 max-w-2xl">
           Posts here were auto-hidden because at least two distinct people flagged them as
           misinformation or unsafe. Restore the post if the flag was wrong, or confirm removal

--- a/components/user/friends-panel.vue
+++ b/components/user/friends-panel.vue
@@ -7,7 +7,7 @@
 <template>
   <section class="kr-container max-w-3xl flex flex-col gap-6 p-4">
     <header>
-      <h1 class="text-2xl font-black">Friends</h1>
+      <h1 class="kr-text-black-2xl">Friends</h1>
       <p class="kr-text-dim-sm-70">
         Connect with people, manage requests, and control who can reach you.
       </p>

--- a/components/user/password-reset.vue
+++ b/components/user/password-reset.vue
@@ -7,7 +7,7 @@
 <template>
   <section class="kr-container max-w-md flex flex-col gap-5 p-6">
     <header class="flex flex-col gap-1">
-      <h1 class="text-2xl font-black">
+      <h1 class="kr-text-black-2xl">
         {{ hasToken ? 'Choose a new password' : 'Reset your password' }}
       </h1>
       <p class="kr-text-dim-sm-70">

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -150,7 +150,7 @@
                     <span class="kr-text-black-sm">Karma</span>
                   </div>
 
-                  <p class="mt-2 text-2xl font-black text-accent">
+                  <p class="kr-text-black-2xl mt-2 text-accent">
                     {{ karmaStore.balance }}
                   </p>
 
@@ -178,7 +178,7 @@
                     <span class="kr-text-black-sm">Mana</span>
                   </div>
 
-                  <p class="mt-2 text-2xl font-black text-secondary">
+                  <p class="kr-text-black-2xl mt-2 text-secondary">
                     {{ manaStore.balance }}
                     <span class="kr-text-bold-sm text-base-content/45">
                       / {{ manaStore.cap }}
@@ -209,7 +209,7 @@
                     <span class="kr-text-black-sm">Achievements</span>
                   </div>
 
-                  <p class="mt-2 text-2xl font-black text-success">
+                  <p class="kr-text-black-2xl mt-2 text-success">
                     {{ earnedAchievements.length }}
                   </p>
 

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -12,7 +12,7 @@
       class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between"
     >
       <div>
-        <h1 class="text-2xl font-black">User Admin</h1>
+        <h1 class="kr-text-black-2xl">User Admin</h1>
         <p class="kr-text-dim-sm-70">
           {{ store.roster.length }} users · manage roles, maturity, access, and
           logins.

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -12,7 +12,7 @@
           </div>
 
           <div class="min-w-0">
-            <h1 class="text-2xl font-black text-primary">Mural Color Studio</h1>
+            <h1 class="kr-text-black-2xl text-primary">Mural Color Studio</h1>
 
             <p class="mt-1 max-w-3xl text-sm text-base-content/65">
               Color the mural plan by section, fill whole groups with one saved

--- a/pages/admin/achievement-art.vue
+++ b/pages/admin/achievement-art.vue
@@ -8,7 +8,7 @@
           <p class="kr-text-eyebrow text-xs tracking-widest text-primary">
             Achievement administration
           </p>
-          <p class="mt-1 text-2xl font-black">Achievement artwork</p>
+          <p class="kr-text-black-2xl mt-1">Achievement artwork</p>
           <p class="kr-text-dim-sm mt-1">
             Generate, upload, and replace the image attached to each achievement
             definition.

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -8,7 +8,7 @@
           <p class="kr-text-eyebrow text-xs tracking-widest text-primary">
             Temporary catalog cleanup
           </p>
-          <div class="mt-1 text-2xl font-black">LoRA maturity triage</div>
+          <div class="kr-text-black-2xl mt-1">LoRA maturity triage</div>
           <p class="kr-text-dim-sm mt-1 max-w-3xl">
             Confirm LoRAs as SFW or NSFW here, then save the changed maturity
             flags in one pass. Review progress stays in this browser until this
@@ -64,25 +64,25 @@
         <section class="grid grid-cols-2 gap-2 sm:grid-cols-4">
           <div class="kr-panel p-3">
             <p class="kr-text-eyebrow kr-text-dim-xs-45">LoRAs</p>
-            <p class="mt-1 text-2xl font-black">
+            <p class="kr-text-black-2xl mt-1">
               {{ triageStore.loras.length }}
             </p>
           </div>
           <div class="kr-panel p-3">
             <p class="kr-text-eyebrow kr-text-dim-xs-45">Confirmed</p>
-            <p class="mt-1 text-2xl font-black text-success">
+            <p class="kr-text-black-2xl mt-1 text-success">
               {{ triageStore.confirmedCount }}
             </p>
           </div>
           <div class="kr-panel p-3">
             <p class="kr-text-eyebrow kr-text-dim-xs-45">Remaining</p>
-            <p class="mt-1 text-2xl font-black">
+            <p class="kr-text-black-2xl mt-1">
               {{ triageStore.remainingCount }}
             </p>
           </div>
           <div class="kr-panel p-3">
             <p class="kr-text-eyebrow kr-text-dim-xs-45">Unsaved changes</p>
-            <p class="mt-1 text-2xl font-black text-warning">
+            <p class="kr-text-black-2xl mt-1 text-warning">
               {{ triageStore.pendingChanges.length }}
             </p>
           </div>

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -182,7 +182,7 @@
                   @click="statusFilter = statusFilter === tile.key ? 'all' : tile.key"
                 >
                   <p class="kr-text-dim-xs font-bold">{{ tile.label }}</p>
-                  <p class="text-2xl font-black">{{ tile.count }}</p>
+                  <p class="kr-text-black-2xl">{{ tile.count }}</p>
                 </button>
               </div>
               <div class="mt-3 flex items-center gap-3">

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -8,7 +8,7 @@
           <p class="kr-text-eyebrow text-xs tracking-widest text-primary">
             AMI social pipeline administration
           </p>
-          <p class="mt-1 text-2xl font-black">Social post review queue</p>
+          <p class="kr-text-black-2xl mt-1">Social post review queue</p>
           <p class="kr-text-dim-sm mt-1 max-w-2xl">
             Draft-only. AMI, our labelled-AI fundraiser character, proposes
             posts from the daily dream/digest cycle. Nothing here posts anywhere

--- a/pages/coloring-page.vue
+++ b/pages/coloring-page.vue
@@ -17,7 +17,7 @@
         </div>
         <div class="min-w-0 flex-1">
           <div class="flex flex-wrap items-center gap-2">
-            <p class="text-2xl font-black tracking-tight text-base-content">
+            <p class="kr-text-black-2xl tracking-tight text-base-content">
               Coloring Page Maker
             </p>
             <span class="kr-badge-primary-sm font-bold">New</span>

--- a/pages/music-mentor.vue
+++ b/pages/music-mentor.vue
@@ -8,7 +8,7 @@
           <Icon name="kind-icon:microphone" class="size-6" />
         </div>
         <div class="min-w-0 flex-1 space-y-1">
-          <p class="text-2xl font-black tracking-tight">Music Mentor</p>
+          <p class="kr-text-black-2xl tracking-tight">Music Mentor</p>
           <p class="kr-text-dim-sm">
             Upload a recording of your sung medley and get honest, specific
             feedback on the singing and the arrangement. Everything is analyzed

--- a/pages/play/aquarium/browse/[username]/[slug].vue
+++ b/pages/play/aquarium/browse/[username]/[slug].vue
@@ -70,7 +70,7 @@
               >
                 @{{ tank.User.username }}'s tank
               </p>
-              <h2 class="truncate text-2xl font-black sm:text-3xl">
+              <h2 class="kr-text-black-2xl truncate sm:text-3xl">
                 {{ tank.title }}
               </h2>
             </div>

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -219,7 +219,7 @@
                 </div>
                 <div class="text-right">
                   <p
-                    class="text-2xl font-black"
+                    class="kr-text-black-2xl"
                     :class="scoreClass(submission.score.netScore)"
                   >
                     {{ signedScore(submission.score.netScore) }}
@@ -251,7 +251,7 @@
                   >
                     Character entry
                   </p>
-                  <h3 class="mt-2 text-2xl font-black">
+                  <h3 class="kr-text-black-2xl mt-2">
                     {{ entityTitle(submission.Character, 'Unnamed character') }}
                   </h3>
                   <p
@@ -270,7 +270,7 @@
                   >
                     Scenario entry
                   </p>
-                  <h3 class="mt-2 text-2xl font-black">
+                  <h3 class="kr-text-black-2xl mt-2">
                     {{ entityTitle(submission.Scenario, 'Untitled scenario') }}
                   </h3>
                   <p

--- a/utils/scripts/codemods/kr_text_black_2xl_codemod.py
+++ b/utils/scripts/codemods/kr_text_black_2xl_codemod.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `font-black text-2xl` heading-emphasis text to
+`kr-text-black-2xl`.
+
+Fifth sibling of kr_text_black_lg_codemod.py / kr_text_black_xl_codemod.py /
+kr_text_black_sm_codemod.py / kr_text_black_xs_codemod.py -- a fresh
+full-repo class-frequency survey after slice 174 closed out the family (at
+the time) at `-lg`/`-xl`/`-sm`/`-xs` found this shape still unnamed at 72
+subset-match occurrences across roughly 50 files (interface-vision t-104
+slice 175), mostly page-header titles. Same "closed at the sizes surveyed,
+not a deliberate exclusion" situation that reopened the family for `-xs`
+one slice earlier.
+
+Dry-run by default, --write to update matching Vue files in place. Only the
+exact `font-black text-2xl` shape is touched, and only in static
+`class="..."` attributes -- never `:class`/`v-bind:class` bindings, and
+regardless of the base tokens' order in the source. A source that already
+carries `kr-text-black-2xl`, or is missing either base token, is left
+untouched. Extra tokens beyond the base set are preserved verbatim after the
+primitive class, matching the kr-badge-*/kr-spinner-*/kr-label-bold/
+kr-text-dim-*/kr-text-black-{lg,xl,sm,xs} codemods' subset-match convention
+-- pass --exact-only to restrict a slice to sources with no extra tokens at
+all, the safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-black-2xl"
+BASE_TOKENS = {"font-black", "text-2xl"}
+
+# components/pages/serendipity-page.vue's "Serendipity" label is pinned
+# verbatim by utils/scripts/verifySerendipityRouteCutover.mjs -- a locked
+# route-cutover contract, not a general layout rule -- via an exact regex
+# on `class="text-2xl font-black tracking-tight"`. Migrating it here broke
+# that check (caught in kind_robots#2553's own CI, interface-vision t-104
+# slice 175); AGENTS.md's Companion PRs/close-out guidance already flags
+# grepping verify*.ts|mjs for hard-coded markup strings before a sweep like
+# this one for exactly this reason. Excluded rather than editing the locked
+# contract, since the contract's own comment says it intends to pin this
+# exact class string, not just the semantic shape.
+EXCLUDED_PATHS = {"components/pages/serendipity-page.vue"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        if path.relative_to(args.root).as_posix() in EXCLUDED_PATHS:
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-black-2xl {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: fifth `kr-text-black-*` sibling (kind: software, recurring)

### What changed / what I produced
- `assets/css/tailwind.css`: new `.kr-text-black-2xl` primitive (`font-black text-2xl`), fifth sibling of the existing `-lg`/`-xl`/`-sm`/`-xs` family
- `utils/scripts/codemods/kr_text_black_2xl_codemod.py`: subset-match codemod, same convention as every prior `kr-text-black-*`/`kr-text-dim-*` sibling (dry-run by default, `--write` to apply, `--exact-only` to narrow the pool). Excludes `components/pages/serendipity-page.vue`, whose "Serendipity" label is pinned verbatim by `utils/scripts/verifySerendipityRouteCutover.mjs`'s locked route-cutover contract.
- 71 occurrences migrated across 57 `.vue` files

**Second commit, unrelated to t-104 — a base-branch fix bundled in because it blocks this PR's required check:** `components/pages/storybook-library-page.vue`'s export-menu `@click` handlers held two statements across separate template lines with no semicolon, which Vue's template compiler parses as a single ambiguous expression rather than a statement list. This broke `npm run build` — confirmed identically red on current `main` (535ff0a) before my fix, same file/line/column, unrelated to my own diff. Fixed by extracting `downloadStoryAsMarkdown()`/`downloadStoryAsJson()` wrapper functions instead of just rejoining the statements onto one semicolon-joined line, because I verified Prettier's own canonical formatting for a multi-statement inline handler *is* the broken multi-line/no-semicolon shape — a plain rejoin would silently regress on the next `prettier --write`.

Both commits: class-only / handler-extraction only. No geometry, template structure (beyond the click-handler refactor), store, or data-flow changes.

### How I verified
- `vue-tsc --noEmit`: clean (both commits)
- `eslint` on all changed files: 6 pre-existing errors, byte-identical to the pre-change baseline (confirmed via `git stash`) — no new issues; `storybook-library-page.vue` itself is fully clean
- `npm run build`: failed before the second commit (identical error to CI), succeeds after
- `npm run test:layout-contract`: holds, zero new violations (same pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet opportunity every recent slice has noted and left untouched, out of scope)
- `npm run test:lint-ratchet`: holds at 333/-59, identical to baseline
- `prettier --check`: clean on both touched files; confirmed `storybook-library-page.vue`'s new form is Prettier-stable (`--write` reports it unchanged)

### Stakes
reversible

### Flags for Reviewer
The second commit is out of scope for t-104 but was the pragmatic call per the "port a fix / don't hand work back you can do yourself" guidance, since the base-branch failure blocks every PR's Build production image check, not just this one.

### Kaizen suggestion
The next slice should do a fresh full-repo class-frequency survey outside the now five-sibling `kr-text-black-*` family and the closed `kr-label-*`/`kr-text-dim-*` families — remaining bare `label-text` occurrences and generic layout-utility combos (`flex items-center gap-2`, icon-sizing pairs like `h-4 w-4`) are candidates but need judgment on whether they're semantically bounded enough to name, versus just common Tailwind sizing/layout idioms that happen to repeat.

### Notes for reviewer
Recurring task — will re-arm `interface-vision/t-104` to `ready` in conductor once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cgzy4Y4xZhye8wLsYJ4VwG