### PR TITLE
feat(interface-vision): add kr-text-bold-lg primitive, migrate 48 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1898,6 +1898,22 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply font-bold text-xs;
   }
 
+  /* Third entry in the `kr-text-bold-*` family -- `font-bold text-lg`
+   * (interface-vision t-104 slice 176), the natural heading-size sibling
+   * left unsurveyed when slices 169-170 built `-sm`/`-xs` (slice 170's own
+   * kaizen note called those two "every candidate surveyed across slices
+   * 168-170" without ever having looked at `-lg`). A fresh full-repo
+   * class-frequency survey outside all now-closed `kr-text-black-*`/
+   * `kr-text-dim-*`/`kr-text-eyebrow-*`/`kr-label-*` families found this
+   * shape at 48 subset-match occurrences across 24 files, the largest
+   * still-unnamed semantically bounded pattern surfaced this slice --
+   * consistently used for `h2`/`h3`/`p` section-heading emphasis text
+   * (`text-lg font-bold text-base-content` etc.), the same bold-heading
+   * role `.kr-text-black-lg` already covers for `font-black`. */
+  .kr-text-bold-lg {
+    @apply font-bold text-lg;
+  }
+
   /* Sibling of `.kr-label-bold` (`label-text font-bold`) for the plain,
    * weightless form-label caption -- `label-text text-xs`, with the dead
    * `label-text` token dropped the same way `.kr-label-bold` already drops

--- a/components/achievements/achievement-leaderboard.vue
+++ b/components/achievements/achievement-leaderboard.vue
@@ -1,7 +1,7 @@
 <!-- /components/content/achievements/achievement-leaderboard.vue -->
 <template>
   <div class="bg-base-300 rounded-2xl border p-4 m-2">
-    <h2 class="text-lg font-bold text-center">Jellybean Collectors</h2>
+    <h2 class="kr-text-bold-lg text-center">Jellybean Collectors</h2>
     <ul class="list-decimal list-inside">
       <li v-for="(entry, index) in leaderboardData" :key="index">
         {{ entry.username }}: {{ entry.count }} jellybeans

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -522,7 +522,7 @@
           <div class="flex items-center gap-2">
             <Icon name="kind-icon:sparkles" class="h-5 w-5 text-primary" />
             <div>
-              <h2 class="text-lg font-bold text-primary">Latest result</h2>
+              <h2 class="kr-text-bold-lg text-primary">Latest result</h2>
               <p class="text-sm text-base-content/55">
                 Your newest render lands here.
               </p>

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -106,7 +106,7 @@
       class="flex min-h-72 flex-col items-center justify-center kr-panel text-center text-base-content/55"
     >
       <Icon name="kind-icon:image" class="h-12 w-12 text-primary" />
-      <p class="mt-2 text-lg font-bold">No image selected.</p>
+      <p class="kr-text-bold-lg mt-2">No image selected.</p>
       <p class="mt-1 max-w-xl text-sm">
         Pick something from the gallery. The pixels are standing around holding
         clipboards.

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -997,7 +997,7 @@ onMounted(async () => {
 
       <main class="flex flex-col gap-6">
         <div class="kr-panel-muted-md md:p-6">
-          <div class="mb-4 text-lg font-bold">Test Builder</div>
+          <div class="kr-text-bold-lg mb-4">Test Builder</div>
 
           <div v-if="endpointDef.mode === 'text'" class="flex flex-col gap-6">
             <div class="flex flex-col gap-3">
@@ -1213,7 +1213,7 @@ onMounted(async () => {
 
         <div class="kr-panel-muted-md md:p-6">
           <div class="mb-3 flex items-center justify-between gap-3">
-            <div class="text-lg font-bold">Built Prompt</div>
+            <div class="kr-text-bold-lg">Built Prompt</div>
             <div class="text-sm opacity-60">{{ endpointDef.label }}</div>
           </div>
 
@@ -1229,7 +1229,7 @@ onMounted(async () => {
           v-if="showPayload"
           class="kr-panel-muted-md md:p-6"
         >
-          <div class="mb-3 text-lg font-bold">Payload Preview</div>
+          <div class="kr-text-bold-lg mb-3">Payload Preview</div>
           <pre
             class="overflow-x-auto kr-panel-flat p-4 text-xs"
             >{{ JSON.stringify(builtPayload, null, 2) }}</pre
@@ -1239,7 +1239,7 @@ onMounted(async () => {
         <div class="kr-panel-muted-md md:p-6">
           <div class="mb-3 flex flex-wrap items-center justify-between gap-3">
             <div>
-              <div class="text-lg font-bold">Generate</div>
+              <div class="kr-text-bold-lg">Generate</div>
               <div class="text-sm opacity-60">
                 Synced to artStore and routed through generate-button.
               </div>
@@ -1284,7 +1284,7 @@ onMounted(async () => {
 
         <div class="kr-panel-muted-md md:p-6">
           <div class="mb-4 flex items-center justify-between gap-3">
-            <div class="text-lg font-bold">Result</div>
+            <div class="kr-text-bold-lg">Result</div>
 
             <div v-if="resultImage" class="flex flex-wrap gap-2">
               <button
@@ -1312,7 +1312,7 @@ onMounted(async () => {
               class="flex flex-col items-center gap-3 text-center"
             >
               <span class="kr-spinner-lg-primary" />
-              <div class="text-lg font-bold">
+              <div class="kr-text-bold-lg">
                 Generating with {{ endpointDef.label }}
               </div>
             </div>
@@ -1329,7 +1329,7 @@ onMounted(async () => {
               class="flex flex-col items-center gap-3 text-center opacity-60"
             >
               <div class="text-5xl">{{ endpointDef.icon }}</div>
-              <div class="text-lg font-bold">
+              <div class="kr-text-bold-lg">
                 Your generated image will appear here
               </div>
               <div class="text-sm">No mystery collage nonsense this time.</div>
@@ -1341,7 +1341,7 @@ onMounted(async () => {
           v-if="showRawResult && resultData"
           class="kr-panel-muted-md md:p-6"
         >
-          <div class="mb-3 text-lg font-bold">Raw API / Store Result</div>
+          <div class="kr-text-bold-lg mb-3">Raw API / Store Result</div>
           <pre
             class="overflow-x-auto kr-panel-flat p-4 text-xs"
             >{{ JSON.stringify(resultData, null, 2) }}</pre

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -124,7 +124,7 @@
             <Icon name="kind-icon:chat" class="h-16 w-16 text-primary/60" />
 
             <div>
-              <p class="text-lg font-bold">Start the conversation</p>
+              <p class="kr-text-bold-lg">Start the conversation</p>
               <p class="mt-1 text-sm">
                 Use a starter prompt, or type something suspiciously brilliant.
               </p>
@@ -215,9 +215,7 @@
       <section class="kr-panel-flat p-4">
         <div class="mb-3 flex items-center justify-between gap-2">
           <div>
-            <h2 class="text-lg font-bold text-base-content">
-              Session Controls
-            </h2>
+            <h2 class="kr-text-bold-lg text-base-content">Session Controls</h2>
 
             <p class="kr-text-dim-sm">Runtime options for this chat session.</p>
           </div>
@@ -293,7 +291,7 @@
       </section>
 
       <section class="kr-panel-flat p-4">
-        <h2 class="text-lg font-bold text-base-content">Selected Bot</h2>
+        <h2 class="kr-text-bold-lg text-base-content">Selected Bot</h2>
 
         <bot-card
           v-if="botStore.currentBot"
@@ -358,7 +356,7 @@
       -->
       <section class="shrink-0 kr-panel-flat p-4">
         <div class="mb-3 flex items-center justify-between gap-2">
-          <h2 class="text-lg font-bold text-base-content">Prompt Preview</h2>
+          <h2 class="kr-text-bold-lg text-base-content">Prompt Preview</h2>
 
           <button
             class="kr-btn-ghost-xs"

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -230,7 +230,7 @@
         v-else-if="botStore.error"
         class="flex h-full items-center justify-center rounded-2xl border border-error/40 bg-error/10 p-6 text-center text-error"
       >
-        <p class="text-lg font-bold">
+        <p class="kr-text-bold-lg">
           {{ botStore.error }}
         </p>
       </div>
@@ -360,7 +360,7 @@
         <Icon name="kind-icon:robot" class="h-12 w-12 text-primary" />
 
         <div>
-          <p class="text-lg font-bold">No bots found.</p>
+          <p class="kr-text-bold-lg">No bots found.</p>
 
           <p class="mt-1 text-sm">
             No public or owned bots match this gallery.

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -106,7 +106,7 @@
           v-if="characterStore.selectedCharacter"
           class="kr-panel-flat p-4"
         >
-          <h2 class="text-lg font-bold text-base-content">Stats</h2>
+          <h2 class="kr-text-bold-lg text-base-content">Stats</h2>
 
           <div class="mt-3 grid grid-cols-2 gap-2">
             <div
@@ -126,9 +126,7 @@
         </section>
 
         <section class="kr-panel-flat p-4">
-          <h2 class="text-lg font-bold text-base-content">
-            Interaction Summary
-          </h2>
+          <h2 class="kr-text-bold-lg text-base-content">Interaction Summary</h2>
 
           <div class="mt-3 grid gap-2 text-sm">
             <div class="kr-tile-md">
@@ -391,7 +389,7 @@
             </div>
 
             <section v-if="adventurePrompt" class="mt-4 kr-panel-muted-md">
-              <h2 class="mb-3 text-lg font-bold text-base-content">
+              <h2 class="kr-text-bold-lg mb-3 text-base-content">
                 Adventure Prompt Preview
               </h2>
 

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -348,7 +348,7 @@
 
         <aside class="flex min-h-0 flex-col gap-4 overflow-hidden">
           <section class="kr-panel-flat p-4">
-            <h2 class="text-lg font-bold text-base-content">
+            <h2 class="kr-text-bold-lg text-base-content">
               Interaction Summary
             </h2>
 
@@ -395,7 +395,7 @@
           <section class="kr-panel-flat p-4">
             <div class="mb-3 flex items-center justify-between gap-2">
               <div>
-                <h2 class="text-lg font-bold text-base-content">
+                <h2 class="kr-text-bold-lg text-base-content">
                   Getting To Know You Questions
                 </h2>
 
@@ -435,7 +435,7 @@
             v-if="adventurePrompt"
             class="min-h-0 flex-1 overflow-hidden kr-panel-flat p-4"
           >
-            <h2 class="mb-3 text-lg font-bold text-base-content">
+            <h2 class="kr-text-bold-lg mb-3 text-base-content">
               Adventure Prompt Preview
             </h2>
 

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -133,7 +133,7 @@
         v-else-if="characterStore.error"
         class="flex h-full items-center justify-center rounded-2xl border border-error/40 bg-error/10 p-6 text-center text-error"
       >
-        <p class="text-lg font-bold">
+        <p class="kr-text-bold-lg">
           {{ characterStore.error }}
         </p>
       </div>
@@ -257,7 +257,7 @@
         <Icon name="kind-icon:theater" class="h-12 w-12 text-primary" />
 
         <div class="max-w-2xl">
-          <p class="text-lg font-bold">
+          <p class="kr-text-bold-lg">
             {{ emptyStateTitle }}
           </p>
 

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -297,7 +297,7 @@
         v-else-if="dreamStore.error"
         class="flex h-full min-h-48 flex-col items-center justify-center gap-3 rounded-2xl border border-error/40 bg-error/10 p-6 text-center text-error"
       >
-        <p class="text-lg font-bold">
+        <p class="kr-text-bold-lg">
           {{ dreamStore.error }}
         </p>
 
@@ -411,7 +411,7 @@
         <Icon name="kind-icon:dream" class="h-12 w-12 text-primary/70" />
 
         <div class="max-w-2xl">
-          <p class="text-lg font-bold">
+          <p class="kr-text-bold-lg">
             {{ emptyStateTitle }}
           </p>
 

--- a/components/dreams/dream-inspire-button.vue
+++ b/components/dreams/dream-inspire-button.vue
@@ -3,7 +3,7 @@
     <!-- Server selection modal -->
     <dialog ref="serverModalRef" class="modal">
       <div class="modal-box">
-        <h3 class="font-bold text-lg">Select Art Server</h3>
+        <h3 class="kr-text-bold-lg">Select Art Server</h3>
         <p class="py-2 text-sm opacity-70">
           No preferred art server found. Choose one to generate inspiration
           images:

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -81,7 +81,7 @@
                 </span>
                 <input
                   v-model="dreamStore.dreamForm.title"
-                  class="input input-bordered rounded-2xl bg-base-200 text-lg font-bold"
+                  class="kr-text-bold-lg input input-bordered rounded-2xl bg-base-200"
                   type="text"
                   placeholder="The Drowned Archive"
                 />

--- a/components/giftshop/credit-purchase.vue
+++ b/components/giftshop/credit-purchase.vue
@@ -17,7 +17,7 @@
         @click="purchaseMana(tier.id)"
       >
         <p class="text-xl font-semibold">{{ tier.label }}</p>
-        <p class="text-lg text-success font-bold">${{ tier.priceUsd }}</p>
+        <p class="kr-text-bold-lg text-success">${{ tier.priceUsd }}</p>
       </button>
     </div>
 

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -14,7 +14,7 @@
       class="flex shrink-0 flex-col gap-3 kr-panel-muted-sm"
     >
       <div class="min-w-0">
-        <h2 class="truncate text-lg font-bold text-base-content">
+        <h2 class="kr-text-bold-lg truncate text-base-content">
           Discover {{ discoverType === 'CHECKPOINT' ? 'Checkpoints' : 'LoRAs' }}
         </h2>
         <p class="kr-text-dim-sm">

--- a/components/mandarin/mandarin-voice-coach.vue
+++ b/components/mandarin/mandarin-voice-coach.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
       <div class="max-w-2xl">
         <div class="flex flex-wrap items-center gap-2">
-          <h3 class="text-lg font-bold">Pronunciation practice</h3>
+          <h3 class="kr-text-bold-lg">Pronunciation practice</h3>
           <span class="badge badge-outline">listen · say · check</span>
         </div>
         <p class="mt-1 text-sm leading-relaxed opacity-70">
@@ -114,7 +114,7 @@
             class="kr-panel-compact"
           >
             <div class="flex flex-wrap items-center gap-2">
-              <span class="text-lg font-bold">{{ observation.syllable }}</span>
+              <span class="kr-text-bold-lg">{{ observation.syllable }}</span>
               <span class="badge badge-outline">{{ observation.expectedArrow }} T{{ observation.expectedTone }}</span>
               <span class="badge" :class="verdictClass(observation.verdict)">
                 heard {{ observation.observedShape }}

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -41,7 +41,7 @@
       </button>
 
       <div class="min-w-0 flex-1">
-        <h1 class="truncate text-lg font-bold text-primary md:text-xl">
+        <h1 class="kr-text-bold-lg truncate text-primary md:text-xl">
           {{ selectedRewardName }}
         </h1>
 
@@ -300,9 +300,7 @@
           ]"
         />
         <section class="shrink-0 kr-panel-flat p-4 shadow-md">
-          <h2 class="mb-3 text-lg font-bold text-base-content">
-            The Encounter
-          </h2>
+          <h2 class="kr-text-bold-lg mb-3 text-base-content">The Encounter</h2>
 
           <div class="grid grid-cols-1 gap-4">
             <label class="form-control">
@@ -365,7 +363,7 @@
         </section>
 
         <section class="shrink-0 kr-panel-flat p-4 shadow-md">
-          <h2 class="mb-1 text-lg font-bold text-base-content">About You</h2>
+          <h2 class="kr-text-bold-lg mb-1 text-base-content">About You</h2>
 
           <p class="kr-text-dim-sm mb-3">
             Give the story engine some context about who's holding this thing.
@@ -394,7 +392,7 @@
             @click="showCharacterPanel = !showCharacterPanel"
           >
             <div class="min-w-0">
-              <h2 class="text-lg font-bold text-base-content">
+              <h2 class="kr-text-bold-lg text-base-content">
                 Add a Character
                 <span class="kr-badge-ghost-sm ml-2">Optional</span>
               </h2>
@@ -444,9 +442,7 @@
               type="button"
               @click="showPromptPreview = !showPromptPreview"
             >
-              <h2 class="text-lg font-bold text-base-content">
-                Prompt Preview
-              </h2>
+              <h2 class="kr-text-bold-lg text-base-content">Prompt Preview</h2>
 
               <Icon
                 :name="

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -194,7 +194,7 @@
         v-else-if="rewardStore.error"
         class="flex h-full items-center justify-center rounded-2xl border border-error/40 bg-error/10 p-6 text-center text-error"
       >
-        <p class="text-lg font-bold">
+        <p class="kr-text-bold-lg">
           {{ rewardStore.error }}
         </p>
       </div>
@@ -302,7 +302,7 @@
       >
         <Icon name="kind-icon:gift" class="h-10 w-10" />
 
-        <p class="text-lg font-bold">No rewards found.</p>
+        <p class="kr-text-bold-lg">No rewards found.</p>
 
         <p class="max-w-xl text-sm opacity-70">
           No public or owned rewards match this gallery.

--- a/components/ruler-hooked/ruler-hooked-card.vue
+++ b/components/ruler-hooked/ruler-hooked-card.vue
@@ -11,7 +11,7 @@
         {{ card.characters.join(' · ') }}
       </span>
     </div>
-    <h3 class="text-lg font-bold">{{ card.title }}</h3>
+    <h3 class="kr-text-bold-lg">{{ card.title }}</h3>
     <p v-if="card.body" class="mt-1 text-sm opacity-80">{{ card.body }}</p>
 
     <div class="mt-4 flex flex-col gap-2">

--- a/components/ruler-hooked/ruler-hooked-catch.vue
+++ b/components/ruler-hooked/ruler-hooked-catch.vue
@@ -11,7 +11,7 @@
         <p class="mt-1 text-sm opacity-75">{{ catchResult.catchBehavior }}</p>
       </div>
       <div class="text-right">
-        <p class="text-lg font-bold">{{ formatSize(catchResult.sizeCm) }}</p>
+        <p class="kr-text-bold-lg">{{ formatSize(catchResult.sizeCm) }}</p>
         <p class="text-xs uppercase tracking-wide opacity-60">{{ catchResult.quality }} · {{ catchResult.qualityScore }}/100</p>
       </div>
     </div>

--- a/components/ruler-hooked/ruler-hooked-cosmetics-picker.vue
+++ b/components/ruler-hooked/ruler-hooked-cosmetics-picker.vue
@@ -33,7 +33,7 @@
         />
         <div
           v-else
-          class="flex aspect-square w-full items-center justify-center rounded-md bg-base-200 text-lg font-bold opacity-50"
+          class="kr-text-bold-lg flex aspect-square w-full items-center justify-center rounded-md bg-base-200 opacity-50"
         >
           {{ preset.title.charAt(0) }}
         </div>

--- a/components/ruler-hooked/ruler-hooked-game.vue
+++ b/components/ruler-hooked/ruler-hooked-game.vue
@@ -61,7 +61,7 @@
 
         <div v-if="store.pendingEnding" class="rounded-xl border border-accent bg-accent/10 p-4">
           <p class="kr-text-bold-sm">An ending is within reach:</p>
-          <p class="mt-1 text-lg font-bold">{{ endingTitle }}</p>
+          <p class="kr-text-bold-lg mt-1">{{ endingTitle }}</p>
           <p v-if="endingBody" class="text-sm opacity-80">{{ endingBody }}</p>
           <div class="mt-3 flex gap-2">
             <button type="button" class="btn btn-accent btn-sm" @click="store.acceptEnding()">Take this ending</button>
@@ -70,7 +70,7 @@
         </div>
 
         <div v-if="store.save.status === 'COMPLETE'" class="rounded-xl border border-success bg-success/10 p-4 text-center">
-          <p class="text-lg font-bold">{{ endingTitleFor(store.save.endingKey) }}</p>
+          <p class="kr-text-bold-lg">{{ endingTitleFor(store.save.endingKey) }}</p>
           <p class="text-sm opacity-80">The reign is complete. Start another from the slots below.</p>
         </div>
 

--- a/components/screenfx/animation-tester.vue
+++ b/components/screenfx/animation-tester.vue
@@ -5,7 +5,7 @@
   >
     <h2 class="mb-6 text-4xl font-bold text-primary">Animation Tester</h2>
 
-    <div class="mb-4 text-lg font-bold text-info">
+    <div class="kr-text-bold-lg mb-4 text-info">
       Current Animation:
       <span v-if="animationStore.isActive">{{ currentAnimationLabel }}</span>
       <span v-else>None</span>

--- a/components/user/forum-thread.vue
+++ b/components/user/forum-thread.vue
@@ -43,7 +43,7 @@
         v-if="userStore.isLoggedIn && composeChannel === channel.slug"
         class="bg-base-200 p-4 rounded-xl shadow"
       >
-        <h3 class="text-lg font-bold mb-2">
+        <h3 class="kr-text-bold-lg mb-2">
           🧵 New Thread in {{ channel.label }}
         </h3>
         <p v-if="channel.postingGuidance" class="kr-text-dim-sm mb-2">

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -65,7 +65,7 @@
         <section v-if="workspaceView === 'sets'" class="kr-panel-flat space-y-4 p-4 shadow-sm">
           <div class="flex flex-wrap items-center justify-between gap-2">
             <div>
-              <h2 class="text-lg font-bold">Study sets</h2>
+              <h2 class="kr-text-bold-lg">Study sets</h2>
               <p class="text-xs opacity-60">Pick a deck, then jump straight back to the flash card.</p>
             </div>
             <span class="badge badge-ghost">{{ allSets.length }} decks</span>

--- a/utils/scripts/codemods/kr_text_bold_lg_codemod.py
+++ b/utils/scripts/codemods/kr_text_bold_lg_codemod.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `font-bold text-lg` heading-emphasis text to
+`kr-text-bold-lg`.
+
+Sibling of `kr_text_bold_sm_codemod.py`/`kr_text_bold_xs_codemod.py`
+(interface-vision t-104 slices 169/170) -- third entry in the
+`kr-text-bold-*` family, one size up from `kr-text-bold-sm`. Slice 170's own
+kaizen note called `-sm`/`-xs` "every candidate surveyed across slices
+168-170" without ever surveying `-lg`; a fresh full-repo class-frequency
+survey outside the now-closed `kr-text-black-*`/`kr-text-dim-*`/
+`kr-text-eyebrow-*`/`kr-label-*` families found `font-bold text-lg` at 48
+subset-match occurrences across 24 files this slice (176) -- the largest
+still-unnamed bounded pattern surfaced, consistently used for `h2`/`h3`/`p`
+section-heading emphasis text.
+
+Dry-run by default, --write to update matching Vue files in place. Only the
+exact `font-bold text-lg` shape is touched, and only in static
+`class="..."` attributes -- never `:class`/`v-bind:class` bindings, and
+regardless of the base tokens' order in the source. A source that already
+carries `kr-text-bold-lg`, or is missing either base token, is left
+untouched. Extra tokens beyond the base set are preserved verbatim after
+the primitive class, matching the kr-badge-*/kr-spinner-*/kr-label-bold/
+kr-text-dim-*/kr-text-black-*/kr-text-eyebrow-*/kr-text-bold-sm/
+kr-text-bold-xs codemods' subset-match convention -- pass --exact-only to
+restrict a slice to sources with no extra tokens at all, the safest and
+most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-bold-lg"
+BASE_TOKENS = {"font-bold", "text-lg"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-bold-lg {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision t-104 slice 176 (recurring front-end consistency sweep — drive live front-end consistency onto shared `kr-*` components)

### What changed
Added `.kr-text-bold-lg` (`@apply font-bold text-lg;`) to `assets/css/tailwind.css` — the third entry in the `kr-text-bold-*` family (`-sm`/`-xs` already existed from slices 169/170). Slice 170's own kaizen note called `-sm`/`-xs` "every candidate surveyed across slices 168-170" without ever having surveyed `-lg`.

A fresh full-repo class-frequency survey outside all now-closed `kr-text-black-*`/`kr-text-dim-*`/`kr-text-eyebrow-*`/`kr-label-*` families found `font-bold text-lg` at 48 subset-match occurrences (21 exact) across 24 files — the largest still-unnamed, semantically bounded pattern surfaced this slice. It's used consistently for `h2`/`h3`/`p` section-heading emphasis text, the same role `.kr-text-black-lg` already covers for `font-black`. Generic layout/sizing idioms (`h-4 w-4` 300x, `flex items-center gap-2` 87x, `min-w-0 flex-1` 103x, etc.) were surveyed and deliberately set aside again, same call as slices 153/157/164/175.

New codemod: `utils/scripts/codemods/kr_text_bold_lg_codemod.py`, a close mirror of `kr_text_bold_xs_codemod.py` (dry-run default, `--write`, `--exact-only`, subset-match preserving extra tokens verbatim). Migrated all 48 occurrences across 24 files. No geometry or behavior change.

### How I verified
- `vue-tsc --noEmit`: clean before and after
- `eslint .`: 333 problems (327 errors, 6 warnings) — identical before/after, confirmed via `git stash`
- `npm run test:layout-contract`: holds, 0 new violations (same pre-existing narrative-ingredient-multi-picker.vue viewport-grid ratchet note as every recent slice, left untouched)
- `npm run test:lint-ratchet`: holds at 333/-59
- `npx prettier --check`: flagged 3 genuinely new fallout files (`bot-chat.vue`, `character-chat.vue`, `reward-encounter.vue`) from the shortened class string; targeted `--write` on just those landed prettier back to the exact pre-existing 1151-file baseline, confirmed via `git stash` diff of the flagged-file list before/after
- No locked source-text contract (`verifySerendipityRouteCutover.mjs`, `verifyStorybookStudio.mjs`, etc.) references this class string

### Stakes: reversible
Pure CSS-class rename via codemod — no template structure, script logic, or visual output changes. Fully reversible by reverting this commit.

### Flags for Reviewer
None — mirrors the established `kr-text-bold-*`/`kr-text-black-*` convention exactly.

### Kaizen suggestion
`kr-text-bold-*` is now `-sm`/`-xs`/`-lg`; worth a quick check for `-xl`/`-2xl` siblings (unsurveyed). Beyond that, the strongest remaining candidates outside all closed families are `text-xs text-error` (36 subset-match/32 files, a coherent "inline validation/error message" caption pattern) and the colorless `badge badge-xs` base (26 subset-match/13 files, the natural xs sibling of the already-established colorless `kr-badge-sm`, whose color is supplied dynamically via a sibling `:class` binding at several call sites — matches `kr-badge-sm`'s own documented rationale exactly).

### Notes for reviewer
Occurrence/file counts were cross-checked by two independent methods (a standalone Python survey script and the codemod's own dry-run output) before writing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HrfbGt6SzbPw6YQU12LyJ2)_