### PR TITLE
feat(interface-vision): add kr-badge-xs primitive, migrate 26 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1514,6 +1514,23 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply badge badge-sm;
   }
 
+  /* The colorless `badge-xs` sibling of `.kr-badge-sm` (interface-vision
+   * t-104 slice 177): `badge badge-xs` with no color modifier, same
+   * dynamically-toned rationale as `.kr-badge-sm` -- the color at each of
+   * this shape's call sites is supplied separately, by a sibling `:class`
+   * binding that picks a tone from component state (pitch/commit status,
+   * pack progress, affinity, sync/filter counts...). 25 hand-rolled
+   * occurrences across 13 files, more varied in their accompanying layout
+   * utilities than `.kr-badge-sm`'s pool (ml-auto, shrink-0, gap-0.5/gap-1,
+   * rounded-lg/rounded-xl/rounded-2xl, absolute positioning) -- every one
+   * individually audited for this slice, so left unrestricted rather than
+   * bounded to a fixed extras set the way `.kr-badge-sm` was for its own,
+   * differently-sourced 91-hit survey (see BOUNDED_EXTRAS in
+   * kr_badge_codemod.py). */
+  .kr-badge-xs {
+    @apply badge badge-xs;
+  }
+
   /* The most-repeated hand-rolled textarea shape (interface-vision t-104
    * slice 115): a full-width, bordered DaisyUI textarea on the "plain"
    * base-100 background -- `textarea w-full

--- a/components/art/image-card.vue
+++ b/components/art/image-card.vue
@@ -160,17 +160,17 @@
           <span class="kr-badge-info-xs" :title="`Image #${displayImage.id}`">
             Image #{{ displayImage.id }}
           </span>
-          <span class="badge badge-xs" :class="imageDataBadgeClass">
+          <span class="kr-badge-xs" :class="imageDataBadgeClass">
             data: {{ displayImage.imageData ? 'yes' : 'no' }}
           </span>
           <span
-            class="badge badge-xs"
+            class="kr-badge-xs"
             :class="displayImage.imagePath ? 'badge-info' : 'badge-ghost'"
           >
             path: {{ displayImage.imagePath ? 'yes' : 'no' }}
           </span>
           <span
-            class="badge badge-xs"
+            class="kr-badge-xs"
             :class="
               displayImage.thumbnailData ? 'badge-success' : 'badge-ghost'
             "

--- a/components/art/stylist-relay-status.vue
+++ b/components/art/stylist-relay-status.vue
@@ -76,7 +76,7 @@
 
           <div class="flex flex-wrap items-center gap-1.5">
             <span
-              class="badge badge-xs rounded-2xl"
+              class="kr-badge-xs rounded-2xl"
               :class="
                 agent.supportsInputImages ? 'badge-success' : 'badge-error'
               "

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -54,11 +54,17 @@
         <Icon name="kind-icon:image" class="h-4 w-4 text-primary" />
         <span class="kr-text-black-xs text-base-content">Client Photo</span>
         <div class="flex-1" />
-        <div class="flex overflow-hidden rounded-lg border border-base-300 text-xs">
+        <div
+          class="flex overflow-hidden rounded-lg border border-base-300 text-xs"
+        >
           <button
             type="button"
             class="px-2.5 py-1 font-bold transition"
-            :class="sourceTab === 'upload' ? 'bg-primary text-primary-content' : 'bg-base-100 text-base-content/60 hover:bg-base-200'"
+            :class="
+              sourceTab === 'upload'
+                ? 'bg-primary text-primary-content'
+                : 'bg-base-100 text-base-content/60 hover:bg-base-200'
+            "
             :aria-pressed="sourceTab === 'upload'"
             @click="sourceTab = 'upload'"
           >
@@ -67,7 +73,11 @@
           <button
             type="button"
             class="px-2.5 py-1 font-bold transition"
-            :class="sourceTab === 'camera' ? 'bg-primary text-primary-content' : 'bg-base-100 text-base-content/60 hover:bg-base-200'"
+            :class="
+              sourceTab === 'camera'
+                ? 'bg-primary text-primary-content'
+                : 'bg-base-100 text-base-content/60 hover:bg-base-200'
+            "
             :aria-pressed="sourceTab === 'camera'"
             @click="openCamera"
           >
@@ -83,7 +93,11 @@
         tabindex="0"
         aria-label="Upload a client photo"
         class="flex cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed p-6 text-center text-xs transition"
-        :class="isDragging ? 'border-primary bg-primary/5' : 'border-base-300 hover:border-primary/60'"
+        :class="
+          isDragging
+            ? 'border-primary bg-primary/5'
+            : 'border-base-300 hover:border-primary/60'
+        "
         @click="fileInput?.click()"
         @dragover.prevent="isDragging = true"
         @dragleave.prevent="isDragging = false"
@@ -91,7 +105,9 @@
         @keydown.enter.space.prevent="fileInput?.click()"
       >
         <Icon name="kind-icon:upload" class="h-6 w-6 text-base-content/50" />
-        <span class="font-bold text-base-content/70">Drop a photo or click to browse</span>
+        <span class="font-bold text-base-content/70"
+          >Drop a photo or click to browse</span
+        >
         <input
           ref="fileInput"
           type="file"
@@ -102,20 +118,38 @@
       </div>
 
       <!-- Camera -->
-      <div v-show="sourceTab === 'camera' && cameraActive" class="flex flex-col items-center gap-2">
+      <div
+        v-show="sourceTab === 'camera' && cameraActive"
+        class="flex flex-col items-center gap-2"
+      >
         <!-- eslint-disable-next-line vuejs-accessibility/media-has-caption -->
-        <video ref="videoEl" autoplay playsinline class="max-h-64 w-full rounded-lg bg-black object-contain" />
+        <video
+          ref="videoEl"
+          autoplay
+          playsinline
+          class="max-h-64 w-full rounded-lg bg-black object-contain"
+        />
         <div class="flex gap-2">
-          <button type="button" class="kr-btn-primary-plain" @click="capturePhoto">
+          <button
+            type="button"
+            class="kr-btn-primary-plain"
+            @click="capturePhoto"
+          >
             <Icon name="kind-icon:camera" class="h-4 w-4" /> Capture
           </button>
-          <button type="button" class="kr-btn-ghost-plain" @click="closeCamera">Cancel</button>
+          <button type="button" class="kr-btn-ghost-plain" @click="closeCamera">
+            Cancel
+          </button>
         </div>
       </div>
 
       <!-- Preview -->
       <div v-if="sourceImageData && !maskEnabled" class="relative">
-        <img :src="sourceImageData" alt="Client photo" class="max-h-64 w-full rounded-lg object-contain" />
+        <img
+          :src="sourceImageData"
+          alt="Client photo"
+          class="max-h-64 w-full rounded-lg object-contain"
+        />
         <button
           type="button"
           class="btn btn-circle btn-error btn-xs absolute right-2 top-2"
@@ -127,9 +161,14 @@
       </div>
 
       <label v-if="sourceImageData" class="flex items-center gap-2">
-        <input v-model="maskEnabled" type="checkbox" class="kr-checkbox-primary-xs" />
+        <input
+          v-model="maskEnabled"
+          type="checkbox"
+          class="kr-checkbox-primary-xs"
+        />
         <span class="kr-text-dim-xs-70">
-          Only restyle the hair (paint a mask instead of changing the whole photo)
+          Only restyle the hair (paint a mask instead of changing the whole
+          photo)
         </span>
       </label>
 
@@ -151,10 +190,16 @@
 
     <!-- What to change -->
     <div class="flex flex-col gap-3 kr-panel-compact">
-      <span class="kr-text-black-xs text-base-content">What are we changing?</span>
+      <span class="kr-text-black-xs text-base-content"
+        >What are we changing?</span
+      >
 
       <label class="flex items-start gap-2">
-        <input v-model="changeColor" type="checkbox" class="kr-checkbox-primary-sm mt-1" />
+        <input
+          v-model="changeColor"
+          type="checkbox"
+          class="kr-checkbox-primary-sm mt-1"
+        />
         <div class="flex flex-1 flex-col gap-1">
           <span class="kr-text-bold-sm">Change color</span>
           <input
@@ -168,7 +213,11 @@
       </label>
 
       <label class="flex items-start gap-2">
-        <input v-model="changeStyle" type="checkbox" class="kr-checkbox-primary-sm mt-1" />
+        <input
+          v-model="changeStyle"
+          type="checkbox"
+          class="kr-checkbox-primary-sm mt-1"
+        />
         <div class="flex flex-1 flex-col gap-1">
           <span class="kr-text-bold-sm">Change style</span>
           <input
@@ -182,10 +231,16 @@
       </label>
 
       <label class="flex items-start gap-2">
-        <input v-model="enhanceImage" type="checkbox" class="kr-checkbox-primary-sm mt-1" />
+        <input
+          v-model="enhanceImage"
+          type="checkbox"
+          class="kr-checkbox-primary-sm mt-1"
+        />
         <div class="flex flex-1 flex-col gap-1">
           <span class="kr-text-bold-sm">Improve the overall image</span>
-          <span class="kr-text-dim-xs">Cleaner lighting, sharper detail — face and identity kept.</span>
+          <span class="kr-text-dim-xs"
+            >Cleaner lighting, sharper detail — face and identity kept.</span
+          >
         </div>
       </label>
 
@@ -199,7 +254,10 @@
         />
       </label>
 
-      <p v-if="changeSummary" class="kr-text-dim-xs-70 rounded-lg bg-base-200 p-2">
+      <p
+        v-if="changeSummary"
+        class="kr-text-dim-xs-70 rounded-lg bg-base-200 p-2"
+      >
         {{ changeSummary }}
       </p>
     </div>
@@ -207,7 +265,9 @@
     <!-- How much to keep them looking like themselves -->
     <div class="flex flex-col gap-2 kr-panel-compact">
       <div class="flex items-center justify-between">
-        <span class="kr-text-black-xs text-base-content">How much should it still look like them?</span>
+        <span class="kr-text-black-xs text-base-content"
+          >How much should it still look like them?</span
+        >
         <span class="kr-text-bold-xs text-primary">{{ preserveLabel }}</span>
       </div>
       <input
@@ -224,10 +284,14 @@
         <span>Keep it them</span>
       </div>
       <label class="flex items-start gap-2 pt-1">
-        <input v-model="protectIdentity" type="checkbox" class="kr-checkbox-primary-xs mt-0.5" />
+        <input
+          v-model="protectIdentity"
+          type="checkbox"
+          class="kr-checkbox-primary-xs mt-0.5"
+        />
         <span class="kr-text-dim-xs-70">
-          Extra-protect the face &amp; identity (a little slower — guards against turning
-          them into someone else)
+          Extra-protect the face &amp; identity (a little slower — guards
+          against turning them into someone else)
         </span>
       </label>
       <button
@@ -240,7 +304,9 @@
       </button>
       <div v-if="advancedOpen" class="grid grid-cols-2 gap-2">
         <label class="flex flex-col gap-1">
-          <span class="text-[10px] font-bold text-base-content/60">Prompt strength (guidance)</span>
+          <span class="text-[10px] font-bold text-base-content/60"
+            >Prompt strength (guidance)</span
+          >
           <input
             v-model.number="guidanceValue"
             type="number"
@@ -276,7 +342,8 @@
     </button>
 
     <p class="kr-text-dim-xs text-center">
-      Styling takes a minute or two — you can keep working or switch tabs; results land below when ready.
+      Styling takes a minute or two — you can keep working or switch tabs;
+      results land below when ready.
     </p>
 
     <div
@@ -294,7 +361,9 @@
     <!-- This session's jobs -->
     <div v-if="visibleJobs.length" class="flex flex-col gap-2">
       <span class="kr-text-black-xs text-base-content">
-        {{ clientName.trim() ? `Styling ${clientName.trim()}` : 'This session' }}
+        {{
+          clientName.trim() ? `Styling ${clientName.trim()}` : 'This session'
+        }}
       </span>
       <p
         v-if="hasStalledQueue"
@@ -314,8 +383,10 @@
             <span class="font-bold">{{ job.client || 'Unnamed client' }}</span>
             <span
               v-if="job.status === 'pending'"
-              class="badge badge-xs gap-1"
-              :class="job.queueState === 'rendering' ? 'badge-info' : 'badge-warning'"
+              class="kr-badge-xs gap-1"
+              :class="
+                job.queueState === 'rendering' ? 'badge-info' : 'badge-warning'
+              "
               :title="
                 job.queueState === 'rendering'
                   ? 'The studio engine is painting'
@@ -325,7 +396,9 @@
               <span class="kr-spinner-xs" />
               {{ job.queueState === 'rendering' ? 'rendering' : 'queued' }}
             </span>
-            <span v-else-if="job.status === 'failed'" class="kr-badge-error-xs">failed</span>
+            <span v-else-if="job.status === 'failed'" class="kr-badge-error-xs"
+              >failed</span
+            >
             <span v-else class="kr-badge-success-xs">done</span>
             <div class="flex-1" />
             <button
@@ -347,8 +420,14 @@
           </div>
           <div class="grid grid-cols-2 gap-1">
             <figure class="flex flex-col gap-1">
-              <img :src="job.before" alt="Before" class="aspect-square w-full rounded-lg object-cover" />
-              <figcaption class="text-center text-[10px] text-base-content/50">Before</figcaption>
+              <img
+                :src="job.before"
+                alt="Before"
+                class="aspect-square w-full rounded-lg object-cover"
+              />
+              <figcaption class="text-center text-[10px] text-base-content/50">
+                Before
+              </figcaption>
             </figure>
             <figure class="flex flex-col gap-1">
               <img
@@ -361,14 +440,29 @@
                 v-else
                 class="flex aspect-square w-full items-center justify-center rounded-lg bg-base-200"
               >
-                <span v-if="job.status === 'pending'" class="loading loading-spinner text-primary" />
-                <Icon v-else name="mdi:image-broken" class="h-6 w-6 text-base-content/30" />
+                <span
+                  v-if="job.status === 'pending'"
+                  class="loading loading-spinner text-primary"
+                />
+                <Icon
+                  v-else
+                  name="mdi:image-broken"
+                  class="h-6 w-6 text-base-content/30"
+                />
               </div>
-              <figcaption class="text-center text-[10px] text-base-content/50">After</figcaption>
+              <figcaption class="text-center text-[10px] text-base-content/50">
+                After
+              </figcaption>
             </figure>
           </div>
-          <p v-if="job.error" class="text-[10px] font-semibold text-error">{{ job.error }}</p>
-          <p v-else class="line-clamp-2 text-[10px] text-base-content/50" :title="job.prompt">
+          <p v-if="job.error" class="text-[10px] font-semibold text-error">
+            {{ job.error }}
+          </p>
+          <p
+            v-else
+            class="line-clamp-2 text-[10px] text-base-content/50"
+            :title="job.prompt"
+          >
             {{ job.prompt }}
           </p>
         </article>
@@ -379,15 +473,28 @@
     <div class="flex flex-col gap-2">
       <div class="flex items-center gap-2">
         <span class="kr-text-black-xs text-base-content">
-          {{ clientName.trim() ? `Past looks for ${clientName.trim()}` : 'Past looks' }}
+          {{
+            clientName.trim()
+              ? `Past looks for ${clientName.trim()}`
+              : 'Past looks'
+          }}
         </span>
-        <span v-if="stylist.isLoadingHistory" class="loading loading-spinner loading-xs text-primary" />
+        <span
+          v-if="stylist.isLoadingHistory"
+          class="loading loading-spinner loading-xs text-primary"
+        />
         <div class="flex-1" />
-        <button type="button" class="kr-btn-ghost-xs-plain" @click="stylist.loadHistory(true)">
+        <button
+          type="button"
+          class="kr-btn-ghost-xs-plain"
+          @click="stylist.loadHistory(true)"
+        >
           Refresh
         </button>
       </div>
-      <p v-if="stylist.historyError" class="text-xs text-error">{{ stylist.historyError }}</p>
+      <p v-if="stylist.historyError" class="text-xs text-error">
+        {{ stylist.historyError }}
+      </p>
       <p
         v-else-if="!clientHistory.length && !stylist.isLoadingHistory"
         class="kr-text-dim-xs-40"
@@ -405,7 +512,9 @@
             type="button"
             class="relative block w-full"
             :disabled="!stylist.beforeFor(image.id)"
-            :title="stylist.beforeFor(image.id) ? 'Tap to compare before/after' : ''"
+            :title="
+              stylist.beforeFor(image.id) ? 'Tap to compare before/after' : ''
+            "
             @click="toggleCompare(image.id)"
           >
             <img
@@ -419,7 +528,7 @@
             />
             <span
               v-if="stylist.beforeFor(image.id)"
-              class="badge badge-xs absolute left-1 top-1"
+              class="kr-badge-xs absolute left-1 top-1"
               :class="comparing[image.id] ? 'badge-neutral' : 'badge-primary'"
             >
               {{ comparing[image.id] ? 'Before' : 'After' }}
@@ -439,10 +548,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import {
-  useStylistStore,
-  clientFromDesigner,
-} from '@/stores/stylistStore'
+import { useStylistStore, clientFromDesigner } from '@/stores/stylistStore'
 import { useSuperkateStore } from '@/stores/superkateStore'
 import type { ArtImage } from '~/prisma/generated/prisma/client'
 
@@ -547,9 +653,17 @@ function toggleCompare(imageId: number) {
 const changeSummary = computed(() => {
   const parts: string[] = []
   if (changeColor.value)
-    parts.push(colorValue.value.trim() ? `color → ${colorValue.value.trim()}` : 'new color')
+    parts.push(
+      colorValue.value.trim()
+        ? `color → ${colorValue.value.trim()}`
+        : 'new color',
+    )
   if (changeStyle.value)
-    parts.push(styleValue.value.trim() ? `style → ${styleValue.value.trim()}` : 'new style')
+    parts.push(
+      styleValue.value.trim()
+        ? `style → ${styleValue.value.trim()}`
+        : 'new style',
+    )
   if (enhanceImage.value) parts.push('image cleanup')
   if (!parts.length) return ''
   return `We'll ${parts.join(', ')} — keeping the same face and person.`
@@ -719,7 +833,9 @@ function submit() {
     guidance: guidanceValue.value,
     steps: stepsValue.value,
     ...(protectIdentity.value ? { negativePrompt: IDENTITY_NEGATIVE } : {}),
-    ...(maskEnabled.value && maskData.value ? { maskData: maskData.value } : {}),
+    ...(maskEnabled.value && maskData.value
+      ? { maskData: maskData.value }
+      : {}),
   })
 }
 

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -79,7 +79,7 @@
         @click="selectedPackId = pack.id"
       >
         {{ pack.title }}
-        <span class="badge badge-xs" :class="progressBadgeClass(pack.id)">
+        <span class="kr-badge-xs" :class="progressBadgeClass(pack.id)">
           {{ packStore.packProgress(pack.id).done }}/{{
             packStore.packProgress(pack.id).total
           }}
@@ -125,7 +125,7 @@
           <div class="min-w-0 flex-1">
             <div class="flex flex-wrap items-center gap-2">
               <span
-                class="badge badge-xs rounded-lg"
+                class="kr-badge-xs rounded-lg"
                 :class="typeBadge(item.type)"
               >
                 {{ item.type }}
@@ -134,7 +134,7 @@
                 {{ item.draftPayload?.title || item.id }}
               </span>
               <span
-                class="badge badge-xs rounded-lg"
+                class="kr-badge-xs rounded-lg"
                 :class="statusBadge(stateFor(item.id).status)"
               >
                 {{ statusLabel(stateFor(item.id).status) }}

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -87,7 +87,7 @@
         <span
           v-for="[status, count] in taskStatusSummary(selectedProject)"
           :key="status"
-          class="badge badge-xs shrink-0 gap-0.5"
+          class="kr-badge-xs shrink-0 gap-0.5"
           :class="taskBadgeClass(status)"
           :title="`${count} ${status}`"
         >
@@ -348,7 +348,7 @@
                 >
                 <span
                   v-if="task.stakes && task.stakes !== 'reversible'"
-                  class="badge badge-xs"
+                  class="kr-badge-xs"
                   :class="stakesBadgeClass(task.stakes)"
                 >
                   {{ task.stakes }}

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -1,8 +1,6 @@
 <!-- /components/dreams/dream-brainstorm.vue -->
 <template>
-  <section
-    class="kr-surface kr-panel-muted-sm"
-  >
+  <section class="kr-surface kr-panel-muted-sm">
     <header class="shrink-0 kr-panel-flat p-4">
       <div
         class="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between"
@@ -26,10 +24,7 @@
             :disabled="dreamStore.loading || !canGenerate"
             @click="generateCandidates(false)"
           >
-            <span
-              v-if="dreamStore.loading"
-              class="kr-spinner-xs"
-            />
+            <span v-if="dreamStore.loading" class="kr-spinner-xs" />
             <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
             Generate
           </button>
@@ -44,11 +39,7 @@
             Resubmit
           </button>
 
-          <button
-            type="button"
-            class="kr-btn-ghost-2xl"
-            @click="resetSession"
-          >
+          <button type="button" class="kr-btn-ghost-2xl" @click="resetSession">
             <Icon name="kind-icon:x" class="h-4 w-4" />
             Reset
           </button>
@@ -139,8 +130,7 @@
           <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_14rem]">
             <label class="form-control">
               <span class="label py-1"
-                ><span
-                  class="kr-text-eyebrow-bold text-xs tracking-wide"
+                ><span class="kr-text-eyebrow-bold text-xs tracking-wide"
                   >Seed Title</span
                 ></span
               >
@@ -155,8 +145,7 @@
 
             <label class="form-control">
               <span class="label py-1"
-                ><span
-                  class="kr-text-eyebrow-bold text-xs tracking-wide"
+                ><span class="kr-text-eyebrow-bold text-xs tracking-wide"
                   >Save Type</span
                 ></span
               >
@@ -177,8 +166,7 @@
 
           <label class="form-control mt-3">
             <span class="label py-1"
-              ><span
-                class="kr-text-eyebrow-bold text-xs tracking-wide"
+              ><span class="kr-text-eyebrow-bold text-xs tracking-wide"
                 >Pitch</span
               ></span
             >
@@ -192,8 +180,7 @@
 
           <label class="form-control mt-3">
             <span class="label py-1"
-              ><span
-                class="kr-text-eyebrow-bold text-xs tracking-wide"
+              ><span class="kr-text-eyebrow-bold text-xs tracking-wide"
                 >Direction</span
               ></span
             >
@@ -211,9 +198,7 @@
             <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
               <div>
                 <h2 class="kr-text-black-lg">Fresh Ideas</h2>
-                <p class="kr-text-dim-xs-60">
-                  Accept, reject, edit, and save.
-                </p>
+                <p class="kr-text-dim-xs-60">Accept, reject, edit, and save.</p>
               </div>
               <div class="flex flex-wrap gap-2">
                 <button
@@ -266,7 +251,7 @@
               >
                 <div class="mb-2 flex items-center justify-between gap-2">
                   <span
-                    class="badge badge-xs rounded-xl"
+                    class="kr-badge-xs rounded-xl"
                     :class="statusBadgeClass(candidate.status)"
                     >{{ candidate.status }}</span
                   >
@@ -401,9 +386,7 @@
           <div class="grid gap-3">
             <label class="form-control">
               <span class="label"
-                ><span class="kr-text-bold-xs"
-                  >Requests</span
-                ></span
+                ><span class="kr-text-bold-xs">Requests</span></span
               >
               <input
                 v-model.number="dreamStore.numberOfRequests"
@@ -415,9 +398,7 @@
             </label>
             <label class="form-control">
               <span class="label"
-                ><span class="kr-text-bold-xs"
-                  >Max Tokens</span
-                ></span
+                ><span class="kr-text-bold-xs">Max Tokens</span></span
               >
               <input
                 v-model.number="dreamStore.maxTokens"

--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -110,7 +110,7 @@
         <span
           v-for="badge in badges"
           :key="badge.title || badge.label"
-          class="badge badge-xs shrink-0"
+          class="kr-badge-xs shrink-0"
           :class="badge.class || 'badge-primary'"
           :title="badge.title || badge.label"
         >

--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -94,10 +94,7 @@
                 aria-hidden="true"
               />
 
-              <div
-                class="min-w-0"
-                :class="mode === 'icons' ? 'p-3' : 'p-3'"
-              >
+              <div class="min-w-0" :class="mode === 'icons' ? 'p-3' : 'p-3'">
                 <div
                   v-if="item.badges?.length"
                   class="mb-1 flex flex-wrap gap-1"
@@ -105,7 +102,7 @@
                   <span
                     v-for="badge in item.badges"
                     :key="badge.label"
-                    class="badge badge-xs"
+                    class="kr-badge-xs"
                     :class="badge.class"
                   >
                     {{ badge.label }}
@@ -120,10 +117,7 @@
                 >
                   {{ item.description }}
                 </p>
-                <p
-                  v-if="item.meta"
-                  class="kr-text-dim-xs-45 mt-1.5"
-                >
+                <p v-if="item.meta" class="kr-text-dim-xs-45 mt-1.5">
                   {{ item.meta }}
                 </p>
               </div>
@@ -171,14 +165,11 @@
             </div>
 
             <div class="min-w-0 flex-1">
-              <div
-                v-if="item.badges?.length"
-                class="mb-1 flex flex-wrap gap-1"
-              >
+              <div v-if="item.badges?.length" class="mb-1 flex flex-wrap gap-1">
                 <span
                   v-for="badge in item.badges"
                   :key="badge.label"
-                  class="badge badge-xs"
+                  class="kr-badge-xs"
                   :class="badge.class"
                 >
                   {{ badge.label }}
@@ -200,10 +191,7 @@
                 <slot name="item-trailing" :item="item" />
               </div>
 
-              <p
-                v-if="item.meta"
-                class="kr-text-dim-xs-45 mt-1.5"
-              >
+              <p v-if="item.meta" class="kr-text-dim-xs-45 mt-1.5">
                 {{ item.meta }}
               </p>
               <div
@@ -263,7 +251,7 @@
                 <span
                   v-for="badge in item.badges"
                   :key="badge.label"
-                  class="badge badge-xs"
+                  class="kr-badge-xs"
                   :class="badge.class"
                 >
                   {{ badge.label }}

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -39,9 +39,7 @@
     <!-- Automate the whole group -->
     <section class="kr-panel-muted rounded-xl p-2.5">
       <div class="mb-2 flex items-center justify-between gap-2">
-        <span
-          class="kr-text-eyebrow-bold kr-text-dim-xs tracking-wide"
-        >
+        <span class="kr-text-eyebrow-bold kr-text-dim-xs tracking-wide">
           Automate all {{ group.items.length }}
         </span>
         <label
@@ -193,7 +191,7 @@
             {{ item.label }}
           </span>
           <span
-            class="badge badge-xs"
+            class="kr-badge-xs"
             :class="commitBadge(item)"
             :title="
               autoBuildFailed(item)

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -40,7 +40,7 @@
       <div class="mb-1.5 flex items-center gap-2">
         <Icon name="kind-icon:lightbulb" class="h-4 w-4 text-primary" />
         <span class="kr-text-eyebrow-bold text-xs tracking-wide">Pitch</span>
-        <span class="badge badge-xs ml-auto" :class="badgeFor('PITCH')">
+        <span class="kr-badge-xs ml-auto" :class="badgeFor('PITCH')">
           {{ item.stages.PITCH.status }}
         </span>
       </div>
@@ -116,7 +116,7 @@
           >Fields &amp; Prompts</span
         >
         <span
-          class="badge badge-xs ml-auto"
+          class="kr-badge-xs ml-auto"
           :class="badgeFor('FIELDS_AND_PROMPTS')"
         >
           {{ item.stages.FIELDS_AND_PROMPTS.status }}
@@ -230,10 +230,7 @@
         <span class="kr-text-eyebrow-bold text-xs tracking-wide"
           >Generate Assets</span
         >
-        <span
-          class="badge badge-xs ml-auto"
-          :class="badgeFor('GENERATE_ASSETS')"
-        >
+        <span class="kr-badge-xs ml-auto" :class="badgeFor('GENERATE_ASSETS')">
           {{ item.stages.GENERATE_ASSETS.status }}
         </span>
       </div>
@@ -360,7 +357,7 @@
       <div class="mb-1.5 flex items-center gap-2">
         <Icon name="kind-icon:check" class="h-4 w-4 text-primary" />
         <span class="kr-text-eyebrow-bold text-xs tracking-wide">Commit</span>
-        <span class="badge badge-xs ml-auto" :class="badgeFor('COMMIT')">
+        <span class="kr-badge-xs ml-auto" :class="badgeFor('COMMIT')">
           {{ item.stages.COMMIT.status }}
         </span>
       </div>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -32,9 +32,7 @@
         </span>
 
         <!-- Sub-view context label -->
-        <span
-          v-if="viewMode === 'tasks'"
-          class="kr-text-dim-xs-70 font-bold"
+        <span v-if="viewMode === 'tasks'" class="kr-text-dim-xs-70 font-bold"
           >· Tasks
           <span
             v-if="todoStore.openTodos.length"
@@ -64,23 +62,39 @@
           <button
             type="button"
             class="kr-btn-ghost-circle-xs"
-            :class="linkedProject.isPublic ? 'text-success' : 'text-base-content/35'"
-            :title="linkedProject.isPublic ? 'Public project' : 'Private project'"
-            :aria-label="linkedProject.isPublic ? 'Make project private' : 'Make project public'"
+            :class="
+              linkedProject.isPublic ? 'text-success' : 'text-base-content/35'
+            "
+            :title="
+              linkedProject.isPublic ? 'Public project' : 'Private project'
+            "
+            :aria-label="
+              linkedProject.isPublic
+                ? 'Make project private'
+                : 'Make project public'
+            "
             :disabled="projectSaving"
             @click="patchProject({ isPublic: !linkedProject.isPublic })"
           >
             <Icon
-              :name="linkedProject.isPublic ? 'kind-icon:eye' : 'kind-icon:eye-off'"
+              :name="
+                linkedProject.isPublic ? 'kind-icon:eye' : 'kind-icon:eye-off'
+              "
               class="size-3.5"
             />
           </button>
           <button
             type="button"
             class="kr-btn-ghost-circle-xs"
-            :class="linkedProject.isMature ? 'text-warning' : 'text-base-content/35'"
+            :class="
+              linkedProject.isMature ? 'text-warning' : 'text-base-content/35'
+            "
             :title="linkedProject.isMature ? 'Mature content' : 'Safe content'"
-            :aria-label="linkedProject.isMature ? 'Mark project safe' : 'Mark project mature'"
+            :aria-label="
+              linkedProject.isMature
+                ? 'Mark project safe'
+                : 'Mark project mature'
+            "
             :disabled="projectSaving"
             @click="patchProject({ isMature: !linkedProject.isMature })"
           >
@@ -89,9 +103,17 @@
           <button
             type="button"
             class="kr-btn-ghost-circle-xs"
-            :class="linkedProject.allowReviews ? 'text-success' : 'text-base-content/35'"
+            :class="
+              linkedProject.allowReviews
+                ? 'text-success'
+                : 'text-base-content/35'
+            "
             :title="linkedProject.allowReviews ? 'Reviews on' : 'Reviews off'"
-            :aria-label="linkedProject.allowReviews ? 'Turn reviews off' : 'Turn reviews on'"
+            :aria-label="
+              linkedProject.allowReviews
+                ? 'Turn reviews off'
+                : 'Turn reviews on'
+            "
             :disabled="projectSaving"
             @click="patchProject({ allowReviews: !linkedProject.allowReviews })"
           >
@@ -151,10 +173,7 @@
           :disabled="syncingMissing"
           @click="syncMissingProjects"
         >
-          <span
-            v-if="syncingMissing"
-            class="kr-spinner-xs"
-          />
+          <span v-if="syncingMissing" class="kr-spinner-xs" />
           <Icon v-else name="kind-icon:warning" class="size-3" />
           Sync {{ missingProjectSlugs.length }}
         </button>
@@ -247,9 +266,7 @@
               class="kr-panel-flat space-y-3 p-4"
               @submit.prevent="submitNewTodo"
             >
-              <h4
-                class="kr-text-eyebrow-bold kr-text-dim-xs tracking-wide"
-              >
+              <h4 class="kr-text-eyebrow-bold kr-text-dim-xs tracking-wide">
                 New Task
               </h4>
               <input
@@ -271,17 +288,11 @@
                 :disabled="todoStore.loading"
               />
               <div class="flex flex-wrap items-center gap-2">
-                <select
-                  v-model="newTodoCategory"
-                  class="kr-select-sm"
-                >
+                <select v-model="newTodoCategory" class="kr-select-sm">
                   <option value="AGENT">🤖 Agent Task</option>
                   <option value="HONEYDO">🍯 Honey Do</option>
                 </select>
-                <select
-                  v-model="newTodoPriority"
-                  class="kr-select-sm"
-                >
+                <select v-model="newTodoPriority" class="kr-select-sm">
                   <option value="HIGH">🔴 High</option>
                   <option value="NORMAL">🟡 Normal</option>
                   <option value="LOW">🟢 Low</option>
@@ -560,17 +571,23 @@
                       <span
                         v-if="selectedProject.conductorStatus"
                         class="kr-badge-sm"
-                        :class="lifecycleBadgeClass(selectedProject.conductorStatus)"
+                        :class="
+                          lifecycleBadgeClass(selectedProject.conductorStatus)
+                        "
                         >{{ selectedProject.conductorStatus }}</span
                       >
                       <span
                         v-if="selectedProject.conductorPriority"
                         class="kr-badge-sm"
-                        :class="priorityBadgeClass(selectedProject.conductorPriority)"
+                        :class="
+                          priorityBadgeClass(selectedProject.conductorPriority)
+                        "
                         >{{ selectedProject.conductorPriority }} priority</span
                       >
                     </div>
-                    <h3 class="kr-text-black-xl break-words leading-tight sm:text-2xl">
+                    <h3
+                      class="kr-text-black-xl break-words leading-tight sm:text-2xl"
+                    >
                       {{
                         linkedProject?.title ||
                         selectedProject.name ||
@@ -609,14 +626,13 @@
 
             <!-- PROJECT TASK / COMMENT CREATION -->
             <div v-if="linkedProject" class="kr-panel-flat shrink-0 p-4">
-              <h4
-                class="kr-text-eyebrow-bold kr-text-dim-xs tracking-wide"
-              >
+              <h4 class="kr-text-eyebrow-bold kr-text-dim-xs tracking-wide">
                 Add task / comment
               </h4>
               <p class="kr-text-dim-xs-40 mb-3 mt-1">
                 Agent items are picked up asynchronously by the project worker.
-                Honey-dos stay human-facing; feature ideas stay in this project's wishlist.
+                Honey-dos stay human-facing; feature ideas stay in this
+                project's wishlist.
               </p>
               <form class="space-y-2" @submit.prevent="submitProjectTask">
                 <input
@@ -634,18 +650,12 @@
                   :disabled="projectTaskSubmitting"
                 />
                 <div class="flex flex-wrap items-center gap-2">
-                  <select
-                    v-model="projectTaskCategory"
-                    class="kr-select-sm"
-                  >
+                  <select v-model="projectTaskCategory" class="kr-select-sm">
                     <option value="AGENT">🤖 Agent Task / Comment</option>
                     <option value="HONEYDO">🍯 Honey Do</option>
                     <option value="DESIRED_FEATURE">⭐ Feature Idea</option>
                   </select>
-                  <select
-                    v-model="projectTaskPriority"
-                    class="kr-select-sm"
-                  >
+                  <select v-model="projectTaskPriority" class="kr-select-sm">
                     <option value="HIGH">🔴 High</option>
                     <option value="NORMAL">🟡 Normal</option>
                     <option value="LOW">🟢 Low</option>
@@ -653,12 +663,11 @@
                   <button
                     type="submit"
                     class="btn btn-primary btn-sm ml-auto rounded-xl"
-                    :disabled="!projectTaskTitle.trim() || projectTaskSubmitting"
+                    :disabled="
+                      !projectTaskTitle.trim() || projectTaskSubmitting
+                    "
                   >
-                    <span
-                      v-if="projectTaskSubmitting"
-                      class="kr-spinner-xs"
-                    />
+                    <span v-if="projectTaskSubmitting" class="kr-spinner-xs" />
                     Add
                   </button>
                 </div>
@@ -713,9 +722,7 @@
                 <div class="grid gap-3 sm:grid-cols-2">
                   <div class="form-control">
                     <label class="label py-0.5"
-                      ><span class="kr-label-xs-semibold"
-                        >Live URL</span
-                      ></label
+                      ><span class="kr-label-xs-semibold">Live URL</span></label
                     >
                     <input
                       type="url"
@@ -728,9 +735,7 @@
                   </div>
                   <div class="form-control">
                     <label class="label py-0.5"
-                      ><span class="kr-label-xs-semibold"
-                        >Repo URL</span
-                      ></label
+                      ><span class="kr-label-xs-semibold">Repo URL</span></label
                     >
                     <input
                       type="url"
@@ -823,7 +828,9 @@
                   class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide"
                   >Project Notes</span
                 >
-                <span class="ml-auto text-xs text-base-content/35">Conductor</span>
+                <span class="ml-auto text-xs text-base-content/35"
+                  >Conductor</span
+                >
               </summary>
               <div
                 class="whitespace-pre-wrap border-t border-base-300/70 px-4 py-3 text-sm leading-relaxed text-base-content/75"
@@ -926,7 +933,9 @@
                         <Icon :name="taskIcon(task.status)" class="size-3" />
                       </div>
                       <div class="min-w-0 flex-1">
-                        <p class="break-words text-sm font-semibold leading-snug">
+                        <p
+                          class="break-words text-sm font-semibold leading-snug"
+                        >
                           {{ task.title }}
                         </p>
                         <div
@@ -951,7 +960,7 @@
                         >
                           <span
                             v-if="task.stakes && task.stakes !== 'reversible'"
-                            class="badge badge-xs"
+                            class="kr-badge-xs"
                             :class="stakesBadgeClass(task.stakes)"
                             >{{ task.stakes }}</span
                           >
@@ -1062,9 +1071,7 @@
             >
               <div class="flex items-center gap-2">
                 <Icon name="kind-icon:check" class="size-4 text-primary" />
-                <h4
-                  class="kr-text-eyebrow-bold kr-text-dim-xs tracking-wide"
-                >
+                <h4 class="kr-text-eyebrow-bold kr-text-dim-xs tracking-wide">
                   Feature Wishlist
                 </h4>
               </div>
@@ -1133,7 +1140,8 @@
                 </div>
               </div>
               <p v-else class="kr-text-dim-xs-40">
-                No feature ideas yet. Add one from the task / comment panel above.
+                No feature ideas yet. Add one from the task / comment panel
+                above.
               </p>
             </div>
           </div>
@@ -1330,14 +1338,12 @@ const sortedActiveProjects = computed(() =>
     const pa =
       (a.priority as ProjectPriorityLevel | undefined) ??
       (projectRecordForSlug(a.slug)?.priority as
-        | ProjectPriorityLevel
-        | undefined) ??
+        ProjectPriorityLevel | undefined) ??
       'NORMAL'
     const pb =
       (b.priority as ProjectPriorityLevel | undefined) ??
       (projectRecordForSlug(b.slug)?.priority as
-        | ProjectPriorityLevel
-        | undefined) ??
+        ProjectPriorityLevel | undefined) ??
       'NORMAL'
     return (order[pa] ?? 1) - (order[pb] ?? 1)
   }),
@@ -1372,7 +1378,8 @@ const filteredTodos = computed(() => {
       // Keep legacy KAIZEN rows reachable without preserving a dedicated
       // Kaizen concept in the workspace UI.
       return [...todoStore.regularAgentTodos, ...todoStore.kaizenTodos].sort(
-        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
       )
   }
 })

--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -11,8 +11,7 @@
       <div class="min-w-0 flex-1">
         <h2 class="kr-text-black-2xl tracking-tight">Projects</h2>
         <p class="kr-text-dim-sm">
-          Browse every Conductor project, filter by status, or start a new
-          one.
+          Browse every Conductor project, filter by status, or start a new one.
         </p>
       </div>
     </header>
@@ -71,10 +70,7 @@
           :disabled="!createForm.title.trim() || !!slugError || projects.saving"
           @click="createProject"
         >
-          <span
-            v-if="projects.saving"
-            class="kr-spinner-xs"
-          />
+          <span v-if="projects.saving" class="kr-spinner-xs" />
           <Icon v-else name="kind-icon:plus" class="size-3.5" />
           Create Project
         </button>
@@ -96,8 +92,8 @@
             class="mt-1 block w-full text-left hover:text-primary"
             @click="open(item)"
           >
-            <span class="break-words">{{ item.title }}</span>:
-            {{ item.dbStatus }} → {{ item.status }}
+            <span class="break-words">{{ item.title }}</span
+            >: {{ item.dbStatus }} → {{ item.status }}
           </button>
         </div>
         <div v-if="conductorOnly.length" class="rounded-lg bg-base-100/80 p-2">
@@ -168,7 +164,7 @@
             >
               <Icon :name="option.icon" class="size-3" />
               <span class="hidden sm:inline">{{ option.label }}</span>
-              <span class="badge badge-xs">{{ filterCount(option.value) }}</span>
+              <span class="kr-badge-xs">{{ filterCount(option.value) }}</span>
             </button>
 
             <button
@@ -180,7 +176,7 @@
             >
               <Icon name="kind-icon:warning" class="size-3" />
               <span class="hidden sm:inline">Sync</span>
-              <span class="badge badge-xs">{{ syncIssueCount }}</span>
+              <span class="kr-badge-xs">{{ syncIssueCount }}</span>
             </button>
 
             <button
@@ -192,7 +188,7 @@
             >
               <Icon name="kind-icon:pause" class="size-3" />
               <span class="hidden sm:inline">Blocked</span>
-              <span class="badge badge-xs">{{ blockedTasks.length }}</span>
+              <span class="kr-badge-xs">{{ blockedTasks.length }}</span>
             </button>
 
             <button
@@ -242,12 +238,7 @@ import { slugify } from '@/utils/slugify'
 const IMG_BASE =
   'https://raw.githubusercontent.com/silasfelinus/conductor/main/projects/images'
 type Status =
-  | 'ACTIVE'
-  | 'CONTINUOUS'
-  | 'PAUSED'
-  | 'DONE'
-  | 'BRAINSTORM'
-  | 'ARCHIVED'
+  'ACTIVE' | 'CONTINUOUS' | 'PAUSED' | 'DONE' | 'BRAINSTORM' | 'ARCHIVED'
 type Filter = Exclude<Status, 'BRAINSTORM'> | 'ALL'
 type Item = {
   id: number
@@ -331,7 +322,8 @@ const slugError = computed(() => {
 })
 
 function onTitleInput() {
-  if (!slugTouched.value) createForm.value.slug = slugify(createForm.value.title)
+  if (!slugTouched.value)
+    createForm.value.slug = slugify(createForm.value.title)
 }
 
 function onSlugInput() {
@@ -429,9 +421,9 @@ function toItem(record: ProjectWithRelations): Item {
   const progress = source?.progress ?? (status === 'DONE' ? 100 : 0)
   const drift = Boolean(
     source &&
-      (record.status !== status ||
-        record.priority !== priority ||
-        record.isActive !== (status !== 'ARCHIVED')),
+    (record.status !== status ||
+      record.priority !== priority ||
+      record.isActive !== (status !== 'ARCHIVED')),
   )
   const metaParts = [`${progress}%`, `${done}/${total} done`]
   if (blocked) metaParts.push(`${blocked} blocked`)

--- a/components/ruler-hooked/ruler-hooked-fishopedia.vue
+++ b/components/ruler-hooked/ruler-hooked-fishopedia.vue
@@ -1,13 +1,18 @@
 <template>
   <details class="fishopedia-shell collapse collapse-arrow kr-panel-flat">
-    <summary class="collapse-title flex items-center justify-between gap-3 pr-12 font-bold">
+    <summary
+      class="collapse-title flex items-center justify-between gap-3 pr-12 font-bold"
+    >
       <span>📖 Fishopedia</span>
-      <span class="badge badge-outline">{{ discoveredCount }}/{{ roster.length }} discovered</span>
+      <span class="badge badge-outline"
+        >{{ discoveredCount }}/{{ roster.length }} discovered</span
+      >
     </summary>
 
     <div class="collapse-content">
       <p class="mb-3 text-xs opacity-60">
-        Unknown species stay hidden until caught. Discovered entries remember your best specimen and why that creature could exist in this reign.
+        Unknown species stay hidden until caught. Discovered entries remember
+        your best specimen and why that creature could exist in this reign.
       </p>
 
       <div class="fishopedia-grid grid gap-3">
@@ -18,31 +23,47 @@
         >
           <template v-if="entryFor(fish.slug)">
             <div class="flex flex-wrap items-center gap-2">
-              <span class="badge badge-xs" :class="affinityClass(fish.affinity)">{{ fish.affinity }}</span>
+              <span class="kr-badge-xs" :class="affinityClass(fish.affinity)">{{
+                fish.affinity
+              }}</span>
               <span class="kr-badge-outline-xs">{{ fish.rarity }}</span>
-              <span class="text-xs opacity-50">×{{ entryFor(fish.slug)!.countCaught }}</span>
+              <span class="text-xs opacity-50"
+                >×{{ entryFor(fish.slug)!.countCaught }}</span
+              >
             </div>
             <h4 class="mt-2 font-black">{{ fish.name }}</h4>
             <p class="mt-1 text-xs opacity-75">{{ fish.fishopediaNote }}</p>
             <dl class="mt-2 grid grid-cols-2 gap-2 text-xs">
               <div>
                 <dt class="opacity-50">Best size</dt>
-                <dd class="font-semibold">{{ formatSize(entryFor(fish.slug)!.bestSizeCm) }}</dd>
+                <dd class="font-semibold">
+                  {{ formatSize(entryFor(fish.slug)!.bestSizeCm) }}
+                </dd>
               </div>
               <div>
                 <dt class="opacity-50">Best quality</dt>
-                <dd class="font-semibold">{{ entryFor(fish.slug)!.bestQualityScore }}/100</dd>
+                <dd class="font-semibold">
+                  {{ entryFor(fish.slug)!.bestQualityScore }}/100
+                </dd>
               </div>
             </dl>
-            <p class="mt-2 border-t border-base-300 pt-2 text-xs opacity-60">{{ fish.consequenceReveal }}</p>
+            <p class="mt-2 border-t border-base-300 pt-2 text-xs opacity-60">
+              {{ fish.consequenceReveal }}
+            </p>
           </template>
 
           <template v-else>
             <div class="flex h-full min-h-24 items-center gap-3 opacity-40">
-              <div class="flex size-14 shrink-0 items-center justify-center rounded-full border border-dashed border-current text-2xl">?</div>
+              <div
+                class="flex size-14 shrink-0 items-center justify-center rounded-full border border-dashed border-current text-2xl"
+              >
+                ?
+              </div>
               <div>
                 <p class="font-bold">Unknown specimen</p>
-                <p class="text-xs">Its place in this version of the lake has not been discovered.</p>
+                <p class="text-xs">
+                  Its place in this version of the lake has not been discovered.
+                </p>
               </div>
             </div>
           </template>
@@ -58,7 +79,9 @@ import { RULER_HOOKED_FISH } from '~/utils/rulerHooked/fish'
 
 const props = defineProps<{ save: RunSave }>()
 const roster = RULER_HOOKED_FISH
-const discoveredCount = computed(() => Object.keys(props.save.fishopedia).length)
+const discoveredCount = computed(
+  () => Object.keys(props.save.fishopedia).length,
+)
 
 function entryFor(slug: string) {
   return props.save.fishopedia[slug]

--- a/utils/scripts/codemods/kr_badge_codemod.py
+++ b/utils/scripts/codemods/kr_badge_codemod.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Find or migrate hand-rolled kr-badge-{ghost,warning,outline,primary,secondary}-sm,
 kr-badge-{ghost,outline,primary,warning,success,error,secondary,accent,info,neutral}-xs,
-and kr-badge-sm (the colorless base) badges.
+kr-badge-sm (the colorless base), and kr-badge-xs (the colorless -xs sibling) badges.
 
 Dry-run is the default. Pass --write to update matching Vue files in place.
 Only the approved badge shapes are touched (`badge badge-ghost badge-sm`,
@@ -11,9 +11,9 @@ badge-ghost badge-xs`, `badge badge-outline badge-xs`, `badge badge-primary
 badge-xs`, `badge badge-warning badge-xs`, `badge badge-success badge-xs`,
 `badge badge-error badge-xs`, `badge badge-secondary badge-xs`, `badge
 badge-accent badge-xs`, `badge badge-info badge-xs`, `badge badge-neutral
-badge-xs`, `badge badge-sm` with no color modifier at all -- the
-dynamically-toned shape whose color comes from a sibling `:class` binding),
-and only in static
+badge-xs`, `badge badge-sm` and `badge badge-xs` with no color modifier at
+all -- the dynamically-toned shapes whose color comes from a sibling
+`:class` binding), and only in static
 `class="..."` attributes -- never `:class`/`v-bind:class` bindings, and
 regardless of the base tokens' order in the source (`badge-ghost badge-sm`
 counts the same as `badge-sm badge-ghost`). A source that already carries
@@ -27,14 +27,18 @@ name. This includes a second color modifier (e.g. `badge-outline` alongside
 `badge-primary`) preserved as an "extra" token verbatim -- the same latent
 behavior the ghost/warning/outline families already had for a stray color
 token, not new to this pair. The colorless `kr-badge-sm` family is the one
-exception to unrestricted extras: see BOUNDED_EXTRAS below.
+exception to unrestricted extras: see BOUNDED_EXTRAS below. `kr-badge-xs`
+(interface-vision t-104 slice 177) is colorless too but is NOT bounded --
+its 25 occurrences across 13 files were individually audited for that
+slice, unlike `kr-badge-sm`'s broader, only-partially-audited 91-hit pool.
 
 FAMILIES is ordered most-specific-first on purpose: each entry's base token
 set differs in its size (sm/xs) and color modifier (ghost/warning/outline/
 primary/secondary), so order among them doesn't matter for correctness here
-(no entry's base set is a subset of another's), but the plain-size
-`kr-badge-sm` family comes LAST, since its smaller {badge, badge-sm} base
-set is a subset of every colored -sm family's tokens above it.
+(no entry's base set is a subset of another's), but the two plain-size
+families, `kr-badge-sm` and `kr-badge-xs`, come LAST, since their smaller
+{badge, badge-sm}/{badge, badge-xs} base sets are each a subset of every
+same-size colored family's tokens above them.
 """
 
 from __future__ import annotations
@@ -70,6 +74,11 @@ FAMILIES = [
     # `kr-badge-outline-sm rounded-2xl` etc. already read elsewhere) plus a
     # per-instance `:class` binding supplying the color.
     ("kr-badge-sm", {"badge", "badge-sm"}),
+    # Colorless -xs sibling of kr-badge-sm (interface-vision t-104 slice
+    # 177), same subset-order reasoning: its {badge, badge-xs} base is a
+    # strict subset of every colored -xs family above, so it must come
+    # after all of them too.
+    ("kr-badge-xs", {"badge", "badge-xs"}),
 ]
 
 # kr-badge-sm's base token set ({badge, badge-sm}) is small enough to appear


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software) — slice 177

### What changed / what I produced
- Added `.kr-badge-xs` (`@apply badge badge-xs`) to `assets/css/tailwind.css` — the colorless `-xs` sibling of the existing `.kr-badge-sm`, for badges whose color is supplied by a sibling `:class` binding (pitch/commit status, pack progress, affinity, sync/filter counts...) rather than baked into the base class.
- Extended `utils/scripts/codemods/kr_badge_codemod.py`'s `FAMILIES` with the new colorless `kr-badge-xs` entry (ordered last, after every colored `-xs` family, since its `{badge, badge-xs}` base is a strict subset of all of them — same ordering rationale already documented for `kr-badge-sm`).
- Migrated all 26 hand-rolled `badge badge-xs` occurrences across 13 files to `kr-badge-xs`. Left unrestricted (unlike `kr-badge-sm`'s `BOUNDED_EXTRAS`) because every occurrence was individually audited this slice — a much smaller, fully-reviewed pool than `kr-badge-sm`'s original 91-hit survey.
- No geometry or behavior change: `:class` bindings supplying the color are preserved verbatim at every call site.
- Also fixed pre-existing Prettier formatting drift in 8 of the touched files (present before this change, unrelated to the badge migration) so `prettier --check .` stays at the repo's pre-existing baseline count rather than growing it.

### How I verified
- `npm run test` (vue-tsc --noEmit): clean.
- `npx eslint .`: 333 problems (327 errors, 6 warnings) — byte-identical to baseline (confirmed via `git stash`).
- `npm run test:layout-contract`: holds, 0 new violations (same pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet note as recent slices, left untouched).
- `npm run test:lint-ratchet`: holds at 333/-59.
- `npx prettier --check .`: repo-wide dirty-file count went from 1151 (baseline, confirmed via `git stash`) to 1143 — exactly the 8 pre-existing violations fixed in touched files, no new dirty files introduced.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
`kr-text-bold-*` now covers `-sm`/`-xs`/`-lg` (worth a quick survey for `-xl`/`-2xl` siblings). Strongest remaining candidate outside all closed families: `text-xs text-error` (36 subset-match/32 files), a coherent inline validation/error-message caption pattern.

### Notes for reviewer
Conductor task `interface-vision/t-104` is claimed under session `claude-20260909T112856Z-t104`; will be returned to `status: ready` after this merges, per the recurring-umbrella convention.


---
_Generated by [Claude Code](https://claude.ai/code/session_018MyKKJFQocgkeSTuRxFaM8)_