### PR TITLE
feat(interface-vision): add kr-text-error-xs primitive, migrate 36 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1964,6 +1964,18 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply text-xs font-semibold;
   }
 
+  /* Inline validation/error-message caption -- `text-xs text-error`
+   * (interface-vision t-104 slice 178), the strongest remaining candidate
+   * outside all now-closed `kr-text-black-*`/`kr-text-bold-*`/
+   * `kr-text-dim-*`/`kr-text-eyebrow-*`/`kr-label-*` families, flagged by
+   * slice 177's own kaizen note. A fresh full-repo class-frequency survey
+   * found this shape at 36 subset-match occurrences across 32 files,
+   * consistently a conditionally-rendered `<p>` (often `role="alert"`)
+   * showing a store/form error message right below its field. */
+  .kr-text-error-xs {
+    @apply text-xs text-error;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -137,7 +137,7 @@
 
             <p
               v-if="engineWarning"
-              class="mt-2 text-xs font-semibold text-error"
+              class="kr-text-error-xs mt-2 font-semibold"
               role="alert"
             >
               {{ engineWarning }}

--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -204,7 +204,7 @@
 
       <div
         v-if="job.error"
-        class="rounded-2xl border border-error/30 bg-error/10 p-2 text-xs text-error"
+        class="kr-text-error-xs rounded-2xl border border-error/30 bg-error/10 p-2"
       >
         {{ job.error }}
       </div>

--- a/components/art/artjob-slideshow.vue
+++ b/components/art/artjob-slideshow.vue
@@ -47,7 +47,7 @@
             class="kr-spinner-lg-primary"
           />
           <p class="text-sm font-semibold">{{ stageMessage }}</p>
-          <p v-if="slideshowStore.error" class="text-xs text-error">
+          <p v-if="slideshowStore.error" class="kr-text-error-xs">
             {{ slideshowStore.error }}
           </p>
         </div>

--- a/components/art/stylist-client-gallery.vue
+++ b/components/art/stylist-client-gallery.vue
@@ -88,7 +88,7 @@
       </label>
     </div>
 
-    <p v-if="error" class="mb-3 rounded-xl bg-error/10 p-2 text-xs text-error">
+    <p v-if="error" class="kr-text-error-xs mb-3 rounded-xl bg-error/10 p-2">
       {{ error }}
     </p>
 

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -22,7 +22,7 @@
       <button v-if="editingId" type="button" class="kr-btn-ghost-plain" @click="resetForm">Cancel</button>
     </form>
 
-    <p v-if="photoError" class="rounded-xl bg-error/10 p-2 text-xs text-error">{{ photoError }}</p>
+    <p v-if="photoError" class="kr-text-error-xs rounded-xl bg-error/10 p-2">{{ photoError }}</p>
     <p v-if="!superkate.sortedCustomers.length" class="kr-text-dim-xs-40">
       No clients yet — add one above, or save an appointment and the client is created automatically.
     </p>

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -492,7 +492,7 @@
           Refresh
         </button>
       </div>
-      <p v-if="stylist.historyError" class="text-xs text-error">
+      <p v-if="stylist.historyError" class="kr-text-error-xs">
         {{ stylist.historyError }}
       </p>
       <p

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -96,7 +96,7 @@
     <p v-if="!characterId" class="kr-text-dim-xs-45">
       These choices will attach when the new Character is saved.
     </p>
-    <p v-if="errorMessage" class="text-xs text-error">{{ errorMessage }}</p>
+    <p v-if="errorMessage" class="kr-text-error-xs">{{ errorMessage }}</p>
   </section>
 </template>
 

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -150,7 +150,7 @@
             </p>
             <p
               v-if="stateFor(item.id).error"
-              class="mt-1 text-xs font-semibold text-error"
+              class="kr-text-error-xs mt-1 font-semibold"
             >
               {{ stateFor(item.id).error }}
             </p>

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -494,7 +494,7 @@
           </div>
         </section>
 
-        <p v-if="store.errorMessage" class="text-xs text-error">
+        <p v-if="store.errorMessage" class="kr-text-error-xs">
           {{ store.errorMessage }}
         </p>
 
@@ -595,7 +595,7 @@
 
         <StorybookStatePanel :session="store.session" />
 
-        <p v-if="store.errorMessage" class="text-xs text-error">
+        <p v-if="store.errorMessage" class="kr-text-error-xs">
           {{ store.errorMessage }}
         </p>
       </div>

--- a/components/conductor/voice-lab-page.vue
+++ b/components/conductor/voice-lab-page.vue
@@ -67,7 +67,7 @@
             {{ message.text }}
           </p>
         </div>
-        <p v-if="voice.lastError" class="text-xs text-error">
+        <p v-if="voice.lastError" class="kr-text-error-xs">
           {{ voice.lastError }}
         </p>
 

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -956,7 +956,7 @@
             parent is consumed -- you'll get a new individual with converged
             stats, and just maybe, a secret evolution.
           </p>
-          <p v-if="!canConfirmBreed" class="text-xs text-error">
+          <p v-if="!canConfirmBreed" class="kr-text-error-xs">
             Not enough coins, or not enough tank room, for this pairing right
             now.
           </p>

--- a/components/dreams/daily-digest-browser.vue
+++ b/components/dreams/daily-digest-browser.vue
@@ -152,7 +152,7 @@
             </p>
             <p
               v-if="archiveStore.lastError"
-              class="mt-3 rounded-xl border border-error/30 bg-error/10 px-3 py-2 text-xs text-error"
+              class="kr-text-error-xs mt-3 rounded-xl border border-error/30 bg-error/10 px-3 py-2"
             >
               {{ archiveStore.lastError }}
             </p>

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -61,7 +61,7 @@
         -->
         <p
           v-if="dreamStore.error"
-          class="min-w-0 flex-1 truncate text-xs font-medium text-error"
+          class="kr-text-error-xs min-w-0 flex-1 truncate font-medium"
           :title="dreamStore.error"
         >
           {{ dreamStore.error }}

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -148,7 +148,7 @@
       </div>
     </details>
 
-    <p v-if="errorMessage" class="text-xs text-error">{{ errorMessage }}</p>
+    <p v-if="errorMessage" class="kr-text-error-xs">{{ errorMessage }}</p>
   </section>
 </template>
 

--- a/components/giftshop/mermaids-pdf-purchase.vue
+++ b/components/giftshop/mermaids-pdf-purchase.vue
@@ -57,7 +57,7 @@
       </button>
     </div>
 
-    <p v-if="error" class="text-xs text-error">{{ error }}</p>
+    <p v-if="error" class="kr-text-error-xs">{{ error }}</p>
   </div>
 </template>
 

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -30,7 +30,7 @@
     <p
       v-if="item.error"
       role="alert"
-      class="rounded-lg bg-error/10 px-2 py-1 text-xs font-semibold text-error"
+      class="kr-text-error-xs rounded-lg bg-error/10 px-2 py-1 font-semibold"
     >
       {{ item.error }}
     </p>

--- a/components/narrative/narrative-ingredient-multi-picker.vue
+++ b/components/narrative/narrative-ingredient-multi-picker.vue
@@ -61,7 +61,7 @@
     <div
       v-if="error"
       role="alert"
-      class="flex items-start gap-2 rounded-2xl border border-error/30 bg-error/5 p-3 text-xs text-error"
+      class="kr-text-error-xs flex items-start gap-2 rounded-2xl border border-error/30 bg-error/5 p-3"
     >
       <Icon
         name="kind-icon:alert"

--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -61,7 +61,7 @@
     <div
       v-if="error"
       role="alert"
-      class="flex items-start gap-2 rounded-2xl border border-error/30 bg-error/5 p-3 text-xs text-error"
+      class="kr-text-error-xs flex items-start gap-2 rounded-2xl border border-error/30 bg-error/5 p-3"
     >
       <Icon
         name="kind-icon:alert"

--- a/components/navigation/maturity-toggle.vue
+++ b/components/navigation/maturity-toggle.vue
@@ -47,7 +47,7 @@
         </span>
       </label>
 
-      <p v-if="updateError" class="px-1 text-xs text-error">
+      <p v-if="updateError" class="kr-text-error-xs px-1">
         {{ updateError }}
       </p>
     </template>

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -59,7 +59,7 @@
               />
             </label>
           </div>
-          <p v-if="slugError" class="text-xs text-error">{{ slugError }}</p>
+          <p v-if="slugError" class="kr-text-error-xs">{{ slugError }}</p>
           <label class="form-control">
             <span class="label-text pb-1"
               >What is it? (one line, also steers its art)</span

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -148,7 +148,7 @@
       <div class="flex-1" />
 
       <!-- Error indicator -->
-      <span v-if="error" class="flex items-center gap-1 text-xs text-error">
+      <span v-if="error" class="kr-text-error-xs flex items-center gap-1">
         <Icon name="kind-icon:warning" class="size-3" />
         <span class="hidden max-w-32 truncate sm:inline">{{
           error.message
@@ -380,7 +380,7 @@
               </p>
               <p
                 v-if="highPriorityHoneyDos > 0"
-                class="mt-1 text-xs font-semibold text-error"
+                class="kr-text-error-xs mt-1 font-semibold"
               >
                 {{ highPriorityHoneyDos }} high-priority item{{
                   highPriorityHoneyDos > 1 ? 's' : ''

--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -74,7 +74,7 @@
           <Icon v-else name="kind-icon:plus" class="size-3.5" />
           Create Project
         </button>
-        <p v-if="createError" class="text-xs text-error">{{ createError }}</p>
+        <p v-if="createError" class="kr-text-error-xs">{{ createError }}</p>
       </div>
     </section>
 

--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -176,7 +176,7 @@
               >
                 {{ store.submitting ? 'Logging…' : 'Log remittance' }}
               </button>
-              <p v-if="store.submitError" class="text-xs text-error">
+              <p v-if="store.submitError" class="kr-text-error-xs">
                 {{ store.submitError }}
               </p>
             </div>

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -166,7 +166,7 @@
         <div v-if="voice.lastAppliedText" class="text-xs text-success">
           Last applied: {{ voice.lastAppliedText }}
         </div>
-        <div v-if="voice.lastError" class="text-xs text-error">
+        <div v-if="voice.lastError" class="kr-text-error-xs">
           {{ voice.lastError }}
         </div>
 

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -369,7 +369,7 @@
 
         <p
           v-if="store.errorMessage"
-          class="relative z-20 mx-4 mb-2 text-xs text-error sm:mx-6"
+          class="kr-text-error-xs relative z-20 mx-4 mb-2 sm:mx-6"
           role="alert"
         >
           {{ store.errorMessage }}
@@ -582,7 +582,7 @@
               </div>
             </section>
 
-            <p v-if="store.errorMessage" class="text-xs text-error" role="alert">
+            <p v-if="store.errorMessage" class="kr-text-error-xs" role="alert">
               {{ store.errorMessage }}
             </p>
 
@@ -880,7 +880,7 @@
               </div>
             </div>
 
-            <p v-if="store.errorMessage" class="text-xs text-error" role="alert">
+            <p v-if="store.errorMessage" class="kr-text-error-xs" role="alert">
               {{ store.errorMessage }}
             </p>
 

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -96,7 +96,7 @@
     <p v-if="!rewardId" class="kr-text-dim-xs-45">
       These choices will attach when the new Reward is saved.
     </p>
-    <p v-if="errorMessage" class="text-xs text-error">{{ errorMessage }}</p>
+    <p v-if="errorMessage" class="kr-text-error-xs">{{ errorMessage }}</p>
   </section>
 </template>
 

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -169,7 +169,7 @@
               placeholder="Perform as [Name]. [Voice, mannerisms, perspective, what they care about]..."
               maxlength="500"
             />
-            <p v-if="llmError" class="text-xs text-error">{{ llmError }}</p>
+            <p v-if="llmError" class="kr-text-error-xs">{{ llmError }}</p>
           </div>
 
           <!-- Art / avatar -->

--- a/components/taskmaster/taskmaster-sample-tasks.vue
+++ b/components/taskmaster/taskmaster-sample-tasks.vue
@@ -79,7 +79,7 @@
       </button>
     </div>
 
-    <p v-if="errorMessage" class="text-xs text-error" role="alert">
+    <p v-if="errorMessage" class="kr-text-error-xs" role="alert">
       {{ errorMessage }}
     </p>
   </section>

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -212,7 +212,7 @@
       />
 
       <div class="shrink-0 border-t border-base-300 bg-base-200 p-3">
-        <p v-if="replyError" class="mb-2 text-xs font-semibold text-error">
+        <p v-if="replyError" class="kr-text-error-xs mb-2 font-semibold">
           {{ replyError }}
         </p>
 

--- a/components/user/messenger.vue
+++ b/components/user/messenger.vue
@@ -123,7 +123,7 @@
             <Icon v-else name="kind-icon:send" class="h-4 w-4" />
           </button>
         </form>
-        <p v-if="convo.lastError" class="px-3 pb-2 text-xs text-error">
+        <p v-if="convo.lastError" class="kr-text-error-xs px-3 pb-2">
           {{ convo.lastError }}
         </p>
       </template>

--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -134,7 +134,7 @@
         </div>
       </div>
 
-      <p v-if="errorMessage" class="text-xs text-error">{{ errorMessage }}</p>
+      <p v-if="errorMessage" class="kr-text-error-xs">{{ errorMessage }}</p>
     </div>
 
     <!-- Related entries -->

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -297,7 +297,7 @@
                       {{ statusLabel(source.status) }}
                     </span>
                   </div>
-                  <p v-if="source.error" class="line-clamp-3 text-xs text-error" :title="source.error">
+                  <p v-if="source.error" class="kr-text-error-xs line-clamp-3" :title="source.error">
                     {{ source.error }}
                   </p>
                   <button

--- a/utils/scripts/codemods/kr_text_error_xs_codemod.py
+++ b/utils/scripts/codemods/kr_text_error_xs_codemod.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `text-xs text-error` inline validation/
+error-message captions to `kr-text-error-xs`.
+
+Flagged by slice 177's own kaizen note (interface-vision t-104): the
+strongest remaining candidate outside all now-closed `kr-text-black-*`/
+`kr-text-bold-*`/`kr-text-dim-*`/`kr-text-eyebrow-*`/`kr-label-*` families.
+A fresh full-repo class-frequency survey this slice (178) found `text-xs
+text-error` at 36 subset-match occurrences across 32 files, consistently a
+conditionally-rendered `<p>` (often `role="alert"`) showing a store/form
+error message right below its field.
+
+Dry-run by default, --write to update matching Vue files in place. Only the
+exact `text-xs text-error` shape is touched, and only in static
+`class="..."` attributes -- never `:class`/`v-bind:class` bindings,
+regardless of the base tokens' order in the source. A source that already
+carries `kr-text-error-xs`, or is missing either base token, is left
+untouched. Extra tokens beyond the base set are preserved verbatim after
+the primitive class, matching the kr-badge-*/kr-spinner-*/kr-label-bold/
+kr-text-dim-*/kr-text-black-*/kr-text-eyebrow-*/kr-text-bold-* codemods'
+subset-match convention -- pass --exact-only to restrict a slice to
+sources with no extra tokens at all, the safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-error-xs"
+BASE_TOKENS = {"text-xs", "text-error"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-error-xs {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: recurring front-end-consistency umbrella, slice 178 (kind: software)

### What changed / what I produced
- Added `.kr-text-error-xs` (`@apply text-xs text-error;`) to `assets/css/tailwind.css` — the inline validation/error-message caption shape flagged as the strongest remaining candidate in slice 177's kaizen note.
- New codemod `utils/scripts/codemods/kr_text_error_xs_codemod.py`, sibling of the `kr-text-bold-*`/`kr-text-black-*`/`kr-text-dim-*` family's codemods (same subset-match convention: static `class="..."` attrs only, extra tokens preserved verbatim, `--exact-only`/`--write` flags).
- Migrated all 36 hand-rolled `text-xs text-error` occurrences across 32 files to `kr-text-error-xs`. No geometry or behavior change.

### How I verified
- Fresh full-repo survey confirmed 36 subset-match occurrences / 32 files (matches slice 177's kaizen note exactly).
- `npm run test` (vue-tsc): clean, byte-identical to baseline.
- `npm run lint:js`: 333 problems (327 errors, 6 warnings) — byte-identical to baseline.
- `npm run test:layout-contract`: holds, 0 new violations (same pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet note as recent slices).
- `npm run test:lint-ratchet`: holds at 333/-59.
- `npx prettier --check .`: dirty-file list byte-identical to baseline (1143 files, no new drift introduced by this change).
- Spot-checked several migrated diffs by hand (art-generator.vue, taskmaster-page.vue, storybook-page.vue, conductor-page.vue) — all conditionally-rendered `<p>`/`<span>` error captions, several with `role="alert"`, extra tokens (`mt-2 font-semibold`, `relative z-20 mx-4 mb-2 sm:mx-6`, etc.) preserved verbatim.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
`kr-text-bold-*` now covers `-sm`/`-xs`/`-lg` (still worth a one-off check for `-xl`/`-2xl` siblings, unsurveyed across the last several slices). Otherwise, run a fresh full-repo class-frequency survey outside all now-closed families (`kr-text-black-*`, `kr-text-bold-*`, `kr-text-dim-*`, `kr-text-eyebrow-*`, `kr-label-*`, `kr-badge-*`, `kr-text-error-xs`) to surface the next bounded candidate — none flagged yet this slice.

### Notes for reviewer
Companion conductor task `interface-vision/t-104` returns to `status: ready` in the same session (roadmap note carries the full slice 178 record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C838zpykLbVgr9yuYXokc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01C838zpykLbVgr9yuYXokc9)_