### PR TITLE
feat(interface-vision): add kr-text-bold-xl primitive, migrate 35 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1931,6 +1931,23 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply font-bold text-lg;
   }
 
+  /* Fourth entry in the `kr-text-bold-*` family -- `font-bold text-xl`
+   * (interface-vision t-104 slice 179). Slice 178's own kaizen note flagged
+   * `kr-text-bold-*` as still covering only `-sm`/`-xs`/`-lg`, the exact gap
+   * `.kr-text-black-lg`/`.kr-text-black-xl`/`.kr-text-black-2xl` already
+   * closed for `font-black` across slices 164-168. A fresh full-repo
+   * class-frequency survey outside all now-closed `kr-text-black-*`/
+   * `kr-text-bold-*`/`kr-text-dim-*`/`kr-text-eyebrow-*`/`kr-label-*`/
+   * `kr-badge-*`/`kr-text-error-xs` families found this shape at 35
+   * subset-match occurrences across 13 files, the same bold-heading-emphasis
+   * role one size up from `.kr-text-bold-lg` -- character/bot/scenario/
+   * reward creation-form section titles and card headings. `-2xl` (10
+   * occurrences, 8 files) is the remaining sibling to close the family out
+   * fully, named as the next slice's candidate below. */
+  .kr-text-bold-xl {
+    @apply font-bold text-xl;
+  }
+
   /* Sibling of `.kr-label-bold` (`label-text font-bold`) for the plain,
    * weightless form-label caption -- `label-text text-xs`, with the dead
    * `label-text` token dropped the same way `.kr-label-bold` already drops

--- a/components/achievements/unearned-achievement-card.vue
+++ b/components/achievements/unearned-achievement-card.vue
@@ -11,7 +11,7 @@
         class="Icon-extra-large mb-2"
       />
       <!-- Achievement Label -->
-      <div class="text-xl font-bold text-gray-700">
+      <div class="kr-text-bold-xl text-gray-700">
         {{ achievement.label }}
       </div>
       <!-- Subtle Hint -->

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -27,7 +27,7 @@
             class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
           >
             <div>
-              <h2 class="text-xl font-bold text-base-content">Identity</h2>
+              <h2 class="kr-text-bold-xl text-base-content">Identity</h2>
 
               <p class="kr-text-dim-sm-70">
                 Define the bot’s visible profile and general vibe.
@@ -148,7 +148,7 @@
         <aside class="kr-panel-flat p-4">
           <div class="mb-4 flex items-center justify-between gap-2">
             <div>
-              <h2 class="text-xl font-bold text-base-content">Avatar</h2>
+              <h2 class="kr-text-bold-xl text-base-content">Avatar</h2>
 
               <p class="kr-text-dim-sm-70">
                 Use a URL/path, upload an image, or borrow a gallery image.
@@ -211,7 +211,7 @@
           class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >
           <div>
-            <h2 class="text-xl font-bold text-base-content">
+            <h2 class="kr-text-bold-xl text-base-content">
               AI Update Controls
             </h2>
 
@@ -289,7 +289,7 @@
 
       <section class="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <div class="kr-panel-flat p-4">
-          <h2 class="mb-3 text-xl font-bold text-base-content">
+          <h2 class="kr-text-bold-xl mb-3 text-base-content">
             Personality and Prompt
           </h2>
 
@@ -336,7 +336,7 @@
         </div>
 
         <div class="kr-panel-flat p-4">
-          <h2 class="mb-3 text-xl font-bold text-base-content">
+          <h2 class="kr-text-bold-xl mb-3 text-base-content">
             Conversation Intros
           </h2>
 
@@ -387,7 +387,7 @@
           class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >
           <div>
-            <h2 class="text-xl font-bold text-base-content">Publishing</h2>
+            <h2 class="kr-text-bold-xl text-base-content">Publishing</h2>
 
             <p class="kr-text-dim-sm-70">
               Control visibility and construction status. The text engine is

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -26,7 +26,7 @@
             class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
           >
             <div>
-              <h2 class="text-xl font-bold text-base-content">
+              <h2 class="kr-text-bold-xl text-base-content">
                 Character Identity
               </h2>
               <p class="kr-text-dim-sm-70">
@@ -145,7 +145,7 @@
         <aside class="kr-panel-flat p-4">
           <div class="mb-4 flex items-center justify-between gap-2">
             <div>
-              <h2 class="text-xl font-bold text-base-content">Portrait</h2>
+              <h2 class="kr-text-bold-xl text-base-content">Portrait</h2>
               <p class="kr-text-dim-sm-70">
                 Upload, borrow, or generate character art.
               </p>
@@ -200,7 +200,7 @@
 
       <section class="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <div class="kr-panel-flat p-4">
-          <h2 class="mb-3 text-xl font-bold text-base-content">
+          <h2 class="kr-text-bold-xl mb-3 text-base-content">
             Personality and Voice
           </h2>
 
@@ -238,7 +238,7 @@
         </div>
 
         <div class="kr-panel-flat p-4">
-          <h2 class="mb-3 text-xl font-bold text-base-content">
+          <h2 class="kr-text-bold-xl mb-3 text-base-content">
             Story and Motivation
           </h2>
 
@@ -282,7 +282,7 @@
           class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >
           <div>
-            <h2 class="text-xl font-bold text-base-content">Character Stats</h2>
+            <h2 class="kr-text-bold-xl text-base-content">Character Stats</h2>
             <p class="kr-text-dim-sm-70">
               Rarity-style strengths for adventures and rewards.
             </p>
@@ -327,7 +327,7 @@
           class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >
           <div>
-            <h2 class="text-xl font-bold text-base-content">
+            <h2 class="kr-text-bold-xl text-base-content">
               AI Update Controls
             </h2>
             <p class="kr-text-dim-sm-70">
@@ -399,7 +399,7 @@
         <div
           class="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >
-          <h2 class="text-xl font-bold text-base-content">Record Settings</h2>
+          <h2 class="kr-text-bold-xl text-base-content">Record Settings</h2>
 
           <allow-reviews-toggle
             v-if="mode === 'edit' && characterStore.selectedCharacter"

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -192,7 +192,7 @@
               class="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
             >
               <div>
-                <h2 class="text-xl font-bold text-base-content">Chat</h2>
+                <h2 class="kr-text-bold-xl text-base-content">Chat</h2>
 
                 <p class="kr-text-dim-sm">
                   Ask something sincere, weird, tactical, or suspiciously
@@ -337,7 +337,7 @@
             v-else-if="activeMode === 'adventure'"
             class="kr-panel-flat p-4"
           >
-            <h2 class="mb-3 text-xl font-bold text-base-content">
+            <h2 class="kr-text-bold-xl mb-3 text-base-content">
               Adventure Setup
             </h2>
 
@@ -403,7 +403,7 @@
             v-else-if="activeMode === 'prompt'"
             class="kr-panel-flat p-4"
           >
-            <h2 class="mb-3 text-xl font-bold text-base-content">
+            <h2 class="kr-text-bold-xl mb-3 text-base-content">
               Character Prompt
             </h2>
 
@@ -442,7 +442,7 @@
           </article>
 
           <article v-else class="kr-panel-flat p-4">
-            <h2 class="mb-3 text-xl font-bold text-base-content">
+            <h2 class="kr-text-bold-xl mb-3 text-base-content">
               Raw Character Context
             </h2>
 

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -68,7 +68,7 @@
           <article class="kr-panel-flat p-4">
             <div class="mb-3 flex items-center justify-between gap-2">
               <div>
-                <h2 class="text-xl font-bold text-base-content">
+                <h2 class="kr-text-bold-xl text-base-content">
                   Selected Character
                 </h2>
 
@@ -98,7 +98,7 @@
               class="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
             >
               <div>
-                <h2 class="text-xl font-bold text-base-content">Chat</h2>
+                <h2 class="kr-text-bold-xl text-base-content">Chat</h2>
 
                 <p class="kr-text-dim-sm">
                   Ask something sincere, weird, tactical, or suspiciously
@@ -241,7 +241,7 @@
             v-else-if="activeMode === 'adventure'"
             class="kr-panel-flat p-4"
           >
-            <h2 class="mb-3 text-xl font-bold text-base-content">
+            <h2 class="kr-text-bold-xl mb-3 text-base-content">
               Adventure Setup
             </h2>
 
@@ -297,7 +297,7 @@
             v-else-if="activeMode === 'prompt'"
             class="kr-panel-flat p-4"
           >
-            <h2 class="mb-3 text-xl font-bold text-base-content">
+            <h2 class="kr-text-bold-xl mb-3 text-base-content">
               Character Prompt
             </h2>
 
@@ -336,7 +336,7 @@
           </article>
 
           <article v-else class="kr-panel-flat p-4">
-            <h2 class="mb-3 text-xl font-bold text-base-content">
+            <h2 class="kr-text-bold-xl mb-3 text-base-content">
               Raw Character Context
             </h2>
 

--- a/components/giftshop/mana-wallet.vue
+++ b/components/giftshop/mana-wallet.vue
@@ -102,7 +102,7 @@
 
       <!-- Spend log -->
       <div class="space-y-3">
-        <h2 class="text-xl font-bold">Recent activity</h2>
+        <h2 class="kr-text-bold-xl">Recent activity</h2>
         <div v-if="manaStore.loading" class="text-base-content/50">
           Loading…
         </div>

--- a/components/pages/memory-dungeon.vue
+++ b/components/pages/memory-dungeon.vue
@@ -340,7 +340,7 @@
             {{ deathFlavor }}
           </p>
 
-          <div class="text-xl font-bold">
+          <div class="kr-text-bold-xl">
             Final Score: {{ score.toLocaleString() }}
           </div>
 

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -149,7 +149,7 @@
 
       <section class="kr-panel-flat p-4">
         <div class="mb-4">
-          <h2 class="text-xl font-bold text-base-content">Publishing</h2>
+          <h2 class="kr-text-bold-xl text-base-content">Publishing</h2>
           <p class="kr-text-dim-sm-70">
             Control who can discover this reward and whether mature-content filtering applies.
           </p>
@@ -181,7 +181,7 @@
           class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >
           <div>
-            <h2 class="text-xl font-bold text-base-content">Reward Essence</h2>
+            <h2 class="kr-text-bold-xl text-base-content">Reward Essence</h2>
 
             <p class="kr-text-dim-sm-70">
               Use reusable choices to shape what kind of story prompt this
@@ -203,7 +203,7 @@
           class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >
           <div>
-            <h2 class="text-xl font-bold text-base-content">Reward Art</h2>
+            <h2 class="kr-text-bold-xl text-base-content">Reward Art</h2>
 
             <p class="kr-text-dim-sm-70">
               Upload, generate, or attach an image for the reward.

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -113,7 +113,7 @@
 
       <section class="kr-panel-flat p-4">
         <div class="mb-4">
-          <h2 class="text-xl font-bold text-base-content">Publishing</h2>
+          <h2 class="kr-text-bold-xl text-base-content">Publishing</h2>
           <p class="kr-text-dim-sm-70">
             Control who can discover this scenario and whether mature-content
             filtering applies.
@@ -144,7 +144,7 @@
       <section class="kr-panel-flat p-4">
         <div class="mb-4 flex items-center justify-between gap-2">
           <div>
-            <h2 class="text-xl font-bold text-base-content">Opening Choices</h2>
+            <h2 class="kr-text-bold-xl text-base-content">Opening Choices</h2>
 
             <p class="kr-text-dim-sm-70">
               These become the starting choices players can click when the
@@ -205,7 +205,7 @@
           class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
         >
           <div>
-            <h2 class="text-xl font-bold text-base-content">Scenario Art</h2>
+            <h2 class="kr-text-bold-xl text-base-content">Scenario Art</h2>
 
             <p class="kr-text-dim-sm-70">
               Upload, randomize, or generate a visual anchor.

--- a/components/scenarios/choice-manager.vue
+++ b/components/scenarios/choice-manager.vue
@@ -4,7 +4,7 @@
     v-if="choiceEntry"
     class="flex flex-col space-y-4 w-full p-4 bg-base-200 rounded-2xl border border-base-300 shadow-md"
   >
-    <h2 class="text-xl font-bold text-center capitalize">
+    <h2 class="kr-text-bold-xl text-center capitalize">
       Choose your {{ choiceEntry.label }}
     </h2>
 

--- a/components/user/forum-thread.vue
+++ b/components/user/forum-thread.vue
@@ -27,7 +27,7 @@
       class="space-y-4"
     >
       <div class="flex justify-between items-center mt-8 mb-2">
-        <h2 class="text-xl font-bold">
+        <h2 class="kr-text-bold-xl">
           {{ channel.label }}
         </h2>
         <button

--- a/components/user/friend-gallery.vue
+++ b/components/user/friend-gallery.vue
@@ -11,7 +11,7 @@
   <div class="flex flex-col gap-4 p-4">
     <!-- Header -->
     <div class="flex items-center justify-between">
-      <h2 class="text-xl font-bold">Community &amp; Friends</h2>
+      <h2 class="kr-text-bold-xl">Community &amp; Friends</h2>
       <span class="kr-text-dim-sm">
         {{ visibleUsers.length }} public profile{{
           visibleUsers.length !== 1 ? 's' : ''

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -363,7 +363,7 @@
                   />
                 </div>
                 <p class="text-3xl font-bold">{{ currentCard.simplified }}</p>
-                <p class="text-xl font-bold tracking-wide">{{ currentCard.pinyin }}</p>
+                <p class="kr-text-bold-xl tracking-wide">{{ currentCard.pinyin }}</p>
                 <p v-if="currentCard.traditional" class="text-xs opacity-55">Traditional: {{ currentCard.traditional }}</p>
                 <div class="flex flex-wrap justify-center gap-1">
                   <button v-if="canQueueArt" type="button" class="kr-btn-outline-xs" :disabled="artBusy" @click="queueCurrentIllustration">

--- a/utils/scripts/codemods/kr_text_bold_xl_codemod.py
+++ b/utils/scripts/codemods/kr_text_bold_xl_codemod.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `font-bold text-xl` heading-emphasis text to
+`kr-text-bold-xl`.
+
+Sibling of kr_text_bold_lg_codemod.py/kr_text_bold_sm_codemod.py/
+kr_text_bold_xs_codemod.py, fourth entry in the `kr-text-bold-*` family
+(interface-vision t-104 slice 179) -- slice 178's own kaizen note flagged
+`kr-text-bold-*` as covering only -sm/-xs/-lg with -xl/-2xl left unsurveyed,
+the exact gap `kr-text-black-*` hit and closed across slices 164-168. Dry-run
+by default, --write to update matching Vue files in place. Only the exact
+`font-bold text-xl` shape is touched, and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings, and regardless of the
+base tokens' order in the source. A source that already carries
+`kr-text-bold-xl`, or is missing either base token, is left untouched. Extra
+tokens beyond the base set are preserved verbatim after the primitive class,
+matching the kr-badge-*/kr-spinner-*/kr-label-bold/kr-text-dim-*/
+kr-text-black-*/kr-text-bold-* codemods' subset-match convention -- pass
+--exact-only to restrict a slice to sources with no extra tokens at all, the
+safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CLASS_ATTR = re.compile(r'class="([^"]*)"')
+
+PRIMITIVE = "kr-text-bold-xl"
+BASE_TOKENS = {"font-bold", "text-xl"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-bold-xl {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- Added `.kr-text-bold-xl` (`@apply font-bold text-xl;`) to `assets/css/tailwind.css` — fourth entry in the `kr-text-bold-*` family, sibling of `-sm`/`-xs`/`-lg`.
- New codemod `utils/scripts/codemods/kr_text_bold_xl_codemod.py`, same subset-match/`--exact-only` convention as the rest of the `kr-text-bold-*`/`kr-text-black-*` family's codemods.
- Migrated all 35 hand-rolled `font-bold text-xl` occurrences across 13 files — consistently character/bot/scenario/reward creation-form section titles and card headings; no geometry or behavior change, extra tokens preserved verbatim.

### How I verified
- `vue-tsc` clean (no new errors)
- `eslint`: 333 problems (327 errors, 6 warnings) — identical to documented baseline
- `test:layout-contract`: holds, 0 new violations (same pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet opportunity as every recent slice, left untouched)
- `test:lint-ratchet`: holds at 333/-59
- `prettier --check .`: 1143 files flagged, byte-identical to baseline; the 6 touched files that show up (`tailwind.css`, `add-bot.vue`, `add-character.vue`, `memory-dungeon.vue`, `add-reward.vue`, `mandarin.vue`) confirmed pre-existing drift via `git stash` before/after comparison — none newly introduced

### Stakes
reversible

### Flags for Reviewer
- `kr-text-bold-*` still has one sibling left to close the family fully: `font-bold text-2xl` (10 occurrences, 8 files), named as the next slice's candidate.

### Kaizen suggestion
Slice 180 should close out `kr-text-bold-2xl` (10 occurrences/8 files) to fully match `kr-text-black-*`'s complete `-sm`/`-xs`/`-lg`/`-xl`/`-2xl` coverage, then run a fresh full-repo class-frequency survey outside all now-closed families.

### Notes for reviewer
Slice 179 of the recurring interface-vision/t-104 consistency sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZRaM4nPUEDjSy1rNpjqFx

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZRaM4nPUEDjSy1rNpjqFx)_