### PR TITLE
feat(interface-vision): add kr-text-bold-2xl primitive, migrate 9 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1948,6 +1948,23 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply font-bold text-xl;
   }
 
+  /* Fifth and final entry in the `kr-text-bold-*` family -- `font-bold
+   * text-2xl` (interface-vision t-104 slice 180). Closes the family out to
+   * fully match `.kr-text-black-*`'s complete `-sm`/`-xs`/`-lg`/`-xl`/`-2xl`
+   * coverage, per slice 179's own kaizen note. 9 subset-match occurrences
+   * across 8 files -- achievement/credit-purchase/subscription-manager/
+   * mandarin-voice-coach card headings and callouts, the same bold-heading-
+   * emphasis role one size up from `.kr-text-bold-xl`. A 10th candidate in
+   * `components/pages/rebel-button.vue` is a `:class="\`...\`"` dynamic
+   * template-literal binding, not a static `class="..."` attribute -- left
+   * untouched; see `kr_text_bold_2xl_codemod.py`'s own docstring for the
+   * regex bug this slice caught and fixed (a bare `class="..."` pattern can
+   * match inside a `:class="..."` binding when its bound expression
+   * contains a literal `class="`-shaped substring). */
+  .kr-text-bold-2xl {
+    @apply font-bold text-2xl;
+  }
+
   /* Sibling of `.kr-label-bold` (`label-text font-bold`) for the plain,
    * weightless form-label caption -- `label-text text-xs`, with the dead
    * `label-text` token dropped the same way `.kr-label-bold` already drops

--- a/components/achievements/earned-achievement-card.vue
+++ b/components/achievements/earned-achievement-card.vue
@@ -19,7 +19,7 @@
         class="text-9xl mb-2 md:w-16 md:h-16"
       />
 
-      <div class="text-2xl font-bold">
+      <div class="kr-text-bold-2xl">
         <a
           v-if="achievement.pageHint"
           :href="achievement.pageHint"

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -725,7 +725,7 @@ onMounted(async () => {
             {{ endpointDef.icon }}
           </div>
           <div>
-            <h1 class="text-2xl font-bold">Art Test Lab</h1>
+            <h1 class="kr-text-bold-2xl">Art Test Lab</h1>
             <p class="text-sm opacity-70">
               Text prompt upgrades, Kontext remix, and animal Kombine chaos.
             </p>

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -4,7 +4,7 @@
     class="flex h-full min-h-0 w-full flex-col gap-4 rounded-2xl bg-base-200 p-4"
   >
     <header class="kr-panel-flat p-4 text-center shadow-md">
-      <h1 class="text-2xl font-bold text-primary md:text-3xl">
+      <h1 class="kr-text-bold-2xl text-primary md:text-3xl">
         Character Interact
       </h1>
 

--- a/components/giftshop/credit-purchase.vue
+++ b/components/giftshop/credit-purchase.vue
@@ -1,7 +1,7 @@
 <!-- /components/giftshop/credit-purchase.vue -->
 <template>
   <div class="p-6 bg-base-200 rounded-2xl shadow-md text-center">
-    <h2 class="text-2xl font-bold text-primary mb-4">Buy Tokens</h2>
+    <h2 class="kr-text-bold-2xl text-primary mb-4">Buy Tokens</h2>
     <p class="mb-6 text-lg text-gray-500">
       Top up your token balance to generate more AI-powered content. Tokens are
       spent before your free mana.

--- a/components/giftshop/mana-wallet.vue
+++ b/components/giftshop/mana-wallet.vue
@@ -38,7 +38,7 @@
           </div>
           <div v-if="!manaStore.isFamily" class="text-right">
             <div class="kr-text-dim-sm">Daily cap</div>
-            <div class="text-2xl font-bold">{{ manaStore.cap }}</div>
+            <div class="kr-text-bold-2xl">{{ manaStore.cap }}</div>
           </div>
         </div>
 

--- a/components/giftshop/subscription-manager.vue
+++ b/components/giftshop/subscription-manager.vue
@@ -17,7 +17,7 @@
         :class="{ 'ring-2 ring-accent': !isPatron }"
       >
         <div class="space-y-3">
-          <h3 class="text-2xl font-bold text-accent-content">Free Plan 🧃</h3>
+          <h3 class="kr-text-bold-2xl text-accent-content">Free Plan 🧃</h3>
           <ul class="list-disc list-inside text-base-content/80 space-y-1">
             <li>Access to public tools</li>
             <li>Community forums</li>
@@ -37,7 +37,7 @@
         :class="{ 'ring-2 ring-primary': isPatron }"
       >
         <div class="space-y-3">
-          <h3 class="text-2xl font-bold text-primary">Patron Plan 🚀</h3>
+          <h3 class="kr-text-bold-2xl text-primary">Patron Plan 🚀</h3>
           <ul class="list-disc list-inside text-base-content/80 space-y-1">
             <li>
               <span class="font-semibold text-primary"

--- a/components/mandarin/mandarin-voice-coach.vue
+++ b/components/mandarin/mandarin-voice-coach.vue
@@ -89,7 +89,7 @@
     >
       <div class="kr-panel-tint-md">
         <p class="text-xs font-semibold uppercase tracking-wide opacity-55">What I heard</p>
-        <p v-if="transcript" class="mt-2 text-2xl font-bold">{{ transcript }}</p>
+        <p v-if="transcript" class="kr-text-bold-2xl mt-2">{{ transcript }}</p>
         <p v-else class="mt-2 text-sm opacity-60">The transcript was unavailable.</p>
         <div v-if="comparison" class="mt-3 text-sm leading-relaxed">
           <span

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -275,7 +275,7 @@
                   </div>
                   <div class="space-y-2 text-center">
                     <p class="text-5xl font-semibold leading-none">{{ currentCard.simplified }}</p>
-                    <p class="text-2xl font-bold tracking-wide">{{ currentCard.pinyin }}</p>
+                    <p class="kr-text-bold-2xl tracking-wide">{{ currentCard.pinyin }}</p>
                     <p class="text-xl font-semibold">{{ currentCard.meaning }}</p>
                     <p v-if="currentCard.meanings.length > 1" class="text-xs leading-relaxed opacity-60">
                       {{ currentCard.meanings.slice(1).join(' · ') }}

--- a/utils/scripts/codemods/kr_text_bold_2xl_codemod.py
+++ b/utils/scripts/codemods/kr_text_bold_2xl_codemod.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `font-bold text-2xl` heading-emphasis text to
+`kr-text-bold-2xl`.
+
+Sibling of kr_text_bold_lg_codemod.py/kr_text_bold_sm_codemod.py/
+kr_text_bold_xs_codemod.py/kr_text_bold_xl_codemod.py, fifth and final entry
+in the `kr-text-bold-*` family (interface-vision t-104 slice 180) -- closes
+the family out to fully match `kr-text-black-*`'s complete
+`-sm`/`-xs`/`-lg`/`-xl`/`-2xl` coverage, per slice 179's own kaizen note. Dry-
+run by default, --write to update matching Vue files in place. Only the
+exact `font-bold text-2xl` shape is touched, and only in static
+`class="..."` attributes -- never `:class`/`v-bind:class` bindings, and
+regardless of the base tokens' order in the source. A source that already
+carries `kr-text-bold-2xl`, or is missing either base token, is left
+untouched. Extra tokens beyond the base set are preserved verbatim after the
+primitive class, matching the kr-badge-*/kr-spinner-*/kr-label-bold/
+kr-text-dim-*/kr-text-black-*/kr-text-bold-* codemods' subset-match
+convention -- pass --exact-only to restrict a slice to sources with no
+extra tokens at all, the safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+# Negative lookbehind excludes `:class="..."`/`v-bind:class="..."` dynamic
+# bindings -- both end in `:` immediately before `class=`, so a bare
+# `class="([^"]*)"` pattern (the convention every sibling kr-* codemod uses)
+# can match into one whenever its bound expression happens to contain a
+# literal `class="`-shaped substring, corrupting a template-literal binding
+# instead of leaving it untouched (interface-vision t-104 slice 180 caught
+# this against components/pages/rebel-button.vue's
+# `:class="\`... text-2xl ... font-bold ...\`"` binding -- fixed here first;
+# the sibling codemods share the same latent gap, flagged as this slice's
+# kaizen candidate rather than rewritten in scope).
+CLASS_ATTR = re.compile(r'(?<!:)class="([^"]*)"')
+
+PRIMITIVE = "kr-text-bold-2xl"
+BASE_TOKENS = {"font-bold", "text-2xl"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-bold-2xl {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- Added `.kr-text-bold-2xl` (`@apply font-bold text-2xl;`) to `assets/css/tailwind.css` — fifth and final entry in the `kr-text-bold-*` family, closing it out to fully match `kr-text-black-*`'s complete `-sm`/`-xs`/`-lg`/`-xl`/`-2xl` coverage.
- New codemod `utils/scripts/codemods/kr_text_bold_2xl_codemod.py`, sibling of the `kr-text-bold-*`/`kr-text-black-*` family's codemods.
- Migrated 9 hand-rolled `font-bold text-2xl` occurrences across 8 files.

### Bug found and fixed
The shared `class="([^"]*)"` regex every prior `kr-*` codemod in this repo uses can match *inside* a `:class="..."` dynamic template-literal binding whenever the bound expression happens to contain a literal `class="`-shaped substring. Caught this against `components/pages/rebel-button.vue`'s `:class="\`... text-2xl ... font-bold ...\`"` binding — the codemod's first run corrupted it (stripped the enclosing structure and inserted `kr-text-bold-2xl` as bare unquoted text). Added a `(?<!:)` negative lookbehind to this codemod's regex, reverted the corrupted file, and re-verified with 0 remaining false-positive matches — `rebel-button.vue`'s occurrence is now correctly left untouched (it's a dynamic binding, not a static class attribute), and the other 9 occurrences migrated cleanly. Confirmed the already-merged slice 179 (`kr-text-bold-xl`, #2558) did not hit this same trap anywhere in the repo. Every sibling `kr-*` codemod shares the same latent regex gap — flagged as this slice's kaizen candidate rather than rewritten in scope (30+ existing scripts, none currently affected).

### How I verified
- `vue-tsc` clean (no new errors)
- `eslint`: 333 problems (327 errors, 6 warnings) — identical to documented baseline
- `test:layout-contract`: holds, 0 new violations (same pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet opportunity as every recent slice, left untouched)
- `test:lint-ratchet`: holds at 333/-59
- `prettier --check .`: 1143 files flagged, byte-identical to baseline; the 4 touched files that show up (`tailwind.css`, `art-test.vue`, `mandarin-voice-coach.vue`, `mandarin.vue`) confirmed pre-existing drift via `git stash` before/after comparison — none newly introduced

### Stakes
reversible

### Flags for Reviewer
- `rebel-button.vue`'s `:class` binding is intentionally left untouched (dynamic template literal, not a static class attribute).
- The `class="..."` regex bug is repo-wide across every `kr-*` codemod, not just this one — worth a dedicated audit/fix pass at some point, named in the kaizen suggestion below.

### Kaizen suggestion
Audit the ~30 existing `kr-*` codemods for the same `class="([^"]*)"` → `:class="..."` false-positive risk this slice caught, and add the `(?<!:)` guard to each (or factor the pattern into a shared helper module all the codemods import, rather than each hand-rolling its own copy). None are currently known to have produced bad output, but the risk is latent in every one until fixed. This closes the `kr-text-bold-*` family fully; the next slice should run a fresh full-repo class-frequency survey outside all now-closed families.

### Notes for reviewer
Slice 180 of the recurring interface-vision/t-104 consistency sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZRaM4nPUEDjSy1rNpjqFx

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZRaM4nPUEDjSy1rNpjqFx)_