### PR TITLE
interface-vision/t-104 slice 181: add kr-badge-ghost, migrate 11 exact-match occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1447,6 +1447,24 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply badge badge-ghost badge-xs;
   }
 
+  /* The sizeless sibling of .kr-badge-ghost-sm/.kr-badge-ghost-xs
+   * (interface-vision t-104 slice 181): bare `badge badge-ghost` with no
+   * size modifier -- the caller relies on DaisyUI's default badge size
+   * (same rationale as .kr-badge-sm/.kr-badge-xs being separate colorless
+   * siblings rather than folded into one shape). Bounded to the 11
+   * exact-match occurrences across 11 files this slice (--exact-only,
+   * same convention .kr-badge-sm's BOUNDED_EXTRAS docstring recommends for
+   * an only-partially-audited pool); a further ~13 occurrences carry
+   * varied extra tokens (hover states, rounded-*, backdrop-blur, ...) not
+   * yet individually audited and left for a future slice. A twelfth exact
+   * match in components/ui/ui-gallery.vue's "Badges & status" showcase
+   * section is a deliberate raw-DaisyUI comparison row (same rationale
+   * ui-gallery.vue's `btn btn-primary` showcase row was excluded for in an
+   * earlier slice) and was left untouched. */
+  .kr-badge-ghost {
+    @apply badge badge-ghost;
+  }
+
   /* The extra-small outline counterpart to .kr-badge-outline-sm (same
    * slice): `badge badge-outline badge-xs`, previously hand-rolled in 16
    * files (18 occurrences). */

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -26,10 +26,7 @@
         </div>
 
         <div class="flex shrink-0 items-center gap-2">
-          <span
-            v-if="!isLoading && !botStore.loading"
-            class="badge badge-ghost"
-          >
+          <span v-if="!isLoading && !botStore.loading" class="kr-badge-ghost">
             {{ filteredBots.length }}
           </span>
 

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -275,7 +275,7 @@
             v-if="characterStore.browseCharacters.length > 0"
             class="mt-3 flex flex-wrap justify-center gap-2 text-xs"
           >
-            <span class="badge badge-ghost">
+            <span class="kr-badge-ghost">
               Loaded: {{ exclusionSummary.total }}
             </span>
 

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -429,7 +429,7 @@
             v-if="dreamStore.creativeDreams.length > 0"
             class="mt-3 flex flex-wrap justify-center gap-2 text-xs"
           >
-            <span class="badge badge-ghost"
+            <span class="kr-badge-ghost"
               >Loaded: {{ exclusionSummary.total }}</span
             >
 

--- a/components/dreams/dream-inspire-button.vue
+++ b/components/dreams/dream-inspire-button.vue
@@ -44,7 +44,7 @@
       <span v-if="pendingPrompts.length > 0" class="badge badge-neutral">
         {{ pendingPrompts.length }}
       </span>
-      <span v-else class="badge badge-ghost">up to date</span>
+      <span v-else class="kr-badge-ghost">up to date</span>
     </button>
 
     <!-- Per-image status row -->

--- a/components/dreams/dream-relationship-gallery.vue
+++ b/components/dreams/dream-relationship-gallery.vue
@@ -17,7 +17,7 @@
         </div>
 
         <div class="kr-toolbar">
-          <span class="badge badge-ghost">{{ filteredDreams.length }}</span>
+          <span class="kr-badge-ghost">{{ filteredDreams.length }}</span>
           <span v-if="resolvedDreamId" class="kr-badge-primary-sm rounded-xl">
             Dream #{{ resolvedDreamId }}
           </span>

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -43,7 +43,7 @@
         </div>
 
         <div class="flex shrink-0 items-center gap-2">
-          <span v-if="!isLoading" class="badge badge-ghost">
+          <span v-if="!isLoading" class="kr-badge-ghost">
             {{ filteredRewards.length }}
           </span>
 

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -152,7 +152,7 @@
             </p>
           </div>
 
-          <span class="badge badge-ghost">
+          <span class="kr-badge-ghost">
             {{ intros.length }}
           </span>
         </div>

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -17,7 +17,7 @@
         </div>
 
         <div class="flex shrink-0 items-center gap-2">
-          <span v-if="!isLoading" class="badge badge-ghost">
+          <span v-if="!isLoading" class="kr-badge-ghost">
             {{ filteredScenarios.length }}
           </span>
 

--- a/components/scenarios/scenario-relationship-gallery.vue
+++ b/components/scenarios/scenario-relationship-gallery.vue
@@ -17,7 +17,7 @@
         </div>
 
         <div class="kr-toolbar">
-          <span class="badge badge-ghost">{{ filteredScenarios.length }}</span>
+          <span class="kr-badge-ghost">{{ filteredScenarios.length }}</span>
           <span v-if="resolvedDreamId" class="kr-badge-primary-sm rounded-xl">
             Dream #{{ resolvedDreamId }}
           </span>

--- a/pages/admin/achievement-art.vue
+++ b/pages/admin/achievement-art.vue
@@ -56,7 +56,7 @@
               />
             </label>
             <div class="flex flex-wrap gap-2 text-xs">
-              <span class="badge badge-ghost"
+              <span class="kr-badge-ghost"
                 >{{ achievements.length }} total</span
               >
               <span class="badge badge-warning"

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -68,7 +68,7 @@
               <h2 class="kr-text-bold-lg">Study sets</h2>
               <p class="text-xs opacity-60">Pick a deck, then jump straight back to the flash card.</p>
             </div>
-            <span class="badge badge-ghost">{{ allSets.length }} decks</span>
+            <span class="kr-badge-ghost">{{ allSets.length }} decks</span>
           </div>
 
           <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,17rem),1fr))] gap-2">

--- a/utils/scripts/codemods/kr_badge_codemod.py
+++ b/utils/scripts/codemods/kr_badge_codemod.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Find or migrate hand-rolled kr-badge-{ghost,warning,outline,primary,secondary}-sm,
 kr-badge-{ghost,outline,primary,warning,success,error,secondary,accent,info,neutral}-xs,
-kr-badge-sm (the colorless base), and kr-badge-xs (the colorless -xs sibling) badges.
+kr-badge-sm (the colorless base), kr-badge-xs (the colorless -xs sibling), and
+kr-badge-ghost (the sizeless ghost sibling) badges.
 
 Dry-run is the default. Pass --write to update matching Vue files in place.
 Only the approved badge shapes are touched (`badge badge-ghost badge-sm`,
@@ -47,7 +48,7 @@ import argparse
 import re
 from pathlib import Path
 
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+CLASS_ATTR = re.compile(r'(?<!:)class="([^"]*)"')
 
 FAMILIES = [
     ("kr-badge-ghost-sm", {"badge", "badge-ghost", "badge-sm"}),
@@ -56,6 +57,12 @@ FAMILIES = [
     ("kr-badge-primary-sm", {"badge", "badge-primary", "badge-sm"}),
     ("kr-badge-secondary-sm", {"badge", "badge-secondary", "badge-sm"}),
     ("kr-badge-ghost-xs", {"badge", "badge-ghost", "badge-xs"}),
+    # Sizeless sibling of kr-badge-ghost-sm/kr-badge-ghost-xs (interface-vision
+    # t-104 slice 181): its {badge, badge-ghost} base is a strict subset of
+    # both of those, so it must come after them. Bounded to an exact match
+    # only (see BOUNDED_EXTRAS below) -- its broader subset-match pool
+    # carries varied, not-yet-individually-audited extra tokens.
+    ("kr-badge-ghost", {"badge", "badge-ghost"}),
     ("kr-badge-outline-xs", {"badge", "badge-outline", "badge-xs"}),
     ("kr-badge-primary-xs", {"badge", "badge-primary", "badge-xs"}),
     ("kr-badge-warning-xs", {"badge", "badge-warning", "badge-xs"}),
@@ -89,8 +96,15 @@ FAMILIES = [
 # color supplied by a sibling `:class` binding -- verified in every one of
 # its 15 call sites). Families not listed here keep the unrestricted
 # subset-match behavior they already had.
+#
+# kr-badge-ghost's {badge, badge-ghost} base is similarly small and appears
+# inside a further ~13 hand-rolled combinations carrying varied extra tokens
+# (hover states, rounded-*, backdrop-blur, ...) not yet individually audited
+# (interface-vision t-104 slice 181) -- bounded to an exact match only until
+# a future slice audits the rest.
 BOUNDED_EXTRAS: dict[str, set[frozenset[str]]] = {
     "kr-badge-sm": {frozenset(), frozenset({"rounded-2xl"})},
+    "kr-badge-ghost": {frozenset()},
 }
 
 


### PR DESCRIPTION
Adds `.kr-badge-ghost` (bare `badge badge-ghost`, no size modifier) as the sizeless sibling of the existing `.kr-badge-ghost-sm`/`.kr-badge-ghost-xs` primitives, following the same colorless/sizeless-sibling convention `.kr-badge-sm`/`.kr-badge-xs` already established.

Extends `utils/scripts/codemods/kr_badge_codemod.py`'s `FAMILIES` list with the new shape, bounded via `BOUNDED_EXTRAS` to an exact-token match only (11 occurrences across 11 files) — a further ~13 occurrences carry varied, not-yet-individually-audited extra tokens and are left for a future slice. A twelfth exact match in `components/ui/ui-gallery.vue`'s "Badges & status" design-system showcase section is a deliberate raw-DaisyUI comparison row and was left untouched, matching the precedent set for that file's `btn btn-primary` showcase row in an earlier slice.

Also adds the `(?<!:)` negative-lookbehind guard to this codemod's `CLASS_ATTR` regex (kaizen from slice 180 / interface-vision t-126: an unanchored `class="..."` regex can match inside a `:class="..."` dynamic binding and corrupt it) — one fewer script for t-126 to still cover.

**Verified:**
- `vue-tsc` clean
- `eslint`: 333/327/6, identical to baseline (git-stash-confirmed)
- `prettier --check .`: byte-identical to baseline after fixing one line-collapse side effect in `bot-gallery.vue` (git-stash-confirmed)
- `test:layout-contract` holds, 0 new violations
- `test:lint-ratchet` holds at 333/-59
- Grepped `utils/scripts/*.mjs`/`*.ts` for the literal `badge-ghost"` class string first — no contract script references it

Conductor: `interface-vision/t-104`, recurring consistency umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4Jju71BpJ46btkKi4pFNp

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4Jju71BpJ46btkKi4pFNp)_