### PR TITLE
interface-vision/t-126: fix the :class false-positive risk shared by every kr-* codemod

### DIFF
--- a/tests/python/test_class_attr.py
+++ b/tests/python/test_class_attr.py
@@ -1,0 +1,82 @@
+"""Regression tests for utils/scripts/codemods/_class_attr.py.
+
+interface-vision t-126: every kr-* codemod under utils/scripts/codemods/
+finds hand-rolled static `class="..."` attributes to migrate onto a shared
+`kr-*` primitive, and must never touch a `:class="..."`/`v-bind:class="..."`
+dynamic binding. A plain `re.compile(r'class="([^"]*)"')` is unanchored
+against the attribute name, so it matches starting at the 'c' of ANY
+`:class="..."` binding too -- dropping the leading ':' makes the binding
+indistinguishable from a real `class="..."` attribute. This is not
+hypothetical: interface-vision t-104 slice 180 hit it for real against
+components/pages/rebel-button.vue's `:class="`... text-2xl ... font-bold
+...`"` binding, stripping its enclosing template-literal structure.
+
+These tests are the direct regression check the task's own note asks for:
+confirm the shared `CLASS_ATTR` guard rejects a `:class="..."` binding while
+still matching every real static `class="..."` attribute shape the kr-*
+codemods rely on (bare, multi-token, empty, and adjacent-on-the-same-line).
+"""
+
+import importlib.util
+import os
+
+_MODULE_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "utils", "scripts", "codemods", "_class_attr.py",
+)
+_spec = importlib.util.spec_from_file_location("_class_attr", _MODULE_PATH)
+_class_attr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_class_attr)
+
+CLASS_ATTR = _class_attr.CLASS_ATTR
+
+
+def test_rejects_class_binding() -> None:
+    # The real incident shape: a template-literal :class binding. No nested
+    # literal `class="` substring is needed to trigger the old bug -- the
+    # binding itself IS the false-positive shape once its leading ':' is
+    # ignored by an unanchored regex.
+    fixture = '<div :class="`text-2xl font-bold ${maybe}`">'
+    assert list(CLASS_ATTR.finditer(fixture)) == []
+
+
+def test_rejects_v_bind_class_binding() -> None:
+    fixture = "<div v-bind:class=\"['text-2xl', isBold && 'font-bold']\">"
+    assert list(CLASS_ATTR.finditer(fixture)) == []
+
+
+def test_matches_real_static_class_attribute() -> None:
+    fixture = '<span class="font-bold text-2xl">hi</span>'
+    matches = list(CLASS_ATTR.finditer(fixture))
+    assert len(matches) == 1
+    assert matches[0].group(1) == "font-bold text-2xl"
+
+
+def test_matches_empty_class_attribute() -> None:
+    fixture = '<span class="">hi</span>'
+    matches = list(CLASS_ATTR.finditer(fixture))
+    assert len(matches) == 1
+    assert matches[0].group(1) == ""
+
+
+def test_static_class_still_matches_immediately_after_a_dynamic_binding() -> None:
+    # A static class="..." attribute on the same tag as a :class binding
+    # (a common real shape: :class for conditional extras, class for the
+    # base primitive) must still be found -- the guard is per-match, not a
+    # whole-tag bailout.
+    fixture = '<div :class="`extra ${x}`" class="font-bold text-2xl">'
+    matches = list(CLASS_ATTR.finditer(fixture))
+    assert len(matches) == 1
+    assert matches[0].group(1) == "font-bold text-2xl"
+
+
+def test_old_unguarded_pattern_would_have_matched_the_binding() -> None:
+    # Proves the fixture above is a real regression check, not vacuously
+    # true: the pre-fix pattern (no negative lookbehind) DOES match it.
+    import re
+
+    old_pattern = re.compile(r'class="([^"]*)"')
+    fixture = '<div :class="`text-2xl font-bold ${maybe}`">'
+    matches = list(old_pattern.finditer(fixture))
+    assert len(matches) == 1
+    assert matches[0].group(1) == "`text-2xl font-bold ${maybe}`"

--- a/utils/scripts/codemods/_class_attr.py
+++ b/utils/scripts/codemods/_class_attr.py
@@ -1,0 +1,38 @@
+"""Shared `class="..."` attribute regex for the kr-* codemods.
+
+Every kr-* codemod under this directory finds hand-rolled static
+`class="..."` attributes to migrate onto a shared `kr-*` primitive. They
+must never touch a `:class="..."` or `v-bind:class="..."` dynamic binding --
+but a plain `re.compile(r'class="([^"]*)"')` is unanchored against the
+attribute name, so it can start matching one character into a `:class="..."`
+binding whenever the bound expression happens to contain a literal
+`class="`-shaped substring, corrupting the binding instead of leaving it
+untouched (interface-vision t-104 slice 180 hit this for real against
+components/pages/rebel-button.vue's `:class="`... text-2xl ... font-bold
+...`"` binding; caught via manual diff review since vue-tsc/eslint don't
+parse `:class` template-literal contents; conductor task interface-vision
+t-126 is the hardening pass this module exists for).
+
+Import `CLASS_ATTR` from this module instead of each codemod defining its
+own copy, so a future codemod can't reintroduce the gap:
+
+    from _class_attr import CLASS_ATTR
+    ...
+    CLASS_ATTR.sub(replace, text)
+
+The `(?<!:)` negative lookbehind rejects a match whose `class` is
+immediately preceded by `:` (covers both `:class="..."` and
+`v-bind:class="..."`, since the latter also ends in `:class="`), while
+leaving every legitimate static `class="..."` attribute -- which is always
+preceded by whitespace or a quote, never `:` -- unaffected. This is the
+same guard already hand-added to kr_text_bold_2xl_codemod.py (slice 180) and
+kr_badge_codemod.py (slice 181); kr_panel_codemod.py's own
+`(?<![:\\w-])class="([^"]*)"` is a stricter superset of the same protection
+and is left as-is rather than folded into this shared module.
+"""
+
+from __future__ import annotations
+
+import re
+
+CLASS_ATTR = re.compile(r'(?<!:)class="([^"]*)"')

--- a/utils/scripts/codemods/kr_badge_codemod.py
+++ b/utils/scripts/codemods/kr_badge_codemod.py
@@ -47,8 +47,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'(?<!:)class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 FAMILIES = [
     ("kr-badge-ghost-sm", {"badge", "badge-ghost", "badge-sm"}),

--- a/utils/scripts/codemods/kr_btn_ghost_outline_codemod.py
+++ b/utils/scripts/codemods/kr_btn_ghost_outline_codemod.py
@@ -29,8 +29,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 FAMILIES = [
     (

--- a/utils/scripts/codemods/kr_btn_order_variant_codemod.py
+++ b/utils/scripts/codemods/kr_btn_order_variant_codemod.py
@@ -30,9 +30,9 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
+from _class_attr import CLASS_ATTR
 
 ROOT = Path(__file__).resolve().parents[3]
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
 EXCLUDED_DIR_PARTS = {"node_modules", ".nuxt", "abandonware", "dist"}
 EXCLUDED_FILES = {ROOT / "components/ui/ui-gallery.vue"}
 

--- a/utils/scripts/codemods/kr_btn_xs_codemod.py
+++ b/utils/scripts/codemods/kr_btn_xs_codemod.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
+from _class_attr import CLASS_ATTR
 
 ROOT = Path(__file__).resolve().parents[3]
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
 REQUIRED = {"btn", "btn-xs", "rounded-xl"}
 EXCLUDED_PARTS = {"node_modules", ".nuxt", "abandonware"}
 

--- a/utils/scripts/codemods/kr_checkbox_codemod.py
+++ b/utils/scripts/codemods/kr_checkbox_codemod.py
@@ -22,8 +22,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 FAMILIES = [
     ("kr-checkbox-primary-sm", {"checkbox", "checkbox-sm", "checkbox-primary"}),

--- a/utils/scripts/codemods/kr_dead_label_text_cleanup_codemod.py
+++ b/utils/scripts/codemods/kr_dead_label_text_cleanup_codemod.py
@@ -40,8 +40,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 DEAD_TOKEN = "label-text"
 PRIMITIVE_PREFIX = "kr-"

--- a/utils/scripts/codemods/kr_icon_tile_codemod.py
+++ b/utils/scripts/codemods/kr_icon_tile_codemod.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-icon-tile"
 BASE_TOKENS = {

--- a/utils/scripts/codemods/kr_input_codemod.py
+++ b/utils/scripts/codemods/kr_input_codemod.py
@@ -20,8 +20,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 FAMILIES = [
     ("kr-input", {"input", "input-bordered", "w-full", "bg-base-100"}),

--- a/utils/scripts/codemods/kr_input_select_codemod.py
+++ b/utils/scripts/codemods/kr_input_select_codemod.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 FAMILIES = [
     ("kr-input-sm", {"input", "input-bordered", "input-sm", "rounded-xl"}),

--- a/utils/scripts/codemods/kr_label_bold_codemod.py
+++ b/utils/scripts/codemods/kr_label_bold_codemod.py
@@ -26,8 +26,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-label-bold"
 BASE_TOKENS = {"label-text", "font-bold"}

--- a/utils/scripts/codemods/kr_label_xs_codemod.py
+++ b/utils/scripts/codemods/kr_label_xs_codemod.py
@@ -34,8 +34,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-label-xs"
 BASE_TOKENS = {"label-text", "text-xs"}

--- a/utils/scripts/codemods/kr_label_xs_semibold_codemod.py
+++ b/utils/scripts/codemods/kr_label_xs_semibold_codemod.py
@@ -36,8 +36,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-label-xs-semibold"
 BASE_TOKENS = {"label-text", "text-xs", "font-semibold"}

--- a/utils/scripts/codemods/kr_panel_section_codemod.py
+++ b/utils/scripts/codemods/kr_panel_section_codemod.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
+from _class_attr import CLASS_ATTR
 
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
 BASE_TOKENS = {
     "rounded-3xl",
     "border",

--- a/utils/scripts/codemods/kr_spinner_codemod.py
+++ b/utils/scripts/codemods/kr_spinner_codemod.py
@@ -26,8 +26,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-spinner-xs"
 BASE_TOKENS = {"loading", "loading-spinner", "loading-xs"}

--- a/utils/scripts/codemods/kr_spinner_lg_primary_codemod.py
+++ b/utils/scripts/codemods/kr_spinner_lg_primary_codemod.py
@@ -26,8 +26,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-spinner-lg-primary"
 BASE_TOKENS = {"loading", "loading-spinner", "loading-lg", "text-primary"}

--- a/utils/scripts/codemods/kr_spinner_sm_codemod.py
+++ b/utils/scripts/codemods/kr_spinner_sm_codemod.py
@@ -26,8 +26,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-spinner-sm"
 BASE_TOKENS = {"loading", "loading-spinner", "loading-sm"}

--- a/utils/scripts/codemods/kr_text_black_2xl_codemod.py
+++ b/utils/scripts/codemods/kr_text_black_2xl_codemod.py
@@ -28,8 +28,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-black-2xl"
 BASE_TOKENS = {"font-black", "text-2xl"}

--- a/utils/scripts/codemods/kr_text_black_lg_codemod.py
+++ b/utils/scripts/codemods/kr_text_black_lg_codemod.py
@@ -21,8 +21,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-black-lg"
 BASE_TOKENS = {"font-black", "text-lg"}

--- a/utils/scripts/codemods/kr_text_black_sm_codemod.py
+++ b/utils/scripts/codemods/kr_text_black_sm_codemod.py
@@ -21,8 +21,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-black-sm"
 BASE_TOKENS = {"font-black", "text-sm"}

--- a/utils/scripts/codemods/kr_text_black_xl_codemod.py
+++ b/utils/scripts/codemods/kr_text_black_xl_codemod.py
@@ -20,8 +20,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-black-xl"
 BASE_TOKENS = {"font-black", "text-xl"}

--- a/utils/scripts/codemods/kr_text_black_xs_codemod.py
+++ b/utils/scripts/codemods/kr_text_black_xs_codemod.py
@@ -28,8 +28,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-black-xs"
 BASE_TOKENS = {"font-black", "text-xs"}

--- a/utils/scripts/codemods/kr_text_bold_2xl_codemod.py
+++ b/utils/scripts/codemods/kr_text_bold_2xl_codemod.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
+from _class_attr import CLASS_ATTR
 
 # Negative lookbehind excludes `:class="..."`/`v-bind:class="..."` dynamic
 # bindings -- both end in `:` immediately before `class=`, so a bare
@@ -35,8 +36,6 @@ from pathlib import Path
 # `:class="\`... text-2xl ... font-bold ...\`"` binding -- fixed here first;
 # the sibling codemods share the same latent gap, flagged as this slice's
 # kaizen candidate rather than rewritten in scope).
-CLASS_ATTR = re.compile(r'(?<!:)class="([^"]*)"')
-
 PRIMITIVE = "kr-text-bold-2xl"
 BASE_TOKENS = {"font-bold", "text-2xl"}
 

--- a/utils/scripts/codemods/kr_text_bold_lg_codemod.py
+++ b/utils/scripts/codemods/kr_text_bold_lg_codemod.py
@@ -31,8 +31,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-bold-lg"
 BASE_TOKENS = {"font-bold", "text-lg"}

--- a/utils/scripts/codemods/kr_text_bold_sm_codemod.py
+++ b/utils/scripts/codemods/kr_text_bold_sm_codemod.py
@@ -30,8 +30,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-bold-sm"
 BASE_TOKENS = {"font-bold", "text-sm"}

--- a/utils/scripts/codemods/kr_text_bold_xl_codemod.py
+++ b/utils/scripts/codemods/kr_text_bold_xl_codemod.py
@@ -24,8 +24,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-bold-xl"
 BASE_TOKENS = {"font-bold", "text-xl"}

--- a/utils/scripts/codemods/kr_text_bold_xs_codemod.py
+++ b/utils/scripts/codemods/kr_text_bold_xs_codemod.py
@@ -30,8 +30,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-bold-xs"
 BASE_TOKENS = {"font-bold", "text-xs"}

--- a/utils/scripts/codemods/kr_text_bold_xs_label_cleanup_codemod.py
+++ b/utils/scripts/codemods/kr_text_bold_xs_label_cleanup_codemod.py
@@ -38,8 +38,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-bold-xs"
 DEAD_TOKEN = "label-text"

--- a/utils/scripts/codemods/kr_text_dim_sm_70_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_sm_70_codemod.py
@@ -26,8 +26,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-dim-sm-70"
 BASE_TOKENS = {"text-sm", "text-base-content/70"}

--- a/utils/scripts/codemods/kr_text_dim_sm_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_sm_codemod.py
@@ -25,8 +25,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-dim-sm"
 BASE_TOKENS = {"text-sm", "text-base-content/60"}

--- a/utils/scripts/codemods/kr_text_dim_xs_40_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_xs_40_codemod.py
@@ -22,8 +22,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-dim-xs-40"
 BASE_TOKENS = {"text-xs", "text-base-content/40"}

--- a/utils/scripts/codemods/kr_text_dim_xs_45_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_xs_45_codemod.py
@@ -20,8 +20,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-dim-xs-45"
 BASE_TOKENS = {"text-xs", "text-base-content/45"}

--- a/utils/scripts/codemods/kr_text_dim_xs_55_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_xs_55_codemod.py
@@ -22,8 +22,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-dim-xs-55"
 BASE_TOKENS = {"text-xs", "text-base-content/55"}

--- a/utils/scripts/codemods/kr_text_dim_xs_60_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_xs_60_codemod.py
@@ -21,8 +21,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-dim-xs-60"
 BASE_TOKENS = {"text-xs", "text-base-content/60"}

--- a/utils/scripts/codemods/kr_text_dim_xs_70_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_xs_70_codemod.py
@@ -22,8 +22,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-dim-xs-70"
 BASE_TOKENS = {"text-xs", "text-base-content/70"}

--- a/utils/scripts/codemods/kr_text_dim_xs_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_xs_codemod.py
@@ -25,8 +25,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-dim-xs"
 BASE_TOKENS = {"text-xs", "text-base-content/50"}

--- a/utils/scripts/codemods/kr_text_error_xs_codemod.py
+++ b/utils/scripts/codemods/kr_text_error_xs_codemod.py
@@ -27,8 +27,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-error-xs"
 BASE_TOKENS = {"text-xs", "text-error"}

--- a/utils/scripts/codemods/kr_text_eyebrow_bold_codemod.py
+++ b/utils/scripts/codemods/kr_text_eyebrow_bold_codemod.py
@@ -27,8 +27,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-eyebrow-bold"
 BASE_TOKENS = {"font-bold", "uppercase"}

--- a/utils/scripts/codemods/kr_text_eyebrow_codemod.py
+++ b/utils/scripts/codemods/kr_text_eyebrow_codemod.py
@@ -27,8 +27,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 PRIMITIVE = "kr-text-eyebrow"
 BASE_TOKENS = {"font-black", "uppercase"}

--- a/utils/scripts/codemods/kr_textarea_codemod.py
+++ b/utils/scripts/codemods/kr_textarea_codemod.py
@@ -21,8 +21,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 FAMILIES = [
     ("kr-textarea", {"textarea", "textarea-bordered", "w-full", "bg-base-100"}),

--- a/utils/scripts/codemods/kr_tile_codemod.py
+++ b/utils/scripts/codemods/kr_tile_codemod.py
@@ -26,8 +26,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
-
-CLASS_ATTR = re.compile(r'class="([^"]*)"')
+from _class_attr import CLASS_ATTR
 
 FAMILIES = [
     (


### PR DESCRIPTION
Every kr-* codemod under `utils/scripts/codemods/` used the same unanchored regex, `re.compile(r'class="([^"]*)"')`, to find static class attributes to migrate. Because the pattern isn't anchored against the attribute name, it matches starting at the `c` of ANY `:class="..."`/`v-bind:class="..."` dynamic binding too — dropping the leading `:` makes the binding indistinguishable from a real `class="..."` attribute, corrupting it instead of leaving it untouched (every codemod's own docstring claims the latter). Confirmed for real against `components/pages/rebel-button.vue` in interface-vision t-104 slice 180 (kind_robots#2559).

Factors the guarded pattern into one shared module, `utils/scripts/codemods/_class_attr.py` (`(?<!:)class="([^"]*)"`), that every affected codemod now imports instead of defining its own copy, so a future codemod can't reintroduce the gap. Covers all 38 codemods that still had the unguarded pattern (2 others — `kr_text_bold_2xl_codemod.py` and `kr_badge_codemod.py` — already carried a hand-added `(?<!:)` guard from slices 180/181 and are switched to import the shared module too, for one source of truth). `kr_panel_codemod.py`'s own `(?<[:\w-])class="([^"]*)"` is a stricter superset of the same protection and is left as-is.

Every touched file's diff is a single mechanical line swap (the old `CLASS_ATTR` definition for a `from _class_attr import CLASS_ATTR` line, plus dropping `import re` where it's now otherwise unused) — verified via `git diff --numstat` that no file changed more than that.

Fixed a real bug this refactor's own mechanical script introduced along the way: `kr_dead_label_text_cleanup_codemod.py`'s module docstring contains the prose sentence "...and are left for a future slice's own survey...", whose line happens to start with the word "from" — an early version of the migration script's "insert after the last top-level import line" heuristic false-matched it as an import statement and inserted the new import inside the docstring, breaking the module (`NameError: CLASS_ATTR not defined`). Caught by literally running every codemod in `--dry-run` mode after the refactor (not just `py_compile`, which docstrings don't fail) and fixed with a targeted single-file edit.

**Verification (matching the task's own note):**
- Every codemod in the repo compiles (`python3 -m py_compile`).
- Ran every affected codemod in `--dry-run` mode before and after the fix; `diff` of the full output is byte-identical — the guard adds no false negatives against any real static `class="..."` attribute currently in the repo.
- New `tests/python/test_class_attr.py` is the synthetic-fixture regression check the task asks for: a `:class="..."` template-literal binding (the exact rebel-button.vue shape) and a `v-bind:class="..."` binding are confirmed rejected, plain/empty static `class="..."` attributes and a static `class="..."` immediately following a dynamic binding on the same tag are confirmed still matched, and a same-fixture check against the old unguarded pattern proves the regression fixture is real (not vacuously true). Full `tests/python/` suite: 73 passed (was 67).

Conductor: `interface-vision/t-126` (kaizen from t-104 slice 180).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4Jju71BpJ46btkKi4pFNp

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4Jju71BpJ46btkKi4pFNp)_