### PR TITLE
interface-vision/t-104 slice 182: expand kr-badge-ghost bounded extras, migrate 8 occurrences

### DIFF
--- a/components/coloring/coloring-book-production-history.vue
+++ b/components/coloring/coloring-book-production-history.vue
@@ -92,16 +92,16 @@
           </p>
 
           <div class="flex flex-wrap gap-2 text-xs">
-            <span v-if="item.artImageId" class="badge badge-ghost rounded-2xl">
+            <span v-if="item.artImageId" class="kr-badge-ghost rounded-2xl">
               ArtImage {{ item.artImageId }}
             </span>
-            <span v-if="item.seed !== null" class="badge badge-ghost rounded-2xl">
+            <span v-if="item.seed !== null" class="kr-badge-ghost rounded-2xl">
               Seed {{ item.seed }}
             </span>
-            <span v-if="item.engine" class="badge badge-ghost rounded-2xl">
+            <span v-if="item.engine" class="kr-badge-ghost rounded-2xl">
               {{ item.engine }}
             </span>
-            <span v-if="item.verdict" class="badge badge-ghost rounded-2xl">
+            <span v-if="item.verdict" class="kr-badge-ghost rounded-2xl">
               {{ item.verdict }}
             </span>
           </div>

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -118,7 +118,7 @@
             copy.
           </p>
         </div>
-        <span class="badge badge-ghost rounded-xl">
+        <span class="kr-badge-ghost rounded-xl">
           Up to 20 recent sessions
         </span>
       </div>

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -69,7 +69,7 @@
                 <span class="badge rounded-lg font-black" :class="statusClass">
                   {{ challenge.status }}
                 </span>
-                <span class="badge badge-ghost rounded-lg font-black">
+                <span class="kr-badge-ghost rounded-lg font-black">
                   {{ challenge.Submissions.length }} contenders
                 </span>
               </div>
@@ -342,7 +342,7 @@
                     <span
                       v-for="[key, value] in randomSelectionsList(submission)"
                       :key="key"
-                      class="badge badge-ghost rounded-lg"
+                      class="kr-badge-ghost rounded-lg"
                     >
                       {{ key }}: {{ value }}
                     </span>

--- a/pages/play/challenges/leaderboard.vue
+++ b/pages/play/challenges/leaderboard.vue
@@ -229,7 +229,7 @@
                   class="hover"
                 >
                   <td>
-                    <span class="badge badge-ghost rounded-lg font-black"
+                    <span class="kr-badge-ghost rounded-lg font-black"
                       >#{{ entry.rank }}</span
                     >
                   </td>

--- a/utils/scripts/codemods/kr_badge_codemod.py
+++ b/utils/scripts/codemods/kr_badge_codemod.py
@@ -27,11 +27,12 @@ resolution order is unaffected by folding the three base tokens into one
 name. This includes a second color modifier (e.g. `badge-outline` alongside
 `badge-primary`) preserved as an "extra" token verbatim -- the same latent
 behavior the ghost/warning/outline families already had for a stray color
-token, not new to this pair. The colorless `kr-badge-sm` family is the one
-exception to unrestricted extras: see BOUNDED_EXTRAS below. `kr-badge-xs`
-(interface-vision t-104 slice 177) is colorless too but is NOT bounded --
-its 25 occurrences across 13 files were individually audited for that
-slice, unlike `kr-badge-sm`'s broader, only-partially-audited 91-hit pool.
+token, not new to this pair. The colorless `kr-badge-sm` family and
+`kr-badge-ghost` are the two exceptions to unrestricted extras: see
+BOUNDED_EXTRAS below. `kr-badge-xs` (interface-vision t-104 slice 177) is
+colorless too but is NOT bounded -- its 25 occurrences across 13 files were
+individually audited for that slice, unlike `kr-badge-sm`'s broader,
+only-partially-audited 91-hit pool.
 
 FAMILIES is ordered most-specific-first on purpose: each entry's base token
 set differs in its size (sm/xs) and color modifier (ghost/warning/outline/
@@ -58,9 +59,11 @@ FAMILIES = [
     ("kr-badge-ghost-xs", {"badge", "badge-ghost", "badge-xs"}),
     # Sizeless sibling of kr-badge-ghost-sm/kr-badge-ghost-xs (interface-vision
     # t-104 slice 181): its {badge, badge-ghost} base is a strict subset of
-    # both of those, so it must come after them. Bounded to an exact match
-    # only (see BOUNDED_EXTRAS below) -- its broader subset-match pool
-    # carries varied, not-yet-individually-audited extra tokens.
+    # both of those, so it must come after them. Bounded to the specific
+    # audited extra-token shapes in BOUNDED_EXTRAS below (slice 181 exact
+    # match only; slice 182 added four more individually-audited shapes) --
+    # a handful of remaining one-off extra-token combinations are still left
+    # unmigrated by design.
     ("kr-badge-ghost", {"badge", "badge-ghost"}),
     ("kr-badge-outline-xs", {"badge", "badge-outline", "badge-xs"}),
     ("kr-badge-primary-xs", {"badge", "badge-primary", "badge-xs"}),
@@ -96,14 +99,32 @@ FAMILIES = [
 # its 15 call sites). Families not listed here keep the unrestricted
 # subset-match behavior they already had.
 #
-# kr-badge-ghost's {badge, badge-ghost} base is similarly small and appears
-# inside a further ~13 hand-rolled combinations carrying varied extra tokens
-# (hover states, rounded-*, backdrop-blur, ...) not yet individually audited
-# (interface-vision t-104 slice 181) -- bounded to an exact match only until
-# a future slice audits the rest.
+# kr-badge-ghost's {badge, badge-ghost} base is similarly small and appeared
+# (slice 181) inside a further ~13 hand-rolled combinations carrying varied
+# extra tokens. Slice 182 individually audited all of them: four clean,
+# repeated shapes are added here --
+#   rounded-2xl            components/coloring/coloring-book-production-history.vue
+#                           (4 identical call sites)
+#   rounded-lg font-black  pages/play/challenges/leaderboard.vue +
+#                           pages/play/challenges/[slug].vue (same badge shape
+#                           reused across the two challenge-list pages)
+#   rounded-lg             pages/play/challenges/[slug].vue (a second,
+#                           plainer badge on the same page)
+#   rounded-xl             components/pages/storybook-library-page.vue
+# -- the remaining ~6 (daily-digest-browser.vue, daily-dream-object-art-
+# workbench.vue, facet-gallery.vue, coloring-book-manager.vue's hover/cursor
+# clickable badge, academy-style-detail.vue, privacy-page.vue's <code> badge)
+# each carry a one-off extra-token combination not shared by any other call
+# site and are left hand-rolled rather than forced into a shared primitive.
 BOUNDED_EXTRAS: dict[str, set[frozenset[str]]] = {
     "kr-badge-sm": {frozenset(), frozenset({"rounded-2xl"})},
-    "kr-badge-ghost": {frozenset()},
+    "kr-badge-ghost": {
+        frozenset(),
+        frozenset({"rounded-2xl"}),
+        frozenset({"rounded-lg", "font-black"}),
+        frozenset({"rounded-lg"}),
+        frozenset({"rounded-xl"}),
+    },
 }
 
 


### PR DESCRIPTION
### Task
interface-vision/t-104: recurring front-end-consistency umbrella — drive live UI onto shared `kr-*` components (kind: software, recurring)

### What changed / what I produced
Slice 181 (#2560) added `.kr-badge-ghost` bounded to an exact-match only, leaving ~13 subset-match occurrences with extra tokens unaudited. This slice individually audited all of them and extended `BOUNDED_EXTRAS["kr-badge-ghost"]` in `utils/scripts/codemods/kr_badge_codemod.py` with four clean, repeated shapes:
- `rounded-2xl` — 4 identical call sites in `components/coloring/coloring-book-production-history.vue`
- `rounded-lg font-black` — 2 call sites shared across `pages/play/challenges/leaderboard.vue` and `pages/play/challenges/[slug].vue`
- `rounded-lg` — 1 call site in `pages/play/challenges/[slug].vue`
- `rounded-xl` — 1 call site in `components/pages/storybook-library-page.vue`

8 occurrences migrated across 4 files. The remaining ~6 occurrences (`daily-digest-browser.vue`, `daily-dream-object-art-workbench.vue`, `facet-gallery.vue`, `coloring-book-manager.vue`'s hover/cursor clickable badge, `academy-style-detail.vue`, `privacy-page.vue`'s `<code>` badge) each carry a one-off extra-token combination not shared by any other call site and are left hand-rolled by design — documented inline in the codemod. `components/ui/ui-gallery.vue`'s exact-match showcase row was left untouched, same precedent as slice 181 (deliberate raw-DaisyUI comparison).

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint .`: 333 problems (327 errors, 6 warnings) — byte-identical to the documented baseline
- `test:layout-contract`: holds, 0 new violations (same pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet opportunity as every recent slice, left untouched)
- `test:lint-ratchet`: holds at 333/-59
- `prettier --check .`: the 2 touched files that surfaced (`coloring-book-production-history.vue`, `[slug].vue`) confirmed pre-existing drift via `git stash` before/after — not newly introduced
- Manually reviewed every migrated diff — only static `class="..."` attributes touched, no `:class` bindings, no geometry/behavior change

### Stakes
reversible

### Kaizen suggestion
Run a fresh full-repo class-frequency survey outside all now-closed families (`kr-text-black-*`, `kr-text-bold-*`, `kr-text-dim-*`, `kr-text-eyebrow-*`, `kr-label-*`, `kr-badge-*`, `kr-text-error-xs`) for the next slice's candidate, or individually audit `coloring-book-manager.vue`'s hover/cursor clickable badge shape as a possible distinct primitive of its own.

### Notes for reviewer
Recurring umbrella task — conductor task will be set back to `status: ready` after this merges, per the recurring-task convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaPKQ7gpw9zktWwF64kg2n

---
_Generated by [Claude Code](https://claude.ai/code/session_01QaPKQ7gpw9zktWwF64kg2n)_