### PR TITLE
interface-vision/t-104 slice 183: add kr-badge-outline, migrate 13 exact-match occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1472,6 +1472,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply badge badge-outline badge-xs;
   }
 
+  /* The sizeless sibling of .kr-badge-outline-sm/.kr-badge-outline-xs
+   * (interface-vision t-104 slice 183): bare `badge badge-outline` with no
+   * size modifier -- the caller relies on DaisyUI's default badge size,
+   * same rationale as .kr-badge-ghost being a separate sizeless sibling
+   * rather than folded into its -sm/-xs counterparts. Bounded to the 13
+   * exact-match occurrences across 8 files this slice (--exact-only, same
+   * convention .kr-badge-ghost's first slice used); a fourteenth exact
+   * match in components/ui/ui-gallery.vue's "Badges & status" showcase
+   * section is a deliberate raw-DaisyUI comparison row and was left
+   * untouched, matching the precedent set for that section's other rows. */
+  .kr-badge-outline {
+    @apply badge badge-outline;
+  }
+
   /* The primary-colored counterpart to .kr-badge-primary-sm at the xs size
    * (interface-vision t-104 slice 113): `badge badge-primary badge-xs`, the
    * largest remaining hand-rolled `badge-xs` pool surveyed (6 files, 10

--- a/components/mandarin/mandarin-voice-coach.vue
+++ b/components/mandarin/mandarin-voice-coach.vue
@@ -4,7 +4,7 @@
       <div class="max-w-2xl">
         <div class="flex flex-wrap items-center gap-2">
           <h3 class="kr-text-bold-lg">Pronunciation practice</h3>
-          <span class="badge badge-outline">listen · say · check</span>
+          <span class="kr-badge-outline">listen · say · check</span>
         </div>
         <p class="mt-1 text-sm leading-relaxed opacity-70">
           Hear the reference, say the word yourself, then compare what the recognizer heard with a separate on-device check of the broad tone shape.
@@ -115,7 +115,7 @@
           >
             <div class="flex flex-wrap items-center gap-2">
               <span class="kr-text-bold-lg">{{ observation.syllable }}</span>
-              <span class="badge badge-outline">{{ observation.expectedArrow }} T{{ observation.expectedTone }}</span>
+              <span class="kr-badge-outline">{{ observation.expectedArrow }} T{{ observation.expectedTone }}</span>
               <span class="badge" :class="verdictClass(observation.verdict)">
                 heard {{ observation.observedShape }}
               </span>

--- a/components/ruler-hooked/ruler-hooked-fishing-encounter.vue
+++ b/components/ruler-hooked/ruler-hooked-fishing-encounter.vue
@@ -6,7 +6,7 @@
         <h3 id="fishing-encounter-title" class="kr-text-black-xl">{{ encounter.fishName }}</h3>
         <p class="mt-1 text-xs opacity-65">{{ encounter.rarity }} · {{ encounter.affinity }} · {{ familyLabel }}</p>
       </div>
-      <span class="badge badge-outline">Beat {{ encounter.beat }}/{{ encounter.maxBeats }}</span>
+      <span class="kr-badge-outline">Beat {{ encounter.beat }}/{{ encounter.maxBeats }}</span>
     </div>
 
     <p class="mt-3 text-sm opacity-80">{{ encounter.catchBehavior }}</p>

--- a/components/ruler-hooked/ruler-hooked-fishopedia.vue
+++ b/components/ruler-hooked/ruler-hooked-fishopedia.vue
@@ -4,7 +4,7 @@
       class="collapse-title flex items-center justify-between gap-3 pr-12 font-bold"
     >
       <span>📖 Fishopedia</span>
-      <span class="badge badge-outline"
+      <span class="kr-badge-outline"
         >{{ discoveredCount }}/{{ roster.length }} discovered</span
       >
     </summary>

--- a/components/user/forum-moderation-panel.vue
+++ b/components/user/forum-moderation-panel.vue
@@ -54,7 +54,7 @@
           <div class="flex items-start justify-between gap-2">
             <div class="flex items-center gap-2">
               <span class="kr-badge-warning-sm">pending review</span>
-              <span v-if="post.channel" class="badge badge-outline">
+              <span v-if="post.channel" class="kr-badge-outline">
                 {{ post.channel }}
               </span>
             </div>

--- a/components/wonderlab/reaction-card.vue
+++ b/components/wonderlab/reaction-card.vue
@@ -27,7 +27,7 @@
         </p>
       </div>
 
-      <span class="badge badge-outline">
+      <span class="kr-badge-outline">
         {{ reactionCategory }}
       </span>
     </div>

--- a/pages/admin/curation-studio.vue
+++ b/pages/admin/curation-studio.vue
@@ -44,9 +44,9 @@
             </button>
           </nav>
           <div class="flex flex-wrap gap-2">
-            <span class="badge badge-outline">Admin only</span>
-            <span class="badge badge-outline">Audited changes</span>
-            <span class="badge badge-outline">ArtJob backed</span>
+            <span class="kr-badge-outline">Admin only</span>
+            <span class="kr-badge-outline">Audited changes</span>
+            <span class="kr-badge-outline">ArtJob backed</span>
           </div>
         </div>
 

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -13,8 +13,8 @@
           </p>
         </div>
         <div class="flex flex-wrap gap-2">
-          <span class="badge badge-outline">Private output</span>
-          <span class="badge badge-outline">ArtJob-backed resume</span>
+          <span class="kr-badge-outline">Private output</span>
+          <span class="kr-badge-outline">ArtJob-backed resume</span>
           <button
             type="button"
             class="kr-btn"

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -51,7 +51,7 @@
             :key="row.platform"
             class="flex items-center gap-3 rounded-xl border border-base-300 bg-base-100 px-4 py-2"
           >
-            <span class="badge badge-outline">{{ row.platform }}</span>
+            <span class="kr-badge-outline">{{ row.platform }}</span>
             <span class="kr-text-black-sm">
               {{ row.approvedToday }}/{{ row.ceiling }}
             </span>
@@ -128,7 +128,7 @@
           >
             <div class="flex items-start justify-between gap-2">
               <div class="flex items-center gap-2">
-                <span class="badge badge-outline">{{ draft.platform }}</span>
+                <span class="kr-badge-outline">{{ draft.platform }}</span>
                 <span
                   class="badge"
                   :class="{

--- a/utils/scripts/codemods/kr_badge_codemod.py
+++ b/utils/scripts/codemods/kr_badge_codemod.py
@@ -2,7 +2,7 @@
 """Find or migrate hand-rolled kr-badge-{ghost,warning,outline,primary,secondary}-sm,
 kr-badge-{ghost,outline,primary,warning,success,error,secondary,accent,info,neutral}-xs,
 kr-badge-sm (the colorless base), kr-badge-xs (the colorless -xs sibling), and
-kr-badge-ghost (the sizeless ghost sibling) badges.
+kr-badge-ghost/kr-badge-outline (the sizeless ghost/outline siblings) badges.
 
 Dry-run is the default. Pass --write to update matching Vue files in place.
 Only the approved badge shapes are touched (`badge badge-ghost badge-sm`,
@@ -66,6 +66,13 @@ FAMILIES = [
     # unmigrated by design.
     ("kr-badge-ghost", {"badge", "badge-ghost"}),
     ("kr-badge-outline-xs", {"badge", "badge-outline", "badge-xs"}),
+    # Sizeless sibling of kr-badge-outline-sm/kr-badge-outline-xs
+    # (interface-vision t-104 slice 183), same reasoning as kr-badge-ghost
+    # above: its {badge, badge-outline} base is a strict subset of both of
+    # those, so it must come after them. Bounded to exact-match only (see
+    # BOUNDED_EXTRAS below) -- a one-off extra-token pool is left for a
+    # future slice, same pattern kr-badge-ghost's first slice followed.
+    ("kr-badge-outline", {"badge", "badge-outline"}),
     ("kr-badge-primary-xs", {"badge", "badge-primary", "badge-xs"}),
     ("kr-badge-warning-xs", {"badge", "badge-warning", "badge-xs"}),
     ("kr-badge-success-xs", {"badge", "badge-success", "badge-xs"}),
@@ -125,6 +132,11 @@ BOUNDED_EXTRAS: dict[str, set[frozenset[str]]] = {
         frozenset({"rounded-lg"}),
         frozenset({"rounded-xl"}),
     },
+    # kr-badge-outline (interface-vision t-104 slice 183): bounded to an
+    # exact match only for this slice, same first-pass convention
+    # kr-badge-ghost used before its own follow-up slice individually
+    # audited the remaining extra-token pool.
+    "kr-badge-outline": {frozenset()},
 }
 
 


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 183: drive live front-end consistency onto shared `kr-*` components and composition rules (kind: software)

### What changed / what I produced
- Added `.kr-badge-outline` to `assets/css/tailwind.css` — the sizeless sibling of `.kr-badge-outline-sm`/`.kr-badge-outline-xs` (bare `badge badge-outline` with no size modifier), matching the `kr-badge-ghost` convention added in slice 181.
- Extended `utils/scripts/codemods/kr_badge_codemod.py`'s `FAMILIES`/`BOUNDED_EXTRAS` with the new shape, bounded to an exact-match only for this slice (same first-pass convention `kr-badge-ghost`'s original slice used, before a follow-up slice individually audited its extra-token pool).
- Migrated 13 exact-match occurrences across 8 files: `components/mandarin/mandarin-voice-coach.vue` (2), `components/ruler-hooked/ruler-hooked-fishing-encounter.vue`, `components/ruler-hooked/ruler-hooked-fishopedia.vue`, `components/user/forum-moderation-panel.vue`, `components/wonderlab/reaction-card.vue`, `pages/admin/curation-studio.vue` (3), `pages/admin/scene-animator.vue` (2), `pages/admin/social-drafts.vue` (2).
- A 14th exact match in `components/ui/ui-gallery.vue`'s "Badges & status" showcase section is a deliberate raw-DaisyUI comparison row and was left untouched, matching the precedent set for that section's other rows (`badge-ghost`, etc.).

No geometry or behavior change — purely a class-name consolidation.

### How I verified
- `vue-tsc --noEmit`: clean (no output).
- `eslint .`: 333 problems (327 errors, 6 warnings) — identical to the documented baseline.
- `test:layout-contract`: holds, 0 new violations (same pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet opportunity as every recent slice, left untouched/out of scope).
- `test:lint-ratchet`: holds at 333/-59.
- `prettier --check .`: 1145 files flagged — confirmed byte-identical to baseline via `git stash` before/after diff (no new drift introduced).
- Manually reviewed every migrated diff: only static `class="..."` attributes touched, no `:class` bindings.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Run a fresh full-repo class-frequency survey outside all now-closed families (`kr-text-black-*`, `kr-text-bold-*`, `kr-text-dim-*`, `kr-text-eyebrow-*`, `kr-label-*`, `kr-badge-*` incl. `-ghost`/`-outline` sizeless siblings, `kr-text-error-xs`), or individually audit the remaining one-off `kr-badge-outline` extra-token occurrences (e.g. `badge-outline rounded-2xl`/`rounded-xl` shapes already partly folded under other families) as a bounded follow-up slice.

### Notes for reviewer
Recurring umbrella task — will re-arm `interface-vision/t-104` to `status: ready` after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HC3VQhXJfMwZv3hvnRegrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HC3VQhXJfMwZv3hvnRegrx)_