### PR TITLE
interface-vision/t-104 slice 184: add kr-text-faded-xs, migrate 23 exact-match occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -2042,6 +2042,29 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply text-xs text-error;
   }
 
+  /* A caption-size status/loading line using generic `opacity-60` rather
+   * than the `text-base-content/NN` alpha-channel family above -- `text-xs
+   * opacity-60` (interface-vision t-104 slice 184), found by a fresh
+   * full-repo class-frequency survey outside every now-closed family
+   * (`kr-text-black-*`, `kr-text-bold-*`, `kr-text-dim-*`,
+   * `kr-text-eyebrow-*`, `kr-label-*`, `kr-badge-*` incl. the `-ghost`/
+   * `-outline` sizeless siblings, `kr-text-error-xs`) at 23 exact
+   * occurrences across 9 files, consistently a conditionally-rendered `<p>`
+   * showing transient loading/empty-state status text. Named
+   * `kr-text-faded-xs` rather than folded into the `kr-text-dim-xs-*`
+   * family or reusing the existing `kr-*-muted` suffix: bare `opacity-N`
+   * dims the whole element (background, border, children too), not just
+   * the text color -- a real mechanical difference from
+   * `text-base-content/NN` -- and `-muted` already means "on the
+   * base-200 tinted background" elsewhere in this file (see
+   * `.kr-text-dim-sm`'s own note). Sibling `opacity-NN` shapes surveyed
+   * alongside this one (`text-sm opacity-70`, `text-sm opacity-80`,
+   * `text-xs opacity-55`, `font-sans opacity-70`, etc.) are left for
+   * future slices, same convention as `.kr-spinner-xs`/`.kr-spinner-sm`. */
+  .kr-text-faded-xs {
+    @apply text-xs opacity-60;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -185,10 +185,10 @@
         @pointercancel="onCanvasPointerUp"
       />
 
-      <p v-if="tankStore.loading" class="text-xs opacity-60">
+      <p v-if="tankStore.loading" class="kr-text-faded-xs">
         Settling into your tank…
       </p>
-      <p v-else class="text-xs opacity-60">
+      <p v-else class="kr-text-faded-xs">
         Feed the hungriest occupant to keep it paying out. Coins accrue on their
         own while you're away and settle the moment you return -- nothing here
         is saved in this browser, it's all your tank.
@@ -326,7 +326,7 @@
             "Today's arrivals -- check back tomorrow for more."
           }}
         </p>
-        <p v-if="tankStore.catalogLoading" class="text-xs opacity-60">
+        <p v-if="tankStore.catalogLoading" class="kr-text-faded-xs">
           Reading the bestiary…
         </p>
         <div
@@ -366,7 +366,7 @@
               </button>
             </div>
           </div>
-          <p v-if="!tankStore.catalog.length" class="text-xs opacity-60">
+          <p v-if="!tankStore.catalog.length" class="kr-text-faded-xs">
             Nothing left to discover right now.
           </p>
         </div>
@@ -404,7 +404,7 @@
         </button>
 
         <template v-if="showBestiary">
-          <p v-if="tankStore.bestiaryLoading" class="text-xs opacity-60">
+          <p v-if="tankStore.bestiaryLoading" class="kr-text-faded-xs">
             Reading the book…
           </p>
           <div
@@ -460,7 +460,7 @@
                 </button>
               </div>
             </div>
-            <p v-if="!tankStore.bestiary.length" class="text-xs opacity-60">
+            <p v-if="!tankStore.bestiary.length" class="kr-text-faded-xs">
               Nothing in the book yet.
             </p>
           </div>
@@ -492,7 +492,7 @@
         </button>
 
         <template v-if="showSets">
-          <p v-if="tankStore.setCatalogLoading" class="text-xs opacity-60">
+          <p v-if="tankStore.setCatalogLoading" class="kr-text-faded-xs">
             Surveying the build layer…
           </p>
           <div
@@ -538,7 +538,7 @@
                 Equip ({{ entry.cost }})
               </button>
             </div>
-            <p v-if="!tankStore.setCatalog.length" class="text-xs opacity-60">
+            <p v-if="!tankStore.setCatalog.length" class="kr-text-faded-xs">
               No set pieces to show right now.
             </p>
           </div>
@@ -571,7 +571,7 @@
         </button>
 
         <template v-if="showDecor">
-          <p v-if="tankStore.decorCatalogLoading" class="text-xs opacity-60">
+          <p v-if="tankStore.decorCatalogLoading" class="kr-text-faded-xs">
             Sorting through the driftwood…
           </p>
           <div
@@ -602,7 +602,7 @@
                 Place ({{ entry.cost }})
               </button>
             </div>
-            <p v-if="!tankStore.decorCatalog.length" class="text-xs opacity-60">
+            <p v-if="!tankStore.decorCatalog.length" class="kr-text-faded-xs">
               Nothing to place right now.
             </p>
           </div>
@@ -681,7 +681,7 @@
             Every rarity comes in every size -- the shell tells you the line,
             not the size; the price tells you the size, not the line.
           </p>
-          <p v-if="tankStore.eggCatalogLoading" class="text-xs opacity-60">
+          <p v-if="tankStore.eggCatalogLoading" class="kr-text-faded-xs">
             Reading the shelf…
           </p>
           <div

--- a/components/mandarin/mandarin-voice-coach.vue
+++ b/components/mandarin/mandarin-voice-coach.vue
@@ -76,7 +76,7 @@
       <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <p class="text-xs font-semibold uppercase tracking-wide opacity-55">Your attempt</p>
-          <p class="text-xs opacity-60">Not saved by Kind Robots. The clip is sent to the configured speech service only for transcription.</p>
+          <p class="kr-text-faded-xs">Not saved by Kind Robots. The clip is sent to the configured speech service only for transcription.</p>
         </div>
         <audio :src="audioUrl" controls class="h-10 max-w-full" />
       </div>

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -83,7 +83,7 @@
               createMessage
             }}</span>
           </div>
-          <p class="text-xs opacity-60">
+          <p class="kr-text-faded-xs">
             Creating an app files a scaffold request for the agents: the
             workspace folder, project roadmap, and art prompts appear after the
             next Worker cycle. Free accounts can run
@@ -138,7 +138,7 @@
                 :value="app.taskDone"
                 :max="app.taskTotal"
               />
-              <p class="text-xs opacity-60">
+              <p class="kr-text-faded-xs">
                 {{ app.taskDone }} of {{ app.taskTotal }} tasks done
                 <span
                   v-if="app.needsHuman > 0"

--- a/components/ruler-hooked/ruler-hooked-card.vue
+++ b/components/ruler-hooked/ruler-hooked-card.vue
@@ -7,7 +7,7 @@
       <span v-if="card.kind === 'arc-step'" class="kr-badge-secondary-sm">story</span>
       <span v-else-if="card.kind === 'finale'" class="badge badge-accent badge-sm">finale</span>
       <span v-else class="kr-badge-sm">the kingdom</span>
-      <span v-if="card.characters?.length" class="text-xs opacity-60">
+      <span v-if="card.characters?.length" class="kr-text-faded-xs">
         {{ card.characters.join(' · ') }}
       </span>
     </div>

--- a/components/ruler-hooked/ruler-hooked-game.vue
+++ b/components/ruler-hooked/ruler-hooked-game.vue
@@ -17,7 +17,7 @@
         <div class="flex items-center justify-between gap-3">
           <div>
             <p class="kr-text-bold-sm">{{ store.save.ruler.honorific }} {{ store.save.ruler.name }}</p>
-            <p class="text-xs opacity-60">Turn {{ store.save.turnCount }} · {{ store.save.status.toLowerCase() }} · {{ store.save.counters.fishCaught ?? 0 }} fish</p>
+            <p class="kr-text-faded-xs">Turn {{ store.save.turnCount }} · {{ store.save.status.toLowerCase() }} · {{ store.save.counters.fishCaught ?? 0 }} fish</p>
           </div>
           <button
             type="button"

--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -5,7 +5,7 @@
         <h2 class="font-semibold">
           LoRAs <span class="opacity-50">(optional)</span>
         </h2>
-        <p class="text-xs opacity-60">
+        <p class="kr-text-faded-xs">
           Stack up to {{ MAX_LORAS_PER_JOB }} {{ engine.toUpperCase() }} LoRAs.
           Trigger words are added to the render prompt automatically.
         </p>

--- a/pages/music-mentor.vue
+++ b/pages/music-mentor.vue
@@ -75,7 +75,7 @@
             {{ opt.label }}
           </button>
         </div>
-        <p class="text-xs opacity-60">
+        <p class="kr-text-faded-xs">
           Pick at least one. All four selected by default.
         </p>
       </section>

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -66,7 +66,7 @@
           <div class="flex flex-wrap items-center justify-between gap-2">
             <div>
               <h2 class="kr-text-bold-lg">Study sets</h2>
-              <p class="text-xs opacity-60">Pick a deck, then jump straight back to the flash card.</p>
+              <p class="kr-text-faded-xs">Pick a deck, then jump straight back to the flash card.</p>
             </div>
             <span class="kr-badge-ghost">{{ allSets.length }} decks</span>
           </div>
@@ -156,7 +156,7 @@
               <div v-else class="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-dashed border-base-300 p-3">
                 <div>
                   <p class="font-semibold">Not in the catalog yet.</p>
-                  <p class="text-xs opacity-60">Create “{{ searchQuery.trim() }}” as a requested learning card.</p>
+                  <p class="kr-text-faded-xs">Create “{{ searchQuery.trim() }}” as a requested learning card.</p>
                 </div>
                 <button class="kr-btn-primary-plain" type="button" :disabled="requestingWord" @click="requestCurrentWord">
                   <span v-if="requestingWord" class="kr-spinner-xs" />

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -27,7 +27,7 @@
             {{ opt.label }}
           </button>
         </div>
-        <p class="text-xs opacity-60">{{ activeEngine.hint }}</p>
+        <p class="kr-text-faded-xs">{{ activeEngine.hint }}</p>
       </section>
 
       <section class="space-y-2">
@@ -78,7 +78,7 @@
             </span>
           </button>
         </div>
-        <p class="text-xs opacity-60">
+        <p class="kr-text-faded-xs">
           Presets fill the controls below. Any value can still be changed for
           this render.
         </p>
@@ -213,7 +213,7 @@
             {{ opt.label }}
           </button>
         </div>
-        <p class="text-xs opacity-60">{{ activeOutputFormat.hint }}</p>
+        <p class="kr-text-faded-xs">{{ activeOutputFormat.hint }}</p>
       </section>
 
       <section class="grid gap-4 sm:grid-cols-3">

--- a/utils/scripts/codemods/kr_text_faded_xs_codemod.py
+++ b/utils/scripts/codemods/kr_text_faded_xs_codemod.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `text-xs opacity-60` status/loading caption
+text to `kr-text-faded-xs`.
+
+Sibling of kr_text_error_xs_codemod.py / kr_text_dim_xs_60_codemod.py, same
+conventions: dry-run by default, --write to update matching Vue files in
+place. Only the exact `text-xs opacity-60` shape is touched, and only in
+static `class="..."` attributes -- never `:class`/`v-bind:class` bindings
+(see _class_attr.py), and regardless of the base tokens' order in the
+source. A source that already carries `kr-text-faded-xs`, or is missing
+either base token, is left untouched. Extra tokens beyond the base set are
+preserved verbatim after the primitive class, matching the
+kr-badge-*/kr-spinner-*/kr-text-dim-*/kr-text-error-xs codemods'
+subset-match convention -- pass --exact-only to restrict a slice to sources
+with no extra tokens at all, the safest and most literal pool.
+
+Deliberately does NOT touch other `opacity-NN` shapes (`text-sm
+opacity-70`, `text-xs opacity-55`, etc.) -- those are real, independently-
+repeated shapes of their own, left for future slices per this codemod's
+own tailwind.css comment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-text-faded-xs"
+BASE_TOKENS = {"text-xs", "opacity-60"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-faded-xs {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring umbrella, slice 184)

### What changed / what I produced
- Fresh full-repo class-frequency survey outside all now-closed families (`kr-text-black-*`, `kr-text-bold-*`, `kr-text-dim-*`, `kr-text-eyebrow-*`, `kr-label-*`, `kr-badge-*` incl. the `-ghost`/`-outline` sizeless siblings, `kr-text-error-xs`) found `text-xs opacity-60` at 23 exact occurrences across 9 files — a status/loading caption shape distinct from the `kr-text-dim-xs-*` family (bare `opacity-N` dims the whole element, not just the text color via `text-base-content/NN`).
- Added `.kr-text-faded-xs` (`@apply text-xs opacity-60;`) to `assets/css/tailwind.css`, with a doc comment explaining why it's a separate name from `kr-text-dim-xs-*`/`-muted`.
- New codemod `utils/scripts/codemods/kr_text_faded_xs_codemod.py`, sibling of `kr_text_error_xs_codemod.py`/`kr_text_dim_xs_60_codemod.py` (imports the shared `_class_attr.py` `CLASS_ATTR` guard, same `--exact-only`/`--write` flags).
- Ran with `--exact-only` for this bounded first slice: migrated all 23 occurrences across `cthulhuquarium-game.vue` (11), `mandarin-voice-coach.vue` (1), `appmaker-page.vue` (2), `ruler-hooked-card.vue` (1), `ruler-hooked-game.vue` (1), `video-lora-picker.vue` (1), `music-mentor.vue` (1), `pages/play/mandarin.vue` (2), `pages/play/video-generator.vue` (3). No geometry or behavior change — every occurrence was a plain `<p>` caption with no extra tokens.

### How I verified
- `vue-tsc --noEmit` clean.
- `eslint .` — 333 problems (327 errors, 6 warnings), identical to documented baseline.
- `npm run test:layout-contract` — holds, 0 new violations (same pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet note as every recent slice, left untouched).
- `npm run test:lint-ratchet` — holds at 333/-59.
- `prettier --check .` — warn list byte-identical to baseline (1144 files), confirmed via a `git stash` before/after diff of the full warning list, not just the count.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Sibling `opacity-NN` shapes surfaced by this slice's survey and left open: `text-sm opacity-70` (13 occurrences), `text-sm opacity-80` (10), `text-xs opacity-55` (7), `font-sans opacity-70` (13). Any of these is a reasonable next bounded slice under the same `kr-text-faded-*` naming convention.

### Notes for reviewer
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpbuJ6gESthJ17pdj7hLvb

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpbuJ6gESthJ17pdj7hLvb)_