### PR TITLE
interface-vision/t-104 slice 185: add kr-text-faded-sm, migrate 16 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -2065,6 +2065,21 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply text-xs opacity-60;
   }
 
+  /* `.kr-text-faded-xs`'s `text-sm` sibling: `text-sm opacity-70`
+   * (interface-vision t-104 slice 185), the largest of the sibling
+   * `opacity-NN` shapes that slice 184's survey left open, found at 14
+   * exact-or-subset occurrences across 10 files, same consistently
+   * conditionally-rendered loading/empty-state caption pattern. Named
+   * `kr-text-faded-sm` (bare, not `kr-text-faded-sm-70`) because it is the
+   * first `sm`-size member of this opacity-based family, the same
+   * bare-name-for-the-first-shape convention `.kr-text-dim-sm` set for the
+   * `text-base-content/NN` family. A later `text-sm opacity-NN` at a
+   * different percentage would follow `.kr-text-dim-sm-70`'s precedent and
+   * take a `-NN` suffix instead of reusing this name. */
+  .kr-text-faded-sm {
+    @apply text-sm opacity-70;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -726,7 +726,7 @@ onMounted(async () => {
           </div>
           <div>
             <h1 class="kr-text-bold-2xl">Art Test Lab</h1>
-            <p class="text-sm opacity-70">
+            <p class="kr-text-faded-sm">
               Text prompt upgrades, Kontext remix, and animal Kombine chaos.
             </p>
           </div>

--- a/components/dreams/dream-inspire-button.vue
+++ b/components/dreams/dream-inspire-button.vue
@@ -4,7 +4,7 @@
     <dialog ref="serverModalRef" class="modal">
       <div class="modal-box">
         <h3 class="kr-text-bold-lg">Select Art Server</h3>
-        <p class="py-2 text-sm opacity-70">
+        <p class="kr-text-faded-sm py-2">
           No preferred art server found. Choose one to generate inspiration
           images:
         </p>

--- a/components/dreams/dream-relationship-gallery.vue
+++ b/components/dreams/dream-relationship-gallery.vue
@@ -63,7 +63,7 @@
         <Icon name="kind-icon:dream" class="h-10 w-10 opacity-50" />
         <div>
           <p class="font-bold">{{ emptyTitle }}</p>
-          <p class="mt-1 text-sm opacity-70">{{ emptySubtitle }}</p>
+          <p class="kr-text-faded-sm mt-1">{{ emptySubtitle }}</p>
         </div>
       </div>
 

--- a/components/mandarin/mandarin-voice-coach.vue
+++ b/components/mandarin/mandarin-voice-coach.vue
@@ -6,7 +6,7 @@
           <h3 class="kr-text-bold-lg">Pronunciation practice</h3>
           <span class="kr-badge-outline">listen · say · check</span>
         </div>
-        <p class="mt-1 text-sm leading-relaxed opacity-70">
+        <p class="kr-text-faded-sm mt-1 leading-relaxed">
           Hear the reference, say the word yourself, then compare what the recognizer heard with a separate on-device check of the broad tone shape.
         </p>
         <div

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -90,7 +90,7 @@
             {{ FREE_PROJECT_LIMIT }} active projects.
           </p>
         </template>
-        <p v-else class="text-sm opacity-70">
+        <p v-else class="kr-text-faded-sm">
           Sign in to create an app. Browsing is open to everyone.
         </p>
       </div>
@@ -117,7 +117,7 @@
       <h2 class="text-lg font-semibold">
         Apps <span class="opacity-60">({{ fleet.length }})</span>
       </h2>
-      <p v-if="!fleet.length && !loading" class="text-sm opacity-70">
+      <p v-if="!fleet.length && !loading" class="kr-text-faded-sm">
         No apps yet — create the first one above.
       </p>
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -129,7 +129,7 @@
                 app.slug
               }}</span>
             </div>
-            <p v-if="app.description" class="line-clamp-2 text-sm opacity-70">
+            <p v-if="app.description" class="kr-text-faded-sm line-clamp-2">
               {{ app.description }}
             </p>
             <template v-if="app.taskTotal > 0">

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -304,7 +304,7 @@
 
         <p class="kr-text-bold-lg">No rewards found.</p>
 
-        <p class="max-w-xl text-sm opacity-70">
+        <p class="kr-text-faded-sm max-w-xl">
           No public or owned rewards match this gallery.
         </p>
 

--- a/components/ruler-hooked/ruler-hooked-slots.vue
+++ b/components/ruler-hooked/ruler-hooked-slots.vue
@@ -3,7 +3,7 @@
      Reads and drives the store directly. -->
 <template>
   <div class="rounded-xl border border-base-300 bg-base-100 p-4">
-    <h3 class="kr-text-eyebrow-bold mb-2 text-sm tracking-wide opacity-70">Save slots</h3>
+    <h3 class="kr-text-faded-sm kr-text-eyebrow-bold mb-2 tracking-wide">Save slots</h3>
 
     <div v-if="store.slots.length" class="mb-3 flex flex-col gap-1">
       <div

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -261,7 +261,7 @@
             }}
           </p>
 
-          <p class="mt-1 text-sm opacity-70">
+          <p class="kr-text-faded-sm mt-1">
             {{
               searchQuery
                 ? 'Try fewer or stranger words.'

--- a/components/scenarios/scenario-relationship-gallery.vue
+++ b/components/scenarios/scenario-relationship-gallery.vue
@@ -116,7 +116,7 @@
         <Icon name="kind-icon:map" class="h-10 w-10 opacity-50" />
         <div>
           <p class="font-bold">{{ emptyTitle }}</p>
-          <p class="mt-1 text-sm opacity-70">{{ emptySubtitle }}</p>
+          <p class="kr-text-faded-sm mt-1">{{ emptySubtitle }}</p>
         </div>
 
         <button

--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -153,7 +153,7 @@
 
     <div
       v-else-if="!compatibleResources.length"
-      class="rounded-lg border border-dashed border-base-300 bg-base-200/50 p-5 text-center text-sm opacity-70"
+      class="kr-text-faded-sm rounded-lg border border-dashed border-base-300 bg-base-200/50 p-5 text-center"
     >
       No active {{ engine.toUpperCase() }} LoRA Resources are available.
     </div>

--- a/pages/music-mentor.vue
+++ b/pages/music-mentor.vue
@@ -95,7 +95,7 @@
           {{ analyzeLabel }}
         </button>
 
-        <div v-if="store.state.message" class="text-sm opacity-70 text-center">
+        <div v-if="store.state.message" class="kr-text-faded-sm text-center">
           {{ store.state.message }}
         </div>
 

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -2,7 +2,7 @@
   <div class="kr-surface">
     <div class="kr-scroll kr-container max-w-7xl space-y-6 p-6">
       <header class="space-y-1">
-        <p class="text-sm opacity-70">
+        <p class="kr-text-faded-sm">
           Animate a still into a short clip. Presets choose sensible studio
           settings, while every generation control remains editable.
         </p>
@@ -247,7 +247,7 @@
               type="checkbox"
               class="toggle toggle-accent"
             />
-            <span class="text-sm opacity-70">
+            <span class="kr-text-faded-sm">
               {{ loop ? 'Seamless loop' : 'Play once' }}
             </span>
           </label>
@@ -338,7 +338,7 @@
 
         <div
           v-if="videoStore.state.message"
-          class="text-center text-sm opacity-70"
+          class="kr-text-faded-sm text-center"
         >
           {{ videoStore.state.message }}
           <span v-if="videoStore.state.jobId" class="opacity-50">

--- a/utils/scripts/codemods/kr_text_faded_sm_codemod.py
+++ b/utils/scripts/codemods/kr_text_faded_sm_codemod.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `text-sm opacity-70` status/loading caption
+text to `kr-text-faded-sm`.
+
+Sibling of kr_text_faded_xs_codemod.py, same conventions: dry-run by
+default, --write to update matching Vue files in place. Only the exact
+`text-sm opacity-70` shape is touched, and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings (see _class_attr.py),
+and regardless of the base tokens' order in the source. A source that
+already carries `kr-text-faded-sm`, or is missing either base token, is
+left untouched. Extra tokens beyond the base set are preserved verbatim
+after the primitive class, matching the kr-badge-*/kr-spinner-*/
+kr-text-dim-*/kr-text-faded-xs codemods' subset-match convention -- pass
+--exact-only to restrict a slice to sources with no extra tokens at all,
+the safest and most literal pool.
+
+Deliberately does NOT touch other `opacity-NN` shapes (`text-sm
+opacity-80`, `text-xs opacity-55`, `font-sans opacity-70`, etc.) -- those
+are real, independently-repeated shapes of their own, left for future
+slices per this codemod's own tailwind.css comment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-text-faded-sm"
+BASE_TOKENS = {"text-sm", "opacity-70"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-faded-sm {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
conductor interface-vision/t-104 (recurring front-end-consistency umbrella), slice 185

### What changed / what I produced
- New `.kr-text-faded-sm` utility (`text-sm opacity-70`) in `assets/css/tailwind.css`, sibling of slice 184's `.kr-text-faded-xs` (`text-xs opacity-60`) — the largest of the sibling `opacity-NN` shapes that slice's survey left open.
- New codemod `utils/scripts/codemods/kr_text_faded_sm_codemod.py`, sibling of `kr_text_faded_xs_codemod.py` (shares the `_class_attr.py` `CLASS_ATTR` guard against `:class`/`v-bind:class` false positives).
- Migrated 16 subset-match occurrences across 13 files — every one a conditionally-rendered `<p>`/`<span>`/`<div>` empty-state or loading/status caption, the same semantic pattern as the `xs` family member. No `--exact-only` this slice since most occurrences carry real extra tokens (`mt-1`, `py-2`, `max-w-xl`, `leading-relaxed`, `tracking-wide`, `text-center`, `line-clamp-2`) worth preserving alongside the primitive. No geometry or behavior change.

### How I verified
- `vue-tsc --noEmit`: clean.
- `eslint .`: 333 problems (327 errors, 6 warnings) — identical to the documented baseline.
- `npm run test:layout-contract`: holds, 0 new violations. (A pre-existing, unrelated `narrative-ingredient-multi-picker.vue` viewport-grid ratchet opportunity surfaced again, same as every recent slice — left untouched, out of scope here.)
- `npm run test:lint-ratchet`: holds at 333/-59.
- `prettier --check .`: warning list byte-identical to baseline (1145 lines, diffed the full before/after list, not just the count).

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
Remaining sibling `opacity-NN` shapes from slice 184's survey: `text-sm opacity-80` (10 occurrences), `text-xs opacity-55` (7), `font-sans opacity-70` (13). Any is a reasonable next bounded slice under the same `kr-text-faded-*` naming convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmpXi78h7qvxKqLmjF12AW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmpXi78h7qvxKqLmjF12AW)_