### PR TITLE
interface-vision/t-104 slice 186: add kr-text-faded-sm-80, migrate 17 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -2080,6 +2080,25 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply text-sm opacity-70;
   }
 
+  /* Sibling of `.kr-text-faded-sm` at the same `text-sm` size but a
+   * heavier 80% opacity -- `text-sm opacity-80` (interface-vision t-104
+   * slice 186), one of the sibling `opacity-NN` shapes slice 184's survey
+   * left open alongside `text-xs opacity-55` and `font-sans opacity-70`.
+   * Found at 16 subset-match occurrences across 6 files
+   * (cthulhuquarium-game.vue, brainstorm-manager.vue, kr-manager.vue,
+   * ruler-hooked-game.vue, ruler-hooked-fishing-encounter.vue,
+   * ruler-hooked-card.vue, appmaker-page.vue), the same conditionally-
+   * rendered status/description caption pattern as its `-70` sibling.
+   * Named `kr-text-faded-sm-80` rather than reusing `kr-text-faded-sm`
+   * because that name is already claimed by the 70%-opacity shape shipped
+   * in slice 185 -- both are real, independently-repeated exact shapes in
+   * the wild, not one that "should normalize" to the other, the same
+   * `kr-text-dim-sm-70`/`kr-text-dim-sm` precedent this family already
+   * follows. */
+  .kr-text-faded-sm-80 {
+    @apply text-sm opacity-80;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -552,7 +552,7 @@
           <span aria-hidden="true">⚠</span>
           <div class="min-w-0 flex-1">
             <p class="font-black">{{ persistenceErrorHeading }}</p>
-            <p class="mt-1 break-words text-sm opacity-80">{{ persistenceError.message }}</p>
+            <p class="kr-text-faded-sm-80 mt-1 break-words">{{ persistenceError.message }}</p>
           </div>
           <button type="button" class="kr-btn-ghost-plain" @click="store.clearPersistenceError()">
             Dismiss
@@ -570,7 +570,7 @@
       <span aria-hidden="true">⚠</span>
       <div class="min-w-0 flex-1">
         <p class="font-black">{{ errorHeading }}</p>
-        <p class="mt-1 break-words text-sm opacity-80">{{ generationError.message }}</p>
+        <p class="kr-text-faded-sm-80 mt-1 break-words">{{ generationError.message }}</p>
       </div>
       <button type="button" class="kr-btn-ghost-plain" @click="store.clearGenerationError()">
         Dismiss
@@ -758,7 +758,7 @@
       <span aria-hidden="true">⚠</span>
       <div class="min-w-0 flex-1">
         <p class="font-black">Art generation hit a snag</p>
-        <p class="mt-1 break-words text-sm opacity-80">
+        <p class="kr-text-faded-sm-80 mt-1 break-words">
           {{ artGenerationError.message }}
         </p>
       </div>

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -840,7 +840,7 @@
           >
             {{ tankStore.revealedUnlock.Monster.species }}
           </p>
-          <p class="text-sm opacity-80">
+          <p class="kr-text-faded-sm-80">
             {{
               tankStore.revealedUnlock.Monster.fieldNote ||
               'Nothing is written about this one yet.'
@@ -898,7 +898,7 @@
           >
             {{ tankStore.revealedHatch.Monster.species }}
           </p>
-          <p class="text-sm opacity-80">
+          <p class="kr-text-faded-sm-80">
             {{
               tankStore.revealedHatch.Monster.fieldNote ||
               'Nothing is written about this one yet.'
@@ -951,7 +951,7 @@
           <h3 class="kr-text-black-lg">
             {{ breedConfirmPair.a.Monster.name }}
           </h3>
-          <p class="text-sm opacity-80">
+          <p class="kr-text-faded-sm-80">
             Costs {{ breedConfirmPair.a.Monster.breedCost }} coins. Neither
             parent is consumed -- you'll get a new individual with converged
             stats, and just maybe, a secret evolution.
@@ -1030,7 +1030,7 @@
           >
             {{ tankStore.revealedBreed.stock.Monster.species }}
           </p>
-          <p class="text-sm opacity-80">
+          <p class="kr-text-faded-sm-80">
             {{
               tankStore.revealedBreed.stock.Monster.fieldNote ||
               'Nothing is written about this one yet.'
@@ -1072,7 +1072,7 @@
             The bestiary is complete
           </p>
           <h3 class="kr-text-black-lg">Every species, observed.</h3>
-          <p class="text-sm opacity-80">
+          <p class="kr-text-faded-sm-80">
             Nothing here resets and nothing leaves the collection -- the tank
             keeps running exactly as it was. This is just the beat that says so.
           </p>
@@ -1124,7 +1124,7 @@
           <h3 class="kr-text-black-lg">
             Everything is exactly as you left it.
           </h3>
-          <p class="text-sm opacity-80">
+          <p class="kr-text-faded-sm-80">
             Nothing in your tank has changed. But through the glass across the
             shop's window, something enormous drifts past, pauses for a moment
             the way you pause at a tank you've already seen today, and moves on.
@@ -1166,7 +1166,7 @@
           <h3 class="kr-text-black-lg">
             {{ tankStore.offlineEarnings }} coins
           </h3>
-          <p class="text-sm opacity-80">
+          <p class="kr-text-faded-sm-80">
             Something kept working{{ offlineDurationLabel }}. Nobody says by
             whom.
           </p>

--- a/components/manager/kr-manager.vue
+++ b/components/manager/kr-manager.vue
@@ -192,7 +192,7 @@
 
       <div>
         <p class="kr-text-black-lg">Unknown tab: {{ activeTab }}</p>
-        <p class="mt-1 text-sm opacity-80">Expected one of: {{ slotTabs }}</p>
+        <p class="kr-text-faded-sm-80 mt-1">Expected one of: {{ slotTabs }}</p>
       </div>
 
       <button

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -79,7 +79,7 @@
             >
               {{ creating ? 'Filing request…' : 'Create app' }}
             </button>
-            <span v-if="createMessage" class="text-sm opacity-80">{{
+            <span v-if="createMessage" class="kr-text-faded-sm-80">{{
               createMessage
             }}</span>
           </div>

--- a/components/pages/memory-dungeon.vue
+++ b/components/pages/memory-dungeon.vue
@@ -167,7 +167,7 @@
         <div class="kr-text-black-2xl leading-tight tracking-tight">
           {{ award.title }}
         </div>
-        <div class="mt-1 text-sm font-medium opacity-80">
+        <div class="kr-text-faded-sm-80 mt-1 font-medium">
           {{ award.subtitle }}
         </div>
       </div>

--- a/components/ruler-hooked/ruler-hooked-card.vue
+++ b/components/ruler-hooked/ruler-hooked-card.vue
@@ -12,7 +12,7 @@
       </span>
     </div>
     <h3 class="kr-text-bold-lg">{{ card.title }}</h3>
-    <p v-if="card.body" class="mt-1 text-sm opacity-80">{{ card.body }}</p>
+    <p v-if="card.body" class="kr-text-faded-sm-80 mt-1">{{ card.body }}</p>
 
     <div class="mt-4 flex flex-col gap-2">
       <button

--- a/components/ruler-hooked/ruler-hooked-fishing-encounter.vue
+++ b/components/ruler-hooked/ruler-hooked-fishing-encounter.vue
@@ -9,7 +9,7 @@
       <span class="kr-badge-outline">Beat {{ encounter.beat }}/{{ encounter.maxBeats }}</span>
     </div>
 
-    <p class="mt-3 text-sm opacity-80">{{ encounter.catchBehavior }}</p>
+    <p class="kr-text-faded-sm-80 mt-3">{{ encounter.catchBehavior }}</p>
 
     <div class="mt-4 grid gap-3">
       <label class="grid gap-1 text-xs font-semibold">

--- a/components/ruler-hooked/ruler-hooked-game.vue
+++ b/components/ruler-hooked/ruler-hooked-game.vue
@@ -62,7 +62,7 @@
         <div v-if="store.pendingEnding" class="rounded-xl border border-accent bg-accent/10 p-4">
           <p class="kr-text-bold-sm">An ending is within reach:</p>
           <p class="kr-text-bold-lg mt-1">{{ endingTitle }}</p>
-          <p v-if="endingBody" class="text-sm opacity-80">{{ endingBody }}</p>
+          <p v-if="endingBody" class="kr-text-faded-sm-80">{{ endingBody }}</p>
           <div class="mt-3 flex gap-2">
             <button type="button" class="btn btn-accent btn-sm" @click="store.acceptEnding()">Take this ending</button>
             <button type="button" class="kr-btn-ghost-plain" @click="store.declineEnding()">Keep fishing</button>
@@ -71,7 +71,7 @@
 
         <div v-if="store.save.status === 'COMPLETE'" class="rounded-xl border border-success bg-success/10 p-4 text-center">
           <p class="kr-text-bold-lg">{{ endingTitleFor(store.save.endingKey) }}</p>
-          <p class="text-sm opacity-80">The reign is complete. Start another from the slots below.</p>
+          <p class="kr-text-faded-sm-80">The reign is complete. Start another from the slots below.</p>
         </div>
 
         <RulerHookedFishopedia :save="store.save" />

--- a/utils/scripts/codemods/kr_text_faded_sm_80_codemod.py
+++ b/utils/scripts/codemods/kr_text_faded_sm_80_codemod.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `text-sm opacity-80` status/description
+caption text to `kr-text-faded-sm-80`.
+
+Sibling of kr_text_faded_sm_codemod.py, same conventions: dry-run by
+default, --write to update matching Vue files in place. Only the exact
+`text-sm opacity-80` shape is touched, and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings (see _class_attr.py),
+and regardless of the base tokens' order in the source. A source that
+already carries `kr-text-faded-sm-80`, or is missing either base token, is
+left untouched. Extra tokens beyond the base set are preserved verbatim
+after the primitive class, matching the kr-badge-*/kr-spinner-*/
+kr-text-dim-*/kr-text-faded-* codemods' subset-match convention -- pass
+--exact-only to restrict a slice to sources with no extra tokens at all,
+the safest and most literal pool.
+
+Deliberately does NOT touch other `opacity-NN` shapes (`text-sm
+opacity-70`, `text-xs opacity-55`, `font-sans opacity-70`, etc.) -- those
+are real, independently-repeated shapes of their own, already named or
+left for future slices per this codemod's own tailwind.css comment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-text-faded-sm-80"
+BASE_TOKENS = {"text-sm", "opacity-80"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-faded-sm-80 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
conductor interface-vision/t-104 (recurring front-end-consistency umbrella), slice 186

### What changed / what I produced
- New `.kr-text-faded-sm-80` utility (`text-sm opacity-80`) in `assets/css/tailwind.css`, sibling of slice 185's `.kr-text-faded-sm` (`text-sm opacity-70`) — one of the sibling `opacity-NN` shapes slice 184's survey left open, alongside `text-xs opacity-55` and `font-sans opacity-70`.
- New codemod `utils/scripts/codemods/kr_text_faded_sm_80_codemod.py`, sibling of `kr_text_faded_sm_codemod.py` (shares the `_class_attr.py` `CLASS_ATTR` guard against `:class`/`v-bind:class` false positives).
- Migrated 17 subset-match occurrences across 8 files (`cthulhuquarium-game.vue` x7, `brainstorm-manager.vue` x3, `kr-manager.vue`, `appmaker-page.vue`, `memory-dungeon.vue`, `ruler-hooked-card.vue`, `ruler-hooked-fishing-encounter.vue`, `ruler-hooked-game.vue` x2) — every one a conditionally-rendered status/description caption. No geometry or behavior change.
- Named `kr-text-faded-sm-80` (not a reuse of `kr-text-faded-sm`) since that name is already claimed by the 70%-opacity shape shipped in slice 185 — both are real, independently-repeated exact shapes in the wild, following the `kr-text-dim-sm-70`/`kr-text-dim-sm` naming precedent this family already established.

### How I verified
- `vue-tsc --noEmit`: clean.
- `eslint .`: 333 problems (327 errors, 6 warnings) — identical to the documented baseline.
- `npm run test:layout-contract`: holds, 0 new violations. (The same pre-existing, unrelated `narrative-ingredient-multi-picker.vue` viewport-grid ratchet opportunity surfaced again — left untouched, out of scope here.)
- `npm run test:lint-ratchet`: holds at 333/-59.
- `prettier --check .`: warning list byte-identical to baseline (1145 lines, diffed the full before/after list via `git stash`, not just the count).

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
Remaining sibling `opacity-NN` shapes from slice 184's survey: `text-xs opacity-55` (10 occurrences across 6 files) and `font-sans opacity-70` (13 occurrences, all in `components/ui/ui-gallery.vue` — worth checking whether that file is a live design-token showcase before treating it as an ordinary migration target). `text-xs opacity-55` is the safer next bounded slice under the same `kr-text-faded-*` naming convention.

### Notes for reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BofFSqTjooRAepNxMdQEyV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BofFSqTjooRAepNxMdQEyV)_