### PR TITLE
interface-vision/t-104 slice 187: add kr-text-faded-xs-55, migrate 16 subset-match occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -2099,6 +2099,23 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply text-sm opacity-80;
   }
 
+  /* `.kr-text-faded-xs`'s (slice 184, `opacity-60`) `opacity-55` sibling at
+   * the same `xs` size -- `text-xs opacity-55` (interface-vision t-104
+   * slice 187), the last of the sibling `opacity-NN` shapes slice 184's
+   * survey left open alongside `text-sm opacity-70`/`text-sm opacity-80`
+   * (both since shipped). Found at 10 subset-match occurrences across 4
+   * files (mandarin-voice-coach.vue, video-lora-picker.vue,
+   * ruler-hooked-fishing-encounter.vue, pages/play/mandarin.vue), the same
+   * conditionally-rendered status/caption pattern as its `xs`/`sm`
+   * siblings. Named `kr-text-faded-xs-55` rather than reusing
+   * `kr-text-faded-xs` because that name is already claimed by the 60%-
+   * opacity shape shipped in slice 184 -- both are real, independently-
+   * repeated exact shapes in the wild, the same `kr-text-faded-sm-80`/
+   * `kr-text-faded-sm` precedent this family already follows. */
+  .kr-text-faded-xs-55 {
+    @apply text-xs opacity-55;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/mandarin/mandarin-voice-coach.vue
+++ b/components/mandarin/mandarin-voice-coach.vue
@@ -75,7 +75,7 @@
     <div v-if="audioUrl" class="mt-4 kr-panel-tint-md">
       <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <p class="text-xs font-semibold uppercase tracking-wide opacity-55">Your attempt</p>
+          <p class="kr-text-faded-xs-55 font-semibold uppercase tracking-wide">Your attempt</p>
           <p class="kr-text-faded-xs">Not saved by Kind Robots. The clip is sent to the configured speech service only for transcription.</p>
         </div>
         <audio :src="audioUrl" controls class="h-10 max-w-full" />
@@ -88,7 +88,7 @@
       aria-live="polite"
     >
       <div class="kr-panel-tint-md">
-        <p class="text-xs font-semibold uppercase tracking-wide opacity-55">What I heard</p>
+        <p class="kr-text-faded-xs-55 font-semibold uppercase tracking-wide">What I heard</p>
         <p v-if="transcript" class="kr-text-bold-2xl mt-2">{{ transcript }}</p>
         <p v-else class="mt-2 text-sm opacity-60">The transcript was unavailable.</p>
         <div v-if="comparison" class="mt-3 text-sm leading-relaxed">
@@ -100,13 +100,13 @@
           </span>
           {{ comparison.message }}
         </div>
-        <p class="mt-3 text-xs opacity-55">
+        <p class="kr-text-faded-xs-55 mt-3">
           Target: <span class="font-semibold">{{ card.simplified }}</span> · {{ card.pinyin }}
         </p>
       </div>
 
       <div class="kr-panel-tint-md">
-        <p class="text-xs font-semibold uppercase tracking-wide opacity-55">Tone shape</p>
+        <p class="kr-text-faded-xs-55 font-semibold uppercase tracking-wide">Tone shape</p>
         <div v-if="toneAnalysis?.observations.length" class="mt-2 space-y-2">
           <div
             v-for="observation in toneAnalysis.observations"
@@ -124,7 +124,7 @@
           </div>
         </div>
         <p v-else class="mt-2 text-sm opacity-60">No stable pitch trace was available for this attempt.</p>
-        <p v-if="toneAnalysis" class="mt-3 text-xs leading-relaxed opacity-55">
+        <p v-if="toneAnalysis" class="kr-text-faded-xs-55 mt-3 leading-relaxed">
           {{ toneAnalysis.note }} Voiced frames: {{ toneAnalysis.voicedPercent }}%.
         </p>
       </div>

--- a/components/ruler-hooked/ruler-hooked-fishing-encounter.vue
+++ b/components/ruler-hooked/ruler-hooked-fishing-encounter.vue
@@ -2,7 +2,7 @@
   <section class="rounded-2xl border border-primary/30 bg-base-100 p-4 shadow-sm" aria-labelledby="fishing-encounter-title">
     <div class="flex flex-wrap items-start justify-between gap-3">
       <div>
-        <p class="kr-text-eyebrow-bold text-xs tracking-wide opacity-55">On the line</p>
+        <p class="kr-text-faded-xs-55 kr-text-eyebrow-bold tracking-wide">On the line</p>
         <h3 id="fishing-encounter-title" class="kr-text-black-xl">{{ encounter.fishName }}</h3>
         <p class="mt-1 text-xs opacity-65">{{ encounter.rarity }} · {{ encounter.affinity }} · {{ familyLabel }}</p>
       </div>
@@ -50,7 +50,7 @@
       </button>
     </div>
 
-    <p class="mt-3 text-xs opacity-55">
+    <p class="kr-text-faded-xs-55 mt-3">
       Fishing is beat-based, not twitch-based. Read the cue, choose an action, and the same action sequence will reproduce the same encounter.
     </p>
   </section>

--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -166,7 +166,7 @@
           class="input input-bordered input-sm min-w-52 flex-1"
           placeholder="Search LoRAs by name, path, or trigger word…"
         />
-        <span class="text-xs opacity-55">
+        <span class="kr-text-faded-xs-55">
           {{ filteredResources.length }} compatible
         </span>
       </div>
@@ -259,7 +259,7 @@
 
       <p
         v-if="search.trim() && !filteredResources.length"
-        class="text-center text-xs opacity-55"
+        class="kr-text-faded-xs-55 text-center"
       >
         No compatible LoRA matches “{{ search.trim() }}”.
       </p>

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -118,7 +118,7 @@
               <div class="flex min-w-0 flex-wrap items-center gap-2">
                 <b class="truncate">{{ selectedSet?.label || 'Study set' }}</b>
                 <span class="kr-badge-ghost-sm">{{ galleryItems.length }}</span>
-                <span class="text-xs opacity-55">Tap a card to study it.</span>
+                <span class="kr-text-faded-xs-55">Tap a card to study it.</span>
               </div>
             </template>
           </kr-gallery>
@@ -258,7 +258,7 @@
                   <div v-else class="space-y-3">
                     <Icon name="kind-icon:volume" class="mx-auto size-12 opacity-60" />
                     <button type="button" class="kr-btn-primary-md-plain" @click="store.speak(currentCard)">Hear prompt</button>
-                    <p class="text-xs opacity-55">Listen without seeing the answer.</p>
+                    <p class="kr-text-faded-xs-55">Listen without seeing the answer.</p>
                   </div>
                 </div>
 
@@ -322,7 +322,7 @@
                     <button type="button" class="btn btn-sm btn-outline btn-success" @click="store.rateStudyCard('good')">Good</button>
                     <button type="button" class="btn btn-sm btn-outline btn-accent" @click="store.rateStudyCard('easy')">Easy</button>
                   </div>
-                  <p class="text-xs opacity-55">Rating saves the review and advances. Previous and Next never rate the card.</p>
+                  <p class="kr-text-faded-xs-55">Rating saves the review and advances. Previous and Next never rate the card.</p>
 
                   <details class="rounded-2xl border border-base-300 bg-base-200/25">
                     <summary class="cursor-pointer p-3 text-sm font-semibold">Pronunciation practice</summary>
@@ -335,7 +335,7 @@
                     <Icon name="kind-icon:back" class="size-4" />
                     Previous
                   </button>
-                  <span class="text-xs opacity-55">{{ currentPositionLabel }}</span>
+                  <span class="kr-text-faded-xs-55">{{ currentPositionLabel }}</span>
                   <button type="button" class="kr-btn-ghost-plain" :disabled="focusNavigationLocked" @click="store.nextCard()">
                     Next
                     <Icon name="kind-icon:forward" class="size-4" />
@@ -364,7 +364,7 @@
                 </div>
                 <p class="text-3xl font-bold">{{ currentCard.simplified }}</p>
                 <p class="kr-text-bold-xl tracking-wide">{{ currentCard.pinyin }}</p>
-                <p v-if="currentCard.traditional" class="text-xs opacity-55">Traditional: {{ currentCard.traditional }}</p>
+                <p v-if="currentCard.traditional" class="kr-text-faded-xs-55">Traditional: {{ currentCard.traditional }}</p>
                 <div class="flex flex-wrap justify-center gap-1">
                   <button v-if="canQueueArt" type="button" class="kr-btn-outline-xs" :disabled="artBusy" @click="queueCurrentIllustration">
                     {{ artBusy ? 'Submitting…' : 'Request illustration' }}
@@ -414,7 +414,7 @@
                         <span class="text-3xl font-semibold">{{ component.glyph }}</span>
                         <div>
                           <p class="font-semibold">{{ component.label }}</p>
-                          <p class="text-xs uppercase tracking-wide opacity-55">{{ roleLabel(component.role) }}</p>
+                          <p class="kr-text-faded-xs-55 uppercase tracking-wide">{{ roleLabel(component.role) }}</p>
                           <p v-if="component.meaning" class="mt-1 text-sm">{{ component.meaning }}</p>
                         </div>
                       </div>
@@ -446,7 +446,7 @@
                 >
                   {{ set.name }}
                 </button>
-                <span v-if="!customSets.length" class="text-xs opacity-55">Create a custom deck in Decks.</span>
+                <span v-if="!customSets.length" class="kr-text-faded-xs-55">Create a custom deck in Decks.</span>
               </div>
             </section>
           </article>

--- a/utils/scripts/codemods/kr_text_faded_xs_55_codemod.py
+++ b/utils/scripts/codemods/kr_text_faded_xs_55_codemod.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `text-xs opacity-55` status/description
+caption text to `kr-text-faded-xs-55`.
+
+Sibling of kr_text_faded_sm_80_codemod.py, same conventions: dry-run by
+default, --write to update matching Vue files in place. Only the exact
+`text-xs opacity-55` shape is touched, and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings (see _class_attr.py),
+and regardless of the base tokens' order in the source. A source that
+already carries `kr-text-faded-xs-55`, or is missing either base token, is
+left untouched. Extra tokens beyond the base set are preserved verbatim
+after the primitive class, matching the kr-badge-*/kr-spinner-*/
+kr-text-dim-*/kr-text-faded-* codemods' subset-match convention -- pass
+--exact-only to restrict a slice to sources with no extra tokens at all,
+the safest and most literal pool.
+
+Deliberately does NOT touch other `opacity-NN` shapes (`font-sans
+opacity-70`, etc.) -- those are real, independently-repeated shapes of
+their own, already named or left for future slices per this codemod's own
+tailwind.css comment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-text-faded-xs-55"
+BASE_TOKENS = {"text-xs", "opacity-55"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-faded-xs-55 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104 (recurring front-end-consistency umbrella), slice 187.

### What changed / what I produced
Added `.kr-text-faded-xs-55` (`@apply text-xs opacity-55;`) to `assets/css/tailwind.css` — the last sibling `opacity-NN` shape slice 184's survey left open (`text-sm opacity-70`/`text-sm opacity-80` shipped in slices 185/186). New codemod `utils/scripts/codemods/kr_text_faded_xs_55_codemod.py`, sibling of `kr_text_faded_sm_80_codemod.py` (imports the shared `_class_attr.py` `CLASS_ATTR` guard, same `--exact-only`/`--write` flags).

Migrated 16 subset-match occurrences across 4 files: `mandarin-voice-coach.vue` (5), `pages/play/mandarin.vue` (7), `ruler-hooked-fishing-encounter.vue` (2), `video-lora-picker.vue` (2). No geometry or behavior change — pure class-string substitution.

### How I verified
- `vue-tsc --noEmit` (via `npm run test`): clean
- `eslint .`: 333/327/6, identical to baseline (no new errors in touched files)
- `npm run test:layout-contract`: holds, 0 new violations (same pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet note as prior slices, left untouched)
- `npm run test:lint-ratchet`: holds at 333/-59
- `prettier --check .`: byte-identical warning list (1145 lines), confirmed via `git stash` before/after diff of the full warning list

### Stakes
Reversible, scoped, CSS/class-only change with no behavior change.

### Flags for Reviewer
None. Kaizen for the next slice: `font-sans opacity-70` (13 occurrences, all in `components/ui/ui-gallery.vue`) needs a check first for whether that file is a live design-token showcase rather than an ordinary migration target, per slice 186's note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNtdcaE1oGVa8C4g5xCYsE

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNtdcaE1oGVa8C4g5xCYsE)_