### PR TITLE
interface-vision/t-104 slice 188: add kr-text-dim-sm-50, migrate 16 exact-match occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -2116,6 +2116,31 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply text-xs opacity-55;
   }
 
+  /* The last unnamed sibling in the `kr-text-dim-*` family (interface-vision
+   * t-104 slice 188) -- `text-sm text-base-content/50`, the same "secondary
+   * caption" role as `.kr-text-dim-sm` (60% opacity) and `.kr-text-dim-sm-70`
+   * (70% opacity) but at 50%, the opacity `.kr-text-dim-xs` already claims at
+   * the smaller `xs` size. Slices 152-163 explicitly surveyed and closed out
+   * the `text-xs text-base-content/NN` family (`/40`-`/70`, all six named)
+   * but never checked `text-sm` against `/50` specifically -- a fresh
+   * full-repo class-frequency survey run after slice 187 closed the
+   * `opacity-NN` sibling set found this exact pair still hand-rolled
+   * identically in 11 files (16 exact occurrences; 39 subset-match including
+   * extra tokens like `flex h-full min-h-32 items-center justify-center
+   * kr-panel-flat border-dashed p-6 text-center`), consistently the "empty
+   * state" dashed-panel caption pattern (model-builder, coloring-book,
+   * facet-gallery, messenger, forum-moderation-panel, etc.). Named
+   * `kr-text-dim-sm-50` rather than reusing `kr-text-dim-sm`/`kr-text-dim-xs`
+   * because both those names are already claimed by their own
+   * independently-repeated exact shapes -- same `kr-text-dim-sm-70`/
+   * `kr-text-dim-sm` precedent this family already follows. Slice 188
+   * deliberately ran the codemod with `--exact-only`, bounding this first
+   * pass to sources with no extra tokens and leaving the fuller subset-match
+   * pool (23 further occurrences) for a later slice. */
+  .kr-text-dim-sm-50 {
+    @apply text-sm text-base-content/50;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/coloring/coloring-book-readiness.vue
+++ b/components/coloring/coloring-book-readiness.vue
@@ -84,7 +84,7 @@
       >
         <div>
           <h4 class="kr-text-black-xl">{{ selectedBook.title }} interiors</h4>
-          <p class="text-sm text-base-content/50">
+          <p class="kr-text-dim-sm-50">
             {{ selectedSummary.actionable }} pages still need an action;
             {{ selectedSummary.final }} are finalized.
           </p>

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -190,7 +190,7 @@
         >
           <div>
             <h4 class="kr-text-black-xl">{{ studio.selectedBook?.title }}</h4>
-            <p class="text-sm text-base-content/50">
+            <p class="kr-text-dim-sm-50">
               Side-by-side production candidates for every proposal slot.
             </p>
           </div>
@@ -504,7 +504,7 @@
         >
           <div>
             <h4 class="kr-text-black-xl">Queue &amp; review problems</h4>
-            <p class="text-sm text-base-content/50">
+            <p class="kr-text-dim-sm-50">
               Semantic gate failures and proposals that exhausted automatic retries.
             </p>
           </div>
@@ -562,7 +562,7 @@
       >
         <div class="mb-4">
           <h4 class="kr-text-black-xl">End-user coloring preview</h4>
-          <p class="text-sm text-base-content/50">
+          <p class="kr-text-dim-sm-50">
             The existing coloring engine lives here without pretending to be the
             production manager.
           </p>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -506,7 +506,7 @@
                     When your AI assigns you an action item, it shows up here.
                   </p>
                 </template>
-                <p v-else class="text-sm text-base-content/50">
+                <p v-else class="kr-text-dim-sm-50">
                   No {{ todoFilter.toLowerCase() }} tasks.
                 </p>
               </div>

--- a/components/pages/creator-earnings-page.vue
+++ b/components/pages/creator-earnings-page.vue
@@ -45,7 +45,7 @@
 
       <div
         v-if="earningsStore.loading && !earningsStore.hasLoaded"
-        class="text-sm text-base-content/50"
+        class="kr-text-dim-sm-50"
       >
         Loading…
       </div>

--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -51,10 +51,7 @@
         </p>
       </div>
 
-      <div
-        v-if="store.loading && !store.hasLoaded"
-        class="text-sm text-base-content/50"
-      >
+      <div v-if="store.loading && !store.hasLoaded" class="kr-text-dim-sm-50">
         Loading…
       </div>
 

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -107,10 +107,7 @@
           Message feed
         </div>
         <div class="kr-scroll flex flex-col gap-2 p-3">
-          <p
-            v-if="voice.recentMessages.length === 0"
-            class="text-sm text-base-content/50"
-          >
+          <p v-if="voice.recentMessages.length === 0" class="kr-text-dim-sm-50">
             Waiting for messages. Connect the relay, then say “Serendipity, turn
             butterflies on.”
           </p>

--- a/components/pages/wallet-page.vue
+++ b/components/pages/wallet-page.vue
@@ -51,12 +51,12 @@
           users — a running score of your community contribution.
         </p>
 
-        <div v-if="karmaStore.loading" class="text-base-content/50 text-sm">
+        <div v-if="karmaStore.loading" class="kr-text-dim-sm-50">
           Loading…
         </div>
         <div
           v-else-if="!karmaStore.transactions.length"
-          class="text-base-content/50 text-sm"
+          class="kr-text-dim-sm-50"
         >
           No karma activity yet. Go react, create, and share! 🌱
         </div>

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -56,10 +56,10 @@
       {{ errorMessage }}
     </div>
 
-    <div v-if="isLoading" class="text-sm text-base-content/50">Loading…</div>
+    <div v-if="isLoading" class="kr-text-dim-sm-50">Loading…</div>
 
     <div v-else class="flex flex-col gap-2">
-      <p v-if="!credentials.length" class="text-sm text-base-content/50">
+      <p v-if="!credentials.length" class="kr-text-dim-sm-50">
         No agent credentials yet.
       </p>
 

--- a/components/user/friend-gallery.vue
+++ b/components/user/friend-gallery.vue
@@ -107,9 +107,7 @@
               </div>
             </div>
 
-            <p v-else class="text-sm text-base-content/50">
-              No art in collection yet.
-            </p>
+            <p v-else class="kr-text-dim-sm-50">No art in collection yet.</p>
           </div>
         </div>
       </template>

--- a/components/user/friends-panel.vue
+++ b/components/user/friends-panel.vue
@@ -48,7 +48,7 @@
       <h2 class="kr-text-black-lg mb-3">
         Your friends ({{ friends.friendCount }})
       </h2>
-      <p v-if="!friends.friendIds.length" class="text-sm text-base-content/50">
+      <p v-if="!friends.friendIds.length" class="kr-text-dim-sm-50">
         No friends yet — find some below.
       </p>
       <div class="flex flex-col gap-2">
@@ -103,7 +103,7 @@
         class="kr-input-muted mb-3 rounded-xl"
         @input="onSearch"
       />
-      <p v-if="isSearching" class="text-sm text-base-content/50">Searching…</p>
+      <p v-if="isSearching" class="kr-text-dim-sm-50">Searching…</p>
       <div class="flex flex-col gap-2">
         <div
           v-for="u in directory"

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -63,10 +63,7 @@
               ceiling reached
             </span>
           </div>
-          <p
-            v-if="!draftsStore.ceilingStatus.length"
-            class="text-sm text-base-content/50"
-          >
+          <p v-if="!draftsStore.ceilingStatus.length" class="kr-text-dim-sm-50">
             No ceiling data yet -- scan for drafts to load it.
           </p>
         </section>

--- a/utils/scripts/codemods/kr_text_dim_sm_50_codemod.py
+++ b/utils/scripts/codemods/kr_text_dim_sm_50_codemod.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `text-sm text-base-content/50` secondary
+caption text to `kr-text-dim-sm-50`.
+
+Sibling of kr_text_dim_sm_70_codemod.py / kr_text_dim_xs_codemod.py, same
+conventions: dry-run by default, --write to update matching Vue files in
+place. Only the exact `text-sm text-base-content/50` shape is touched, and
+only in static `class="..."` attributes -- never `:class`/`v-bind:class`
+bindings, and regardless of the base tokens' order in the source. A source
+that already carries `kr-text-dim-sm-50`, or is missing either base token, is
+left untouched. Extra tokens beyond the base set are preserved verbatim after
+the primitive class, matching the kr-badge-*/kr-spinner-*/kr-text-dim-*/
+kr-text-faded-* codemods' subset-match convention -- pass --exact-only to
+restrict a slice to sources with no extra tokens at all, the safest and most
+literal pool.
+
+This deliberately does NOT touch the `text-xs text-base-content/NN` family
+already fully named in slices 152-163, nor the `text-sm text-base-content/60`
+(`.kr-text-dim-sm`) or `/70` (`.kr-text-dim-sm-70`) siblings shipped earlier
+-- each opacity/size pairing is its own bounded family, not folded in here
+just because the grep that found them overlaps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-text-dim-sm-50"
+BASE_TOKENS = {"text-sm", "text-base-content/50"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-dim-sm-50 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- Added `.kr-text-dim-sm-50` (`@apply text-sm text-base-content/50;`) to `assets/css/tailwind.css` — sibling of `.kr-text-dim-sm` (60% opacity) and `.kr-text-dim-sm-70` (70% opacity), the last unnamed sibling in the `kr-text-dim-*` family at the `sm` size (the opacity `.kr-text-dim-xs` already claims at the `xs` size).
- A fresh full-repo class-frequency survey run after slice 187 closed out the `opacity-NN` sibling set found `text-sm text-base-content/50` still hand-rolled identically in 11 files (16 exact occurrences; 39 subset-match across 27 files) — consistently the "empty state" dashed-panel/loading caption pattern.
- New codemod `utils/scripts/codemods/kr_text_dim_sm_50_codemod.py`, sibling of `kr_text_dim_sm_70_codemod.py` (imports the shared `_class_attr.py` `CLASS_ATTR` guard, same `--exact-only`/`--write` flags).
- Ran with `--exact-only` for this bounded first slice: migrated 16 occurrences across 11 files. No geometry or behavior change.

### How I verified
- `vue-tsc --noEmit` clean.
- `eslint` clean on all changed files.
- `test:layout-contract` holds, 0 new violations (same pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet note as every recent slice, left untouched).
- `test:lint-ratchet` holds at 333/-59.
- `prettier --check .` warning list byte-identical to baseline, confirmed via a `git stash` before/after diff of the full warning list (not just the count) — the shortened class attribute let 4 tags collapse to a single line under the repo's printWidth, so `prettier --write` was run on those 4 files to match.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
The fuller subset-match pool for `text-sm text-base-content/50` (23 further occurrences across 16 more files, mostly "empty state" panels carrying extra layout tokens like `flex h-full min-h-32 items-center justify-center kr-panel-flat border-dashed p-6 text-center`) is a reasonable next bounded slice under the same `kr-text-dim-sm-50` primitive.

### Notes for reviewer
Session log/close-out lands in the companion conductor PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAcnwUQ4x8yTCWUrwAbqX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAcnwUQ4x8yTCWUrwAbqX1)_