### PR TITLE
interface-vision/t-104 slice 189: migrate remaining kr-text-dim-sm-50 subset-match occurrences

### DIFF
--- a/components/art/artjob-feedback-manager.vue
+++ b/components/art/artjob-feedback-manager.vue
@@ -213,7 +213,7 @@
 
       <div
         v-else
-        class="flex min-h-56 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 p-6 text-center text-sm text-base-content/50"
+        class="kr-text-dim-sm-50 flex min-h-56 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-base-300 p-6 text-center"
       >
         <span v-if="artJobStore.loadingTrainerJobs">Loading finished art…</span>
         <span v-else-if="reviewMode === 'pending'">

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -328,7 +328,7 @@
 
           <div
             v-if="!artJobStore.jobs.length && !artJobStore.loadingJobs"
-            class="kr-panel-dashed-plain text-center text-sm text-base-content/50 xl:col-span-2"
+            class="kr-text-dim-sm-50 kr-panel-dashed-plain text-center xl:col-span-2"
           >
             No {{ artJobStore.jobStatusFilter }} jobs on this page.
           </div>

--- a/components/coloring/coloring-book-production-history.vue
+++ b/components/coloring/coloring-book-production-history.vue
@@ -30,7 +30,7 @@
 
     <div
       v-if="!filteredHistory.length"
-      class="flex min-h-28 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-5 text-center text-sm text-base-content/50"
+      class="kr-text-dim-sm-50 flex min-h-28 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-5 text-center"
     >
       No {{ filter === 'all' ? '' : `${filter} ` }}revision or rejection records yet.
     </div>

--- a/components/coloring/coloring-book-readiness.vue
+++ b/components/coloring/coloring-book-readiness.vue
@@ -140,7 +140,7 @@
 
       <div
         v-if="!filteredEntries.length"
-        class="flex min-h-28 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-5 text-center text-sm text-base-content/50"
+        class="kr-text-dim-sm-50 flex min-h-28 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-5 text-center"
       >
         No pages match this readiness filter.
       </div>

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -118,7 +118,7 @@
 
           <div
             v-else
-            class="flex h-full min-h-56 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-200 p-4 text-center text-sm text-base-content/50"
+            class="kr-text-dim-sm-50 flex h-full min-h-56 items-center justify-center rounded-2xl border border-dashed border-base-300 bg-base-200 p-4 text-center"
           >
             No source Dreams found.
           </div>

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -90,7 +90,7 @@
 
       <p
         v-if="!catalog.loading && !visibleGroups.length"
-        class="kr-panel-dashed-plain text-center text-sm text-base-content/50"
+        class="kr-text-dim-sm-50 kr-panel-dashed-plain text-center"
       >
         No facets match these filters.
       </p>

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -175,7 +175,7 @@
     />
     <div
       v-else
-      class="flex flex-1 items-center justify-center kr-panel-flat border-dashed p-6 text-center text-sm text-base-content/50"
+      class="kr-text-dim-sm-50 flex flex-1 items-center justify-center kr-panel-flat border-dashed p-6 text-center"
     >
       Select a row to work through its stages.
     </div>

--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -45,7 +45,7 @@
 
       <div
         v-else-if="!store.runs.length"
-        class="flex h-full min-h-32 flex-col items-center justify-center gap-2 kr-panel-flat border-dashed p-6 text-center text-sm text-base-content/50"
+        class="kr-text-dim-sm-50 flex h-full min-h-32 flex-col items-center justify-center gap-2 kr-panel-flat border-dashed p-6 text-center"
       >
         <Icon
           name="kind-icon:blueprint"

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -63,7 +63,7 @@
     <div class="min-h-0 flex-1 overflow-y-auto">
       <div
         v-if="!store.sourceType"
-        class="flex h-full min-h-32 items-center justify-center kr-panel-flat border-dashed p-6 text-center text-sm text-base-content/50"
+        class="kr-text-dim-sm-50 flex h-full min-h-32 items-center justify-center kr-panel-flat border-dashed p-6 text-center"
       >
         Select a source type above to load records.
       </div>
@@ -107,7 +107,7 @@
       -->
       <div
         v-else-if="!store.sources.length"
-        class="flex h-full min-h-32 flex-col items-center justify-center gap-1 kr-panel-flat border-dashed p-6 text-center text-sm text-base-content/50"
+        class="kr-text-dim-sm-50 flex h-full min-h-32 flex-col items-center justify-center gap-1 kr-panel-flat border-dashed p-6 text-center"
       >
         <Icon
           :name="activeType?.icon || 'kind-icon:blueprint'"

--- a/components/narrative/kr-chat-window.vue
+++ b/components/narrative/kr-chat-window.vue
@@ -41,7 +41,7 @@
 
     <div
       v-if="!turns.length && !isStreaming"
-      class="rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-5 text-center text-sm text-base-content/50"
+      class="kr-text-dim-sm-50 rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-5 text-center"
     >
       {{ emptyLabel }}
     </div>

--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -340,7 +340,7 @@
         <div class="max-h-56 overflow-y-auto rounded-2xl bg-base-200/60 p-1">
           <p
             v-if="!notifications.items.length"
-            class="px-2 py-4 text-center text-sm text-base-content/50"
+            class="kr-text-dim-sm-50 px-2 py-4 text-center"
           >
             You're all caught up.
           </p>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -238,7 +238,7 @@
 
           <p
             v-if="!projectStore.publicProjects.length"
-            class="py-8 text-center text-sm text-base-content/50"
+            class="kr-text-dim-sm-50 py-8 text-center"
           >
             No public projects yet.
           </p>
@@ -499,7 +499,7 @@
                     name="kind-icon:check-circle"
                     class="mx-auto mb-2 size-8 text-success/40"
                   />
-                  <p class="text-sm font-semibold text-base-content/50">
+                  <p class="kr-text-dim-sm-50 font-semibold">
                     No honey-dos right now.
                   </p>
                   <p class="mt-1 text-xs text-base-content/30">

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -283,7 +283,7 @@
             <Icon :name="emptyIcon" class="size-8" />
           </span>
           <h3 class="kr-text-black-xl mt-4">{{ emptyTitle }}</h3>
-          <p class="mt-1 max-w-lg text-sm text-base-content/50">
+          <p class="kr-text-dim-sm-50 mt-1 max-w-lg">
             {{ emptyMessage }}
           </p>
           <button

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -299,7 +299,7 @@
               <p class="font-black">
                 No active Conductor gates are waiting on you.
               </p>
-              <p class="mt-1 text-sm text-base-content/50">
+              <p class="kr-text-dim-sm-50 mt-1">
                 <template v-if="conductorStore.pausedHumanGates.length">
                   {{ conductorStore.pausedHumanGates.length }} paused-project
                   gate{{

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -133,10 +133,7 @@
           <p class="kr-text-eyebrow-bold kr-text-dim-xs-60">
             Active animations
           </p>
-          <p
-            v-if="activeEffects.length === 0"
-            class="mt-1 text-sm text-base-content/50"
-          >
+          <p v-if="activeEffects.length === 0" class="kr-text-dim-sm-50 mt-1">
             None running.
           </p>
           <ul v-else class="mt-1 space-y-1">

--- a/components/user/forum-moderation-panel.vue
+++ b/components/user/forum-moderation-panel.vue
@@ -90,7 +90,7 @@
 
         <p
           v-if="!moderationStore.posts.length"
-          class="col-span-full rounded-xl border border-dashed border-base-300 p-6 text-center text-sm text-base-content/50"
+          class="kr-text-dim-sm-50 col-span-full rounded-xl border border-dashed border-base-300 p-6 text-center"
         >
           Nothing pending review right now.
         </p>

--- a/components/user/messenger.vue
+++ b/components/user/messenger.vue
@@ -23,7 +23,7 @@
       <div class="kr-pane-scroll">
         <p
           v-if="!convo.conversations.length && !convo.isLoadingList"
-          class="p-4 text-sm text-base-content/50"
+          class="kr-text-dim-sm-50 p-4"
         >
           No conversations yet. Find people on the
           <NuxtLink to="/friends" class="link">friends page</NuxtLink>.
@@ -80,10 +80,7 @@
         </header>
 
         <div ref="scrollBox" class="kr-pane-scroll space-y-2 p-3">
-          <p
-            v-if="convo.isLoadingThread"
-            class="text-center text-sm text-base-content/50"
-          >
+          <p v-if="convo.isLoadingThread" class="kr-text-dim-sm-50 text-center">
             Loading…
           </p>
           <div

--- a/pages/admin/achievement-art.vue
+++ b/pages/admin/achievement-art.vue
@@ -107,7 +107,7 @@
 
               <p
                 v-if="!filteredAchievements.length"
-                class="kr-panel-flat border-dashed p-6 text-center text-sm text-base-content/50"
+                class="kr-text-dim-sm-50 kr-panel-flat border-dashed p-6 text-center"
               >
                 No matching achievements.
               </p>

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -216,7 +216,7 @@
               <div>
                 <Icon name="kind-icon:server" class="mx-auto size-10 text-base-content/30" />
                 <p class="mt-3 font-black">No source images in this folder</p>
-                <p class="mt-1 max-w-lg text-sm text-base-content/50">
+                <p class="kr-text-dim-sm-50 mt-1 max-w-lg">
                   Add PNG, JPG, WebP, or GIF stills under the configured animate source root,
                   then refresh this page.
                 </p>

--- a/pages/admin/social-drafts.vue
+++ b/pages/admin/social-drafts.vue
@@ -183,7 +183,7 @@
 
           <p
             v-if="!draftsStore.drafts.length"
-            class="col-span-full rounded-xl border border-dashed border-base-300 p-6 text-center text-sm text-base-content/50"
+            class="kr-text-dim-sm-50 col-span-full rounded-xl border border-dashed border-base-300 p-6 text-center"
           >
             No drafts match this filter. Try "Scan daily dreams for new drafts."
           </p>


### PR DESCRIPTION
### Task
interface-vision/t-104 (conductor): drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- Slice 188 (#2568) added the `kr-text-dim-sm-50` primitive and migrated its 16 exact-match occurrences with `--exact-only`, leaving the fuller subset-match pool (23 further occurrences) for a future slice per its own note.
- This slice runs `utils/scripts/codemods/kr_text_dim_sm_50_codemod.py` without `--exact-only` and migrates all 23 remaining occurrences across 20 files. No geometry or behavior change — every occurrence keeps its extra utility tokens after the primitive class.

### How I verified
- `vue-tsc --noEmit` clean.
- `eslint` on changed files: 2 pre-existing errors (`conductor-pitch-manager.vue`, `for-you-manager.vue`) confirmed identical before/after via `git stash`.
- `npm run test:layout-contract`: holds, 0 new violations (same pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet note as every recent slice, left untouched).
- `npm run test:lint-ratchet`: holds at 333/-59.
- `prettier --check .`: warning list byte-identical to baseline, confirmed via `git stash` before/after diff of the full list, after running `prettier --write` on the 2 files whose shortened class attribute collapsed to a single line under printWidth (`serendipity-page.vue`, `messenger.vue`).

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
A fresh full-repo class-frequency survey is needed for the next slice — this closes out the `kr-text-dim-sm-50` family fully (both exact and subset pools now migrated).

### Notes for reviewer
Sibling of slices 184-188 in the same recurring umbrella task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyjV7uNGrBy1pvBibGdtYP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyjV7uNGrBy1pvBibGdtYP)_