### PR TITLE
interface-vision/t-125: thread navigation frontmatter through ResolvedTab

### DIFF
--- a/components/navigation/workspace-header.vue
+++ b/components/navigation/workspace-header.vue
@@ -484,6 +484,7 @@ const fallbackTab: ResolvedTab = {
   cards: null,
   tutorial: null,
   requiredBeforeNext: [],
+  navigation: true,
   requiredRole: '',
   requiredPermission: '',
   loadingMessage: pageStore.loadingMessage || 'Loading…',

--- a/stores/helpers/channelContent.ts
+++ b/stores/helpers/channelContent.ts
@@ -49,6 +49,7 @@ export type ChannelContentItem = {
   requiredRole?: string
   requiredPermission?: string
   visible?: boolean
+  navigation?: boolean
   status?: string
   loadingMessage?: string
   refreshLabel?: string
@@ -103,6 +104,7 @@ export type ResolvedTab = {
   cards: string | NavigationCard[] | null
   tutorial: ResolvedTutorialSection | null
   requiredBeforeNext: string[]
+  navigation: boolean
   requiredRole: string
   requiredPermission: string
   loadingMessage: string
@@ -324,6 +326,7 @@ function resolveTabItem(
     requiredBeforeNext: Array.isArray(item.requiredBeforeNext)
       ? item.requiredBeforeNext
       : [],
+    navigation: item.navigation !== false,
     requiredRole: text(item.requiredRole) || channel.requiredRole,
     requiredPermission:
       text(item.requiredPermission) || channel.requiredPermission,

--- a/utils/channelTabGroups.ts
+++ b/utils/channelTabGroups.ts
@@ -10,20 +10,11 @@ export type ChannelTabGroup = {
   admin: boolean
 }
 
-const NAVIGATION_HIDDEN_TABS = new Set([
-  'home:newsfeed',
-  'home:friends',
-  'home:giving',
-  'home:giftshop',
-  'admin:project-placement',
-  'admin:forum-moderation',
-])
-
 export function isNavigationTab(
-  channel: ResolvedChannel,
+  _channel: ResolvedChannel,
   tab: ResolvedTab,
 ): boolean {
-  return !NAVIGATION_HIDDEN_TABS.has(`${channel.channelKey}:${tab.tabKey}`)
+  return tab.navigation !== false
 }
 
 export function navigationTabs(channel: ResolvedChannel): ResolvedTab[] {

--- a/utils/scripts/verifyNavigationConsolidation.ts
+++ b/utils/scripts/verifyNavigationConsolidation.ts
@@ -12,6 +12,19 @@ function source(path: string): string {
   return readFileSync(path, 'utf8')
 }
 
+// Mirrors the six nested destinations' `navigation: false` frontmatter --
+// resolveTabItem() carries that field onto ResolvedTab.navigation, and these
+// hand-built fixtures stand in for that resolution step for tabs that
+// aren't reachable directly from the tab menus/navigation directory.
+const NESTED_TABS = new Set([
+  'home:newsfeed',
+  'home:friends',
+  'home:giving',
+  'home:giftshop',
+  'admin:project-placement',
+  'admin:forum-moderation',
+])
+
 function tab(channelKey: string, tabKey: string): ResolvedTab {
   return {
     channelKey,
@@ -20,6 +33,7 @@ function tab(channelKey: string, tabKey: string): ResolvedTab {
     label: tabKey,
     title: tabKey,
     requiredRole: '',
+    navigation: !NESTED_TABS.has(`${channelKey}:${tabKey}`),
   } as ResolvedTab
 }
 


### PR DESCRIPTION
### Task
interface-vision/t-125 (conductor): propagate the authored `navigation` frontmatter field through `ResolvedTab` instead of mirroring hidden-tab keys (kind: software)

### What changed / what I produced
- Kaizen from t-104's navigation-consolidation slice (kind_robots#2548). That slice hid six nested destinations (`home:newsfeed`, `home:friends`, `home:giving`, `home:giftshop`, `admin:project-placement`, `admin:forum-moderation`) from tab menus, the navigation directory, and fallback card decks via a hand-maintained `NAVIGATION_HIDDEN_TABS` set in `utils/channelTabGroups.ts` — duplicating intent already authored as `navigation: false` frontmatter on each of those six content files.
- `stores/helpers/channelContent.ts`: `ChannelContentItem` gains `navigation?: boolean`; `ResolvedTab` gains `navigation: boolean`; `resolveTabItem()` sets `navigation: item.navigation !== false` (same pattern as the existing `visible !== false` handling).
- `utils/channelTabGroups.ts`: `isNavigationTab()` now reads `tab.navigation !== false` instead of the hardcoded set; `NAVIGATION_HIDDEN_TABS` is deleted.
- `components/navigation/workspace-header.vue`: added `navigation: true` to the hand-built `fallbackTab` (now a required `ResolvedTab` field; this fallback is correctly navigable).
- `utils/scripts/verifyNavigationConsolidation.ts`: the regression check's synthetic `tab()`/`channel()` fixtures build `ResolvedTab` objects directly rather than through `resolveTabItem()`, so they now set `navigation` on the same six known-nested tab keys real frontmatter does. Same expected assertions/output as before — only the fixture construction changed to reflect the new mechanism.

No visible behavior change intended.

### How I verified
- `vue-tsc --noEmit`: clean (caught the missing required `navigation` field on `workspace-header.vue`'s `fallbackTab`, fixed above).
- `eslint` on all touched files: clean, no new errors.
- `npx tsx utils/scripts/verifyNavigationConsolidation.ts`: passes — same hub/nested/admin/access-metadata assertions hold.
- `npx tsx utils/scripts/verifyNavigationRouteAccess.ts`: passes.
- `npx tsx utils/scripts/verifyChannelResolver.ts`: passes.
- `npm run test:layout-contract`: holds, 0 new violations (pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid note untouched, out of scope).
- `npm run test:lint-ratchet`: holds at 333/-59.
- `prettier --check .`: warning list byte-identical to baseline, confirmed via a `git stash` before/after diff of the full 1145-line list.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
A fresh full-repo class-frequency survey is a reasonable next slice for the recurring t-104 umbrella (separate task); for this refactor specifically, `ResolvedChannel` doesn't carry an analogous "hidden from directory" flag at the channel level — if a future slice ever needs to hide a whole channel rather than individual tabs, the same frontmatter-carried-field pattern (rather than a new hardcoded set) is the way to do it.

### Notes for reviewer
Kaizen task from t-104's roadmap note (interface-vision/t-125).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015r2PSChnUSQsZRqvvjpa6g

---
_Generated by [Claude Code](https://claude.ai/code/session_015r2PSChnUSQsZRqvvjpa6g)_