### PR TITLE
interface-vision/t-104 slice 190: extend kr-badge-outline bounded extras to rounded-2xl/rounded-xl

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1477,11 +1477,16 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
    * size modifier -- the caller relies on DaisyUI's default badge size,
    * same rationale as .kr-badge-ghost being a separate sizeless sibling
    * rather than folded into its -sm/-xs counterparts. Bounded to the 13
-   * exact-match occurrences across 8 files this slice (--exact-only, same
+   * exact-match occurrences across 8 files that slice (--exact-only, same
    * convention .kr-badge-ghost's first slice used); a fourteenth exact
    * match in components/ui/ui-gallery.vue's "Badges & status" showcase
    * section is a deliberate raw-DaisyUI comparison row and was left
-   * untouched, matching the precedent set for that section's other rows. */
+   * untouched, matching the precedent set for that section's other rows.
+   * Slice 190 extended the bounded-extras pool with two clean, repeated
+   * shapes found layering a plain Tailwind `rounded-2xl`/`rounded-xl` on
+   * top (15 more occurrences across 10 files, kept as a preserved extra
+   * token after the primitive -- see kr_badge_codemod.py's
+   * BOUNDED_EXTRAS for the exact file list). */
   .kr-badge-outline {
     @apply badge badge-outline;
   }

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -26,7 +26,7 @@
         <span v-if="cover.semanticScore !== null" class="badge badge-info rounded-2xl">
           Score {{ cover.semanticScore }}
         </span>
-        <span v-if="cover.revisionHistory.length" class="badge badge-outline rounded-2xl">
+        <span v-if="cover.revisionHistory.length" class="kr-badge-outline rounded-2xl">
           {{ cover.revisionHistory.length }} archived revision{{ cover.revisionHistory.length === 1 ? '' : 's' }}
         </span>
       </div>

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -22,7 +22,7 @@
         </p>
       </div>
       <div class="flex flex-wrap gap-2">
-        <span class="badge badge-outline rounded-2xl">
+        <span class="kr-badge-outline rounded-2xl">
           {{ sourceReadyCount }}/{{ packageData.books.length }} source-ready
         </span>
         <span

--- a/components/coloring/coloring-book-production-history.vue
+++ b/components/coloring/coloring-book-production-history.vue
@@ -70,7 +70,7 @@
             >
               {{ item.variant === 'color' ? 'Color' : 'B&W' }}
             </span>
-            <span class="badge badge-outline rounded-2xl">
+            <span class="kr-badge-outline rounded-2xl">
               {{ historyLabel(item.kind) }}
             </span>
             <span v-if="item.score !== null" class="badge badge-info rounded-2xl">

--- a/components/coloring/coloring-book-production-toolbar.vue
+++ b/components/coloring/coloring-book-production-toolbar.vue
@@ -18,13 +18,13 @@
         </p>
       </div>
       <div class="flex flex-wrap gap-2">
-        <span class="badge badge-outline rounded-2xl">
+        <span class="kr-badge-outline rounded-2xl">
           Color {{ production?.colorStatus || proposal.queue.status }}
         </span>
-        <span class="badge badge-outline rounded-2xl">
+        <span class="kr-badge-outline rounded-2xl">
           B&amp;W {{ production?.bwStatus || 'missing' }}
         </span>
-        <span v-if="production?.pairStatus" class="badge badge-outline rounded-2xl">
+        <span v-if="production?.pairStatus" class="kr-badge-outline rounded-2xl">
           Pair {{ production.pairStatus }}
         </span>
       </div>
@@ -97,10 +97,10 @@
           <span v-if="hasBwScore" class="badge badge-info rounded-2xl">
             Pair score {{ production?.bwSemanticScore }}
           </span>
-          <span v-if="production?.bwSemanticVerdict" class="badge badge-outline rounded-2xl">
+          <span v-if="production?.bwSemanticVerdict" class="kr-badge-outline rounded-2xl">
             {{ production.bwSemanticVerdict }}
           </span>
-          <span v-if="production?.bwRevisionCount" class="badge badge-outline rounded-2xl">
+          <span v-if="production?.bwRevisionCount" class="kr-badge-outline rounded-2xl">
             {{ production.bwRevisionCount }} archived revision{{ production.bwRevisionCount === 1 ? '' : 's' }}
           </span>
         </div>

--- a/components/coloring/coloring-book-readiness.vue
+++ b/components/coloring/coloring-book-readiness.vue
@@ -11,7 +11,7 @@
           production blockers until they have their own canonical workflow.
         </p>
       </div>
-      <span class="badge badge-outline rounded-2xl">
+      <span class="kr-badge-outline rounded-2xl">
         {{ totalFinalPairs }}/{{ totalInteriors }} final interior pairs
       </span>
     </header>

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -84,7 +84,7 @@
               </p>
               <h4 class="kr-text-black-xl">{{ book.title }}</h4>
             </div>
-            <span class="badge badge-outline rounded-2xl">{{ book.status }}</span>
+            <span class="kr-badge-outline rounded-2xl">{{ book.status }}</span>
           </div>
 
           <progress
@@ -549,7 +549,7 @@
             >
               {{ problem.proposal.queue.status }}
             </span>
-            <span class="badge badge-outline rounded-2xl">
+            <span class="kr-badge-outline rounded-2xl">
               {{ problem.proposal.queue.semanticAttempts }} attempts
             </span>
           </div>

--- a/components/dreams/daily-digest-object-dialog.vue
+++ b/components/dreams/daily-digest-object-dialog.vue
@@ -76,7 +76,7 @@
                 <span
                   v-for="badge in badges"
                   :key="badge"
-                  class="badge badge-outline rounded-xl"
+                  class="kr-badge-outline rounded-xl"
                 >
                   {{ badge }}
                 </span>

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -13,7 +13,7 @@
             <h1 class="kr-text-black-2xl text-primary">Dreammaker</h1>
             <span
               v-if="dreamStore.dreamForm.id"
-              class="badge badge-outline rounded-xl"
+              class="kr-badge-outline rounded-xl"
             >
               Editing #{{ dreamStore.dreamForm.id }}
             </span>

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -152,7 +152,7 @@
               </p>
 
               <div class="mt-3 flex flex-wrap items-center gap-2">
-                <span class="badge badge-outline rounded-xl">
+                <span class="kr-badge-outline rounded-xl">
                   {{ thread.count }}
                   {{ thread.count === 1 ? 'message' : 'messages' }}
                 </span>

--- a/pages/users/[id].vue
+++ b/pages/users/[id].vue
@@ -49,7 +49,7 @@
                 @{{ user.username }}
               </p>
             </div>
-            <span v-if="user.Role" class="badge badge-outline rounded-xl">
+            <span v-if="user.Role" class="kr-badge-outline rounded-xl">
               {{ formatRole(user.Role) }}
             </span>
           </div>

--- a/utils/scripts/codemods/kr_badge_codemod.py
+++ b/utils/scripts/codemods/kr_badge_codemod.py
@@ -133,10 +133,30 @@ BOUNDED_EXTRAS: dict[str, set[frozenset[str]]] = {
         frozenset({"rounded-xl"}),
     },
     # kr-badge-outline (interface-vision t-104 slice 183): bounded to an
-    # exact match only for this slice, same first-pass convention
+    # exact match only for that first slice, same first-pass convention
     # kr-badge-ghost used before its own follow-up slice individually
-    # audited the remaining extra-token pool.
-    "kr-badge-outline": {frozenset()},
+    # audited the remaining extra-token pool. Slice 190 is that follow-up:
+    # of the ~14 remaining hand-rolled `badge badge-outline <extra>`
+    # call sites, two clean, repeated shapes surveyed clean --
+    #   rounded-2xl  11 occurrences / 6 files (coloring-book-production-
+    #                history.vue, coloring-book-production-toolbar.vue x5,
+    #                coloring-book-package-readiness.vue,
+    #                coloring-book-cover-studio.vue,
+    #                coloring-book-studio.vue x2, coloring-book-readiness.vue)
+    #   rounded-xl   4 occurrences / 4 files (chat-gallery.vue,
+    #                daily-digest-object-dialog.vue, dream-maker.vue,
+    #                pages/users/[id].vue)
+    # -- added here. The remaining one-offs (a second color modifier
+    # alongside badge-outline in coloring-book-package-readiness.vue/
+    # artjob-editor.vue, or a stray `group-open:badge-primary` variant
+    # utility in coloring-book-page.vue) each carry a shape not shared by
+    # any other call site and are left hand-rolled rather than forced into
+    # this bounded set.
+    "kr-badge-outline": {
+        frozenset(),
+        frozenset({"rounded-2xl"}),
+        frozenset({"rounded-xl"}),
+    },
 }
 
 


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Per slice 187/189's kaizen note ("individually audit the remaining one-off kr-badge-outline extra-token occurrences"), surveyed the remaining hand-rolled `badge badge-outline <extra>` pool for clean, repeated shapes.
- Two qualified: `rounded-2xl` (11 occurrences / 6 files, all in `components/coloring/*`) and `rounded-xl` (4 occurrences / 4 files), each layering a plain Tailwind rounding utility on top of the outline badge — same shape `kr-badge-sm`/`kr-badge-ghost` already bound for their own extras.
- Extended `utils/scripts/codemods/kr_badge_codemod.py`'s `BOUNDED_EXTRAS["kr-badge-outline"]` with both shapes and ran it with `--write`; migrated 15 occurrences across 10 files.
- Manually reverted the two pre-existing bare-badge showcase rows in `components/ui/ui-gallery.vue` (`outline`/`ghost`) back to raw DaisyUI classes — unrelated to this slice's new extras, matching the precedent every prior badge-family slice has followed for that file's intentional showcase section.
- No geometry or behavior change; static `class="..."` attributes only, no `:class` bindings touched.

### How I verified
- `vue-tsc --noEmit`: clean.
- `eslint .`: 333 problems (327 errors, 6 warnings) — byte-identical to the documented baseline.
- `npm run test:layout-contract`: holds, 0 new violations.
- `npm run test:lint-ratchet`: holds at 333/-59.
- `prettier --check .`: byte-identical warning list (1145 lines), confirmed via a `git stash` before/after diff of the full warning list.
- Manually reviewed every migrated diff.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
The remaining `kr-badge-outline` extra-token occurrences are now genuine one-offs (a second color modifier alongside `badge-outline`, or a `group-open:badge-primary` variant utility) — no more bounded pool left in this family. Next slice should run a fresh full-repo class-frequency survey outside all now-closed families to find its own bounded target.

### Notes for reviewer
Session also noticed `test:layout-contract`'s `narrative-ingredient-multi-picker.vue` viewport-grid entries (`md:grid-cols-2`, `xl:grid-cols-3`) no longer violate the contract — unrelated to this diff, left untouched per scope discipline; worth a `--update` ratchet in an unrelated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hh8ZeKLCRxLtvL64wbzkHr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hh8ZeKLCRxLtvL64wbzkHr)_