### PR TITLE
interface-vision/t-104 slice 191: add kr-icon-primary-5, migrate h-5 w-5 text-primary icons

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1617,6 +1617,27 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-primary/15 text-primary;
   }
 
+  /* A bare 20px primary-tinted icon -- `h-5 w-5 text-primary`, no tile/
+   * background, just size + color (interface-vision t-104 slice 191). A
+   * fresh full-repo class-frequency survey outside all now-closed families
+   * (kr-text-black-*, kr-text-bold-*, kr-text-dim-*, kr-text-eyebrow-*,
+   * kr-label-*, kr-badge-* incl. -ghost/-outline sizeless siblings and
+   * their bounded extras, kr-text-error-xs, kr-text-faded-*) found this
+   * shape at 17 exact occurrences across 16 files, plus 11 further
+   * subset-match occurrences (mostly carrying an extra `shrink-0`) across 8
+   * more files. Distinct from `.kr-icon-tile` -- that one is a tinted
+   * rounded square housing a page-header icon; this is the bare icon glyph
+   * itself, most often inline beside a label or in a list row. Sibling
+   * sizes surveyed alongside this one and left open for future slices:
+   * `h-4 w-4 text-primary` (12 files), `h-6 w-6 text-primary` (11 files),
+   * `h-7 w-7 text-primary` (5 files), `h-10 w-10 text-primary/60` (3
+   * files, different opacity), `h-12 w-12 text-primary` (5 files, distinct
+   * from `.kr-icon-tile`'s own `h-12 w-12` which also carries the tile's
+   * background/shape tokens). */
+  .kr-icon-primary-5 {
+    @apply h-5 w-5 text-primary;
+  }
+
   /* The colorless DaisyUI busy indicator: a bare tiny spinner dropped into
    * a button or inline slot while an action is pending, no tint (the
    * button/text color around it usually already carries the tone)

--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -8,7 +8,7 @@
         <h2
           class="flex items-center gap-2 text-base font-black text-base-content"
         >
-          <Icon name="kind-icon:magic" class="h-5 w-5 text-primary" />
+          <Icon name="kind-icon:magic" class="kr-icon-primary-5" />
           Remix Studio
         </h2>
         <p class="kr-text-dim-sm-70">

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -8,7 +8,7 @@
       class="shrink-0 kr-panel-muted-compact-row"
     >
       <div class="flex items-center gap-2">
-        <Icon name="kind-icon:gallery" class="h-5 w-5 shrink-0 text-primary" />
+        <Icon name="kind-icon:gallery" class="kr-icon-primary-5 shrink-0" />
         <h2 class="min-w-0 truncate text-base font-black text-base-content">
           {{ activeGroup ? activeGroup.title : 'Gallery' }}
         </h2>

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -520,7 +520,7 @@
       <section class="kr-panel-flat p-4">
         <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
           <div class="flex items-center gap-2">
-            <Icon name="kind-icon:sparkles" class="h-5 w-5 text-primary" />
+            <Icon name="kind-icon:sparkles" class="kr-icon-primary-5" />
             <div>
               <h2 class="kr-text-bold-lg text-primary">Latest result</h2>
               <p class="text-sm text-base-content/55">

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -149,7 +149,7 @@
                 {{ currentArtImage.checkpoint || 'No checkpoint recorded' }}
               </span>
             </span>
-            <Icon name="kind-icon:brain" class="h-5 w-5 text-primary" />
+            <Icon name="kind-icon:brain" class="kr-icon-primary-5" />
           </summary>
 
           <div class="mt-3 grid gap-2 text-xs">
@@ -458,7 +458,7 @@
                     Send back to generator.
                   </p>
                 </div>
-                <Icon name="kind-icon:sparkles" class="h-5 w-5 text-primary" />
+                <Icon name="kind-icon:sparkles" class="kr-icon-primary-5" />
               </div>
               <textarea
                 v-model="remixPrompt"

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -3,7 +3,7 @@
   <section class="flex flex-col gap-4 kr-panel-muted-md">
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-2">
-        <Icon name="kind-icon:magic" class="h-5 w-5 text-primary" />
+        <Icon name="kind-icon:magic" class="kr-icon-primary-5" />
         <h2 class="text-base font-black text-base-content">Style Transfer</h2>
         <span class="kr-badge-primary-sm">Kontext</span>
       </div>
@@ -311,7 +311,7 @@
           >
             <Icon
               name="mdi:arrow-right"
-              class="h-5 w-5 text-primary drop-shadow"
+              class="kr-icon-primary-5 drop-shadow"
             />
           </div>
         </div>

--- a/components/art/stylist-calculator.vue
+++ b/components/art/stylist-calculator.vue
@@ -7,7 +7,7 @@
 <template>
   <section class="flex flex-col gap-4 kr-panel-muted-md">
     <header class="flex items-center gap-2">
-      <Icon name="kind-icon:sparkles" class="h-5 w-5 text-primary" />
+      <Icon name="kind-icon:sparkles" class="kr-icon-primary-5" />
       <h2 class="text-base font-black text-base-content">New Appointment</h2>
     </header>
 

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -2,7 +2,7 @@
 <template>
   <section class="stylist-clients kr-panel-muted flex flex-col gap-4 p-4">
     <header class="flex items-center gap-2">
-      <Icon name="kind-icon:heart" class="h-5 w-5 text-primary" />
+      <Icon name="kind-icon:heart" class="kr-icon-primary-5" />
       <h2 class="text-base font-black text-base-content">Clients</h2>
       <span class="kr-badge-ghost-sm">{{ superkate.sortedCustomers.length }}</span>
     </header>

--- a/components/art/stylist-history.vue
+++ b/components/art/stylist-history.vue
@@ -6,7 +6,7 @@
 <template>
   <section class="flex flex-col gap-4 kr-panel-muted-md">
     <header class="flex items-center gap-2">
-      <Icon name="kind-icon:book" class="h-5 w-5 text-primary" />
+      <Icon name="kind-icon:book" class="kr-icon-primary-5" />
       <h2 class="text-base font-black text-base-content">Appointments</h2>
       <span class="kr-badge-ghost-sm">{{ results.length }}</span>
     </header>

--- a/components/art/stylist-manager.vue
+++ b/components/art/stylist-manager.vue
@@ -4,7 +4,7 @@
     <nav
       class="flex flex-wrap items-center gap-1 rounded-2xl border border-base-300 bg-base-200 p-2"
     >
-      <Icon name="kind-icon:sparkles" class="ml-1 h-5 w-5 text-primary" />
+      <Icon name="kind-icon:sparkles" class="kr-icon-primary-5 ml-1" />
       <span class="kr-text-black-sm mr-2 text-base-content">
         {{ superkate.settings.salonName }} Services
       </span>

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -13,7 +13,7 @@
 <template>
   <section class="flex flex-col gap-4 kr-panel-muted-md">
     <header class="flex items-center gap-2">
-      <Icon name="kind-icon:magic" class="h-5 w-5 text-primary" />
+      <Icon name="kind-icon:magic" class="kr-icon-primary-5" />
       <h2 class="text-base font-black text-base-content">Hair Studio</h2>
       <span class="kr-badge-primary-sm">Kontext</span>
       <span class="kr-badge-ghost-sm">Private</span>

--- a/components/art/stylist-settings.vue
+++ b/components/art/stylist-settings.vue
@@ -7,7 +7,7 @@
 <template>
   <section class="flex flex-col gap-4 kr-panel-muted-md">
     <header class="flex items-center gap-2">
-      <Icon name="kind-icon:adjust" class="h-5 w-5 text-primary" />
+      <Icon name="kind-icon:adjust" class="kr-icon-primary-5" />
       <h2 class="text-base font-black text-base-content">Receipt Settings</h2>
     </header>
 

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -253,7 +253,7 @@
                 </p>
               </div>
 
-              <Icon :name="field.icon" class="h-5 w-5 shrink-0 text-primary" />
+              <Icon :name="field.icon" class="kr-icon-primary-5 shrink-0" />
             </div>
 
             <div class="mt-3 grid grid-cols-2 gap-2">

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -363,7 +363,7 @@
                   {{ field.description }}
                 </p>
               </div>
-              <Icon :name="field.icon" class="h-5 w-5 shrink-0 text-primary" />
+              <Icon :name="field.icon" class="kr-icon-primary-5 shrink-0" />
             </div>
 
             <div class="mt-3 grid grid-cols-2 gap-2">

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -9,7 +9,7 @@
           <h2
             class="flex items-center gap-2 text-base font-black text-base-content"
           >
-            <Icon name="kind-icon:paintbrush" class="h-5 w-5 text-primary" />
+            <Icon name="kind-icon:paintbrush" class="kr-icon-primary-5" />
             Coloring Book
           </h2>
           <p class="kr-text-dim-sm-70">

--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -251,7 +251,7 @@
       <Icon
         v-if="selected"
         name="kind-icon:check"
-        class="h-5 w-5 shrink-0 text-primary"
+        class="kr-icon-primary-5 shrink-0"
         aria-hidden="true"
       />
     </div>

--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -67,7 +67,7 @@
         >
           <Icon
             :name="sourceIcon(run)"
-            class="h-5 w-5 shrink-0 text-primary"
+            class="kr-icon-primary-5 shrink-0"
             aria-hidden="true"
           />
 

--- a/components/navigation/workspace-narrator.vue
+++ b/components/navigation/workspace-narrator.vue
@@ -182,7 +182,7 @@
 
                       <Icon
                         name="kind-icon:rotate"
-                        class="h-5 w-5 text-primary"
+                        class="kr-icon-primary-5"
                       />
                     </div>
                   </div>
@@ -367,7 +367,7 @@
                     <div class="flex items-start gap-3">
                       <Icon
                         :name="selectedTopicIcon"
-                        class="mt-0.5 h-5 w-5 shrink-0 text-primary"
+                        class="kr-icon-primary-5 mt-0.5 shrink-0"
                       />
 
                       <div class="min-w-0 flex-1">

--- a/components/navigation/workspace-sheet.vue
+++ b/components/navigation/workspace-sheet.vue
@@ -70,7 +70,7 @@
         @click="showTutorial = !showTutorial"
       >
         <span class="flex items-center gap-2">
-          <Icon name="kind-icon:info" class="h-5 w-5 text-primary" />
+          <Icon name="kind-icon:info" class="kr-icon-primary-5" />
           <span
             class="kr-text-eyebrow kr-text-dim-sm-70 tracking-widest"
           >

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -12,7 +12,7 @@
       class="flex shrink-0 items-center justify-between gap-3 border-b border-base-300 bg-base-100/80 px-4 py-2.5 backdrop-blur-sm"
     >
       <div class="flex items-center gap-2.5">
-        <Icon name="mdi:theater" class="h-5 w-5 text-primary" />
+        <Icon name="mdi:theater" class="kr-icon-primary-5" />
         <h1 class="kr-text-black-lg tracking-tight">Stage</h1>
         <span
           v-if="store.selectedStage"

--- a/components/stages/stage-preset.vue
+++ b/components/stages/stage-preset.vue
@@ -31,7 +31,7 @@
         <Icon
           v-if="!preset.imagePath"
           :name="preset.icon"
-          class="h-5 w-5 shrink-0 text-primary"
+          class="kr-icon-primary-5 shrink-0"
         />
         <h3 class="card-title text-sm leading-tight">
           {{ preset.label }}

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="agent-credentials" class="kr-panel-flat p-4">
     <div class="mb-2 flex items-center gap-2">
-      <Icon name="kind-icon:key" class="h-5 w-5 text-primary" />
+      <Icon name="kind-icon:key" class="kr-icon-primary-5" />
       <span class="kr-text-black-sm">Agent credentials</span>
     </div>
 

--- a/components/user/login-page.vue
+++ b/components/user/login-page.vue
@@ -105,7 +105,7 @@
             >
               <Icon
                 name="kind-icon:person"
-                class="h-5 w-5 shrink-0 text-primary"
+                class="kr-icon-primary-5 shrink-0"
               />
               <input
                 id="login"

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -2,7 +2,7 @@
 <template>
   <section class="kr-tile-md kr-surface gap-4 sm:p-4">
     <header class="kr-toolbar kr-panel-flat px-4 py-3">
-      <Icon name="kind-icon:sparkles" class="h-5 w-5 shrink-0 text-primary" />
+      <Icon name="kind-icon:sparkles" class="kr-icon-primary-5 shrink-0" />
 
       <div class="min-w-0 flex-1">
         <p class="truncate text-base font-black text-base-content">
@@ -246,7 +246,7 @@
                   <div class="flex items-center gap-2">
                     <Icon
                       name="kind-icon:paintbrush"
-                      class="h-5 w-5 text-primary"
+                      class="kr-icon-primary-5"
                     />
                     <span class="kr-text-black-sm">Theme</span>
                   </div>

--- a/components/user/user-galleries.vue
+++ b/components/user/user-galleries.vue
@@ -37,7 +37,7 @@
               <div
                 class="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10"
               >
-                <Icon :name="section.icon" class="h-5 w-5 text-primary" />
+                <Icon :name="section.icon" class="kr-icon-primary-5" />
               </div>
 
               <div class="min-w-0">

--- a/utils/scripts/codemods/kr_icon_primary_5_codemod.py
+++ b/utils/scripts/codemods/kr_icon_primary_5_codemod.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `h-5 w-5 text-primary` bare icon glyphs to
+`kr-icon-primary-5`.
+
+Sibling of kr_icon_tile in spirit (both live in the icon-sizing corner of
+tailwind.css) but distinct in shape: `.kr-icon-tile` is a tinted rounded
+square housing a page-header icon (`h-12 w-12` plus background/shape
+tokens); this primitive is the bare 20px icon glyph itself, most often
+inline beside a label or in a list row, no background or shape tokens at
+all. Dry-run by default, --write to update matching Vue files in place.
+Only the exact `h-5 w-5 text-primary` shape is touched, and only in static
+`class="..."` attributes -- never `:class`/`v-bind:class` bindings (see
+_class_attr.py), and regardless of the base tokens' order in the source. A
+source that already carries `kr-icon-primary-5`, or is missing any of the
+three base tokens, is left untouched. Extra tokens beyond the base set
+(most commonly `shrink-0`) are preserved verbatim after the primitive
+class, matching the kr-badge-*/kr-spinner-*/kr-text-dim-*/kr-text-faded-*
+codemods' subset-match convention -- pass --exact-only to restrict a slice
+to sources with no extra tokens at all, the safest and most literal pool.
+
+Deliberately does NOT touch sibling icon sizes (`h-4 w-4 text-primary`,
+`h-6 w-6 text-primary`, `h-7 w-7 text-primary`, `h-10 w-10
+text-primary/60`, `h-12 w-12 text-primary`) -- those are real,
+independently-repeated shapes of their own, left for future slices per
+this codemod's own tailwind.css comment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-primary-5"
+BASE_TOKENS = {"h-5", "w-5", "text-primary"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-primary-5 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fresh full-repo class-frequency survey outside all now-closed families (`kr-text-black-*`, `kr-text-bold-*`, `kr-text-dim-*`, `kr-text-eyebrow-*`, `kr-label-*`, `kr-badge-*` incl. `-ghost`/`-outline` sizeless siblings and their bounded extras, `kr-text-error-xs`, `kr-text-faded-*`) found `h-5 w-5 text-primary` — a bare 20px primary-tinted icon glyph, distinct from `.kr-icon-tile`'s tinted rounded-square page-header treatment — at 17 exact occurrences across 16 files, plus 11 further subset-match occurrences (mostly carrying an extra `shrink-0`) across 8 more files.

- Added `.kr-icon-primary-5` to `assets/css/tailwind.css`.
- New codemod `utils/scripts/codemods/kr_icon_primary_5_codemod.py`, sibling of the other `kr-*` codemods (imports the shared `_class_attr.py` `CLASS_ATTR` guard, honors `--exact-only`).
- Ran the full subset-match pass: migrated 28 occurrences across 24 files; no geometry or behavior change — only static `class="..."` attributes touched, extras preserved verbatim.

## Verification

- `vue-tsc --noEmit`: clean
- `eslint .`: 333/327/6, identical to documented baseline
- `npm run test:layout-contract`: holds, 0 new violations (same pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet note as every recent slice, left untouched)
- `npm run test:lint-ratchet`: holds at 333/-59
- `prettier --check .`: byte-identical warning list (1145 lines, confirmed via a `git stash` before/after diff)
- Manually reviewed every migrated diff — only static `class="..."` attributes changed, no `:class` bindings touched.

## Flags for Reviewer

None. Pure class-token substitution, same shape as every prior `kr-*` migration slice in this recurring umbrella (interface-vision/t-104).

## Kaizen for next slice

Sibling icon sizes surveyed alongside this one and left open: `h-4 w-4 text-primary` (7 files), `h-6 w-6 text-primary` (11 files), `h-7 w-7 text-primary` (5 files), `h-10 w-10 text-primary/60` (3 files, different opacity), `h-12 w-12 text-primary` (5 files, distinct from `.kr-icon-tile`'s own `h-12 w-12` which also carries the tile's background/shape tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADLjBxQAfV19jqDGVgHbDg

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADLjBxQAfV19jqDGVgHbDg)_