### PR TITLE
interface-vision/t-104 slice 192: add kr-icon-primary-6, migrate h-6 w-6 text-primary icons

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1638,6 +1638,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply h-5 w-5 text-primary;
   }
 
+  /* Same bare-icon shape one size up -- `h-6 w-6 text-primary`, no tile/
+   * background (interface-vision t-104 slice 192): 13 exact occurrences
+   * across 13 files. Sibling of `.kr-icon-primary-5` above, not a
+   * generalization of it -- kept as its own fixed-size primitive to match
+   * every other kr-icon-primary-* sibling. Remaining sibling sizes still
+   * open for future slices: `h-4 w-4 text-primary` (8 files), `h-7 w-7
+   * text-primary` (6 files, excluding the sample/ template file), `h-10
+   * w-10 text-primary/60` (3 files, different opacity), `h-12 w-12
+   * text-primary` (7 files, distinct from `.kr-icon-tile`'s own `h-12
+   * w-12` which also carries the tile's background/shape tokens). */
+  .kr-icon-primary-6 {
+    @apply h-6 w-6 text-primary;
+  }
+
   /* The colorless DaisyUI busy indicator: a bare tiny spinner dropped into
    * a button or inline slot while an action is pending, no tint (the
    * button/text color around it usually already carries the tone)

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -11,7 +11,7 @@
             <span
               class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-primary/15"
             >
-              <Icon name="kind-icon:paintbrush" class="h-6 w-6 text-primary" />
+              <Icon name="kind-icon:paintbrush" class="kr-icon-primary-6" />
             </span>
             <div class="min-w-0">
               <h1 class="kr-text-black-2xl text-primary">Image Generator</h1>

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -220,7 +220,7 @@
             <p class="kr-text-dim-sm">Runtime options for this chat session.</p>
           </div>
 
-          <Icon name="kind-icon:sliders" class="h-6 w-6 text-primary" />
+          <Icon name="kind-icon:sliders" class="kr-icon-primary-6" />
         </div>
 
         <div class="grid gap-4">

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -239,7 +239,7 @@
               <div
                 class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-base-300 bg-primary/10"
               >
-                <Icon name="kind-icon:robot" class="h-6 w-6 text-primary" />
+                <Icon name="kind-icon:robot" class="kr-icon-primary-6" />
               </div>
 
               <div class="min-w-0">

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -145,7 +145,7 @@
               <div
                 class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-base-300 bg-primary/10"
               >
-                <Icon name="kind-icon:person" class="h-6 w-6 text-primary" />
+                <Icon name="kind-icon:person" class="kr-icon-primary-6" />
               </div>
 
               <div class="min-w-0">

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -319,7 +319,7 @@
               <div
                 class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-base-300 bg-primary/10"
               >
-                <Icon name="kind-icon:dream" class="h-6 w-6 text-primary" />
+                <Icon name="kind-icon:dream" class="kr-icon-primary-6" />
               </div>
 
               <div class="min-w-0">

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -328,7 +328,7 @@
               <div class="flex items-start gap-3">
                 <Icon
                   :name="dreamStore.dreamForm.icon || 'kind-icon:dream'"
-                  class="mt-1 h-6 w-6 text-primary"
+                  class="kr-icon-primary-6 mt-1"
                 />
                 <div class="min-w-0">
                   <p class="kr-text-black-xl truncate text-primary">

--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -5,7 +5,7 @@
       <div class="flex flex-col gap-3 p-5 sm:flex-row sm:items-start sm:justify-between">
         <div class="min-w-0">
           <div class="flex items-center gap-2">
-            <Icon name="kind-icon:compass" class="h-6 w-6 text-primary" />
+            <Icon name="kind-icon:compass" class="kr-icon-primary-6" />
             <h1 class="kr-text-black-xl sm:text-2xl">Navigation Health</h1>
           </div>
           <p class="mt-2 max-w-3xl text-sm leading-relaxed text-base-content/65">

--- a/components/navigation/workspace-sheet.vue
+++ b/components/navigation/workspace-sheet.vue
@@ -150,7 +150,7 @@
               <div
                 class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-primary/20 bg-base-100/85 shadow-sm backdrop-blur"
               >
-                <Icon :name="card.icon" class="h-6 w-6 text-primary" />
+                <Icon :name="card.icon" class="kr-icon-primary-6" />
               </div>
 
               <div class="min-w-0 flex-1">

--- a/components/projects/project-placement-manager.vue
+++ b/components/projects/project-placement-manager.vue
@@ -7,7 +7,7 @@
       >
         <div class="min-w-0">
           <div class="flex items-center gap-2">
-            <Icon name="kind-icon:map" class="h-6 w-6 text-primary" />
+            <Icon name="kind-icon:map" class="kr-icon-primary-6" />
             <h1 class="kr-text-black-xl sm:text-2xl">Project Placement</h1>
           </div>
           <p

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -206,7 +206,7 @@
               <div
                 class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-base-300 bg-primary/10"
               >
-                <Icon :name="selectedRewardIcon" class="h-6 w-6 text-primary" />
+                <Icon :name="selectedRewardIcon" class="kr-icon-primary-6" />
               </div>
 
               <div class="min-w-0">

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -378,7 +378,7 @@
                   v-else
                   class="flex h-12 w-12 items-center justify-center rounded-2xl bg-base-300"
                 >
-                  <Icon name="mdi:account-star" class="h-6 w-6 text-primary" />
+                  <Icon name="mdi:account-star" class="kr-icon-primary-6" />
                 </div>
 
                 <div class="min-w-0 flex-1">

--- a/components/stages/stage-preset.vue
+++ b/components/stages/stage-preset.vue
@@ -22,7 +22,7 @@
       />
       <Icon
         :name="preset.icon"
-        class="absolute bottom-2 left-2 h-6 w-6 text-primary drop-shadow"
+        class="kr-icon-primary-6 absolute bottom-2 left-2 drop-shadow"
       />
     </figure>
 

--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -17,7 +17,7 @@
           class="h-full w-full object-cover"
           @error="onPreviewError"
         />
-        <Icon v-else name="kind-icon:user" class="h-6 w-6 text-primary" />
+        <Icon v-else name="kind-icon:user" class="kr-icon-primary-6" />
       </span>
 
       <div class="min-w-0 flex-1">

--- a/utils/scripts/codemods/kr_icon_primary_6_codemod.py
+++ b/utils/scripts/codemods/kr_icon_primary_6_codemod.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `h-6 w-6 text-primary` bare icon glyphs to
+`kr-icon-primary-6`.
+
+Sibling of kr_icon_primary_5_codemod.py, one size up. Same shape family --
+a bare icon glyph, no tile/background tokens, most often inline beside a
+label or in a list row. Dry-run by default, --write to update matching Vue
+files in place. Only the exact `h-6 w-6 text-primary` shape is touched, and
+only in static `class="..."` attributes -- never `:class`/`v-bind:class`
+bindings (see _class_attr.py), and regardless of the base tokens' order in
+the source. A source that already carries `kr-icon-primary-6`, or is
+missing any of the three base tokens, is left untouched. Extra tokens
+beyond the base set are preserved verbatim after the primitive class,
+matching the kr-icon-primary-5/kr-badge-*/kr-spinner-*/kr-text-dim-*/
+kr-text-faded-* codemods' subset-match convention -- pass --exact-only to
+restrict a slice to sources with no extra tokens at all.
+
+Deliberately does NOT touch sibling icon sizes (`h-4 w-4 text-primary`,
+`h-5 w-5 text-primary`, `h-7 w-7 text-primary`, `h-10 w-10
+text-primary/60`, `h-12 w-12 text-primary`) -- those are real,
+independently-repeated shapes of their own, left for future slices per
+this codemod's own tailwind.css comment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-primary-6"
+BASE_TOKENS = {"h-6", "w-6", "text-primary"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-primary-6 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Added `.kr-icon-primary-6` to `assets/css/tailwind.css` (`h-6 w-6 text-primary`), sibling of `.kr-icon-primary-5` (slice 191), one size up.
- New codemod `utils/scripts/codemods/kr_icon_primary_6_codemod.py`, same shape as `kr_icon_primary_5_codemod.py`.
- Migrated 13 exact `h-6 w-6 text-primary` occurrences across 13 files to `kr-icon-primary-6`. Extra tokens (`mt-1`, `absolute bottom-2 left-2 drop-shadow`) preserved verbatim after the primitive class.

### How I verified
- `vue-tsc --noEmit`: clean.
- `eslint .`: 333 problems (327 errors, 6 warnings) — identical to the documented baseline.
- `npm run test:layout-contract`: holds, 0 new violations (pre-existing `narrative-ingredient-multi-picker.vue` ratchet-shrink note untouched, out of scope for this slice).
- `npm run test:lint-ratchet`: holds at 333/-59.
- `prettier --check .`: byte-identical warning list (1145 lines) confirmed via a `git stash` before/after diff.
- Manually reviewed every migrated diff — only static `class="..."` attributes touched, no `:class` bindings, no geometry/behavior change.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Remaining sibling icon sizes surveyed alongside this one, still open for future slices: `h-4 w-4 text-primary` (8 files), `h-7 w-7 text-primary` (6 files, excluding a `sample/*.vue.txt` template file out of codemod scope), `h-10 w-10 text-primary/60` (3 files, different opacity), `h-12 w-12 text-primary` (7 files, distinct from `.kr-icon-tile`'s own `h-12 w-12` which also carries the tile's background/shape tokens).

### Notes for reviewer
Companion conductor close-out PR tracks the roadmap task state transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xx29F1Wa4GKFcZssS34TK5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xx29F1Wa4GKFcZssS34TK5)_