### PR TITLE
interface-vision/t-104 slice 193: add kr-icon-primary-4, migrate h-4 w-4 text-primary icons

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1652,6 +1652,21 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply h-6 w-6 text-primary;
   }
 
+  /* Same bare-icon shape one size down -- `h-4 w-4 text-primary`, no
+   * tile/background (interface-vision t-104 slice 193): 16 subset-match
+   * occurrences across 10 files (most carrying an extra `shrink-0`).
+   * Sibling of `.kr-icon-primary-5`/`.kr-icon-primary-6` above, not a
+   * generalization of either -- kept as its own fixed-size primitive to
+   * match every other kr-icon-primary-* sibling. Remaining sibling sizes
+   * still open for future slices: `h-7 w-7 text-primary` (6 files,
+   * excluding the sample/ template file), `h-10 w-10 text-primary/60` (3
+   * files, different opacity), `h-12 w-12 text-primary` (7 files, distinct
+   * from `.kr-icon-tile`'s own `h-12 w-12` which also carries the tile's
+   * background/shape tokens). */
+  .kr-icon-primary-4 {
+    @apply h-4 w-4 text-primary;
+  }
+
   /* The colorless DaisyUI busy indicator: a bare tiny spinner dropped into
    * a button or inline slot while an action is pending, no tint (the
    * button/text color around it usually already carries the tone)

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -210,7 +210,7 @@
         >
           <Icon
             :name="activeGroup.isVirtual ? 'kind-icon:archive' : 'kind-icon:folder'"
-            class="h-4 w-4 shrink-0 text-primary"
+            class="kr-icon-primary-4 shrink-0"
           />
           <h3 class="kr-text-black-sm min-w-0 truncate text-base-content">
             {{ activeGroup.title }}

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -20,7 +20,7 @@
 
     <div class="flex flex-col gap-2 kr-panel-compact">
       <div class="flex items-center gap-2">
-        <Icon name="kind-icon:image" class="h-4 w-4 text-primary" />
+        <Icon name="kind-icon:image" class="kr-icon-primary-4" />
         <span class="kr-text-black-xs text-base-content">Source Image</span>
         <div class="flex-1" />
         <div
@@ -475,7 +475,7 @@
         class="flex flex-col gap-3 rounded-xl border border-primary/30 bg-base-100 p-3"
       >
         <div class="flex items-center gap-1.5">
-          <Icon name="kind-icon:edit" class="h-4 w-4 text-primary" />
+          <Icon name="kind-icon:edit" class="kr-icon-primary-4" />
           <span class="kr-text-black-xs text-base-content">Prompt</span>
           <span class="kr-text-dim-xs-40 ml-auto">
             {{

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -142,7 +142,7 @@
         <div class="kr-panel-divider">
           <!-- Metadata section header -->
           <div class="mb-3 flex items-center gap-2">
-            <icon name="kind-icon:settings" class="h-4 w-4 text-primary" />
+            <icon name="kind-icon:settings" class="kr-icon-primary-4" />
             <h3 class="kr-text-black-sm text-base-content">Image Metadata</h3>
             <span class="kr-text-dim-xs-40"
               >Optional — added to every image in this batch</span
@@ -344,7 +344,7 @@
               v-if="connectedModelId"
               class="mb-2 flex items-center gap-2 rounded-xl bg-primary/10 px-3 py-2 text-xs"
             >
-              <Icon name="mdi:link-variant" class="h-4 w-4 text-primary" />
+              <Icon name="mdi:link-variant" class="kr-icon-primary-4" />
               <span class="font-semibold text-primary"
                 >{{ connectedModelType }} #{{ connectedModelId }}</span
               >

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -51,7 +51,7 @@
     <!-- Source image -->
     <div class="flex flex-col gap-2 kr-panel-compact">
       <div class="flex items-center gap-2">
-        <Icon name="kind-icon:image" class="h-4 w-4 text-primary" />
+        <Icon name="kind-icon:image" class="kr-icon-primary-4" />
         <span class="kr-text-black-xs text-base-content">Client Photo</span>
         <div class="flex-1" />
         <div

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -35,7 +35,7 @@
           class="flex min-w-0 shrink-0 items-center gap-1.5 pr-1"
           :title="subtitle"
         >
-          <Icon name="kind-icon:dream" class="h-4 w-4 text-primary" />
+          <Icon name="kind-icon:dream" class="kr-icon-primary-4" />
           <h2
             class="kr-text-black-sm max-w-36 truncate text-primary sm:max-w-48"
           >

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -14,7 +14,7 @@
         <h4
           class="kr-text-black-sm flex items-center gap-1.5 text-base-content"
         >
-          <Icon name="kind-icon:layers" class="h-4 w-4 text-primary" />
+          <Icon name="kind-icon:layers" class="kr-icon-primary-4" />
           Batch edit — {{ group.label }}
         </h4>
         <p class="kr-text-dim-xs-60 mt-0.5">

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -38,7 +38,7 @@
     <!-- Stage: PITCH -->
     <section class="kr-panel-flat rounded-xl p-2.5">
       <div class="mb-1.5 flex items-center gap-2">
-        <Icon name="kind-icon:lightbulb" class="h-4 w-4 text-primary" />
+        <Icon name="kind-icon:lightbulb" class="kr-icon-primary-4" />
         <span class="kr-text-eyebrow-bold text-xs tracking-wide">Pitch</span>
         <span class="kr-badge-xs ml-auto" :class="badgeFor('PITCH')">
           {{ item.stages.PITCH.status }}
@@ -111,7 +111,7 @@
     <!-- Stage: FIELDS_AND_PROMPTS -->
     <section class="kr-panel-flat rounded-xl p-2.5">
       <div class="mb-1.5 flex items-center gap-2">
-        <Icon name="kind-icon:list" class="h-4 w-4 text-primary" />
+        <Icon name="kind-icon:list" class="kr-icon-primary-4" />
         <span class="kr-text-eyebrow-bold text-xs tracking-wide"
           >Fields &amp; Prompts</span
         >
@@ -226,7 +226,7 @@
     <!-- Stage: GENERATE_ASSETS -->
     <section class="kr-panel-flat rounded-xl p-2.5">
       <div class="mb-1.5 flex items-center gap-2">
-        <Icon name="kind-icon:sparkles" class="h-4 w-4 text-primary" />
+        <Icon name="kind-icon:sparkles" class="kr-icon-primary-4" />
         <span class="kr-text-eyebrow-bold text-xs tracking-wide"
           >Generate Assets</span
         >
@@ -355,7 +355,7 @@
     <!-- Stage: COMMIT -->
     <section class="kr-panel-flat rounded-xl p-2.5">
       <div class="mb-1.5 flex items-center gap-2">
-        <Icon name="kind-icon:check" class="h-4 w-4 text-primary" />
+        <Icon name="kind-icon:check" class="kr-icon-primary-4" />
         <span class="kr-text-eyebrow-bold text-xs tracking-wide">Commit</span>
         <span class="kr-badge-xs ml-auto" :class="badgeFor('COMMIT')">
           {{ item.stages.COMMIT.status }}

--- a/components/model-builder/model-builder-manager.vue
+++ b/components/model-builder/model-builder-manager.vue
@@ -7,7 +7,7 @@
     <header
       class="flex h-10 shrink-0 items-center gap-2 border-b border-base-300 bg-base-100 px-2 sm:px-3"
     >
-      <Icon name="kind-icon:blueprint" class="h-4 w-4 shrink-0 text-primary" />
+      <Icon name="kind-icon:blueprint" class="kr-icon-primary-4 shrink-0" />
 
       <h2
         class="kr-text-black-sm truncate leading-none text-base-content sm:text-base"

--- a/components/navigation/workspace-sheet.vue
+++ b/components/navigation/workspace-sheet.vue
@@ -248,7 +248,7 @@
                           ? 'kind-icon:chevron-up'
                           : 'kind-icon:info'
                       "
-                      class="h-4 w-4 shrink-0 text-primary"
+                      class="kr-icon-primary-4 shrink-0"
                     />
                   </div>
 

--- a/components/themes/theme-gallery.vue
+++ b/components/themes/theme-gallery.vue
@@ -160,7 +160,7 @@
                     <Icon
                       v-if="activeThemeName === String(item.id)"
                       name="kind-icon:check"
-                      class="h-4 w-4 shrink-0 text-primary"
+                      class="kr-icon-primary-4 shrink-0"
                     />
                   </div>
 
@@ -329,7 +329,7 @@
         <section v-if="inspectValues" class="kr-panel-flat p-3 shadow">
           <div class="mb-2 flex items-center justify-between gap-2">
             <div class="flex min-w-0 items-center gap-2">
-              <Icon name="kind-icon:code" class="h-4 w-4 text-primary" />
+              <Icon name="kind-icon:code" class="kr-icon-primary-4" />
 
               <h2 class="kr-text-black-sm truncate text-base-content">
                 Active Theme Snapshot

--- a/utils/scripts/codemods/kr_icon_primary_4_codemod.py
+++ b/utils/scripts/codemods/kr_icon_primary_4_codemod.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `h-4 w-4 text-primary` bare icon glyphs to
+`kr-icon-primary-4`.
+
+Sibling of kr_icon_primary_5_codemod.py / kr_icon_primary_6_codemod.py, one
+size down. Same shape family -- a bare icon glyph, no tile/background
+tokens, most often inline beside a label or in a list row. Dry-run by
+default, --write to update matching Vue files in place. Only the exact
+`h-4 w-4 text-primary` shape is touched, and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings (see _class_attr.py),
+and regardless of the base tokens' order in the source. A source that
+already carries `kr-icon-primary-4`, or is missing any of the three base
+tokens, is left untouched. Extra tokens beyond the base set are preserved
+verbatim after the primitive class, matching the kr-icon-primary-5/6-*/
+kr-badge-*/kr-spinner-*/kr-text-dim-*/kr-text-faded-* codemods' subset-match
+convention -- pass --exact-only to restrict a slice to sources with no
+extra tokens at all.
+
+Deliberately does NOT touch sibling icon sizes (`h-5 w-5 text-primary`,
+`h-6 w-6 text-primary`, `h-7 w-7 text-primary`, `h-10 w-10
+text-primary/60`, `h-12 w-12 text-primary`) -- those are real,
+independently-repeated shapes of their own, already migrated (h-5/h-6) or
+left for future slices per this codemod's own tailwind.css comment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-primary-4"
+BASE_TOKENS = {"h-4", "w-4", "text-primary"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-primary-4 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Added `.kr-icon-primary-4` (`h-4 w-4 text-primary`) to `assets/css/tailwind.css`, sibling of `.kr-icon-primary-5` (slice 191) and `.kr-icon-primary-6` (slice 192), one size down.
- Added `utils/scripts/codemods/kr_icon_primary_4_codemod.py`, sibling of the other `kr-icon-primary-*` codemods — subset-match, static `class="..."` only, `--exact-only` flag for a narrower pass.
- Migrated 16 subset-match occurrences across 10 files: `art-gallery.vue`, `art-styler.vue` (x2), `image-upload.vue` (x2), `stylist-restyle.vue`, `dream-gallery.vue`, `model-builder-batch-editor.vue`, `model-builder-item-panel.vue` (x4), `model-builder-manager.vue`, `workspace-sheet.vue`, `theme-gallery.vue`. No geometry or behavior change — only static `class="..."` attributes touched.

### How I verified
- `npx vue-tsc --noEmit` — clean
- `npx eslint .` — 333/327/6, identical to the documented baseline
- `npm run test:layout-contract` — holds, 0 new violations (pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet note left untouched, unrelated to this diff)
- `npm run test:lint-ratchet` — holds at 333/-59
- `npx prettier --check .` — byte-identical warning list (1145 lines) before/after via `git stash` diff
- Manually reviewed every migrated diff — only static `class="..."` attributes touched, no `:class` bindings, no geometry/behavior change

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Sibling icon sizes still open for future slices: `h-7 w-7 text-primary` (6 files, excluding a `sample/*.vue.txt` template file out of codemod scope), `h-10 w-10 text-primary/60` (3 files, different opacity — a distinct token set, not a subset match), `h-12 w-12 text-primary` (7 files, distinct from `.kr-icon-tile`'s own `h-12 w-12` which also carries the tile's background/shape tokens).

### Notes for reviewer
Continues the recurring interface-vision/t-104 consistency umbrella (slice 193). Companion conductor close-out PR reconciles roadmap state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DVXHs8UpeggsEeX5mhWAV

---
_Generated by [Claude Code](https://claude.ai/code/session_019DVXHs8UpeggsEeX5mhWAV)_