### PR TITLE
interface-vision/t-104 slice 194: add kr-icon-primary-7, migrate h-7 w-7 text-primary icons

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1667,6 +1667,24 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply h-4 w-4 text-primary;
   }
 
+  /* Same bare-icon shape one size up from `.kr-icon-primary-6` -- `h-7 w-7
+   * text-primary`, no tile/background (interface-vision t-104 slice 194): 8
+   * exact occurrences across 6 files (academy-style-detail.vue,
+   * dream-brainstorm.vue, dream-maker.vue, giftshop-interact.vue,
+   * home-account-links.vue x3, tutorial-flyer.vue), excluding a
+   * `sample/*.vue.txt` template file out of codemod scope. Sibling of
+   * `.kr-icon-primary-4`/`.kr-icon-primary-5`/`.kr-icon-primary-6` above,
+   * not a generalization of any of them -- kept as its own fixed-size
+   * primitive to match every other kr-icon-primary-* sibling. Remaining
+   * sibling sizes still open for future slices: `h-10 w-10 text-primary/60`
+   * (3 files, different opacity -- a distinct token set, not a subset
+   * match of this family), `h-12 w-12 text-primary` (7 files, distinct
+   * from `.kr-icon-tile`'s own `h-12 w-12` which also carries the tile's
+   * background/shape tokens). */
+  .kr-icon-primary-7 {
+    @apply h-7 w-7 text-primary;
+  }
+
   /* The colorless DaisyUI busy indicator: a bare tiny spinner dropped into
    * a button or inline slot while an action is pending, no tint (the
    * button/text color around it usually already carries the tone)

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -204,7 +204,7 @@
               class="flex items-start gap-3 rounded-2xl border border-base-300 bg-base-200/45 p-3"
             >
               <span
-                class="kr-text-black-xs flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary"
+                class="kr-icon-primary-7 kr-text-black-xs flex shrink-0 items-center justify-center rounded-full bg-primary/10"
               >
                 {{ index + 1 }}
               </span>

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -7,7 +7,7 @@
       >
         <div class="min-w-0">
           <div class="flex flex-wrap items-center gap-2">
-            <Icon name="kind-icon:sparkles" class="h-7 w-7 text-primary" />
+            <Icon name="kind-icon:sparkles" class="kr-icon-primary-7" />
             <h1 class="kr-text-black-2xl text-primary">Brainstorm</h1>
             <span class="badge badge-info rounded-xl">Dream Riffs</span>
           </div>

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -9,7 +9,7 @@
       >
         <div class="min-w-0">
           <div class="flex flex-wrap items-center gap-2">
-            <Icon name="kind-icon:dream" class="h-7 w-7 text-primary" />
+            <Icon name="kind-icon:dream" class="kr-icon-primary-7" />
             <h1 class="kr-text-black-2xl text-primary">Dreammaker</h1>
             <span
               v-if="dreamStore.dreamForm.id"

--- a/components/giftshop/giftshop-interact.vue
+++ b/components/giftshop/giftshop-interact.vue
@@ -8,7 +8,7 @@
         >
           <div class="min-w-0 space-y-2">
             <div class="flex flex-wrap items-center gap-2">
-              <Icon name="kind-icon:gift" class="h-7 w-7 text-primary" />
+              <Icon name="kind-icon:gift" class="kr-icon-primary-7" />
 
               <h3 class="kr-text-black-2xl text-primary sm:text-3xl">
                 Swarm Giftshop

--- a/components/home/home-account-links.vue
+++ b/components/home/home-account-links.vue
@@ -19,7 +19,7 @@
         to="/account"
         class="kr-panel flex min-h-40 flex-col gap-3 p-5 transition hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-md"
       >
-        <Icon name="kind-icon:settings" class="h-7 w-7 text-primary" />
+        <Icon name="kind-icon:settings" class="kr-icon-primary-7" />
         <div>
           <h2 class="font-black">Account</h2>
           <p class="kr-text-dim-sm mt-1">
@@ -33,7 +33,7 @@
         to="/plan/newsfeed"
         class="kr-panel flex min-h-40 flex-col gap-3 p-5 transition hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-md"
       >
-        <Icon name="kind-icon:news" class="h-7 w-7 text-primary" />
+        <Icon name="kind-icon:news" class="kr-icon-primary-7" />
         <div>
           <h2 class="font-black">Newsfeed</h2>
           <p class="kr-text-dim-sm mt-1">
@@ -47,7 +47,7 @@
         to="/friends"
         class="kr-panel flex min-h-40 flex-col gap-3 p-5 transition hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-md"
       >
-        <Icon name="kind-icon:users" class="h-7 w-7 text-primary" />
+        <Icon name="kind-icon:users" class="kr-icon-primary-7" />
         <div>
           <h2 class="font-black">Friends</h2>
           <p class="kr-text-dim-sm mt-1">

--- a/components/navigation/tutorial-flyer.vue
+++ b/components/navigation/tutorial-flyer.vue
@@ -119,7 +119,7 @@
                 loading="lazy"
                 class="h-full w-full object-cover"
               />
-              <Icon v-else name="kind-icon:info" class="h-7 w-7 text-primary" />
+              <Icon v-else name="kind-icon:info" class="kr-icon-primary-7" />
             </div>
 
             <div class="min-w-0 flex-1 pr-8">

--- a/utils/scripts/codemods/kr_icon_primary_7_codemod.py
+++ b/utils/scripts/codemods/kr_icon_primary_7_codemod.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `h-7 w-7 text-primary` bare icon glyphs to
+`kr-icon-primary-7`.
+
+Sibling of kr_icon_primary_4_codemod.py / kr_icon_primary_5_codemod.py /
+kr_icon_primary_6_codemod.py, one size up from primary-6. Same shape family
+-- a bare icon glyph, no tile/background tokens, most often inline beside a
+label or in a list row. Dry-run by default, --write to update matching Vue
+files in place. Only the exact `h-7 w-7 text-primary` shape is touched, and
+only in static `class="..."` attributes -- never `:class`/`v-bind:class`
+bindings (see _class_attr.py), and regardless of the base tokens' order in
+the source. A source that already carries `kr-icon-primary-7`, or is
+missing any of the three base tokens, is left untouched. Extra tokens
+beyond the base set are preserved verbatim after the primitive class,
+matching the other kr-icon-primary-*/kr-badge-*/kr-spinner-*/kr-text-dim-*/
+kr-text-faded-* codemods' subset-match convention -- pass --exact-only to
+restrict a slice to sources with no extra tokens at all.
+
+Only walks `*.vue` files (see main()'s rglob), so a `sample/*.vue.txt`
+template file carrying this shape is out of scope by construction, not by
+a special-case exclusion.
+
+Deliberately does NOT touch sibling icon sizes (`h-4 w-4 text-primary`,
+`h-5 w-5 text-primary`, `h-6 w-6 text-primary`, `h-10 w-10
+text-primary/60`, `h-12 w-12 text-primary`) -- those are real,
+independently-repeated shapes of their own, already migrated (h-4/h-5/h-6)
+or left for future slices per this codemod's own tailwind.css comment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-primary-7"
+BASE_TOKENS = {"h-7", "w-7", "text-primary"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-primary-7 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Added `.kr-icon-primary-7` (`h-7 w-7 text-primary`) to `assets/css/tailwind.css`, sibling of `.kr-icon-primary-4/5/6` (slices 193/191/192), one size up from `.kr-icon-primary-6`.
- Added `utils/scripts/codemods/kr_icon_primary_7_codemod.py`, sibling of the other `kr-icon-primary-*` codemods.
- Migrated 8 exact occurrences across 6 files: `academy-style-detail.vue`, `dream-brainstorm.vue`, `dream-maker.vue`, `giftshop-interact.vue`, `home-account-links.vue` (x3), `tutorial-flyer.vue`. No geometry or behavior change — only static `class="..."` attributes touched. A `sample/*.vue.txt` template file carrying this shape stays out of scope because the codemod only walks `*.vue` files.

### How I verified
- `npx vue-tsc --noEmit` — clean
- `npx eslint .` — 333/327/6, identical to the documented baseline
- `npm run test:layout-contract` — holds, 0 new violations (pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet note left untouched, unrelated to this diff)
- `npm run test:lint-ratchet` — holds at 333/-59
- `npx prettier --check .` — byte-identical warning list (1145 lines) before/after via `git stash` diff
- Manually reviewed every migrated diff — only static `class="..."` attributes touched, no `:class` bindings, no geometry/behavior change (one occurrence, `academy-style-detail.vue`'s numbered index badge, carries extra `rounded-full bg-primary/10` tokens preserved verbatim — same subset-match convention as every prior kr-icon-primary-* slice)

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Sibling icon sizes still open for future slices: `h-10 w-10 text-primary/60` (3 files, different opacity — a distinct token set, not a subset match), `h-12 w-12 text-primary` (7 files, distinct from `.kr-icon-tile`'s own `h-12 w-12` which also carries the tile's background/shape tokens).

### Notes for reviewer
Continues the recurring interface-vision/t-104 consistency umbrella (slice 194). Companion conductor close-out PR reconciles roadmap state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DVXHs8UpeggsEeX5mhWAV

---
_Generated by [Claude Code](https://claude.ai/code/session_019DVXHs8UpeggsEeX5mhWAV)_