### PR TITLE
interface-vision/t-104 slice 195: add kr-icon-primary-10, migrate h-10 w-10 text-primary/60 icons

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1685,6 +1685,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply h-7 w-7 text-primary;
   }
 
+  /* Same bare-icon shape family, but a distinct token set -- `h-10 w-10
+   * text-primary/60` carries a `/60` opacity modifier on the color instead
+   * of the bare `text-primary` every other kr-icon-primary-* sibling uses,
+   * so it is not a subset match of any of them (interface-vision t-104
+   * slice 195): 7 exact occurrences across 3 files (dream-art-chooser.vue,
+   * dream-list.vue x5, avatar-picker.vue). Kept as its own fixed-size
+   * primitive to match every other kr-icon-primary-* sibling. Remaining
+   * sibling size still open for a future slice: `h-12 w-12 text-primary`
+   * (7 files, distinct from `.kr-icon-tile`'s own `h-12 w-12` which also
+   * carries the tile's background/shape tokens). */
+  .kr-icon-primary-10 {
+    @apply h-10 w-10 text-primary/60;
+  }
+
   /* The colorless DaisyUI busy indicator: a bare tiny spinner dropped into
    * a button or inline slot while an action is pending, no tint (the
    * button/text color around it usually already carries the tone)

--- a/components/dreams/dream-art-chooser.vue
+++ b/components/dreams/dream-art-chooser.vue
@@ -157,7 +157,7 @@
         v-if="!visibleImages.length"
         class="kr-text-dim-sm kr-panel-muted col-span-full flex min-h-40 flex-col items-center justify-center border-dashed text-center"
       >
-        <Icon name="kind-icon:image" class="h-10 w-10 text-primary/60" />
+        <Icon name="kind-icon:image" class="kr-icon-primary-10" />
         <p class="mt-2 font-bold">No art found for this filter.</p>
         <p class="text-xs">Try another collection, or clear the search.</p>
       </div>

--- a/components/dreams/dream-list.vue
+++ b/components/dreams/dream-list.vue
@@ -40,7 +40,7 @@
         </template>
 
         <div v-else :class="emptyClass">
-          <Icon :name="emptyIcon" class="h-10 w-10 text-primary/60" />
+          <Icon :name="emptyIcon" class="kr-icon-primary-10" />
           <div>
             <p class="font-black">{{ emptyTitle }}</p>
             <p class="mt-1">{{ emptyMessage }}</p>
@@ -68,7 +68,7 @@
         </template>
 
         <div v-else :class="emptyClass">
-          <Icon :name="emptyIcon" class="h-10 w-10 text-primary/60" />
+          <Icon :name="emptyIcon" class="kr-icon-primary-10" />
           <div>
             <p class="font-black">{{ emptyTitle }}</p>
             <p class="mt-1">{{ emptyMessage }}</p>
@@ -94,7 +94,7 @@
         </template>
 
         <div v-else :class="emptyClass">
-          <Icon :name="emptyIcon" class="h-10 w-10 text-primary/60" />
+          <Icon :name="emptyIcon" class="kr-icon-primary-10" />
           <div>
             <p class="font-black">{{ emptyTitle }}</p>
             <p class="mt-1">{{ emptyMessage }}</p>
@@ -120,7 +120,7 @@
         </template>
 
         <div v-else :class="emptyClass">
-          <Icon :name="emptyIcon" class="h-10 w-10 text-primary/60" />
+          <Icon :name="emptyIcon" class="kr-icon-primary-10" />
           <div>
             <p class="font-black">{{ emptyTitle }}</p>
             <p class="mt-1">{{ emptyMessage }}</p>
@@ -169,7 +169,7 @@
       </div>
 
       <div v-else :class="emptyClass">
-        <Icon :name="emptyIcon" class="h-10 w-10 text-primary/60" />
+        <Icon :name="emptyIcon" class="kr-icon-primary-10" />
         <div>
           <p class="font-black">{{ emptyTitle }}</p>
           <p class="mt-1">{{ emptyMessage }}</p>

--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -152,7 +152,7 @@
             v-else-if="!galleryImages.length"
             class="flex flex-1 flex-col items-center justify-center gap-2 text-center text-base-content/55"
           >
-            <Icon name="kind-icon:gallery" class="h-10 w-10 text-primary/60" />
+            <Icon name="kind-icon:gallery" class="kr-icon-primary-10" />
             <p class="kr-text-bold-sm text-base-content">No images here yet.</p>
             <p class="text-xs">Try the Upload or Generate tab to make your first one.</p>
           </div>

--- a/utils/scripts/codemods/kr_icon_primary_10_codemod.py
+++ b/utils/scripts/codemods/kr_icon_primary_10_codemod.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `h-10 w-10 text-primary/60` bare icon glyphs to
+`kr-icon-primary-10`.
+
+Sibling of kr_icon_primary_4_codemod.py / kr_icon_primary_5_codemod.py /
+kr_icon_primary_6_codemod.py / kr_icon_primary_7_codemod.py -- same bare
+icon-glyph shape, no tile/background tokens, but a distinct token set: this
+size carries a `/60` opacity modifier on `text-primary` rather than the bare
+color, so it is not a subset match of any other kr-icon-primary-* sibling
+and needs its own exact base-token set. Dry-run by default, --write to
+update matching Vue files in place. Only the exact `h-10 w-10
+text-primary/60` shape is touched, and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings (see _class_attr.py),
+regardless of the base tokens' order in the source. A source that already
+carries `kr-icon-primary-10`, or is missing any of the three base tokens,
+is left untouched. Extra tokens beyond the base set are preserved verbatim
+after the primitive class, matching the other kr-icon-primary-*/
+kr-badge-*/kr-spinner-*/kr-text-dim-*/kr-text-faded-* codemods' subset-match
+convention -- pass --exact-only to restrict a slice to sources with no
+extra tokens at all.
+
+Only walks `*.vue` files (see main()'s rglob).
+
+Deliberately does NOT touch sibling icon sizes (`h-4 w-4 text-primary`,
+`h-5 w-5 text-primary`, `h-6 w-6 text-primary`, `h-7 w-7 text-primary`,
+`h-12 w-12 text-primary`) -- those are real, independently-repeated shapes
+of their own, already migrated (h-4/h-5/h-6/h-7) or left for a future
+slice.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-primary-10"
+BASE_TOKENS = {"h-10", "w-10", "text-primary/60"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-primary-10 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- New `.kr-icon-primary-10` primitive in `assets/css/tailwind.css` (`h-10 w-10 text-primary/60`) — sibling of `.kr-icon-primary-4/5/6/7`, same bare icon-glyph shape (no tile/background tokens), but a distinct token set: this size carries a `/60` opacity modifier on `text-primary` rather than the bare color, so it is not a subset match of any other kr-icon-primary-* sibling.
- New codemod `utils/scripts/codemods/kr_icon_primary_10_codemod.py`, mirroring the existing siblings' exact base-token matching (dry-run by default, `--write` to migrate, `--exact-only` to restrict to sources with no extra tokens).
- Migrated 7 exact occurrences across 3 files: `dream-art-chooser.vue`, `dream-list.vue` (x5), `avatar-picker.vue`.

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint .`: 333/327/6, identical to the documented baseline
- `npm run test:layout-contract`: holds, 0 new violations
- `npm run test:lint-ratchet`: holds at 333/-59
- `npx prettier --check .`: byte-identical warning list (1145 lines, `git stash` before/after diff)
- Manually reviewed every diff line — only static `class="..."` attributes touched, no `:class` bindings, no geometry/behavior change

### Stakes
reversible

### Kaizen suggestion
Only one kr-icon-primary-* sibling remains open: `h-12 w-12 text-primary` (7 files, distinct from `.kr-icon-tile`'s own `h-12 w-12` which also carries the tile's background/shape tokens). After that lands, a fresh full-repo class-frequency survey outside all now-closed families is the right next step.

### Notes for reviewer
Recurring task (interface-vision/t-104), slice 195 of the ongoing kr-* consistency sweep. Prior slices: #2571–#2575.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dh5yVEUPzkfDcspu3t6Jat

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dh5yVEUPzkfDcspu3t6Jat)_