### PR TITLE
interface-vision/t-104 slice 196: add kr-icon-primary-12, migrate h-12 w-12 text-primary icons

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1699,6 +1699,33 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply h-10 w-10 text-primary/60;
   }
 
+  /* Final documented sibling in this family -- `h-12 w-12 text-primary`, no
+   * tile/background tokens (interface-vision t-104 slice 196): a live
+   * re-search against current `main` found 9 exact occurrences across 8
+   * files (art-gallery.vue x2, art-interact.vue, bot-gallery.vue,
+   * character-gallery.vue, giftshop-manager.vue, giving-page.vue,
+   * serendipity-page.vue, chat-gallery.vue). Two of those sit inside a
+   * larger tile-shaped class string that already matches `.kr-icon-tile`'s
+   * own tokens almost verbatim (serendipity-page.vue's
+   * `grid h-12 w-12 place-items-center rounded-2xl bg-primary/15
+   * text-primary`, chat-gallery.vue's `kr-text-black-lg flex h-12 w-12
+   * shrink-0 items-center justify-center overflow-hidden rounded-2xl
+   * bg-primary/15 text-primary`) -- left as subset-match candidates rather
+   * than folded into `.kr-icon-tile`, matching every prior kr-icon-primary-*
+   * slice's convention of preserving extra tokens verbatim rather than
+   * reinterpreting the shape; no rendered output changes either way since
+   * `.kr-icon-primary-12` contributes exactly `h-12 w-12 text-primary` and
+   * the remaining tokens are carried through unchanged. A distinct
+   * `h-12 w-12 text-primary/70` occurrence (dream-gallery.vue) was found and
+   * correctly excluded -- not a subset match, same reasoning as
+   * `.kr-icon-primary-10`'s own `/60` opacity carve-out above. This closes
+   * out the kr-icon-primary-* family (4/5/6/7/10/12); a fresh full-repo
+   * class-frequency survey outside all now-closed families is the next
+   * step. */
+  .kr-icon-primary-12 {
+    @apply h-12 w-12 text-primary;
+  }
+
   /* The colorless DaisyUI busy indicator: a bare tiny spinner dropped into
    * a button or inline slot while an action is pending, no tint (the
    * button/text color around it usually already carries the tone)

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -166,7 +166,7 @@
         v-if="!activeGroup && visibleGroups.length === 0"
         class="flex min-h-56 flex-col items-center justify-center rounded-xl border border-base-300 bg-base-100 p-6 text-center text-base-content/60"
       >
-        <Icon name="kind-icon:folder" class="h-12 w-12 text-primary" />
+        <Icon name="kind-icon:folder" class="kr-icon-primary-12" />
         <p class="kr-text-black-lg mt-2 text-base-content">Nothing to show.</p>
         <p class="text-sm">No collections match the current filters.</p>
       </div>
@@ -450,7 +450,7 @@
             <div
               class="flex min-h-56 w-full flex-col items-center justify-center rounded-xl border border-base-300 bg-base-100 p-6 text-center text-base-content/60"
             >
-              <Icon name="kind-icon:image" class="h-12 w-12 text-primary" />
+              <Icon name="kind-icon:image" class="kr-icon-primary-12" />
               <p class="kr-text-black-lg mt-2 text-base-content">
                 No images here.
               </p>

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -105,7 +105,7 @@
       v-if="!currentArtImage"
       class="flex min-h-72 flex-col items-center justify-center kr-panel text-center text-base-content/55"
     >
-      <Icon name="kind-icon:image" class="h-12 w-12 text-primary" />
+      <Icon name="kind-icon:image" class="kr-icon-primary-12" />
       <p class="kr-text-bold-lg mt-2">No image selected.</p>
       <p class="mt-1 max-w-xl text-sm">
         Pick something from the gallery. The pixels are standing around holding

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -354,7 +354,7 @@
         v-else-if="filteredBots.length === 0"
         class="flex h-full flex-col items-center justify-center gap-3 kr-panel-muted text-center text-base-content/60"
       >
-        <Icon name="kind-icon:robot" class="h-12 w-12 text-primary" />
+        <Icon name="kind-icon:robot" class="kr-icon-primary-12" />
 
         <div>
           <p class="kr-text-bold-lg">No bots found.</p>

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -254,7 +254,7 @@
         v-else-if="filteredCharacters.length === 0"
         class="flex h-full flex-col items-center justify-center gap-3 kr-panel-muted text-center text-base-content/60"
       >
-        <Icon name="kind-icon:theater" class="h-12 w-12 text-primary" />
+        <Icon name="kind-icon:theater" class="kr-icon-primary-12" />
 
         <div class="max-w-2xl">
           <p class="kr-text-bold-lg">

--- a/components/giftshop/giftshop-manager.vue
+++ b/components/giftshop/giftshop-manager.vue
@@ -82,7 +82,7 @@
             v-else
             class="flex min-h-full flex-col items-center justify-center gap-3 text-center"
           >
-            <Icon name="kind-icon:forum" class="h-12 w-12 text-primary" />
+            <Icon name="kind-icon:forum" class="kr-icon-primary-12" />
 
             <div class="max-w-xl space-y-2">
               <h2 class="kr-text-black-2xl text-base-content">

--- a/components/pages/giving-page.vue
+++ b/components/pages/giving-page.vue
@@ -6,7 +6,7 @@
     >
       <Icon
         name="kind-icon:hand-heart"
-        class="mx-auto h-12 w-12 text-primary"
+        class="kr-icon-primary-12 mx-auto"
       />
 
       <p class="mt-4 text-3xl font-black text-base-content sm:text-4xl">

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -14,7 +14,7 @@
     <header class="flex flex-wrap items-center justify-between gap-3">
       <div class="flex items-center gap-3">
         <span
-          class="grid h-12 w-12 place-items-center rounded-2xl bg-primary/15 text-primary"
+          class="kr-icon-primary-12 grid place-items-center rounded-2xl bg-primary/15"
         >
           <Icon name="kind-icon:butterfly" class="h-7 w-7" />
         </span>

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -105,7 +105,7 @@
             @click="openThread(thread)"
           >
             <div
-              class="kr-text-black-lg flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-primary/15 text-primary"
+              class="kr-icon-primary-12 kr-text-black-lg flex shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-primary/15"
             >
               <img
                 v-if="thread.otherAvatar"

--- a/utils/scripts/codemods/kr_icon_primary_12_codemod.py
+++ b/utils/scripts/codemods/kr_icon_primary_12_codemod.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `h-12 w-12 text-primary` bare icon glyphs to
+`kr-icon-primary-12`.
+
+Sibling of kr_icon_primary_4_codemod.py / kr_icon_primary_5_codemod.py /
+kr_icon_primary_6_codemod.py / kr_icon_primary_7_codemod.py -- same bare
+icon-glyph shape, no tile/background tokens. Final documented size in the
+kr-icon-primary-* family (interface-vision t-104 slice 196). Dry-run by
+default, --write to update matching Vue files in place. Only the exact
+`h-12 w-12 text-primary` shape is touched, and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings (see _class_attr.py),
+regardless of the base tokens' order in the source. A source that already
+carries `kr-icon-primary-12`, or is missing any of the three base tokens,
+is left untouched. A `text-primary/NN` opacity-modified variant (e.g.
+`text-primary/70`) is a distinct token, not a subset match, and is
+correctly left untouched -- same reasoning as kr_icon_primary_10_codemod.py's
+own `/60` carve-out. Extra tokens beyond the base set are preserved verbatim
+after the primitive class, matching the other kr-icon-primary-*/
+kr-badge-*/kr-spinner-*/kr-text-dim-*/kr-text-faded-* codemods' subset-match
+convention -- pass --exact-only to restrict a slice to sources with no
+extra tokens at all.
+
+Only walks `*.vue` files (see main()'s rglob).
+
+Deliberately does NOT touch sibling icon sizes (`h-4 w-4 text-primary`,
+`h-5 w-5 text-primary`, `h-6 w-6 text-primary`, `h-7 w-7 text-primary`,
+`h-10 w-10 text-primary/60`) -- those are real, independently-repeated
+shapes of their own, already migrated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-primary-12"
+BASE_TOKENS = {"h-12", "w-12", "text-primary"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-primary-12 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 196: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Added `.kr-icon-primary-12` (`h-12 w-12 text-primary`) to `assets/css/tailwind.css`, the final documented sibling in the `kr-icon-primary-*` family alongside `-4`/`-5`/`-6`/`-7`/`-10`.
- New codemod `utils/scripts/codemods/kr_icon_primary_12_codemod.py`, sibling of the existing `4/5/6/7/10` codemods (same subset-match convention, `_class_attr` guard against `:class` bindings).
- Migrated all 9 exact occurrences across 8 files: `art-gallery.vue` (x2), `art-interact.vue`, `bot-gallery.vue`, `character-gallery.vue`, `giftshop-manager.vue`, `giving-page.vue`, `serendipity-page.vue`, `chat-gallery.vue`.
- Two of those (`serendipity-page.vue`, `chat-gallery.vue`) sit inside a larger tile-shaped class string that closely resembles `.kr-icon-tile`'s own tokens — left as subset-match candidates per every prior slice's convention (extra tokens preserved verbatim, no rendered-output change).
- A distinct `h-12 w-12 text-primary/70` occurrence (`dream-gallery.vue`) was correctly excluded — not a subset match, same reasoning as `kr-icon-primary-10`'s own `/60` carve-out.
- This closes out the previously-scoped `kr-icon-primary-*` family (4/5/6/7/10/12).

### How I verified
- `vue-tsc --noEmit` — clean.
- `eslint .` — 333 problems (327 errors, 6 warnings), identical to the documented baseline (no new errors).
- `npm run test:layout-contract` — holds, 0 new violations (same pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet note as every recent slice, left untouched, out of scope for this slice).
- `npm run test:lint-ratchet` — holds at 333/-59.
- `prettier --check .` — 1145 lines flagged, byte-identical to baseline; confirmed via `git stash` before/after that the 3 touched files it flags (`art-gallery.vue`, `giving-page.vue`, `tailwind.css`) carry pre-existing drift, not new drift from this change.
- Manually reviewed every diff hunk — only static `class="..."` attributes touched, no `:class`/`v-bind:class` bindings, no geometry or behavior change.

### Stakes
reversible

### Flags for Reviewer
A prior connector-only Worker session (interface-vision t-104, 2026-09-10 05:17 UTC) attempted this exact slice and re-armed the task because the GitHub Contents API returned a truncated response for `tailwind.css`, which its protocol correctly refused to reconstruct from. This session has full local git/shell access to the checkout, so the central CSS edit and verification could be done directly and safely — no other blocker.

### Kaizen suggestion
The `kr-icon-primary-*` family is now fully closed out (4/5/6/7/10/12). A fresh full-repo class-frequency survey outside all now-closed kr-* families (kr-text-black-*, kr-text-bold-*, kr-text-dim-*, kr-text-eyebrow-*, kr-label-*, kr-badge-*, kr-text-error-xs, kr-text-faded-*, kr-icon-primary-*) is the right next bounded slice.

### Notes for reviewer
Conductor task interface-vision/t-104 is `recurring: true`; the conductor close-out will return it to `ready` for the next bounded slice rather than `done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTt36K4C4kCgVCTwGCGTbL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTt36K4C4kCgVCTwGCGTbL)_