### PR TITLE
interface-vision/t-104 slice 197: add kr-label-row, migrate label py-1 form captions

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1726,6 +1726,27 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply h-12 w-12 text-primary;
   }
 
+  /* DaisyUI's `.label` wrapper span around a form-field caption, with its
+   * default vertical padding overridden down to `py-1` -- `label py-1`
+   * (interface-vision t-104 slice 197), the strongest remaining candidate
+   * outside all now-closed `kr-text-black-*`/`kr-text-bold-*`/
+   * `kr-text-dim-*`/`kr-text-eyebrow-*`/`kr-label-xs*`/`kr-text-error-xs`/
+   * `kr-text-faded-*`/`kr-icon-primary-*` families, flagged by slice 196's
+   * own kaizen note. A fresh full-repo class-frequency survey found this
+   * exact shape at 42 occurrences across 11 files, plus 2 subset-match
+   * occurrences in a 12th file carrying an extra `kr-text-bold-xs` token on
+   * the wrapper itself (44 total) -- consistently a `<span class="label
+   * py-1">` wrapping an inner eyebrow/label-styled span, immediately inside
+   * a `<label class="form-control">`. Named `kr-label-row` rather than
+   * folded into the existing `kr-label-xs`/`kr-label-xs-semibold`/
+   * `kr-label-bold` family: those three apply typography (`text-xs`,
+   * `font-semibold`) to the inner `label-text` span, while this class is
+   * the outer wrapper's own layout override -- a different element in the
+   * same field, not a sibling size/weight of the same one. */
+  .kr-label-row {
+    @apply label py-1;
+  }
+
   /* The colorless DaisyUI busy indicator: a bare tiny spinner dropped into
    * a button or inline slot while an action is pending, no tint (the
    * button/text color around it usually already carries the tone)

--- a/components/art/add-collection.vue
+++ b/components/art/add-collection.vue
@@ -21,7 +21,7 @@
 
     <form v-else class="grid gap-3" @submit.prevent="createCollection">
       <label class="form-control">
-        <span class="label py-1">
+        <span class="kr-label-row">
           <span class="kr-label-bold">New Collection</span>
 
           <button

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -249,7 +249,7 @@
 
             <template v-if="activeProfile.supports.checkpoint">
               <label class="form-control mt-2">
-                <span class="label py-1">
+                <span class="kr-label-row">
                   <span class="kr-label-bold">Checkpoint</span>
                   <span class="label-text-alt text-base-content/50">
                     {{ checkpointFamilyLabel }}
@@ -308,7 +308,7 @@
               class="mt-3 grid grid-cols-[repeat(auto-fit,minmax(min(100%,8rem),1fr))] gap-3"
             >
               <label class="form-control">
-                <span class="label py-1">
+                <span class="kr-label-row">
                   <span class="kr-label-bold">Steps</span>
                 </span>
                 <input
@@ -322,7 +322,7 @@
               </label>
 
               <label class="form-control">
-                <span class="label py-1">
+                <span class="kr-label-row">
                   <span class="kr-label-bold">
                     {{ activeProfile.supports.guidance ? 'Guidance' : 'CFG' }}
                   </span>
@@ -350,7 +350,7 @@
               </label>
 
               <label v-if="activeProfile.supports.sampler" class="form-control">
-                <span class="label py-1">
+                <span class="kr-label-row">
                   <span class="kr-label-bold">Sampler</span>
                 </span>
                 <select
@@ -372,7 +372,7 @@
                 v-if="activeProfile.supports.scheduler"
                 class="form-control"
               >
-                <span class="label py-1">
+                <span class="kr-label-row">
                   <span class="kr-label-bold">Scheduler</span>
                 </span>
                 <select
@@ -392,7 +392,7 @@
 
               <template v-if="activeProfile.supports.size">
                 <label class="form-control">
-                  <span class="label py-1">
+                  <span class="kr-label-row">
                     <span class="kr-label-bold">Width</span>
                   </span>
                   <input
@@ -406,7 +406,7 @@
                   />
                 </label>
                 <label class="form-control">
-                  <span class="label py-1">
+                  <span class="kr-label-row">
                     <span class="kr-label-bold">Height</span>
                   </span>
                   <input
@@ -422,7 +422,7 @@
               </template>
 
               <label class="form-control col-span-full">
-                <span class="label py-1">
+                <span class="kr-label-row">
                   <span class="kr-label-bold">Seed</span>
                   <span class="label-text-alt text-base-content/50">
                     blank = random
@@ -448,7 +448,7 @@
             </h2>
 
             <label class="form-control mt-2">
-              <span class="label py-1">
+              <span class="kr-label-row">
                 <span class="kr-label-bold">Comfy server</span>
               </span>
               <select
@@ -466,7 +466,7 @@
                   {{ serverLabel(server) }}
                 </option>
               </select>
-              <span class="label py-1">
+              <span class="kr-label-row">
                 <span class="label-text-alt text-base-content/55">
                   {{ serverDetail }}
                 </span>
@@ -474,7 +474,7 @@
             </label>
 
             <label class="form-control mt-1">
-              <span class="label py-1">
+              <span class="kr-label-row">
                 <span class="kr-label-bold"
                   >Also save to collection</span
                 >

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -216,7 +216,7 @@
 
             <div class="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-4">
               <label class="form-control">
-                <span class="label py-1"
+                <span class="kr-label-row"
                   ><span class="kr-text-bold-xs">Designer</span></span
                 >
                 <input
@@ -228,7 +228,7 @@
               </label>
 
               <label class="form-control">
-                <span class="label py-1"
+                <span class="kr-label-row"
                   ><span class="kr-text-bold-xs">Sampler</span></span
                 >
                 <input
@@ -239,7 +239,7 @@
               </label>
 
               <label class="form-control">
-                <span class="label py-1"
+                <span class="kr-label-row"
                   ><span class="kr-text-bold-xs">Checkpoint</span></span
                 >
                 <input
@@ -250,7 +250,7 @@
               </label>
 
               <label class="form-control">
-                <span class="label py-1"
+                <span class="kr-label-row"
                   ><span class="kr-text-bold-xs">Steps</span></span
                 >
                 <input
@@ -262,7 +262,7 @@
               </label>
 
               <label class="form-control">
-                <span class="label py-1"
+                <span class="kr-label-row"
                   ><span class="kr-text-bold-xs">Seed</span></span
                 >
                 <input
@@ -273,7 +273,7 @@
               </label>
 
               <label class="form-control">
-                <span class="label py-1"
+                <span class="kr-label-row"
                   ><span class="kr-text-bold-xs">CFG</span></span
                 >
                 <input
@@ -314,7 +314,7 @@
               </summary>
               <div class="grid gap-2 p-3">
                 <label class="form-control">
-                  <span class="label py-1"
+                  <span class="kr-label-row"
                     ><span class="kr-text-bold-xs">Prompt</span></span
                   >
                   <textarea
@@ -324,7 +324,7 @@
                   />
                 </label>
                 <label class="form-control">
-                  <span class="label py-1"
+                  <span class="kr-label-row"
                     ><span class="kr-text-bold-xs">Negative Prompt</span></span
                   >
                   <textarea

--- a/components/art/forum-art-generation-context.vue
+++ b/components/art/forum-art-generation-context.vue
@@ -87,7 +87,7 @@
       </article>
 
       <label class="form-control mt-4">
-        <span class="label py-1">
+        <span class="kr-label-row">
           <span class="kr-label-bold">Contribution prompt</span>
           <span class="label-text-alt"
             >{{ store.promptDraft.length }} / 4000</span

--- a/components/art/generate-button.vue
+++ b/components/art/generate-button.vue
@@ -11,7 +11,7 @@
       class="grid w-full grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_auto]"
     >
       <label class="form-control w-full">
-        <div class="label py-1">
+        <div class="kr-label-row">
           <span class="kr-text-eyebrow text-xs tracking-wide">
             Image Server
           </span>

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -344,7 +344,7 @@
 
         <div class="mt-4 grid grid-cols-[auto_minmax(0,1fr)_auto] items-end gap-2">
           <label class="form-control">
-            <span class="label py-1"
+            <span class="kr-label-row"
               ><span class="kr-text-eyebrow-bold kr-text-dim-xs-55 tracking-[0.12em]"
                 >Type</span
               ></span
@@ -360,7 +360,7 @@
             </select>
           </label>
           <label class="form-control">
-            <span class="label py-1"
+            <span class="kr-label-row"
               ><span class="kr-text-eyebrow-bold kr-text-dim-xs-55 tracking-[0.12em]"
                 >Search</span
               ></span

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -177,7 +177,7 @@
 
           <div class="kr-panel-tint-sm">
             <label class="form-control">
-              <div class="label py-1">
+              <div class="kr-label-row">
                 <span class="kr-text-eyebrow text-xs tracking-wide">
                   Adopt an existing set-local cover file
                 </span>

--- a/components/dreams/daily-dream-generator.vue
+++ b/components/dreams/daily-dream-generator.vue
@@ -29,7 +29,7 @@
         class="grid gap-3 md:grid-cols-[8rem_8rem_minmax(0,1fr)_auto] md:items-end"
       >
         <label class="form-control">
-          <span class="kr-text-bold-xs label py-1">Characters</span>
+          <span class="kr-label-row kr-text-bold-xs">Characters</span>
           <select
             v-model.number="characterCount"
             class="kr-select-sm"
@@ -41,7 +41,7 @@
           </select>
         </label>
         <label class="form-control">
-          <span class="kr-text-bold-xs label py-1">Objects</span>
+          <span class="kr-label-row kr-text-bold-xs">Objects</span>
           <select
             v-model.number="rewardCount"
             class="kr-select-sm"

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -129,7 +129,7 @@
         <section class="shrink-0 kr-panel-header-muted">
           <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_14rem]">
             <label class="form-control">
-              <span class="label py-1"
+              <span class="kr-label-row"
                 ><span class="kr-text-eyebrow-bold text-xs tracking-wide"
                   >Seed Title</span
                 ></span
@@ -144,7 +144,7 @@
             </label>
 
             <label class="form-control">
-              <span class="label py-1"
+              <span class="kr-label-row"
                 ><span class="kr-text-eyebrow-bold text-xs tracking-wide"
                   >Save Type</span
                 ></span
@@ -165,7 +165,7 @@
           </div>
 
           <label class="form-control mt-3">
-            <span class="label py-1"
+            <span class="kr-label-row"
               ><span class="kr-text-eyebrow-bold text-xs tracking-wide"
                 >Pitch</span
               ></span
@@ -179,7 +179,7 @@
           </label>
 
           <label class="form-control mt-3">
-            <span class="label py-1"
+            <span class="kr-label-row"
               ><span class="kr-text-eyebrow-bold text-xs tracking-wide"
                 >Direction</span
               ></span

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -73,7 +73,7 @@
           <div class="kr-panel-flat p-4">
             <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_14rem]">
               <label class="form-control">
-                <span class="label py-1">
+                <span class="kr-label-row">
                   <span
                     class="kr-text-eyebrow-bold text-xs tracking-wide"
                     >Title</span
@@ -88,7 +88,7 @@
               </label>
 
               <label class="form-control">
-                <span class="label py-1">
+                <span class="kr-label-row">
                   <span
                     class="kr-text-eyebrow-bold text-xs tracking-wide"
                     >Type</span
@@ -111,7 +111,7 @@
 
             <div class="mt-3 grid gap-3 lg:grid-cols-[minmax(0,1fr)_16rem]">
               <label class="form-control">
-                <span class="label py-1">
+                <span class="kr-label-row">
                   <span
                     class="kr-text-eyebrow-bold text-xs tracking-wide"
                     >Slug</span
@@ -138,7 +138,7 @@
 
           <div class="kr-panel-flat p-4">
             <label class="form-control">
-              <span class="label py-1">
+              <span class="kr-label-row">
                 <span
                   class="kr-text-eyebrow-bold text-xs tracking-wide"
                   >Dream Pitch</span
@@ -152,7 +152,7 @@
             </label>
 
             <label class="form-control mt-3">
-              <span class="label py-1">
+              <span class="kr-label-row">
                 <span
                   class="kr-text-eyebrow-bold text-xs tracking-wide"
                   >Description</span
@@ -166,7 +166,7 @@
             </label>
 
             <label class="form-control mt-3">
-              <span class="label py-1">
+              <span class="kr-label-row">
                 <span
                   class="kr-text-eyebrow-bold text-xs tracking-wide"
                   >Flavor Text</span
@@ -215,7 +215,7 @@
           <div class="kr-panel-flat p-4">
             <div class="grid gap-3 md:grid-cols-3">
               <label class="form-control">
-                <span class="label py-1"
+                <span class="kr-label-row"
                   ><span class="kr-label-bold">Icon</span></span
                 >
                 <input
@@ -227,7 +227,7 @@
               </label>
 
               <label class="form-control">
-                <span class="label py-1"
+                <span class="kr-label-row"
                   ><span class="kr-label-bold">Art Image ID</span></span
                 >
                 <input
@@ -240,7 +240,7 @@
               </label>
 
               <label class="form-control">
-                <span class="label py-1"
+                <span class="kr-label-row"
                   ><span class="kr-label-bold"
                     >Art Collection ID</span
                   ></span
@@ -257,7 +257,7 @@
 
             <div class="mt-3 grid gap-3 md:grid-cols-2">
               <label class="form-control">
-                <span class="label py-1"
+                <span class="kr-label-row"
                   ><span class="kr-label-bold">Designer</span></span
                 >
                 <input

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -136,7 +136,7 @@
             />
 
             <label class="form-control w-full">
-              <div class="label py-1">
+              <div class="kr-label-row">
                 <span
                   class="kr-text-eyebrow text-[0.68rem] tracking-[0.12em] text-base-content/55"
                 >
@@ -320,7 +320,7 @@
                 </details>
 
                 <label class="form-control w-full">
-                  <div class="label py-1">
+                  <div class="kr-label-row">
                     <span
                       class="kr-text-eyebrow text-[0.68rem] tracking-[0.12em] text-base-content/55"
                     >

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -181,7 +181,7 @@
           <template v-if="canShowCustomFollowup" #footer>
             <div class="kr-panel-flat p-3">
               <label class="form-control">
-                <span class="label py-1">
+                <span class="kr-label-row">
                   <span
                     class="kr-text-eyebrow-bold kr-text-dim-xs tracking-wide"
                   >

--- a/utils/scripts/codemods/kr_label_row_codemod.py
+++ b/utils/scripts/codemods/kr_label_row_codemod.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `label py-1` form-field caption wrappers to
+`kr-label-row`.
+
+The strongest remaining candidate outside all now-closed `kr-text-black-*`/
+`kr-text-bold-*`/`kr-text-dim-*`/`kr-text-eyebrow-*`/`kr-label-xs*`/
+`kr-text-error-xs`/`kr-text-faded-*`/`kr-icon-primary-*` families, flagged
+by interface-vision t-104 slice 196's own kaizen note. Distinct from the
+existing `kr-label-xs`/`kr-label-xs-semibold`/`kr-label-bold` family: those
+apply typography to the inner `label-text` span, while this is the outer
+DaisyUI `.label` wrapper span's own padding override, consistently used as
+`<span class="label py-1">` immediately inside a `<label class="form-control">`.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+the exact `label py-1` shape is touched, and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings (see _class_attr.py),
+regardless of the base tokens' order in the source. A source that already
+carries `kr-label-row`, or is missing either base token, is left untouched.
+Extra tokens beyond the base set are preserved verbatim after the
+primitive class, matching every other kr-*-codemod's subset-match
+convention -- pass --exact-only to restrict a slice to sources with no
+extra tokens at all.
+
+Only walks `*.vue` files (see main()'s rglob).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-label-row"
+BASE_TOKENS = {"label", "py-1"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-label-row {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 197: drive live front-end consistency onto shared kr-* components (kind: software)

### What changed / what I produced
- Added `.kr-label-row { @apply label py-1; }` to `assets/css/tailwind.css` — the strongest remaining candidate outside all now-closed `kr-*` families per slice 196's kaizen note, found by a fresh full-repo class-frequency survey.
- Added `utils/scripts/codemods/kr_label_row_codemod.py`, sibling of the existing kr-*-codemods (same `_class_attr.py`-guarded subset-match convention).
- Ran the codemod with `--write`: migrated 44 occurrences across 12 files (42 exact `label py-1`, plus 2 subset-match occurrences in `daily-dream-generator.vue` carrying an extra `kr-text-bold-xs` token, preserved verbatim).
- Distinct from the existing `kr-label-xs`/`kr-label-xs-semibold`/`kr-label-bold` family: those style the inner `label-text` span's typography; `kr-label-row` is the outer DaisyUI `.label` wrapper span's own layout override — a different element in the same field, not a sibling of the same one.

### How I verified
- `vue-tsc --noEmit`: clean.
- `eslint .`: 333 problems (327 errors, 6 warnings) — identical to the documented pre-existing baseline.
- `npm run test:layout-contract`: holds, 0 new violations (flags the same pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid baseline shrink opportunity as prior slices, unrelated to this diff, left untouched per scope discipline).
- `npm run test:lint-ratchet`: holds at 333/-59.
- `prettier --check .`: 1145 lines flagged, byte-identical to a `git stash` before/after diff.
- Manually reviewed every diff hunk: only static `class="..."` attributes touched, no `:class` bindings, no geometry/behavior change.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Only one strand remains from prior surveys: `test:layout-contract`'s viewport-grid baseline can shrink by 2 entries (`narrative-ingredient-multi-picker.vue` no longer violates the contract) — run with `--update` in a future slice to ratchet it down. Beyond that, the next class-frequency survey should look at plain sizeless icon glyphs (`h-4 w-4`, `h-3.5 w-3.5`, `h-5 w-5`, `h-3 w-3`, `h-7 w-7` with no color modifier) — a much larger family (e.g. `h-4 w-4` alone is 299 occurrences across 94 files) that will need to be split into several bounded slices rather than one, since it's an order of magnitude larger than any family closed so far.

### Notes for reviewer
Session-scoped conductor task: `projects/interface-vision/roadmap.yaml` t-104 (claimed session `claude-scheduled-20260910T063151Z-t104s197`). Companion conductor close-out PR will follow after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsTejujBPB5J1CpDguEU8N

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsTejujBPB5J1CpDguEU8N)_