### PR TITLE
interface-vision/t-104 slice 198: add kr-icon-6, migrate bare h-6 w-6 icon glyphs

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1747,6 +1747,27 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply label py-1;
   }
 
+  /* A bare, colorless 24px icon glyph -- `h-6 w-6`, no tile/background and
+   * no `text-*` tint of its own (interface-vision t-104 slice 198). Opens
+   * the sizeless-and-colorless sibling family to the now-closed
+   * `kr-icon-primary-*` family (slices 191-196): those all carry a
+   * `text-primary`/`text-primary/60` color token alongside the size; this
+   * shape has none, usually inheriting color from surrounding text or a
+   * parent's own `text-*` class. Flagged by slice 197's kaizen note --
+   * `h-4 w-4` alone runs ~326 occurrences across 102 files, an order of
+   * magnitude too large for one slice, so this family is being opened size
+   * by size the same way `kr-icon-primary-*` was. `h-6 w-6` was picked
+   * first as the smallest well-bounded size: 9 exact occurrences across 8
+   * files, plus 2 further subset-match occurrences (an extra `shrink-0` in
+   * one, a larger rounded-full badge composition in the other) across 2
+   * more files (11 total, 10 files). Sibling sizes surveyed alongside this
+   * one and left open for future slices: `h-3 w-3` (19 files), `h-3.5
+   * w-3.5` (31 files), `h-4 w-4` (102 files, needs further splitting),
+   * `h-5 w-5` (35 files), `h-7 w-7` (15 files), `h-8 w-8` (18 files). */
+  .kr-icon-6 {
+    @apply h-6 w-6;
+  }
+
   /* The colorless DaisyUI busy indicator: a bare tiny spinner dropped into
    * a button or inline slot while an action is pending, no tint (the
    * button/text color around it usually already carries the tone)

--- a/components/achievements/achievement-gallery.vue
+++ b/components/achievements/achievement-gallery.vue
@@ -11,7 +11,7 @@
         <span
           class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/15 text-primary"
         >
-          <Icon name="kind-icon:jellybean" class="h-6 w-6" />
+          <Icon name="kind-icon:jellybean" class="kr-icon-6" />
         </span>
         <div>
           <h1 class="kr-text-black-lg text-base-content">

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -9,7 +9,7 @@
         <span
           class="flex h-11 w-11 items-center justify-center rounded-2xl border border-accent/40 bg-accent/10 text-accent"
         >
-          <Icon name="kind-icon:sparkles" class="h-6 w-6" />
+          <Icon name="kind-icon:sparkles" class="kr-icon-6" />
         </span>
         <div>
           <h2 class="kr-text-black-lg leading-tight text-base-content">
@@ -77,7 +77,7 @@
               class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border"
               :style="{ borderColor: effect.color, color: effect.color }"
             >
-              <Icon :name="effect.icon" class="h-6 w-6" />
+              <Icon :name="effect.icon" class="kr-icon-6" />
             </span>
 
             <span class="min-w-0 flex-1">

--- a/components/art/hair-studio-manager.vue
+++ b/components/art/hair-studio-manager.vue
@@ -5,7 +5,7 @@
       <span
         class="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/15 text-primary"
       >
-        <Icon name="kind-icon:magic" class="h-6 w-6" />
+        <Icon name="kind-icon:magic" class="kr-icon-6" />
       </span>
       <div class="min-w-0 flex-1">
         <h2 class="kr-text-black-lg">Hair Studio</h2>

--- a/components/builder/builder-card.vue
+++ b/components/builder/builder-card.vue
@@ -36,7 +36,7 @@
         <div
           class="flex h-12 w-12 items-center justify-center rounded-full bg-success text-success-content shadow-lg"
         >
-          <Icon name="kind-icon:check" class="h-6 w-6" />
+          <Icon name="kind-icon:check" class="kr-icon-6" />
         </div>
       </div>
     </div>

--- a/components/home/home-account-links.vue
+++ b/components/home/home-account-links.vue
@@ -4,7 +4,7 @@
       <span
         class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/12 text-primary"
       >
-        <Icon name="kind-icon:users" class="h-6 w-6" />
+        <Icon name="kind-icon:users" class="kr-icon-6" />
       </span>
       <div>
         <h1 class="kr-text-black-2xl">Connect</h1>

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -84,7 +84,7 @@
         role="alert"
         class="flex h-full min-h-32 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-error/30 bg-error/5 p-6 text-center text-sm text-error"
       >
-        <Icon name="kind-icon:warning" class="h-6 w-6" />
+        <Icon name="kind-icon:warning" class="kr-icon-6" />
         {{ store.sourcesError }}
         <button
           type="button"

--- a/components/navigation/server-selector.vue
+++ b/components/navigation/server-selector.vue
@@ -8,7 +8,7 @@
       aria-label="Server settings"
       @click="openSelector"
     >
-      <Icon name="kind-icon:server" class="h-6 w-6 shrink-0" />
+      <Icon name="kind-icon:server" class="kr-icon-6 shrink-0" />
     </button>
 
     <dialog ref="selectorDialog" class="modal modal-bottom sm:modal-middle">

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -927,7 +927,7 @@
                   >
                     <div class="flex items-start gap-3">
                       <div
-                        class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border"
+                        class="kr-icon-6 mt-0.5 flex shrink-0 items-center justify-center rounded-full border"
                         :class="taskIconClass(task.status)"
                       >
                         <Icon :name="taskIcon(task.status)" class="size-3" />

--- a/components/screenfx/animation-selector.vue
+++ b/components/screenfx/animation-selector.vue
@@ -8,7 +8,7 @@
         <span
           class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-secondary/15 text-secondary"
         >
-          <Icon name="kind-icon:sparkles" class="h-6 w-6" />
+          <Icon name="kind-icon:sparkles" class="kr-icon-6" />
         </span>
 
         <div class="min-w-0">

--- a/components/user/login-page.vue
+++ b/components/user/login-page.vue
@@ -221,7 +221,7 @@
             <div
               class="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-warning/25 text-warning"
             >
-              <Icon name="kind-icon:warning" class="h-6 w-6" />
+              <Icon name="kind-icon:warning" class="kr-icon-6" />
             </div>
 
             <div class="min-w-0 flex-1">

--- a/utils/scripts/codemods/kr_icon_6_codemod.py
+++ b/utils/scripts/codemods/kr_icon_6_codemod.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `h-6 w-6` bare (colorless) icon glyphs to
+`kr-icon-6`.
+
+Distinct from the now-closed `kr-icon-primary-*` family (interface-vision
+t-104 slices 191-196): those all carry a `text-primary`/`text-primary/60`
+color token alongside the size, this is the plain sizeless-and-colorless
+glyph shape -- no tint at all, most often an icon that inherits its color
+from surrounding text or a parent's `text-*` class rather than carrying its
+own. Flagged by slice 197's kaizen note as the next family to open, split
+into per-size slices the same way `kr-icon-primary-*` was rather than
+attempted as one giant migration (`h-4 w-4` alone runs ~326 occurrences
+across 102 files -- an order of magnitude larger than any single slice this
+project has done). `h-6 w-6` was picked first for this family as the
+smallest well-bounded size not yet covered by a subset-match survey (11
+occurrences across 10 files).
+
+Dry-run by default, --write to update matching Vue files in place. Only
+class strings containing both `h-6` and `w-6` tokens are touched, and only
+in static `class="..."` attributes -- never `:class`/`v-bind:class` bindings
+(see _class_attr.py). A class string carrying any `text-*`/`stroke-*`/
+`fill-*` color token is left alone (that is the `kr-icon-primary-6`/future
+colored-sibling shape, not this one), regardless of the base tokens' order
+in the source. A source that already carries `kr-icon-6`, or is missing
+either base token, is also left untouched. Extra tokens beyond the base set
+are preserved verbatim after the primitive class, matching every other
+kr-*-codemod's subset-match convention -- pass --exact-only to restrict a
+slice to sources with no extra tokens at all.
+
+Deliberately does NOT touch sibling sizes (`h-3 w-3`, `h-3.5 w-3.5`,
+`h-4 w-4`, `h-5 w-5`, `h-7 w-7`, `h-8 w-8`) -- those are real,
+independently-repeated shapes of their own, left for future slices.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-6"
+BASE_TOKENS = {"h-6", "w-6"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-6 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Added `.kr-icon-6` (`@apply h-6 w-6;`) to `assets/css/tailwind.css` — opens the sizeless-and-colorless sibling family to the now-closed `kr-icon-primary-*` family (slices 191-196, which all carry a `text-primary` color token). This shape is a bare 24px icon glyph with no tint of its own.
- Added `utils/scripts/codemods/kr_icon_6_codemod.py`, sibling of the existing `kr_icon_primary_*_codemod.py` scripts (same subset-match convention, excludes any `text-*`/`stroke-*`/`fill-*` color token so it doesn't clash with the primary-colored sibling primitive).
- Ran `--write`: migrated all 11 occurrences across 10 files (achievement-gallery.vue, animation-manager.vue x2, hair-studio-manager.vue, builder-card.vue, home-account-links.vue, model-builder-source-picker.vue, server-selector.vue, conductor-page.vue, animation-selector.vue, login-page.vue) — 9 exact `h-6 w-6` matches plus 2 subset-match occurrences carrying extra tokens (`shrink-0` in one, a larger rounded-full badge composition in another).

### How I verified
- Manually reviewed every diff: only static `class="..."` attributes touched, no `:class`/`v-bind:class` bindings, no geometry or behavior change.
- `vue-tsc --noEmit`: clean.
- `eslint .`: 333 problems (327 errors, 6 warnings) — byte-identical to the documented pre-existing baseline, no new issues.
- `npm run test:layout-contract`: holds, 0 new violations (pre-existing `narrative-ingredient-multi-picker.vue` viewport-grid ratchet opportunity noted but left untouched per scope discipline, same as prior slices).
- `npm run test:lint-ratchet`: holds at 333 problems / -59, no rule regressed.
- `prettier --check .`: 1145 warning lines, byte-identical before/after (`git stash` before/after diff).

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
Continue opening the sizeless-and-colorless icon-glyph family size by size (this slice did `h-6 w-6`, 11/10). Remaining sibling sizes surveyed and left open: `h-3 w-3` (19 files), `h-3.5 w-3.5` (31 files), `h-5 w-5` (35 files), `h-7 w-7` (15 files), `h-8 w-8` (18 files). `h-4 w-4` alone is ~326 occurrences/102 files — needs further splitting (e.g. by subset-match extras) before it's a bounded slice on its own.

### Notes for reviewer
Companion Conductor close-out PR will follow in the same session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182pRJAoYHnL4hSNKFsXqZE

---
_Generated by [Claude Code](https://claude.ai/code/session_0182pRJAoYHnL4hSNKFsXqZE)_