### PR TITLE
interface-vision/t-104 slice 199: add kr-icon-7, migrate bare h-7 w-7 icon glyphs

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1768,6 +1768,18 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply h-6 w-6;
   }
 
+  /* Same bare sizeless-and-colorless icon-glyph shape as `.kr-icon-6`, one
+   * size up (interface-vision t-104 slice 199) -- `h-7 w-7`, previously
+   * hand-rolled identically in 15 files (16 occurrences), the next
+   * smallest well-bounded sibling per slice 198's kaizen note. Sibling
+   * sizes still open: `h-3 w-3` (19 files), `h-3.5 w-3.5` (31 files),
+   * `h-4 w-4` (102 files, needs further splitting), `h-5 w-5` (35 files),
+   * `h-8 w-8` (18 files). Distinct from `.kr-icon-primary-7` (same size,
+   * carries `text-primary`) -- this is the untinted sibling. */
+  .kr-icon-7 {
+    @apply h-7 w-7;
+  }
+
   /* The colorless DaisyUI busy indicator: a bare tiny spinner dropped into
    * a button or inline slot while an action is pending, no tint (the
    * button/text color around it usually already carries the tone)

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -3,7 +3,7 @@
     <header class="flex flex-wrap items-center justify-between gap-3">
       <div class="flex items-center gap-3">
         <span class="kr-icon-tile">
-          <Icon name="kind-icon:server" class="h-7 w-7" />
+          <Icon name="kind-icon:server" class="kr-icon-7" />
         </span>
         <div>
           <p class="kr-text-black-2xl tracking-tight">Build Bench</p>

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -35,7 +35,7 @@
             : 'text-base-content/40'
         "
       >
-        <Icon :name="icon" class="h-7 w-7" />
+        <Icon :name="icon" class="kr-icon-7" />
       </span>
       <div class="text-center">
         <p class="kr-text-dim-sm-70 font-semibold">

--- a/components/dreams/dream-list.vue
+++ b/components/dreams/dream-list.vue
@@ -146,7 +146,7 @@
             v-else
             class="flex h-16 w-16 shrink-0 items-center justify-center rounded-xl bg-base-300 text-primary"
           >
-            <Icon :name="entry.icon" class="h-7 w-7" />
+            <Icon :name="entry.icon" class="kr-icon-7" />
           </div>
 
           <div class="min-w-0 flex-1">

--- a/components/giftshop/shopping-cart.vue
+++ b/components/giftshop/shopping-cart.vue
@@ -4,7 +4,7 @@
     <div class="flex flex-wrap items-center justify-between gap-3">
       <div>
         <h1 class="kr-text-black-2xl flex items-center gap-2 text-primary">
-          <Icon name="kind-icon:cart" class="h-7 w-7" />
+          <Icon name="kind-icon:cart" class="kr-icon-7" />
           Your Cart
         </h1>
         <p class="mt-1 text-sm text-base-content/65">

--- a/components/pages/appmaker-page.vue
+++ b/components/pages/appmaker-page.vue
@@ -6,7 +6,7 @@
     <header class="flex flex-wrap items-center justify-between gap-3">
       <div class="flex items-center gap-3">
         <span class="kr-icon-tile">
-          <Icon name="kind-icon:toolbox" class="h-7 w-7" />
+          <Icon name="kind-icon:toolbox" class="kr-icon-7" />
         </span>
         <div>
           <p class="kr-text-black-2xl tracking-tight">AppMaker</p>

--- a/components/pages/click-leaderboard.vue
+++ b/components/pages/click-leaderboard.vue
@@ -4,7 +4,7 @@
     <div class="kr-scroll p-4">
       <header class="flex items-center gap-3 mb-4">
         <span class="kr-icon-tile">
-          <Icon name="kind-icon:trophy" class="h-7 w-7" />
+          <Icon name="kind-icon:trophy" class="kr-icon-7" />
         </span>
         <div>
           <p class="kr-text-black-2xl tracking-tight">Global Leaderboard</p>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -867,7 +867,7 @@
                   class="flex items-center gap-3 rounded-2xl border border-base-300 bg-base-200 px-4 py-3"
                 >
                   <div
-                    class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border"
+                    class="kr-icon-7 flex shrink-0 items-center justify-center rounded-full border"
                     :class="milestoneIconClass(milestone.status)"
                   >
                     <Icon

--- a/components/pages/creator-earnings-page.vue
+++ b/components/pages/creator-earnings-page.vue
@@ -2,7 +2,7 @@
   <div class="kr-unbound kr-container max-w-3xl p-6 space-y-8">
     <header class="flex items-center gap-3">
       <span class="kr-icon-tile">
-        <Icon name="kind-icon:coin" class="h-7 w-7" />
+        <Icon name="kind-icon:coin" class="kr-icon-7" />
       </span>
       <div>
         <p class="kr-text-black-2xl tracking-tight">Creator Earnings</p>

--- a/components/pages/mission-accrual-page.vue
+++ b/components/pages/mission-accrual-page.vue
@@ -2,7 +2,7 @@
   <div class="kr-unbound kr-container max-w-3xl p-6 space-y-8">
     <header class="flex items-center gap-3">
       <span class="kr-icon-tile">
-        <Icon name="kind-icon:hand-heart" class="h-7 w-7" />
+        <Icon name="kind-icon:hand-heart" class="kr-icon-7" />
       </span>
       <div>
         <p class="kr-text-black-2xl tracking-tight">Mission Accrual</p>

--- a/components/pages/privacy-page.vue
+++ b/components/pages/privacy-page.vue
@@ -4,7 +4,7 @@
   >
     <header class="mb-10 flex items-center gap-3">
       <span class="kr-icon-tile">
-        <Icon name="kind-icon:shield" class="h-7 w-7" />
+        <Icon name="kind-icon:shield" class="kr-icon-7" />
       </span>
       <div>
         <p class="kr-text-black-2xl tracking-tight">Privacy Policy</p>

--- a/components/pages/rebel-button.vue
+++ b/components/pages/rebel-button.vue
@@ -3,7 +3,7 @@
   <main class="kr-unbound">
     <header class="flex items-center gap-3 m-2">
       <span class="kr-icon-tile">
-        <Icon name="kind-icon:button" class="h-7 w-7" />
+        <Icon name="kind-icon:button" class="kr-icon-7" />
       </span>
       <div>
         <p class="kr-text-black-2xl tracking-tight">Rebel Button</p>

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -16,7 +16,7 @@
         <span
           class="kr-icon-primary-12 grid place-items-center rounded-2xl bg-primary/15"
         >
-          <Icon name="kind-icon:butterfly" class="h-7 w-7" />
+          <Icon name="kind-icon:butterfly" class="kr-icon-7" />
         </span>
         <div>
           <p class="text-2xl font-black tracking-tight">Serendipity</p>

--- a/components/pages/wallet-page.vue
+++ b/components/pages/wallet-page.vue
@@ -2,7 +2,7 @@
   <div class="kr-unbound kr-container max-w-3xl p-6 space-y-8">
     <header class="flex items-center gap-3">
       <span class="kr-icon-tile">
-        <Icon name="kind-icon:money" class="h-7 w-7" />
+        <Icon name="kind-icon:money" class="kr-icon-7" />
       </span>
       <div>
         <p class="kr-text-black-2xl tracking-tight">Wallet</p>

--- a/components/screenfx/screen-fx.vue
+++ b/components/screenfx/screen-fx.vue
@@ -5,7 +5,7 @@
       <div class="fx-header">
         <div v-if="showHeader" class="fx-title">
           <span class="fx-logo">
-            <Icon name="kind-icon:sparkles" class="h-7 w-7" />
+            <Icon name="kind-icon:sparkles" class="kr-icon-7" />
           </span>
           <div>
             <h2>Screen FX</h2>

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -144,7 +144,7 @@
               <div
                 v-for="slot in slotsForRole(role.key)"
                 :key="slot.slotId"
-                class="flex h-7 w-7 items-center justify-center overflow-hidden rounded-full border-2"
+                class="kr-icon-7 flex items-center justify-center overflow-hidden rounded-full border-2"
                 :class="
                   isSlotFilled(slot)
                     ? 'border-success bg-success/15'
@@ -174,7 +174,7 @@
                   role.min - slotsForRole(role.key).length,
                 )"
                 :key="`empty-${i}`"
-                class="flex h-7 w-7 items-center justify-center rounded-full border-2 border-dashed border-warning/40 bg-warning/8"
+                class="kr-icon-7 flex items-center justify-center rounded-full border-2 border-dashed border-warning/40 bg-warning/8"
               >
                 <Icon name="mdi:plus" class="h-3 w-3 text-warning/50" />
               </div>

--- a/utils/scripts/codemods/kr_icon_7_codemod.py
+++ b/utils/scripts/codemods/kr_icon_7_codemod.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `h-7 w-7` bare (colorless) icon glyphs to
+`kr-icon-7`.
+
+Same sizeless-and-colorless icon-glyph shape as `.kr-icon-6` (interface-
+vision t-104 slice 198), one size up. Distinct from `.kr-icon-primary-7`
+(slice 194): that one carries a `text-primary` color token alongside the
+size, this is the plain untinted glyph -- most often an icon that inherits
+its color from surrounding text or a parent's `text-*` class rather than
+carrying its own. Picked as the next smallest well-bounded sibling per
+slice 198's kaizen note: 16 occurrences across 15 files, smaller than
+`h-3 w-3` (19 files), `h-3.5 w-3.5` (31 files), `h-5 w-5` (35 files), and
+`h-8 w-8` (18 files) surveyed alongside it. `h-4 w-4` (102 files) remains
+flagged as needing further splitting before any slice attempts it.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+class strings containing both `h-7` and `w-7` tokens are touched, and only
+in static `class="..."` attributes -- never `:class`/`v-bind:class` bindings
+(see _class_attr.py). A class string carrying any `text-*`/`stroke-*`/
+`fill-*` color token is left alone (that is the `kr-icon-primary-7`/future
+colored-sibling shape, not this one), regardless of the base tokens' order
+in the source. A source that already carries `kr-icon-7`, or is missing
+either base token, is also left untouched. Extra tokens beyond the base set
+are preserved verbatim after the primitive class, matching every other
+kr-*-codemod's subset-match convention -- pass --exact-only to restrict a
+slice to sources with no extra tokens at all.
+
+Deliberately does NOT touch sibling sizes (`h-3 w-3`, `h-3.5 w-3.5`,
+`h-4 w-4`, `h-5 w-5`, `h-6 w-6`, `h-8 w-8`) -- those are real,
+independently-repeated shapes of their own, left for future slices.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-7"
+BASE_TOKENS = {"h-7", "w-7"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-7 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Layout-contract allow-list. RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyLayoutContract.ts.",
-  "recorded": "2026-08-29",
+  "recorded": "2026-09-10",
   "violations": {
     "one-header": [],
     "one-scroll": [],
@@ -155,8 +155,6 @@
       "components/model-builder/model-builder-source-picker.vue → xl:grid-cols-6",
       "components/model/add-model.vue → lg:grid-cols-2",
       "components/narrative/kr-narrator-stage.vue → md:grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)]",
-      "components/narrative/narrative-ingredient-multi-picker.vue → md:grid-cols-2",
-      "components/narrative/narrative-ingredient-multi-picker.vue → xl:grid-cols-3",
       "components/navigation/card-picker.vue → lg:grid-cols-5",
       "components/navigation/card-picker.vue → sm:grid-cols-3",
       "components/navigation/navigation-health.vue → sm:grid-cols-2",


### PR DESCRIPTION
### Task
conductor `interface-vision/t-104` (recurring umbrella: drive live front-end consistency onto shared `kr-*` components and composition rules), slice 199.

### What changed / what I produced
Adds `.kr-icon-7` (sizeless, colorless `h-7 w-7` icon glyph) as the sibling to the now-closed `kr-icon-6` (slice 198), one size up in the plain icon-glyph family. Migrated all 16 exact occurrences across 15 files via a new `utils/scripts/codemods/kr_icon_7_codemod.py` (subset-match convention, same as every other `kr-icon` codemod). Distinct from `.kr-icon-primary-7` (same size, carries `text-primary`) — this is the untinted sibling.

Also ratchets the `test:layout-contract` viewport-grid baseline down by 2 entries (`components/narrative/narrative-ingredient-multi-picker.vue` no longer violates the contract), flagged by slice 197/198's kaizen note as a pending cleanup.

No geometry or behavior change — only static `class="..."` attributes touched, no `:class` bindings.

### How I verified
- `vue-tsc --noEmit` clean
- `eslint .` 333/327/6, identical to the documented baseline
- `test:layout-contract` holds (0 new violations; baseline ratcheted down 2 entries as above)
- `test:lint-ratchet` holds at 333/-59
- `prettier --check .` byte-identical (1145 lines)

### Stakes
Reversible, scoped CSS/markup consolidation. No behavior change.

### Flags for Reviewer
None.

### Kaizen suggestion
Continue opening the sizeless-and-colorless icon-glyph family size by size: `h-3 w-3` (19 files), `h-3.5 w-3.5` (31 files), `h-5 w-5` (35 files), `h-8 w-8` (18 files) all still open. `h-4 w-4` (102 files) still needs further splitting before any slice attempts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc3TvU1mDyTWoJ6a4ttPSj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uc3TvU1mDyTWoJ6a4ttPSj)_