### PR TITLE
feat(grants): expose manual sharing CRUD routes

### DIFF
--- a/server/api/grants/[id].delete.ts
+++ b/server/api/grants/[id].delete.ts
@@ -1,0 +1,38 @@
+import { createError, defineEventHandler, getRouterParam } from 'h3'
+import { requireApiUser } from '../../utils/authGuard'
+import { errorHandler } from '../../utils/error'
+import { assertCanManageGrantSubject } from '../../utils/grantAccess'
+import prisma from '../../utils/prisma'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireApiUser(event)
+    const id = Number(getRouterParam(event, 'id'))
+    if (!Number.isInteger(id) || id <= 0) {
+      throw createError({ statusCode: 400, message: 'Grant id must be a positive integer.' })
+    }
+
+    const existing = await prisma.grant.findUnique({ where: { id } })
+    if (!existing) throw createError({ statusCode: 404, message: 'Grant not found.' })
+
+    await assertCanManageGrantSubject(
+      { id: auth.user.id, isAdmin: auth.isAdmin },
+      existing.subjectType,
+      existing.subjectId,
+    )
+
+    const grant =
+      existing.status === 'REVOKED'
+        ? existing
+        : await prisma.grant.update({
+            where: { id },
+            data: { status: 'REVOKED' },
+          })
+
+    return { success: true, data: grant, statusCode: 200 }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return { success: false, message: handled.message || 'Failed to revoke grant.', data: null, statusCode: event.node.res.statusCode }
+  }
+})

--- a/server/api/grants/index.get.ts
+++ b/server/api/grants/index.get.ts
@@ -1,0 +1,39 @@
+import { createError, defineEventHandler, getQuery } from 'h3'
+import { GrantSubject, type GrantSubject as GrantSubjectValue } from '~/prisma/generated/prisma/client'
+import { requireApiUser } from '../../utils/authGuard'
+import { errorHandler } from '../../utils/error'
+import { assertCanManageGrantSubject } from '../../utils/grantAccess'
+import prisma from '../../utils/prisma'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireApiUser(event)
+    const query = getQuery(event)
+    const subjectType = String(query.subjectType ?? '').toUpperCase() as GrantSubjectValue
+    const subjectId = Number(query.subjectId)
+
+    if (!Object.values(GrantSubject).includes(subjectType)) {
+      throw createError({ statusCode: 400, message: 'A valid subjectType is required.' })
+    }
+    if (!Number.isInteger(subjectId) || subjectId <= 0) {
+      throw createError({ statusCode: 400, message: 'subjectId must be a positive integer.' })
+    }
+
+    await assertCanManageGrantSubject(
+      { id: auth.user.id, isAdmin: auth.isAdmin },
+      subjectType,
+      subjectId,
+    )
+
+    const grants = await prisma.grant.findMany({
+      where: { subjectType, subjectId },
+      orderBy: { createdAt: 'desc' },
+    })
+
+    return { success: true, data: grants, statusCode: 200 }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return { success: false, message: handled.message || 'Failed to list grants.', data: null, statusCode: event.node.res.statusCode }
+  }
+})

--- a/server/api/grants/index.post.ts
+++ b/server/api/grants/index.post.ts
@@ -1,0 +1,85 @@
+import { createError, defineEventHandler, readBody } from 'h3'
+import {
+  GrantLevel,
+  GrantSubject,
+  type GrantLevel as GrantLevelValue,
+  type GrantSubject as GrantSubjectValue,
+} from '~/prisma/generated/prisma/client'
+import { requireApiUser } from '../../utils/authGuard'
+import { errorHandler } from '../../utils/error'
+import { assertCanManageGrantSubject } from '../../utils/grantAccess'
+import prisma from '../../utils/prisma'
+
+type GrantCreateBody = {
+  granteeId?: unknown
+  subjectType?: unknown
+  subjectId?: unknown
+  level?: unknown
+  expiresAt?: unknown
+}
+
+const isPositiveInt = (value: unknown): value is number =>
+  Number.isInteger(value) && Number(value) > 0
+
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireApiUser(event)
+    const body = await readBody<GrantCreateBody>(event)
+
+    const unknownFields = Object.keys(body ?? {}).filter(
+      (field) => !['granteeId', 'subjectType', 'subjectId', 'level', 'expiresAt'].includes(field),
+    )
+    if (unknownFields.length) {
+      throw createError({ statusCode: 400, message: `Unsupported grant fields: ${unknownFields.join(', ')}.` })
+    }
+
+    if (!isPositiveInt(body?.granteeId) || !isPositiveInt(body?.subjectId)) {
+      throw createError({ statusCode: 400, message: 'granteeId and subjectId must be positive integers.' })
+    }
+
+    if (!Object.values(GrantSubject).includes(body.subjectType as GrantSubjectValue)) {
+      throw createError({ statusCode: 400, message: 'Invalid subjectType.' })
+    }
+    if (!Object.values(GrantLevel).includes(body.level as GrantLevelValue)) {
+      throw createError({ statusCode: 400, message: 'Invalid level.' })
+    }
+
+    const subjectType = body.subjectType as GrantSubjectValue
+    const level = body.level as GrantLevelValue
+    let expiresAt: Date | null = null
+    if (body.expiresAt != null) {
+      if (typeof body.expiresAt !== 'string' || Number.isNaN(Date.parse(body.expiresAt))) {
+        throw createError({ statusCode: 400, message: 'expiresAt must be an ISO date string or null.' })
+      }
+      expiresAt = new Date(body.expiresAt)
+    }
+
+    await assertCanManageGrantSubject(
+      { id: auth.user.id, isAdmin: auth.isAdmin },
+      subjectType,
+      body.subjectId,
+    )
+
+    const grantee = await prisma.user.findUnique({ where: { id: body.granteeId }, select: { id: true } })
+    if (!grantee) throw createError({ statusCode: 404, message: 'Grantee user not found.' })
+
+    const grant = await prisma.grant.create({
+      data: {
+        granterId: auth.user.id,
+        granteeId: body.granteeId,
+        subjectType,
+        subjectId: body.subjectId,
+        level,
+        source: 'MANUAL',
+        expiresAt,
+      },
+    })
+
+    event.node.res.statusCode = 201
+    return { success: true, data: grant, statusCode: 201 }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return { success: false, message: handled.message || 'Failed to create grant.', data: null, statusCode: event.node.res.statusCode }
+  }
+})

--- a/server/api/grants/mine.get.ts
+++ b/server/api/grants/mine.get.ts
@@ -1,0 +1,24 @@
+import { defineEventHandler } from 'h3'
+import { requireApiUser } from '../../utils/authGuard'
+import { errorHandler } from '../../utils/error'
+import prisma from '../../utils/prisma'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const { user } = await requireApiUser(event)
+    const grants = await prisma.grant.findMany({
+      where: {
+        granteeId: user.id,
+        status: 'ACTIVE',
+        OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+      },
+      orderBy: { createdAt: 'desc' },
+    })
+
+    return { success: true, data: grants, statusCode: 200 }
+  } catch (error) {
+    const handled = errorHandler(error)
+    event.node.res.statusCode = handled.statusCode || 500
+    return { success: false, message: handled.message || 'Failed to list shared content.', data: null, statusCode: event.node.res.statusCode }
+  }
+})

--- a/server/utils/grantAccess.ts
+++ b/server/utils/grantAccess.ts
@@ -1,0 +1,51 @@
+import { createError } from 'h3'
+import type { GrantSubject } from '~/prisma/generated/prisma/client'
+import prisma from './prisma'
+
+export type GrantActor = {
+  id: number
+  isAdmin: boolean
+}
+
+export async function assertCanManageGrantSubject(
+  actor: GrantActor,
+  subjectType: GrantSubject,
+  subjectId: number,
+): Promise<void> {
+  if (actor.isAdmin) return
+
+  let ownerId: number | null | undefined
+
+  if (subjectType === 'PROJECT') {
+    ownerId = (
+      await prisma.project.findUnique({
+        where: { id: subjectId },
+        select: { userId: true },
+      })
+    )?.userId
+  } else if (subjectType === 'RESOURCE') {
+    ownerId = (
+      await prisma.resource.findUnique({
+        where: { id: subjectId },
+        select: { userId: true },
+      })
+    )?.userId
+  } else if (subjectType === 'PACK') {
+    ownerId = (
+      await prisma.pack.findUnique({
+        where: { id: subjectId },
+        select: { ownerId: true },
+      })
+    )?.ownerId
+  } else {
+    throw createError({ statusCode: 400, message: 'Unsupported grant subject type.' })
+  }
+
+  if (ownerId === undefined) {
+    throw createError({ statusCode: 404, message: 'Grant subject not found.' })
+  }
+
+  if (ownerId !== actor.id) {
+    throw createError({ statusCode: 403, message: 'Only the subject owner or an admin may manage grants.' })
+  }
+}

--- a/server/utils/grantAccess.ts
+++ b/server/utils/grantAccess.ts
@@ -12,8 +12,6 @@ export async function assertCanManageGrantSubject(
   subjectType: GrantSubject,
   subjectId: number,
 ): Promise<void> {
-  if (actor.isAdmin) return
-
   let ownerId: number | null | undefined
 
   if (subjectType === 'PROJECT') {
@@ -38,14 +36,20 @@ export async function assertCanManageGrantSubject(
       })
     )?.ownerId
   } else {
-    throw createError({ statusCode: 400, message: 'Unsupported grant subject type.' })
+    throw createError({
+      statusCode: 400,
+      message: 'Unsupported grant subject type.',
+    })
   }
 
   if (ownerId === undefined) {
     throw createError({ statusCode: 404, message: 'Grant subject not found.' })
   }
 
-  if (ownerId !== actor.id) {
-    throw createError({ statusCode: 403, message: 'Only the subject owner or an admin may manage grants.' })
+  if (!actor.isAdmin && ownerId !== actor.id) {
+    throw createError({
+      statusCode: 403,
+      message: 'Only the subject owner or an admin may manage grants.',
+    })
   }
 }


### PR DESCRIPTION
## Summary
- add owner/admin subject authorization for PROJECT, RESOURCE, and PACK grants
- add manual `POST /api/grants`
- add owner/admin `GET /api/grants?subjectType=&subjectId=`
- add authenticated `GET /api/grants/mine` for active, unexpired shares
- add audit-preserving `DELETE /api/grants/:id` that flips status to REVOKED

## Conductor
Implements the first bounded backend slice of `kind-robots/t-062`, per the approved Grant-sharing pitch. Later `canView()` route migrations and minimal Share / Shared-with-me UI remain follow-up slices.

Session: `openai-scheduled-20260910T091149Z-iv104-p2x7`

## Safety
No schema migration, production data mutation, publishing, billing, DNS, or secrets.