### PR TITLE
interface-vision/t-104 slice 200: add kr-icon-8, migrate bare h-8 w-8 icon glyphs

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1780,6 +1780,18 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply h-7 w-7;
   }
 
+  /* Same bare sizeless-and-colorless icon-glyph shape as `.kr-icon-6`/
+   * `.kr-icon-7`, one size up (interface-vision t-104 slice 200) --
+   * `h-8 w-8`, previously hand-rolled identically in 18 files (20
+   * occurrences), the smallest well-bounded sibling remaining after slice
+   * 199 per its own kaizen note (18 files vs. `h-3 w-3`'s 19). Sibling
+   * sizes still open: `h-3 w-3` (19 files), `h-3.5 w-3.5` (31 files),
+   * `h-4 w-4` (102 files, needs further splitting), `h-5 w-5` (35
+   * files). */
+  .kr-icon-8 {
+    @apply h-8 w-8;
+  }
+
   /* The colorless DaisyUI busy indicator: a bare tiny spinner dropped into
    * a button or inline slot while an action is pending, no tint (the
    * button/text color around it usually already carries the tone)

--- a/components/achievements/achievement-gallery.vue
+++ b/components/achievements/achievement-gallery.vue
@@ -72,7 +72,7 @@
               <div
                 class="kr-text-dim-xs-40 flex min-h-32 flex-col items-center justify-center rounded-xl border border-dashed border-base-300 p-4 text-center"
               >
-                <Icon name="kind-icon:trophy" class="mb-2 h-8 w-8 opacity-30" />
+                <Icon name="kind-icon:trophy" class="kr-icon-8 mb-2 opacity-30" />
                 No achievements earned yet.
               </div>
             </template>
@@ -129,7 +129,7 @@
               <div
                 class="flex min-h-32 flex-col items-center justify-center rounded-xl border border-dashed border-success/30 bg-success/5 p-4 text-center text-xs text-success/70"
               >
-                <Icon name="kind-icon:check" class="mb-2 h-8 w-8" />
+                <Icon name="kind-icon:check" class="kr-icon-8 mb-2" />
                 All achievements discovered!
               </div>
             </template>

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -392,7 +392,7 @@
               <div v-if="image" class="relative">
                 <button
                   v-if="bulkSelectEnabled"
-                  class="absolute left-2 top-2 z-10 flex h-8 w-8 items-center justify-center rounded-xl border shadow-lg transition"
+                  class="kr-icon-8 absolute left-2 top-2 z-10 flex items-center justify-center rounded-xl border shadow-lg transition"
                   :class="
                     isImageSelected(image.id)
                       ? 'border-primary bg-primary text-primary-content'

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -141,7 +141,7 @@
             v-if="result(side).status === 'idle'"
             class="kr-text-dim-xs flex flex-col items-center gap-2"
           >
-            <Icon name="kind-icon:image" class="h-8 w-8 opacity-60" />
+            <Icon name="kind-icon:image" class="kr-icon-8 opacity-60" />
             No render yet
           </div>
           <div v-else-if="result(side).status === 'queued' || result(side).status === 'rendering'" class="flex flex-col items-center gap-2 text-xs">

--- a/components/giftshop/shopping-cart.vue
+++ b/components/giftshop/shopping-cart.vue
@@ -28,7 +28,7 @@
       v-if="cartStore.initializing"
       class="rounded-2xl border border-info/30 bg-info/10 p-8 text-center text-info"
     >
-      <Icon name="kind-icon:spinner" class="mx-auto h-8 w-8 animate-spin" />
+      <Icon name="kind-icon:spinner" class="kr-icon-8 mx-auto animate-spin" />
       <p class="mt-2 font-bold">Gathering the cart butterflies...</p>
     </div>
 

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -221,7 +221,7 @@
           @click="store.selectSource(record)"
         >
           <div
-            class="grid h-8 w-8 shrink-0 place-items-center overflow-hidden rounded-lg bg-base-200"
+            class="kr-icon-8 grid shrink-0 place-items-center overflow-hidden rounded-lg bg-base-200"
           >
             <img
               v-if="recordImage(record)"

--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -168,7 +168,7 @@
             <img
               :src="account.avatarImage || fallbackAvatar"
               :alt="`${account.username} avatar`"
-              class="h-8 w-8 shrink-0 rounded-lg border border-base-300 object-cover"
+              class="kr-icon-8 shrink-0 rounded-lg border border-base-300 object-cover"
             />
 
             <span class="min-w-0 flex-1">

--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -16,7 +16,7 @@
       @focus="scheduleChannelMenuViewportUpdate"
     >
       <span
-        class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-base-300/70 bg-base-200 sm:h-9 sm:w-9 xl:h-10 xl:w-10"
+        class="kr-icon-8 flex shrink-0 items-center justify-center rounded-lg border border-base-300/70 bg-base-200 sm:h-9 sm:w-9 xl:h-10 xl:w-10"
       >
         <Icon
           :name="activeChannel.icon"

--- a/components/navigation/channel-tab-list.vue
+++ b/components/navigation/channel-tab-list.vue
@@ -33,7 +33,7 @@
             @click="emit('select', tab)"
           >
             <span
-              class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-base-200"
+              class="kr-icon-8 relative flex shrink-0 overflow-hidden rounded-lg bg-base-200"
             >
               <img
                 v-if="tab.image"

--- a/components/navigation/tab-select.vue
+++ b/components/navigation/tab-select.vue
@@ -41,7 +41,7 @@
       aria-haspopup="menu"
     >
       <span
-        class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-base-300/70 bg-base-200 sm:h-9 sm:w-9 xl:h-10 xl:w-10"
+        class="kr-icon-8 flex shrink-0 items-center justify-center rounded-lg border border-base-300/70 bg-base-200 sm:h-9 sm:w-9 xl:h-10 xl:w-10"
       >
         <Icon
           :name="activeTab?.icon || channel.icon"

--- a/components/pages/about-page.vue
+++ b/components/pages/about-page.vue
@@ -5,7 +5,7 @@
         <span
           class="flex h-14 w-14 items-center justify-center rounded-2xl bg-linear-to-br from-primary to-accent text-primary-content shadow-lg"
         >
-          <Icon name="kind-icon:robot-color" class="h-8 w-8" />
+          <Icon name="kind-icon:robot-color" class="kr-icon-8" />
         </span>
         <p class="text-3xl font-black text-base-content">Kind Robots</p>
         <p class="kr-text-dim-sm max-w-md">

--- a/components/pages/memory-dungeon.vue
+++ b/components/pages/memory-dungeon.vue
@@ -137,7 +137,7 @@
           <img
             v-if="challenge.targetImagePath"
             :src="challenge.targetImagePath"
-            class="h-8 w-8 shrink-0 rounded border-2 border-black object-cover shadow"
+            class="kr-icon-8 shrink-0 rounded border-2 border-black object-cover shadow"
             alt="Challenge target"
           />
 

--- a/components/stages/stage-message.vue
+++ b/components/stages/stage-message.vue
@@ -32,7 +32,7 @@
     class="self-end max-w-[80%] flex flex-row-reverse items-start gap-2"
   >
     <div
-      class="w-8 h-8 rounded-full bg-secondary/20 flex items-center justify-center shrink-0"
+      class="kr-icon-8 rounded-full bg-secondary/20 flex items-center justify-center shrink-0"
     >
       <Icon name="mdi:account" class="w-4 h-4" />
     </div>

--- a/components/user/first-launch-intro.vue
+++ b/components/user/first-launch-intro.vue
@@ -29,7 +29,7 @@
         <div
           class="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10 text-primary"
         >
-          <Icon :name="currentStep.icon" class="h-8 w-8" />
+          <Icon :name="currentStep.icon" class="kr-icon-8" />
         </div>
 
         <p

--- a/components/user/friends-panel.vue
+++ b/components/user/friends-panel.vue
@@ -59,7 +59,7 @@
         >
           <div class="flex items-center gap-2">
             <div class="avatar">
-              <div class="h-8 w-8 rounded-full bg-base-300">
+              <div class="kr-icon-8 rounded-full bg-base-300">
                 <img
                   v-if="avatarFor(id)"
                   :src="avatarFor(id)"
@@ -112,7 +112,7 @@
         >
           <div class="flex items-center gap-2">
             <div class="avatar">
-              <div class="h-8 w-8 rounded-full bg-base-300">
+              <div class="kr-icon-8 rounded-full bg-base-300">
                 <img
                   v-if="u.avatarImage"
                   :src="u.avatarImage"

--- a/components/user/messenger.vue
+++ b/components/user/messenger.vue
@@ -66,7 +66,7 @@
       <template v-if="convo.activeId">
         <header class="flex items-center gap-2 kr-panel-header-sm">
           <div class="avatar">
-            <div class="h-8 w-8 rounded-full bg-base-300">
+            <div class="kr-icon-8 rounded-full bg-base-300">
               <img
                 v-if="activePeer?.avatarImage"
                 :src="activePeer?.avatarImage || ''"

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -49,7 +49,7 @@
           <span
             class="flex h-14 w-14 items-center justify-center rounded-2xl bg-base-200 text-base-content/40"
           >
-            <Icon name="kind-icon:user" class="h-8 w-8" />
+            <Icon name="kind-icon:user" class="kr-icon-8" />
           </span>
 
           <div>

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -70,7 +70,7 @@
             <td>
               <div class="flex items-center gap-2">
                 <div class="avatar">
-                  <div class="h-8 w-8 rounded-full bg-base-300">
+                  <div class="kr-icon-8 rounded-full bg-base-300">
                     <img
                       v-if="u.avatarImage"
                       :src="u.avatarImage"

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -99,7 +99,7 @@
                 @click="coloringStore.setActiveColor(color.id)"
               >
                 <span
-                  class="h-8 w-8 shrink-0 rounded-xl border border-base-300 shadow-inner"
+                  class="kr-icon-8 shrink-0 rounded-xl border border-base-300 shadow-inner"
                   :style="{ backgroundColor: color.value }"
                 />
                 <span class="min-w-0">

--- a/utils/scripts/codemods/kr_icon_8_codemod.py
+++ b/utils/scripts/codemods/kr_icon_8_codemod.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `h-8 w-8` bare (colorless) icon glyphs to
+`kr-icon-8`.
+
+Same sizeless-and-colorless icon-glyph shape as `.kr-icon-6`/`.kr-icon-7`
+(interface-vision t-104 slices 198-199), one size up. Distinct from any
+future `.kr-icon-primary-8` (same size, carries a `text-primary` color
+token): this is the plain untinted glyph. Picked as the next smallest
+well-bounded sibling per slice 199's kaizen note: 18 files (20
+occurrences), smaller than `h-3 w-3` (19 files), `h-3.5 w-3.5` (31 files),
+and `h-5 w-5` (35 files) surveyed alongside it. `h-4 w-4` (102 files)
+remains flagged as needing further splitting before any slice attempts it.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+class strings containing both `h-8` and `w-8` tokens are touched, and only
+in static `class="..."` attributes -- never `:class`/`v-bind:class` bindings
+(see _class_attr.py). A class string carrying any `text-*`/`stroke-*`/
+`fill-*` color token is left alone (that is the `kr-icon-primary-8`/future
+colored-sibling shape, not this one), regardless of the base tokens' order
+in the source. A source that already carries `kr-icon-8`, or is missing
+either base token, is also left untouched. Extra tokens beyond the base set
+are preserved verbatim after the primitive class, matching every other
+kr-*-codemod's subset-match convention -- pass --exact-only to restrict a
+slice to sources with no extra tokens at all.
+
+Deliberately does NOT touch sibling sizes (`h-3 w-3`, `h-3.5 w-3.5`,
+`h-4 w-4`, `h-5 w-5`, `h-6 w-6`, `h-7 w-7`) -- those are real,
+independently-repeated shapes of their own, left for future slices.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-8"
+BASE_TOKENS = {"h-8", "w-8"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-8 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules — slice 200 (kind: software)

### What changed / what I produced
- Added `.kr-icon-8` to `assets/css/tailwind.css` (`@apply h-8 w-8`), the next size in the sizeless-and-colorless bare icon-glyph family opened at `.kr-icon-6`/`.kr-icon-7` (slices 198-199).
- Added `utils/scripts/codemods/kr_icon_8_codemod.py`, sibling of `kr_icon_7_codemod.py` (same subset-match convention, same `text-*`/`stroke-*`/`fill-*` exclusion to stay distinct from a future `kr-icon-primary-8`).
- Ran `--write`: migrated all 20 occurrences across 18 files (achievement-gallery.vue x2, art-gallery.vue, build-bench.vue, shopping-cart.vue, model-builder-source-picker.vue, account-hub.vue, channel-select.vue, channel-tab-list.vue, tab-select.vue, about-page.vue, memory-dungeon.vue, stage-message.vue, first-launch-intro.vue, friends-panel.vue x2, messenger.vue, user-dashboard.vue, user-manager-directory.vue, mural-manager.vue).
- Manually reviewed every diff — only static `class="..."` attributes touched, no geometry or behavior change.

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint .`: 333/327/6, identical to the documented baseline
- `test:layout-contract`: holds, 0 new violations
- `test:lint-ratchet`: holds at 333 (-59)
- `prettier --check .`: 1144 files flagged, matching the pre-existing repo-wide formatting-drift baseline (no new files introduced by this change)

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Continue opening the sizeless-and-colorless icon-glyph family size by size — remaining sibling sizes: `h-3 w-3` (19 files), `h-3.5 w-3.5` (31 files), `h-5 w-5` (35 files). `h-4 w-4` (102 files) still needs further splitting before it is a bounded slice on its own.

### Notes for reviewer
Part of the ongoing interface-vision/t-104 recurring consistency sweep (conductor roadmap). Conductor close-out PR to follow once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXCZ55EFHbQUbMKbP4ruka

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXCZ55EFHbQUbMKbP4ruka)_