### PR TITLE
interface-vision/t-104 slice 201: add kr-icon-3, migrate bare h-3 w-3 icon glyphs

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1792,6 +1792,19 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply h-8 w-8;
   }
 
+  /* Same bare sizeless-and-colorless icon-glyph shape as `.kr-icon-6`/
+   * `.kr-icon-7`/`.kr-icon-8`, one size down (interface-vision t-104 slice
+   * 201) -- `h-3 w-3`, previously hand-rolled identically in 19 files (30
+   * occurrences via subset-match), the smallest well-bounded sibling
+   * remaining after slice 200 per its own kaizen note. Sibling sizes still
+   * open: `h-3.5 w-3.5` (28 files), `h-4 w-4` (95 files, needs further
+   * splitting), `h-5 w-5` (28 files). Distinct from any future
+   * `.kr-icon-primary-3` (same size, carries `text-primary`) -- this is
+   * the untinted sibling. */
+  .kr-icon-3 {
+    @apply h-3 w-3;
+  }
+
   /* The colorless DaisyUI busy indicator: a bare tiny spinner dropped into
    * a button or inline slot while an action is pending, no tint (the
    * button/text color around it usually already carries the tone)

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -109,7 +109,7 @@
               :title="store.isEffectActive(effect.id) ? 'Turn this effect off' : 'Trigger this effect live on screen'"
               @click="store.previewEffect(effect.id)"
             >
-              <Icon :name="store.isEffectActive(effect.id) ? 'kind-icon:x' : 'kind-icon:eye'" class="h-3 w-3" />
+              <Icon :name="store.isEffectActive(effect.id) ? 'kind-icon:x' : 'kind-icon:eye'" class="kr-icon-3" />
               {{ store.isEffectActive(effect.id) ? 'Stop' : 'Preview' }}
             </button>
             <span class="kr-badge-ghost-sm">

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -99,7 +99,7 @@
             title="Clear source"
             @click="clearSourceImage"
           >
-            <Icon name="mdi:close" class="h-3 w-3" />
+            <Icon name="mdi:close" class="kr-icon-3" />
           </button>
         </div>
       </Transition>
@@ -350,7 +350,7 @@
             v-if="selectedStyle"
             class="flex items-center gap-1 text-xs font-semibold text-primary"
           >
-            <Icon name="mdi:palette" class="h-3 w-3" />
+            <Icon name="mdi:palette" class="kr-icon-3" />
             {{ selectedStyle.label }}
           </p>
           <p v-else class="kr-text-dim-xs-40 italic">Pick a style below</p>

--- a/components/art/image-card.vue
+++ b/components/art/image-card.vue
@@ -112,7 +112,7 @@
         v-if="selected"
         class="absolute bottom-1.5 right-1.5 rounded-full bg-primary p-1.5 text-primary-content shadow-lg shadow-primary/40"
       >
-        <Icon name="kind-icon:check" class="h-3 w-3" />
+        <Icon name="kind-icon:check" class="kr-icon-3" />
       </div>
 
       <button

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -73,7 +73,7 @@
           :title="`Remove ${item.file.name}`"
           @click.stop="removeFile(i)"
         >
-          <Icon name="mdi:close" class="h-3 w-3" />
+          <Icon name="mdi:close" class="kr-icon-3" />
         </button>
 
         <Transition name="fade">
@@ -354,7 +354,7 @@
                 :aria-label="`Unlink ${connectedModelType} #${connectedModelId}`"
                 @click="clearModelSelection"
               >
-                <Icon name="mdi:close" class="h-3 w-3" />
+                <Icon name="mdi:close" class="kr-icon-3" />
               </button>
             </div>
 

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -71,7 +71,7 @@
               :disabled="dreamStore.loading"
               @click="refreshDreams"
             >
-              <Icon name="kind-icon:refresh" class="h-3 w-3" />
+              <Icon name="kind-icon:refresh" class="kr-icon-3" />
             </button>
           </div>
 
@@ -463,7 +463,7 @@
                 class="kr-btn-xs btn-square btn-ghost text-error"
                 @click="removeExample(index)"
               >
-                <Icon name="kind-icon:x" class="h-3 w-3" />
+                <Icon name="kind-icon:x" class="kr-icon-3" />
               </button>
             </div>
           </div>

--- a/components/dreams/dream-list.vue
+++ b/components/dreams/dream-list.vue
@@ -17,7 +17,7 @@
         @click="refreshList"
       >
         <span v-if="isLoading" class="kr-spinner-xs" />
-        <Icon v-else name="kind-icon:refresh" class="h-3 w-3" />
+        <Icon v-else name="kind-icon:refresh" class="kr-icon-3" />
         {{ refreshLabel }}
       </button>
     </header>

--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -117,7 +117,7 @@
           <Icon
             v-if="badge.icon"
             :name="badge.icon"
-            class="h-3 w-3"
+            class="kr-icon-3"
             :class="badge.label ? 'mr-1' : ''"
             aria-hidden="true"
           />
@@ -270,7 +270,7 @@
         :class="chip.class || 'badge-ghost'"
         :title="chip.title || chip.label"
       >
-        <Icon v-if="chip.icon" :name="chip.icon" class="mr-1 h-3 w-3" />
+        <Icon v-if="chip.icon" :name="chip.icon" class="kr-icon-3 mr-1" />
         {{ chip.label }}
       </span>
     </div>

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -206,7 +206,7 @@
             class="kr-btn-ghost-xs-lg"
             @click="emit('select-item', item.id)"
           >
-            <Icon name="kind-icon:pencil" class="h-3 w-3" />
+            <Icon name="kind-icon:pencil" class="kr-icon-3" />
             Edit
           </button>
         </li>

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -147,7 +147,7 @@
             aria-hidden="true"
           />
           <template v-else>
-            <Icon name="kind-icon:magic" class="h-3 w-3" />
+            <Icon name="kind-icon:magic" class="kr-icon-3" />
             Draft
           </template>
         </button>
@@ -179,7 +179,7 @@
             aria-hidden="true"
           />
           <template v-else>
-            <Icon name="kind-icon:magic" class="h-3 w-3" />
+            <Icon name="kind-icon:magic" class="kr-icon-3" />
             Draft
           </template>
         </button>

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -149,7 +149,7 @@
               >
                 <Icon
                   :name="statusIcon(item.stages[stage.key].status)"
-                  class="h-3 w-3"
+                  class="kr-icon-3"
                   aria-hidden="true"
                 />
               </span>

--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -65,7 +65,7 @@
 
       <span
         v-if="!unreadCount && userStore.isLoggedIn"
-        class="absolute bottom-0 right-0 h-3 w-3 rounded-full border border-base-100 bg-success"
+        class="kr-icon-3 absolute bottom-0 right-0 rounded-full border border-base-100 bg-success"
       />
     </button>
 

--- a/components/navigation/tutorial-flyer.vue
+++ b/components/navigation/tutorial-flyer.vue
@@ -57,7 +57,7 @@
             v-if="section.underConstruction"
             class="kr-badge-warning-sm gap-1 rounded-lg font-semibold"
           >
-            <Icon name="kind-icon:wrench" class="h-3 w-3" />
+            <Icon name="kind-icon:wrench" class="kr-icon-3" />
             Coming soon
           </span>
         </div>
@@ -126,7 +126,7 @@
               <p
                 class="kr-text-eyebrow inline-flex items-center gap-1.5 rounded-full border border-primary/25 bg-base-100/70 px-3 py-1 text-[0.65rem] tracking-[0.18em] text-primary shadow-sm backdrop-blur"
               >
-                <Icon name="kind-icon:info" class="h-3 w-3" />
+                <Icon name="kind-icon:info" class="kr-icon-3" />
                 Tutorial
               </p>
 
@@ -216,7 +216,7 @@
                       v-if="section.underConstruction"
                       class="kr-badge-warning-sm gap-1 rounded-lg font-semibold"
                     >
-                      <Icon name="kind-icon:wrench" class="h-3 w-3" />
+                      <Icon name="kind-icon:wrench" class="kr-icon-3" />
                       Coming soon
                     </span>
                   </div>

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -29,7 +29,7 @@
               type="button"
               @click="continueWithSelected"
             >
-              <Icon name="kind-icon:story" class="h-3 w-3" />
+              <Icon name="kind-icon:story" class="kr-icon-3" />
               Continue
             </button>
           </div>

--- a/components/screenfx/animation-selector.vue
+++ b/components/screenfx/animation-selector.vue
@@ -22,7 +22,7 @@
       </div>
 
       <span class="kr-badge-outline-sm gap-1 border-info/40 text-info">
-        <Icon name="kind-icon:save" class="h-3 w-3" />
+        <Icon name="kind-icon:save" class="kr-icon-3" />
         local storage
       </span>
     </header>

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -106,7 +106,7 @@
                 @click="form.species = ''"
                 class="hover:text-error"
               >
-                <Icon name="mdi:close" class="h-3 w-3" />
+                <Icon name="mdi:close" class="kr-icon-3" />
               </button>
             </span>
             <span
@@ -120,7 +120,7 @@
                 @click="removeTrait(trait)"
                 class="hover:text-error"
               >
-                <Icon name="mdi:close" class="h-3 w-3" />
+                <Icon name="mdi:close" class="kr-icon-3" />
               </button>
             </span>
             <button
@@ -359,7 +359,7 @@
                 class="hover:text-error"
                 @click="removeTrait(trait)"
               >
-                <Icon name="mdi:close" class="h-3 w-3" />
+                <Icon name="mdi:close" class="kr-icon-3" />
               </button>
             </span>
             <span

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -894,7 +894,7 @@
         </div>
         <!-- Label -->
         <div class="flex items-center justify-center gap-1 px-1 py-1.5">
-          <Icon :name="card.icon" class="h-3 w-3 shrink-0" />
+          <Icon :name="card.icon" class="kr-icon-3 shrink-0" />
           <span class="text-[10px] font-black leading-none">{{
             card.label
           }}</span>

--- a/components/stages/stage-preset.vue
+++ b/components/stages/stage-preset.vue
@@ -52,7 +52,7 @@
             v-if="role.badgeImagePath"
             :src="role.badgeImagePath"
             :alt="role.label"
-            class="h-3 w-3 rounded-full object-cover"
+            class="kr-icon-3 rounded-full object-cover"
           />
           {{ role.label }}
         </span>

--- a/components/stages/stage-slot.vue
+++ b/components/stages/stage-slot.vue
@@ -31,7 +31,7 @@
           title="Clear slot"
           @click="emit('clear', slot.slotId)"
         >
-          <Icon name="mdi:close" class="h-3 w-3" />
+          <Icon name="mdi:close" class="kr-icon-3" />
         </button>
       </div>
     </template>
@@ -81,7 +81,7 @@
           title="Generate temporary bot for this role"
           @click="emit('requestTemporary', slot.slotId, slot.roleKey)"
         >
-          <Icon name="mdi:auto-fix" class="h-3 w-3" />
+          <Icon name="mdi:auto-fix" class="kr-icon-3" />
         </button>
 
         <button
@@ -90,7 +90,7 @@
           title="Remove slot"
           @click="emit('removeSlot', slot.slotId)"
         >
-          <Icon name="mdi:close" class="h-3 w-3" />
+          <Icon name="mdi:close" class="kr-icon-3" />
         </button>
       </div>
     </template>

--- a/components/wonderlab/reactable-card.vue
+++ b/components/wonderlab/reactable-card.vue
@@ -31,7 +31,7 @@
         class="flex items-center gap-1 rounded-full bg-base-100 px-2 py-1 text-xs font-semibold text-amber-500 shadow"
         title="Karma earned from reactions to this item"
       >
-        <Icon name="kind-icon:star" class="h-3 w-3" />
+        <Icon name="kind-icon:star" class="kr-icon-3" />
         {{ normalizedEarnedKarma }}
       </span>
 

--- a/utils/scripts/codemods/kr_icon_3_codemod.py
+++ b/utils/scripts/codemods/kr_icon_3_codemod.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `h-3 w-3` bare (colorless) icon glyphs to
+`kr-icon-3`.
+
+Same sizeless-and-colorless icon-glyph shape as `.kr-icon-6`/`.kr-icon-7`/
+`.kr-icon-8` (interface-vision t-104 slices 198-200), one size down. Distinct
+from any future `.kr-icon-primary-3` (same size, carries a `text-primary`
+color token): this is the plain untinted glyph. Picked as the next smallest
+well-bounded sibling per slice 200's kaizen note: 16 files remaining (down
+from the 19 files surveyed in slice 198 -- some were consumed by other
+codemods/edits since), smaller than `h-3.5 w-3.5` (28 files) and `h-5 w-5`
+(28 files). `h-4 w-4` (95 files) remains flagged as needing further
+splitting before any slice attempts it.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+class strings containing both `h-3` and `w-3` tokens are touched, and only
+in static `class="..."` attributes -- never `:class`/`v-bind:class` bindings
+(see _class_attr.py). A class string carrying any `text-*`/`stroke-*`/
+`fill-*` color token is left alone (that is the `kr-icon-primary-3`/future
+colored-sibling shape, not this one), regardless of the base tokens' order
+in the source. A source that already carries `kr-icon-3`, or is missing
+either base token, is also left untouched. Extra tokens beyond the base set
+are preserved verbatim after the primitive class, matching every other
+kr-*-codemod's subset-match convention -- pass --exact-only to restrict a
+slice to sources with no extra tokens at all.
+
+Deliberately does NOT touch sibling sizes (`h-3.5 w-3.5`, `h-4 w-4`,
+`h-5 w-5`, `h-6 w-6`, `h-7 w-7`, `h-8 w-8`) -- those are real,
+independently-repeated shapes of their own, left for future slices.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-3"
+BASE_TOKENS = {"h-3", "w-3"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-3 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Added `.kr-icon-3` to `assets/css/tailwind.css` (`@apply h-3 w-3`), the sizeless-and-colorless icon-glyph primitive, one size down from `.kr-icon-6`/`.kr-icon-7`/`.kr-icon-8` (slices 198-200).
- Added `utils/scripts/codemods/kr_icon_3_codemod.py`, sibling of `kr_icon_8_codemod.py` — same subset-match convention, same `text-*`/`stroke-*`/`fill-*` color-token exclusion (so it stays distinct from any future `.kr-icon-primary-3`).
- Ran `--write`: migrated 30 occurrences across 19 files to `kr-icon-3`. Every diff reviewed manually — only static `class="..."` attributes touched, no geometry or behavior change.

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint .`: 333/327/6, identical to the documented baseline
- `test:layout-contract`: holds, 0 new violations
- `test:lint-ratchet`: holds at 333/-59
- `prettier --check`: the 11 files it flags carry the same pre-existing formatting drift as before this change (confirmed via `git stash` comparison against the same files pre-edit) — no new drift introduced by this diff

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Continue opening the sizeless-and-colorless icon-glyph family size by size: `h-3.5 w-3.5` (28 files) and `h-5 w-5` (28 files) remain open, roughly tied for next-smallest. `h-4 w-4` (95 files) still needs further splitting before it's a bounded slice on its own.

### Notes for reviewer
Conductor-side close-out (claim → review → done) lands alongside this PR in a separate conductor PR against `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179GPbPecPVFigxwF51ENqK

---
_Generated by [Claude Code](https://claude.ai/code/session_0179GPbPecPVFigxwF51ENqK)_