### PR TITLE
interface-vision/t-104 slice 203: add kr-icon-3-5, migrate bare h-3.5 w-3.5 icon glyphs

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1819,6 +1819,23 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply h-5 w-5;
   }
 
+  /* Same bare sizeless-and-colorless icon-glyph shape as `.kr-icon-3`/
+   * `.kr-icon-5`/`.kr-icon-6`/`.kr-icon-7`/`.kr-icon-8` (interface-vision
+   * t-104 slice 203) -- `h-3.5 w-3.5`, previously hand-rolled identically
+   * in 31 files (78 occurrences via subset-match). Naming convention
+   * decided this slice (left undecided by slices 201 and 202's kaizen
+   * notes): a literal `.` is not a valid bare character in a CSS class
+   * selector without an escape (`.kr-icon-3\.5`), which is fragile to
+   * write and grep for; dash substitution (`kr-icon-3-5`) reads
+   * unambiguously and matches the plain-digit naming every other sibling
+   * in this family already uses. Sibling sizes still open: `h-4 w-4` (95
+   * files, needs further splitting). Distinct from any future
+   * `.kr-icon-primary-3-5` (same size, carries `text-primary`) -- this is
+   * the untinted sibling. */
+  .kr-icon-3-5 {
+    @apply h-3.5 w-3.5;
+  }
+
   /* The colorless DaisyUI busy indicator: a bare tiny spinner dropped into
    * a button or inline slot while an action is pending, no tint (the
    * button/text color around it usually already carries the tone)

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -70,7 +70,7 @@
             v-if="isViewed"
             class="badge border-0 bg-success text-success-content font-bold"
           >
-            <Icon name="kind-icon:check" class="mr-1 h-3.5 w-3.5" />
+            <Icon name="kind-icon:check" class="kr-icon-3-5 mr-1" />
             Explored
           </span>
         </div>

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -27,7 +27,7 @@
               :aria-pressed="lessonFilter === option.value"
               @click="lessonFilter = option.value"
             >
-              <Icon :name="option.icon" class="h-3.5 w-3.5" aria-hidden="true" />
+              <Icon :name="option.icon" class="kr-icon-3-5" aria-hidden="true" />
               {{ option.label }}
             </button>
           </div>
@@ -139,7 +139,7 @@
           class="absolute right-2.5 top-2.5 flex h-7 w-7 items-center justify-center rounded-full bg-success text-success-content shadow-md"
           title="Lesson explored"
         >
-          <Icon name="kind-icon:check" class="h-3.5 w-3.5" aria-hidden="true" />
+          <Icon name="kind-icon:check" class="kr-icon-3-5" aria-hidden="true" />
           <span class="sr-only">Lesson explored</span>
         </div>
 
@@ -153,7 +153,7 @@
           </p>
           <div class="kr-text-eyebrow mt-3 flex items-center gap-1 text-[0.68rem] tracking-wide text-white/90">
             Open lesson
-            <Icon name="kind-icon:arrow-right" class="h-3.5 w-3.5 transition-transform group-hover:translate-x-1" aria-hidden="true" />
+            <Icon name="kind-icon:arrow-right" class="kr-icon-3-5 transition-transform group-hover:translate-x-1" aria-hidden="true" />
           </div>
         </div>
       </button>

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -47,7 +47,7 @@
             type="button"
             @click="clearActiveGroup"
           >
-            <Icon name="kind-icon:arrow-left" class="h-3.5 w-3.5" />
+            <Icon name="kind-icon:arrow-left" class="kr-icon-3-5" />
             Back
           </button>
 
@@ -58,7 +58,7 @@
             type="button"
             @click="toggleBulkSelect"
           >
-            <Icon name="kind-icon:checklist" class="h-3.5 w-3.5" />
+            <Icon name="kind-icon:checklist" class="kr-icon-3-5" />
             {{ bulkSelectEnabled ? 'Selecting' : 'Select' }}
           </button>
 
@@ -76,7 +76,7 @@
             @click="refreshGallery"
           >
             <span v-if="isLoading" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:refresh" class="h-3.5 w-3.5" />
+            <Icon v-else name="kind-icon:refresh" class="kr-icon-3-5" />
           </button>
 
           <button
@@ -85,7 +85,7 @@
             type="button"
             @click="clearSelectedImage"
           >
-            <Icon name="kind-icon:x" class="h-3.5 w-3.5" />
+            <Icon name="kind-icon:x" class="kr-icon-3-5" />
           </button>
         </div>
       </div>
@@ -139,7 +139,7 @@
       v-if="errorMessage"
       class="shrink-0 flex items-center gap-2 kr-note kr-note-error rounded-xl px-3 py-2 text-xs"
     >
-      <icon name="kind-icon:alert" class="h-3.5 w-3.5 shrink-0" />
+      <icon name="kind-icon:alert" class="kr-icon-3-5 shrink-0" />
       {{ errorMessage }}
     </div>
 
@@ -147,7 +147,7 @@
       v-if="successMessage"
       class="shrink-0 flex items-center gap-2 kr-note kr-note-success rounded-xl px-3 py-2 text-xs"
     >
-      <icon name="kind-icon:check" class="h-3.5 w-3.5 shrink-0" />
+      <icon name="kind-icon:check" class="kr-icon-3-5 shrink-0" />
       {{ successMessage }}
     </div>
 
@@ -229,7 +229,7 @@
             type="button"
             @click="clearActiveGroup"
           >
-            <Icon name="kind-icon:arrow-left" class="h-3.5 w-3.5" />
+            <Icon name="kind-icon:arrow-left" class="kr-icon-3-5" />
             Collections
           </button>
         </div>
@@ -249,7 +249,7 @@
               :disabled="isBatchWorking"
               @click="selectAllFilteredImages"
             >
-              <Icon name="kind-icon:gallery" class="h-3.5 w-3.5" />
+              <Icon name="kind-icon:gallery" class="kr-icon-3-5" />
               Select all filtered
             </button>
 
@@ -259,7 +259,7 @@
               :disabled="isBatchWorking || !selectedImageCount"
               @click="clearImageSelection"
             >
-              <Icon name="kind-icon:x" class="h-3.5 w-3.5" />
+              <Icon name="kind-icon:x" class="kr-icon-3-5" />
               Clear
             </button>
 
@@ -301,7 +301,7 @@
               "
               @click="addSelectedToCollection"
             >
-              <Icon name="kind-icon:plus" class="h-3.5 w-3.5" />
+              <Icon name="kind-icon:plus" class="kr-icon-3-5" />
               Add
             </button>
 
@@ -315,7 +315,7 @@
               "
               @click="removeSelectedFromCollection"
             >
-              <Icon name="kind-icon:minus" class="h-3.5 w-3.5" />
+              <Icon name="kind-icon:minus" class="kr-icon-3-5" />
               Remove
             </button>
 
@@ -326,7 +326,7 @@
               :disabled="isBatchWorking || !selectedImageCount"
               @click="removeSelectedFromActiveCollection"
             >
-              <Icon name="kind-icon:folder" class="h-3.5 w-3.5" />
+              <Icon name="kind-icon:folder" class="kr-icon-3-5" />
               Remove from here
             </button>
           </div>
@@ -358,7 +358,7 @@
               :disabled="isBatchWorking || !canBatchModifyImages"
               @click="applySelectedImageFlags"
             >
-              <Icon name="kind-icon:edit" class="h-3.5 w-3.5" />
+              <Icon name="kind-icon:edit" class="kr-icon-3-5" />
               Apply edits
             </button>
 
@@ -372,7 +372,7 @@
                 v-if="isBatchWorking"
                 class="kr-spinner-xs"
               />
-              <Icon v-else name="kind-icon:trash" class="h-3.5 w-3.5" />
+              <Icon v-else name="kind-icon:trash" class="kr-icon-3-5" />
               Delete
             </button>
           </div>

--- a/components/art/collection-card.vue
+++ b/components/art/collection-card.vue
@@ -114,7 +114,7 @@
         v-if="activeSelected"
         class="absolute bottom-2 right-2 rounded-full bg-primary p-1.5 text-primary-content shadow"
       >
-        <Icon name="kind-icon:check" class="h-3.5 w-3.5" />
+        <Icon name="kind-icon:check" class="kr-icon-3-5" />
       </div>
     </div>
 
@@ -174,7 +174,7 @@
           :disabled="isHiddenMature"
           @click.stop="selectCollection"
         >
-          <Icon name="kind-icon:folder" class="h-3.5 w-3.5" />
+          <Icon name="kind-icon:folder" class="kr-icon-3-5" />
           {{ activeSelected ? 'Selected' : 'Open' }}
         </button>
       </div>

--- a/components/art/image-card.vue
+++ b/components/art/image-card.vue
@@ -273,7 +273,7 @@
           type="button"
           @click.stop="selectImage"
         >
-          <Icon name="kind-icon:check" class="h-3.5 w-3.5" />
+          <Icon name="kind-icon:check" class="kr-icon-3-5" />
           {{ selected ? 'Selected' : 'Select' }}
         </button>
       </div>

--- a/components/art/stylist-mask-brush.vue
+++ b/components/art/stylist-mask-brush.vue
@@ -40,7 +40,7 @@
         class="kr-btn-ghost-xs-plain"
         @click="clear"
       >
-        <Icon name="mdi:eraser" class="h-3.5 w-3.5" /> Clear
+        <Icon name="mdi:eraser" class="kr-icon-3-5" /> Clear
       </button>
       <span class="text-base-content/50">
         {{

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -415,7 +415,7 @@
               title="Dismiss"
               @click="stylist.dismissJob(job.id)"
             >
-              <Icon name="mdi:close" class="h-3.5 w-3.5" />
+              <Icon name="mdi:close" class="kr-icon-3-5" />
             </button>
           </div>
           <div class="grid grid-cols-2 gap-1">

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -334,7 +334,7 @@
             data-testid="brainstorm-source-remove"
             @click="clearSource"
           >
-            <Icon name="kind-icon:x" class="h-3.5 w-3.5" />
+            <Icon name="kind-icon:x" class="kr-icon-3-5" />
             Remove
           </button>
         </div>

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -175,7 +175,7 @@
           <p
             class="kr-text-eyebrow kr-text-dim-xs-60 flex items-center gap-1.5 tracking-wide"
           >
-            <Icon name="kind-icon:palette" class="h-3.5 w-3.5" />
+            <Icon name="kind-icon:palette" class="kr-icon-3-5" />
             Palette
           </p>
 

--- a/components/gallery/kr-card-back.vue
+++ b/components/gallery/kr-card-back.vue
@@ -178,7 +178,7 @@
             class="kr-btn-ghost-xs"
             @click="editing = false"
           >
-            <Icon name="kind-icon:x" class="h-3.5 w-3.5" />
+            <Icon name="kind-icon:x" class="kr-icon-3-5" />
             Done
           </button>
         </div>

--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -189,7 +189,7 @@
             <Icon
               v-if="badge.icon"
               :name="badge.icon"
-              class="h-3.5 w-3.5"
+              class="kr-icon-3-5"
               :class="badge.label ? 'mr-1' : ''"
               aria-hidden="true"
             />
@@ -238,7 +238,7 @@
             <Icon
               v-if="badge.icon"
               :name="badge.icon"
-              class="h-3.5 w-3.5"
+              class="kr-icon-3-5"
               :class="badge.label ? 'mr-1' : ''"
               aria-hidden="true"
             />

--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -20,7 +20,7 @@
         :aria-pressed="mode === entry.value"
         @click="emit('update:mode', entry.value)"
       >
-        <Icon :name="entry.icon" class="h-3.5 w-3.5 shrink-0" />
+        <Icon :name="entry.icon" class="kr-icon-3-5 shrink-0" />
         <span class="hidden lg:inline">{{ entry.label }}</span>
       </button>
     </div>

--- a/components/gallery/kr-search-field.vue
+++ b/components/gallery/kr-search-field.vue
@@ -106,7 +106,7 @@
         :title="modelValue ? 'Clear search' : 'Close search'"
         @click="clearAndCollapse"
       >
-        <Icon name="kind-icon:close" class="h-3.5 w-3.5" />
+        <Icon name="kind-icon:close" class="kr-icon-3-5" />
       </button>
     </div>
   </div>

--- a/components/giftshop/mermaids-pdf-purchase.vue
+++ b/components/giftshop/mermaids-pdf-purchase.vue
@@ -21,7 +21,7 @@
       <span
         class="kr-text-dim-xs-70 badge badge-outline badge-lg gap-1 rounded-2xl"
       >
-        <Icon name="kind-icon:sparkles" class="h-3.5 w-3.5" />
+        <Icon name="kind-icon:sparkles" class="kr-icon-3-5" />
         PDF edition — $9.99
       </span>
       <NuxtLink to="/login" class="kr-btn-outline-plain rounded-2xl">

--- a/components/model-builder/model-builder-batch-editor.vue
+++ b/components/model-builder/model-builder-batch-editor.vue
@@ -60,7 +60,7 @@
           :disabled="anyBatching || store.autoBuilding"
           @click="draftAll('pitch')"
         >
-          <Icon name="kind-icon:sparkles" class="h-3.5 w-3.5" />
+          <Icon name="kind-icon:sparkles" class="kr-icon-3-5" />
           Draft pitches
         </button>
         <button
@@ -70,7 +70,7 @@
           :disabled="anyBatching || store.autoBuilding"
           @click="draftAll('fields')"
         >
-          <Icon name="kind-icon:sparkles" class="h-3.5 w-3.5" />
+          <Icon name="kind-icon:sparkles" class="kr-icon-3-5" />
           Draft fields
         </button>
         <button
@@ -80,7 +80,7 @@
           :disabled="anyBatching || store.autoBuilding"
           @click="draftAll('artPrompt')"
         >
-          <Icon name="kind-icon:sparkles" class="h-3.5 w-3.5" />
+          <Icon name="kind-icon:sparkles" class="kr-icon-3-5" />
           Draft prompts
         </button>
         <button
@@ -91,7 +91,7 @@
             store.batchApproveStage(group.outputKey, 'FIELDS_AND_PROMPTS')
           "
         >
-          <Icon name="kind-icon:check" class="h-3.5 w-3.5" />
+          <Icon name="kind-icon:check" class="kr-icon-3-5" />
           Approve fields
         </button>
         <button
@@ -101,7 +101,7 @@
           :title="autoBuildGroupTitle"
           @click="store.batchAutoBuild(group.outputKey)"
         >
-          <Icon name="kind-icon:bolt" class="h-3.5 w-3.5" />
+          <Icon name="kind-icon:bolt" class="kr-icon-3-5" />
           Auto-build group
           <span v-if="busyCount" class="kr-badge-ghost-xs"
             >{{ busyCount }} busy</span

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -21,7 +21,7 @@
           aria-hidden="true"
         />
         <template v-else>
-          <Icon name="kind-icon:bolt" class="h-3.5 w-3.5" />
+          <Icon name="kind-icon:bolt" class="kr-icon-3-5" />
           Auto
         </template>
       </button>
@@ -74,7 +74,7 @@
             aria-hidden="true"
           />
           <template v-else>
-            <Icon name="kind-icon:magic" class="h-3.5 w-3.5" />
+            <Icon name="kind-icon:magic" class="kr-icon-3-5" />
             Draft with AI
           </template>
         </button>

--- a/components/model-builder/model-builder-manager.vue
+++ b/components/model-builder/model-builder-manager.vue
@@ -50,7 +50,7 @@
         :aria-pressed="showHistory"
         @click="showHistory = !showHistory"
       >
-        <Icon name="kind-icon:clock" class="h-3.5 w-3.5" />
+        <Icon name="kind-icon:clock" class="kr-icon-3-5" />
         <span class="hidden sm:inline">History</span>
       </button>
 
@@ -61,7 +61,7 @@
         aria-label="Reset Model Builder"
         @click="store.resetAll()"
       >
-        <Icon name="kind-icon:trash" class="h-3.5 w-3.5" />
+        <Icon name="kind-icon:trash" class="kr-icon-3-5" />
         <span class="hidden sm:inline">Reset</span>
       </button>
     </header>

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -35,7 +35,7 @@
             aria-hidden="true"
           />
           <template v-else>
-            <Icon name="kind-icon:bolt" class="h-3.5 w-3.5" />
+            <Icon name="kind-icon:bolt" class="kr-icon-3-5" />
             Auto-build all
             <span v-if="busyCount" class="kr-badge-ghost-xs"
               >{{ busyCount }} busy</span
@@ -47,7 +47,7 @@
           class="kr-btn-ghost-xs text-base-content/60"
           @click="store.resetRun()"
         >
-          <Icon name="kind-icon:arrow-left" class="h-3.5 w-3.5" />
+          <Icon name="kind-icon:arrow-left" class="kr-icon-3-5" />
           New run
         </button>
       </div>

--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -19,7 +19,7 @@
         :disabled="store.startingRun"
         @click="store.goToStep('source')"
       >
-        <Icon name="kind-icon:arrow-left" class="h-3.5 w-3.5" />
+        <Icon name="kind-icon:arrow-left" class="kr-icon-3-5" />
         Change source
       </button>
     </div>

--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -16,7 +16,7 @@
           :disabled="store.loadingRuns || Boolean(cancellingRunId)"
           @click="store.fetchRuns()"
         >
-          <Icon name="kind-icon:refresh" class="h-3.5 w-3.5" aria-hidden="true" />
+          <Icon name="kind-icon:refresh" class="kr-icon-3-5" aria-hidden="true" />
           Refresh
         </button>
         <button
@@ -25,7 +25,7 @@
           :disabled="Boolean(cancellingRunId)"
           @click="startNew"
         >
-          <Icon name="kind-icon:add" class="h-3.5 w-3.5" aria-hidden="true" />
+          <Icon name="kind-icon:add" class="kr-icon-3-5" aria-hidden="true" />
           New run
         </button>
       </div>
@@ -96,7 +96,7 @@
             :aria-label="`Cancel run ${run.sourceLabel || `#${run.sourceId}`}`"
             @click="armedRunId = run.id"
           >
-            <Icon name="kind-icon:trash" class="h-3.5 w-3.5" aria-hidden="true" />
+            <Icon name="kind-icon:trash" class="kr-icon-3-5" aria-hidden="true" />
           </button>
           <button
             v-else
@@ -115,7 +115,7 @@
             <Icon
               v-else
               name="kind-icon:trash"
-              class="h-3.5 w-3.5"
+              class="kr-icon-3-5"
               aria-hidden="true"
             />
             {{ cancellingRunId === run.id ? 'Cancelling…' : 'Confirm?' }}

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -27,7 +27,7 @@
           :aria-pressed="viewMode === mode.value"
           @click="setViewMode(mode.value)"
         >
-          <Icon :name="mode.icon" class="h-3.5 w-3.5" />
+          <Icon :name="mode.icon" class="kr-icon-3-5" />
         </button>
       </div>
     </div>

--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -207,7 +207,7 @@
               class="kr-btn-xs"
               @click="captureCurrent"
             >
-              <Icon name="kind-icon:save" class="h-3.5 w-3.5" />
+              <Icon name="kind-icon:save" class="kr-icon-3-5" />
               Save
             </button>
 
@@ -216,7 +216,7 @@
               class="kr-btn-xs btn-secondary"
               @click="addAccount"
             >
-              <Icon name="kind-icon:plus" class="h-3.5 w-3.5" />
+              <Icon name="kind-icon:plus" class="kr-icon-3-5" />
               Add
             </button>
           </div>
@@ -227,7 +227,7 @@
             class="kr-btn-xs btn-primary w-full justify-center gap-1.5"
             @click="store.close"
           >
-            <Icon name="kind-icon:login" class="h-3.5 w-3.5 shrink-0" />
+            <Icon name="kind-icon:login" class="kr-icon-3-5 shrink-0" />
             Log in
           </NuxtLink>
 
@@ -237,7 +237,7 @@
             class="kr-btn-ghost-xs text-error"
             @click="logout"
           >
-            <Icon name="kind-icon:logout" class="h-3.5 w-3.5" />
+            <Icon name="kind-icon:logout" class="kr-icon-3-5" />
             Log out
           </button>
         </div>

--- a/components/navigation/workspace-narrator.vue
+++ b/components/navigation/workspace-narrator.vue
@@ -53,7 +53,7 @@
                       "
                       @click="togglePin"
                     >
-                      <Icon name="kind-icon:pin" class="h-3.5 w-3.5" />
+                      <Icon name="kind-icon:pin" class="kr-icon-3-5" />
                     </button>
 
                     <button
@@ -62,7 +62,7 @@
                       aria-label="Close narrator"
                       @click="closeNarrator"
                     >
-                      <Icon name="kind-icon:close" class="h-3.5 w-3.5" />
+                      <Icon name="kind-icon:close" class="kr-icon-3-5" />
                     </button>
                   </div>
                 </div>
@@ -227,7 +227,7 @@
                       aria-label="Toggle narrator topics"
                       @click="showTopics = !showTopics"
                     >
-                      <Icon name="kind-icon:map" class="h-3.5 w-3.5" />
+                      <Icon name="kind-icon:map" class="kr-icon-3-5" />
                     </button>
 
                     <button
@@ -236,7 +236,7 @@
                       aria-label="Return to narrator portrait"
                       @click="closeChatFace"
                     >
-                      <Icon name="kind-icon:close" class="h-3.5 w-3.5" />
+                      <Icon name="kind-icon:close" class="kr-icon-3-5" />
                     </button>
                   </div>
                 </div>

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -421,7 +421,7 @@ onMounted(async () => {
             class="btn btn-primary btn-xs rounded-2xl"
             @click="openAddChoice"
           >
-            <icon name="kind-icon:plus" class="h-3.5 w-3.5" />
+            <icon name="kind-icon:plus" class="kr-icon-3-5" />
             Add
           </button>
 
@@ -432,7 +432,7 @@ onMounted(async () => {
             @click="resourceGalleryStore.loadResources()"
           >
             <span v-if="resourceGalleryStore.isLoading" class="kr-spinner-xs" />
-            <icon v-else name="kind-icon:refresh" class="h-3.5 w-3.5" />
+            <icon v-else name="kind-icon:refresh" class="kr-icon-3-5" />
             Refresh
           </button>
         </div>
@@ -696,7 +696,7 @@ onMounted(async () => {
             title="Show only Resources flagged mature"
             @click="matureOnly = !matureOnly"
           >
-            <Icon name="kind-icon:eye" class="h-3.5 w-3.5" />
+            <Icon name="kind-icon:eye" class="kr-icon-3-5" />
             <span class="hidden sm:inline">Mature only</span>
           </button>
 

--- a/components/resources/resource-manager.vue
+++ b/components/resources/resource-manager.vue
@@ -41,7 +41,7 @@
             :title="tab.label"
             @click="selectTab(tab.key)"
           >
-            <Icon :name="tab.icon" class="h-3.5 w-3.5" />
+            <Icon :name="tab.icon" class="kr-icon-3-5" />
             <span class="hidden sm:inline">{{ tab.label }}</span>
           </button>
         </div>
@@ -63,7 +63,7 @@
           :title="tab.label"
           @click="selectTab(tab.key)"
         >
-          <Icon :name="tab.icon" class="h-3.5 w-3.5" />
+          <Icon :name="tab.icon" class="kr-icon-3-5" />
           <span class="hidden sm:inline">{{ tab.label }}</span>
         </button>
       </div>

--- a/components/screenfx/screen-fx.vue
+++ b/components/screenfx/screen-fx.vue
@@ -24,7 +24,7 @@
             {{ animationStore.effects.length }} effects
           </span>
           <NuxtLink to="/build/animation-manager" class="fx-manage-link">
-            <Icon name="kind-icon:trophy" class="h-3.5 w-3.5" />
+            <Icon name="kind-icon:trophy" class="kr-icon-3-5" />
             Manage builds
           </NuxtLink>
         </div>

--- a/components/servers/checkpoint-gallery.vue
+++ b/components/servers/checkpoint-gallery.vue
@@ -38,7 +38,7 @@
         type="button"
         @click="showAdd = !showAdd"
       >
-        <Icon name="kind-icon:plus" class="h-3.5 w-3.5" />
+        <Icon name="kind-icon:plus" class="kr-icon-3-5" />
         Add
       </button>
     </header>
@@ -117,7 +117,7 @@
             type="button"
             @click="refreshStatus"
           >
-            <Icon name="kind-icon:refresh-cw" class="h-3.5 w-3.5" />
+            <Icon name="kind-icon:refresh-cw" class="kr-icon-3-5" />
             <span class="hidden sm:inline">Refresh</span>
           </button>
         </div>

--- a/components/servers/server-gallery.vue
+++ b/components/servers/server-gallery.vue
@@ -26,7 +26,7 @@
         type="button"
         @click="startAddServer"
       >
-        <Icon name="kind-icon:plus" class="h-3.5 w-3.5" />
+        <Icon name="kind-icon:plus" class="kr-icon-3-5" />
         Add Server
       </button>
     </header>
@@ -77,7 +77,7 @@
             type="button"
             @click="refreshServers"
           >
-            <Icon name="kind-icon:refresh-cw" class="h-3.5 w-3.5" />
+            <Icon name="kind-icon:refresh-cw" class="kr-icon-3-5" />
             <span class="hidden sm:inline">Refresh</span>
           </button>
         </div>

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -51,7 +51,7 @@
           "
           @click="activeTab = tab.key"
         >
-          <Icon :name="tab.icon" class="h-3.5 w-3.5" />
+          <Icon :name="tab.icon" class="kr-icon-3-5" />
           {{ tab.label }}
         </button>
       </div>
@@ -158,7 +158,7 @@
                   v-if="llmLoading"
                   class="kr-spinner-xs"
                 />
-                <Icon v-else name="mdi:sparkles" class="h-3.5 w-3.5" />
+                <Icon v-else name="mdi:sparkles" class="kr-icon-3-5" />
                 {{ form.prompt ? 'Regenerate' : 'Generate' }}
               </button>
             </div>
@@ -185,7 +185,7 @@
                 :disabled="!form.name.trim()"
                 @click="buildArtPrompt"
               >
-                <Icon name="mdi:auto-fix" class="h-3.5 w-3.5" /> Build art
+                <Icon name="mdi:auto-fix" class="kr-icon-3-5" /> Build art
                 prompt
               </button>
             </div>
@@ -247,7 +247,7 @@
               class="ml-auto text-secondary/50 hover:text-error"
               @click="form.species = ''"
             >
-              <Icon name="mdi:close" class="h-3.5 w-3.5" />
+              <Icon name="mdi:close" class="kr-icon-3-5" />
             </button>
           </div>
 

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -43,7 +43,7 @@
             class="kr-btn-xs btn-warning"
             @click="store.pause()"
           >
-            <Icon name="mdi:pause" class="h-3.5 w-3.5" /> Pause
+            <Icon name="mdi:pause" class="kr-icon-3-5" /> Pause
           </button>
           <button
             v-else
@@ -51,14 +51,14 @@
             class="kr-btn-xs btn-success"
             @click="store.resume()"
           >
-            <Icon name="mdi:play" class="h-3.5 w-3.5" /> Resume
+            <Icon name="mdi:play" class="kr-icon-3-5" /> Resume
           </button>
           <button
             type="button"
             class="kr-btn-ghost-xs"
             @click="store.stop()"
           >
-            <Icon name="mdi:stop" class="h-3.5 w-3.5" />
+            <Icon name="mdi:stop" class="kr-icon-3-5" />
           </button>
         </template>
         <button
@@ -66,14 +66,14 @@
           class="kr-btn-ghost-xs"
           @click="store.persist()"
         >
-          <Icon name="mdi:content-save" class="h-3.5 w-3.5" />
+          <Icon name="mdi:content-save" class="kr-icon-3-5" />
         </button>
         <button
           type="button"
           class="kr-btn-xs btn-ghost text-error/60 hover:text-error"
           @click="store.clearTranscript()"
         >
-          <Icon name="mdi:broom" class="h-3.5 w-3.5" />
+          <Icon name="mdi:broom" class="kr-icon-3-5" />
         </button>
       </div>
     </header>
@@ -395,7 +395,7 @@
                   class="kr-btn-ghost-xs"
                   @click="clearPendingCastMember"
                 >
-                  <Icon name="mdi:close" class="h-3.5 w-3.5" />
+                  <Icon name="mdi:close" class="kr-icon-3-5" />
                 </button>
               </div>
             </Transition>
@@ -434,7 +434,7 @@
                     class="kr-btn-ghost-xs"
                     @click="store.addCastSlot(role.key)"
                   >
-                    <Icon name="mdi:plus" class="h-3.5 w-3.5" />
+                    <Icon name="mdi:plus" class="kr-icon-3-5" />
                   </button>
                 </div>
               </header>

--- a/components/themes/theme-gallery.vue
+++ b/components/themes/theme-gallery.vue
@@ -76,7 +76,7 @@
             v-if="activeThemeName"
             class="kr-text-black-xs inline-flex max-w-44 items-center gap-1.5 truncate rounded-full border border-accent/40 bg-accent/10 px-2.5 py-1 text-accent"
           >
-            <Icon name="kind-icon:check" class="h-3.5 w-3.5 shrink-0" />
+            <Icon name="kind-icon:check" class="kr-icon-3-5 shrink-0" />
             <span class="truncate">{{ activeThemeName }}</span>
           </span>
         </div>

--- a/utils/scripts/codemods/kr_icon_3_5_codemod.py
+++ b/utils/scripts/codemods/kr_icon_3_5_codemod.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `h-3.5 w-3.5` bare (colorless) icon glyphs to
+`kr-icon-3-5`.
+
+Same sizeless-and-colorless icon-glyph shape as `.kr-icon-3`/`.kr-icon-5`/
+`.kr-icon-6`/`.kr-icon-7`/`.kr-icon-8` (interface-vision t-104 slices
+198-202). Distinct from any future `.kr-icon-primary-3-5` (same size,
+carries a `text-primary` color token): this is the plain untinted glyph.
+
+Naming convention decided this slice (flagged as undecided by slices 201
+and 202's kaizen notes): a literal `.` is not a valid bare character in a
+CSS class selector without an escape (`.kr-icon-3\.5`), which is fragile to
+write and grep for across a codebase full of sibling `kr-icon-*` classes.
+Dash substitution (`kr-icon-3-5`) reads unambiguously, greps cleanly, and
+matches the plain-digit naming every other sibling in this family already
+uses -- picked over an escaped-dot selector for exactly those reasons.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+class strings containing both `h-3.5` and `w-3.5` tokens are touched, and
+only in static `class="..."` attributes -- never `:class`/`v-bind:class`
+bindings (see _class_attr.py). A class string carrying any `text-*`/
+`stroke-*`/`fill-*` color token is left alone (that is the
+`kr-icon-primary-3-5`/future colored-sibling shape, not this one),
+regardless of the base tokens' order in the source. A source that already
+carries `kr-icon-3-5`, or is missing either base token, is also left
+untouched. Extra tokens beyond the base set are preserved verbatim after
+the primitive class, matching every other kr-*-codemod's subset-match
+convention -- pass --exact-only to restrict a slice to sources with no
+extra tokens at all.
+
+Deliberately does NOT touch sibling sizes (`h-3 w-3`, `h-4 w-4`, `h-5 w-5`,
+`h-6 w-6`, `h-7 w-7`, `h-8 w-8`) -- those are real, independently-repeated
+shapes of their own, already covered or left for future slices.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-3-5"
+BASE_TOKENS = {"h-3.5", "w-3.5"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-3-5 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Added `.kr-icon-3-5` to `assets/css/tailwind.css` (`@apply h-3.5 w-3.5`), the sizeless-and-colorless icon-glyph primitive, one size down from `.kr-icon-5` (slice 202).
- Decided the naming convention left open by slices 201/202's kaizen notes: dash substitution (`kr-icon-3-5`) over an escaped-dot selector (`.kr-icon-3\.5`) — reads unambiguously, greps cleanly, matches the plain-digit naming every other sibling in this family already uses.
- Added `utils/scripts/codemods/kr_icon_3_5_codemod.py`, sibling of `kr_icon_5_codemod.py` — same subset-match convention, same `text-*`/`stroke-*`/`fill-*` color-token exclusion (so it stays distinct from any future `.kr-icon-primary-3-5`).
- Ran `--write`: migrated 78 occurrences across 31 files to `kr-icon-3-5`. Every diff reviewed manually — only static `class="..."` attributes touched, no geometry or behavior change.

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint .`: 333/327/6, identical to the documented baseline
- `test:layout-contract`: holds, 0 new violations
- `test:lint-ratchet`: holds at 333/-59
- `prettier --check`: the same 16 files flagged before and after this diff (confirmed via `git stash` comparison against the pre-edit tree) — no new formatting drift introduced

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
`h-4 w-4` (95 files) is the last remaining sibling in this family and still needs further splitting (by directory or usage pattern) before it's a bounded slice on its own — it's an order of magnitude larger than every other size handled so far.

### Notes for reviewer
Conductor-side close-out (claim → review → ready, recurring task) lands alongside this PR in a separate conductor PR against `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEUFcFX6z3gP4YA2TXFw6X

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEUFcFX6z3gP4YA2TXFw6X)_