### PR TITLE
interface-vision/t-104 slice 204: add kr-icon-4, migrate bare h-4 w-4 icon glyphs in components/art

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1836,6 +1836,23 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply h-3.5 w-3.5;
   }
 
+  /* Same bare sizeless-and-colorless icon-glyph shape as `.kr-icon-3`/
+   * `.kr-icon-3-5`/`.kr-icon-5`/`.kr-icon-6`/`.kr-icon-7`/`.kr-icon-8`
+   * (interface-vision t-104 slice 204) -- `h-4 w-4`, the largest sibling in
+   * this family (~100 files) and flagged by every prior slice's kaizen note
+   * as needing further splitting before any slice attempted it. This slice
+   * takes the `components/art/` directory only (15 files, 47 occurrences
+   * via subset-match) as the first bounded sub-slice, splitting the giant
+   * family by directory the way the kaizen notes suggested. Sibling
+   * directories still open: `components/navigation` (12 files),
+   * `components/dreams` (9 files), `components/user` (7 files), and the
+   * rest of the ~100-file family. Distinct from any future
+   * `.kr-icon-primary-4` (same size, carries `text-primary`) -- this is the
+   * untinted sibling. */
+  .kr-icon-4 {
+    @apply h-4 w-4;
+  }
+
   /* The colorless DaisyUI busy indicator: a bare tiny spinner dropped into
    * a button or inline slot while an action is pending, no tint (the
    * button/text color around it usually already carries the tone)

--- a/components/art/add-collection.vue
+++ b/components/art/add-collection.vue
@@ -12,11 +12,11 @@
       @click="openForm"
     >
       <span class="flex items-center gap-2">
-        <Icon name="kind-icon:plus" class="h-4 w-4" />
+        <Icon name="kind-icon:plus" class="kr-icon-4" />
         New collection
       </span>
 
-      <Icon name="kind-icon:folder" class="h-4 w-4" />
+      <Icon name="kind-icon:folder" class="kr-icon-4" />
     </button>
 
     <form v-else class="grid gap-3" @submit.prevent="createCollection">

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -412,7 +412,7 @@
                         ? 'kind-icon:check'
                         : 'kind-icon:plus'
                     "
-                    class="h-4 w-4"
+                    class="kr-icon-4"
                   />
                 </button>
 
@@ -474,7 +474,7 @@
               <span
                 class="flex h-8 w-8 items-center justify-center rounded-xl bg-primary/15 text-primary"
               >
-                <icon name="kind-icon:image" class="h-4 w-4" />
+                <icon name="kind-icon:image" class="kr-icon-4" />
               </span>
               <div class="min-w-0">
                 <p
@@ -492,7 +492,7 @@
               type="button"
               @click="clearSelectedImage"
             >
-              <Icon name="kind-icon:x" class="h-4 w-4" />
+              <Icon name="kind-icon:x" class="kr-icon-4" />
               Close
             </button>
           </header>

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -64,7 +64,7 @@
                 ? 'kind-icon:alert'
                 : 'kind-icon:check'
             "
-            class="mt-0.5 h-4 w-4 shrink-0"
+            class="kr-icon-4 mt-0.5 shrink-0"
           />
           {{ artStore.generationMessage }}
         </div>
@@ -89,7 +89,7 @@
                 <h2
                   class="flex items-center gap-2 text-base font-bold text-primary"
                 >
-                  <Icon name="kind-icon:settings" class="h-4 w-4" />
+                  <Icon name="kind-icon:settings" class="kr-icon-4" />
                   Recipe
                 </h2>
                 <p class="kr-text-dim-xs-55 mt-0.5">
@@ -150,7 +150,7 @@
                 <span
                   class="label-text flex items-center gap-1.5 text-base font-bold text-primary"
                 >
-                  <Icon name="kind-icon:prompt" class="h-4 w-4" />
+                  <Icon name="kind-icon:prompt" class="kr-icon-4" />
                   Prompt
                 </span>
                 <button
@@ -243,7 +243,7 @@
             <h2
               class="flex items-center gap-2 text-base font-bold text-primary"
             >
-              <Icon name="kind-icon:checkpoint" class="h-4 w-4" />
+              <Icon name="kind-icon:checkpoint" class="kr-icon-4" />
               Model
             </h2>
 
@@ -300,7 +300,7 @@
             <h2
               class="flex items-center gap-2 text-base font-bold text-primary"
             >
-              <Icon name="kind-icon:settings" class="h-4 w-4" />
+              <Icon name="kind-icon:settings" class="kr-icon-4" />
               Settings
             </h2>
 
@@ -443,7 +443,7 @@
             <h2
               class="flex items-center gap-2 text-base font-bold text-primary"
             >
-              <Icon name="kind-icon:server" class="h-4 w-4" />
+              <Icon name="kind-icon:server" class="kr-icon-4" />
               Destination
             </h2>
 
@@ -533,7 +533,7 @@
             class="kr-btn-ghost"
             @click="goToGallery"
           >
-            <Icon name="kind-icon:gallery" class="h-4 w-4" />
+            <Icon name="kind-icon:gallery" class="kr-icon-4" />
             Gallery
           </button>
         </div>

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -19,7 +19,7 @@
           type="button"
           @click="navStore.setDashboardTab('art', 'gallery')"
         >
-          <Icon name="kind-icon:image" class="h-4 w-4" />
+          <Icon name="kind-icon:image" class="kr-icon-4" />
           Gallery
         </button>
 
@@ -29,7 +29,7 @@
           type="button"
           @click="deselectAndReturn"
         >
-          <Icon name="kind-icon:x" class="h-4 w-4" />
+          <Icon name="kind-icon:x" class="kr-icon-4" />
           Deselect
         </button>
 
@@ -49,7 +49,7 @@
           @click="setAsAvatar"
         >
           <span v-if="isSettingAvatar" class="kr-spinner-xs" />
-          <Icon v-else name="kind-icon:user" class="h-4 w-4" />
+          <Icon v-else name="kind-icon:user" class="kr-icon-4" />
           {{ isCurrentAvatar ? 'Avatar' : 'Set avatar' }}
         </button>
 
@@ -59,7 +59,7 @@
           :disabled="!currentArtImage"
           @click="startRemix"
         >
-          <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+          <Icon name="kind-icon:sparkles" class="kr-icon-4" />
           Remix
         </button>
 
@@ -72,7 +72,7 @@
             title="Delete this image"
             @click="deleteArmed = true"
           >
-            <Icon name="kind-icon:trash" class="h-4 w-4" />
+            <Icon name="kind-icon:trash" class="kr-icon-4" />
             <span class="hidden sm:inline">Delete</span>
           </button>
 
@@ -85,7 +85,7 @@
             @blur="deleteArmed = false"
           >
             <span v-if="isDeleting" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:trash" class="h-4 w-4" />
+            <Icon v-else name="kind-icon:trash" class="kr-icon-4" />
             Confirm?
           </button>
         </template>
@@ -209,7 +209,7 @@
                 @click="saveImageEdits"
               >
                 <span v-if="isSaving" class="kr-spinner-xs" />
-                <Icon v-else name="kind-icon:save" class="h-4 w-4" />
+                <Icon v-else name="kind-icon:save" class="kr-icon-4" />
                 Save
               </button>
             </div>
@@ -371,7 +371,7 @@
                       ? 'kind-icon:chevron-up'
                       : 'kind-icon:chevron-down'
                   "
-                  class="h-4 w-4"
+                  class="kr-icon-4"
                 />
               </button>
 
@@ -388,7 +388,7 @@
                     type="button"
                     @click="isCollectionMenuOpen = false"
                   >
-                    <Icon name="kind-icon:x" class="h-4 w-4" />
+                    <Icon name="kind-icon:x" class="kr-icon-4" />
                   </button>
                 </div>
 
@@ -470,7 +470,7 @@
                 type="button"
                 @click="startRemix"
               >
-                <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+                <Icon name="kind-icon:sparkles" class="kr-icon-4" />
                 Send to Generator
               </button>
             </div>

--- a/components/art/art-studio.vue
+++ b/components/art/art-studio.vue
@@ -11,7 +11,7 @@
         :aria-pressed="activeTab === 'generate'"
         @click="selectPrimaryTab('generate')"
       >
-        <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+        <Icon name="kind-icon:sparkles" class="kr-icon-4" />
         Generate
       </button>
 
@@ -22,7 +22,7 @@
         :aria-pressed="activeTab === 'gallery'"
         @click="selectPrimaryTab('gallery')"
       >
-        <Icon name="kind-icon:gallery" class="h-4 w-4" />
+        <Icon name="kind-icon:gallery" class="kr-icon-4" />
         Gallery
       </button>
 

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -14,7 +14,7 @@
         title="Close"
         @click="emit('close')"
       >
-        <Icon name="mdi:close" class="h-4 w-4" />
+        <Icon name="mdi:close" class="kr-icon-4" />
       </button>
     </div>
 
@@ -453,7 +453,7 @@
         <Transition name="pop">
           <div
             v-if="isSelectedStyle(style)"
-            class="absolute right-1.5 top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-primary"
+            class="kr-icon-4 absolute right-1.5 top-1.5 flex items-center justify-center rounded-full bg-primary"
           >
             <Icon name="mdi:check" class="h-3 w-3 text-primary-content" />
           </div>
@@ -541,7 +541,7 @@
         v-if="errorMessage"
         class="flex items-center gap-1.5 text-sm font-semibold text-error"
       >
-        <Icon name="kind-icon:alert" class="h-4 w-4" />
+        <Icon name="kind-icon:alert" class="kr-icon-4" />
         {{ errorMessage }}
       </p>
     </Transition>
@@ -551,7 +551,7 @@
         v-if="successMessage"
         class="flex items-center gap-1.5 text-sm font-semibold text-success"
       >
-        <Icon name="kind-icon:check" class="h-4 w-4" />
+        <Icon name="kind-icon:check" class="kr-icon-4" />
         {{ successMessage }}
       </p>
     </Transition>

--- a/components/art/collection-card.vue
+++ b/components/art/collection-card.vue
@@ -22,7 +22,7 @@
         title="Edit Collection"
         @click.stop="emit('edit', collection.id)"
       >
-        <Icon name="kind-icon:pencil" class="h-4 w-4" />
+        <Icon name="kind-icon:pencil" class="kr-icon-4" />
       </button>
 
       <button
@@ -34,7 +34,7 @@
         title="Delete Collection"
         @click.stop="deleteCollection"
       >
-        <Icon name="kind-icon:trash" class="h-4 w-4" />
+        <Icon name="kind-icon:trash" class="kr-icon-4" />
       </button>
     </template>
 

--- a/components/art/collection-picker.vue
+++ b/components/art/collection-picker.vue
@@ -11,7 +11,7 @@
         @click="handleBrowseClick"
       >
         <span class="flex min-w-0 items-center gap-2">
-          <Icon name="kind-icon:gallery" class="h-4 w-4 shrink-0" />
+          <Icon name="kind-icon:gallery" class="kr-icon-4 shrink-0" />
           <span class="truncate text-left">
             <span class="font-black">{{ title }}:</span>
             {{ selectedSummary }}
@@ -19,7 +19,7 @@
         </span>
         <Icon
           :name="expanded ? 'kind-icon:chevron-up' : 'kind-icon:chevron-down'"
-          class="h-4 w-4 shrink-0"
+          class="kr-icon-4 shrink-0"
         />
       </button>
 
@@ -30,7 +30,7 @@
         title="Use all available art"
         @click="useAllArt"
       >
-        <Icon name="kind-icon:trash" class="h-4 w-4" />
+        <Icon name="kind-icon:trash" class="kr-icon-4" />
         <span class="hidden sm:inline">All art</span>
       </button>
     </div>

--- a/components/art/generate-button.vue
+++ b/components/art/generate-button.vue
@@ -102,7 +102,7 @@
             ? 'kind-icon:alert'
             : 'kind-icon:check'
         "
-        class="mt-0.5 h-4 w-4 shrink-0"
+        class="kr-icon-4 mt-0.5 shrink-0"
       />
       {{ artStore.generationMessage }}
     </div>

--- a/components/art/image-card.vue
+++ b/components/art/image-card.vue
@@ -19,7 +19,7 @@
         title="Edit Image"
         @click.stop="emit('edit', displayImage.id)"
       >
-        <Icon name="kind-icon:pencil" class="h-4 w-4" />
+        <Icon name="kind-icon:pencil" class="kr-icon-4" />
       </button>
 
       <button
@@ -29,7 +29,7 @@
         title="Make coloring page"
         @click.stop="makeColoringPage"
       >
-        <Icon name="kind-icon:paintbrush" class="h-4 w-4" />
+        <Icon name="kind-icon:paintbrush" class="kr-icon-4" />
       </button>
 
       <button
@@ -44,7 +44,7 @@
         title="Copy Prompt"
         @click.stop="copyPrompt"
       >
-        <Icon name="kind-icon:copy" class="h-4 w-4" />
+        <Icon name="kind-icon:copy" class="kr-icon-4" />
       </button>
 
       <button
@@ -54,7 +54,7 @@
         title="Delete Image"
         @click.stop="emit('delete', displayImage.id)"
       >
-        <Icon name="kind-icon:trash" class="h-4 w-4" />
+        <Icon name="kind-icon:trash" class="kr-icon-4" />
       </button>
     </template>
 

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -478,7 +478,7 @@
         v-if="message"
         class="flex items-center gap-1.5 text-sm font-semibold text-success"
       >
-        <icon name="kind-icon:check" class="h-4 w-4" />{{ message }}
+        <icon name="kind-icon:check" class="kr-icon-4" />{{ message }}
       </p>
     </Transition>
     <Transition name="fade">
@@ -486,7 +486,7 @@
         v-if="error"
         class="flex items-center gap-1.5 text-sm font-semibold text-error"
       >
-        <icon name="kind-icon:alert" class="h-4 w-4" />{{ error }}
+        <icon name="kind-icon:alert" class="kr-icon-4" />{{ error }}
       </p>
     </Transition>
   </section>

--- a/components/art/stylist-calculator.vue
+++ b/components/art/stylist-calculator.vue
@@ -129,7 +129,7 @@
         :href="superkate.receiptMailto(savedAppointment)"
         class="kr-btn-outline-plain"
       >
-        <Icon name="mdi:email-outline" class="h-4 w-4" />
+        <Icon name="mdi:email-outline" class="kr-icon-4" />
         Open receipt email
       </a>
     </div>

--- a/components/art/stylist-history.vue
+++ b/components/art/stylist-history.vue
@@ -77,7 +77,7 @@
         >
           <pre class="whitespace-pre-wrap text-xs">{{ superkate.receiptText(appointment) }}</pre>
           <a :href="superkate.receiptMailto(appointment)" class="kr-btn-outline-xs">
-            <Icon name="mdi:email-outline" class="h-4 w-4" />
+            <Icon name="mdi:email-outline" class="kr-icon-4" />
             Open receipt email
           </a>
         </div>

--- a/components/art/stylist-manager.vue
+++ b/components/art/stylist-manager.vue
@@ -16,7 +16,7 @@
         :class="superkate.activeView === view.key ? 'btn-primary' : 'btn-ghost'"
         @click="superkate.activeView = view.key"
       >
-        <Icon :name="view.icon" class="h-4 w-4" />
+        <Icon :name="view.icon" class="kr-icon-4" />
         {{ view.label }}
       </button>
       <div class="flex-1" />

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -135,7 +135,7 @@
             class="kr-btn-primary-plain"
             @click="capturePhoto"
           >
-            <Icon name="kind-icon:camera" class="h-4 w-4" /> Capture
+            <Icon name="kind-icon:camera" class="kr-icon-4" /> Capture
           </button>
           <button type="button" class="kr-btn-ghost-plain" @click="closeCamera">
             Cancel
@@ -156,7 +156,7 @@
           title="Remove photo"
           @click="clearSource"
         >
-          <Icon name="mdi:close" class="h-4 w-4" />
+          <Icon name="mdi:close" class="kr-icon-4" />
         </button>
       </div>
 
@@ -183,7 +183,7 @@
           title="Remove photo"
           @click="clearSource"
         >
-          <Icon name="mdi:close" class="h-4 w-4" /> Remove photo
+          <Icon name="mdi:close" class="kr-icon-4" /> Remove photo
         </button>
       </div>
     </div>
@@ -337,7 +337,7 @@
       :disabled="!canGenerate"
       @click="submit"
     >
-      <Icon name="kind-icon:magic" class="h-4 w-4" />
+      <Icon name="kind-icon:magic" class="kr-icon-4" />
       Style it
     </button>
 

--- a/utils/scripts/codemods/kr_icon_4_codemod.py
+++ b/utils/scripts/codemods/kr_icon_4_codemod.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `h-4 w-4` bare (colorless) icon glyphs to
+`kr-icon-4`.
+
+Same sizeless-and-colorless icon-glyph shape as `.kr-icon-3`/`.kr-icon-3-5`/
+`.kr-icon-5`/`.kr-icon-6`/`.kr-icon-7`/`.kr-icon-8` (interface-vision t-104
+slices 198-203). Distinct from any future `.kr-icon-primary-4` (same size,
+carries a `text-primary` color token): this is the plain untinted glyph.
+
+`h-4 w-4` is the largest sibling in this family by a wide margin (~100
+files) and every prior slice's kaizen note flagged it as needing further
+splitting before any slice attempts it whole. This script migrates the
+*whole* family (no size-based sub-split possible, since it's already the
+smallest size unit) but is meant to be invoked with `--root` scoped to one
+directory per slice (e.g. `--root components/art`), splitting the giant
+family by directory/usage area the way the kaizen notes suggested, rather
+than attempting all ~100 files in one pass.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+class strings containing both `h-4` and `w-4` tokens are touched, and only
+in static `class="..."` attributes -- never `:class`/`v-bind:class` bindings
+(see _class_attr.py). A class string carrying any `text-*`/`stroke-*`/
+`fill-*` color token is left alone (that is the `kr-icon-primary-4`/future
+colored-sibling shape, not this one), regardless of the base tokens' order
+in the source. A source that already carries `kr-icon-4`, or is missing
+either base token, is also left untouched. Extra tokens beyond the base set
+are preserved verbatim after the primitive class, matching every other
+kr-*-codemod's subset-match convention -- pass --exact-only to restrict a
+slice to sources with no extra tokens at all.
+
+Deliberately does NOT touch sibling sizes (`h-3 w-3`, `h-3.5 w-3.5`,
+`h-5 w-5`, `h-6 w-6`, `h-7 w-7`, `h-8 w-8`) -- those are real,
+independently-repeated shapes of their own, already migrated by prior
+slices.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-4"
+BASE_TOKENS = {"h-4", "w-4"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-4 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- Added `.kr-icon-4` (`h-4 w-4`) to `assets/css/tailwind.css`, completing the sizeless-and-colorless icon-glyph family alongside `.kr-icon-3`/`.kr-icon-3-5`/`.kr-icon-5`/`.kr-icon-6`/`.kr-icon-7`/`.kr-icon-8` (interface-vision t-104 slices 198-203).
- Added `utils/scripts/codemods/kr_icon_4_codemod.py`, sibling of `kr_icon_5_codemod.py` (same subset-match convention, same `text-*`/`stroke-*`/`fill-*` color-token exclusion to stay distinct from any future `.kr-icon-primary-4`). Supports `--root` so the ~100-file `h-4 w-4` family (flagged by every prior slice's kaizen note as needing splitting) can be migrated directory-by-directory instead of in one giant pass.
- Ran `--write --root components/art`: migrated all 47 occurrences across 15 files (add-collection.vue, art-gallery.vue, art-generator.vue, art-interact.vue, art-studio.vue, art-styler.vue, collection-card.vue, collection-picker.vue, generate-button.vue, image-card.vue, image-upload.vue, stylist-calculator.vue, stylist-history.vue, stylist-manager.vue, stylist-restyle.vue). Manually reviewed every diff — only static `class="..."` attributes touched, no geometry or behavior change.

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint .`: 333/327/6 — identical to the documented pre-existing baseline
- `test:layout-contract`: holds, 0 new violations
- `test:lint-ratchet`: holds at 333/-59
- `prettier --check`: flags the same 19 files before and after this diff (confirmed via `git stash` comparison against the pre-edit tree) — pre-existing drift, not introduced by this change

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Continue splitting the `h-4 w-4` family by directory — remaining bounded sibling directories: `components/navigation` (12 files), `components/dreams` (9 files), `components/user` (7 files), `components/giftshop` (6 files), `components/scenarios` (5 files), `components/characters` (5 files), and the rest scattered across smaller directories.

### Notes for reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CozBRkNfsKpr6MRBKDqPpa

---
_Generated by [Claude Code](https://claude.ai/code/session_01CozBRkNfsKpr6MRBKDqPpa)_