### PR TITLE
interface-vision/t-104 slice 205: migrate bare h-4 w-4 icon glyphs in components/navigation

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1838,13 +1838,13 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
 
   /* Same bare sizeless-and-colorless icon-glyph shape as `.kr-icon-3`/
    * `.kr-icon-3-5`/`.kr-icon-5`/`.kr-icon-6`/`.kr-icon-7`/`.kr-icon-8`
-   * (interface-vision t-104 slice 204) -- `h-4 w-4`, the largest sibling in
-   * this family (~100 files) and flagged by every prior slice's kaizen note
-   * as needing further splitting before any slice attempted it. This slice
-   * takes the `components/art/` directory only (15 files, 47 occurrences
-   * via subset-match) as the first bounded sub-slice, splitting the giant
-   * family by directory the way the kaizen notes suggested. Sibling
-   * directories still open: `components/navigation` (12 files),
+   * (interface-vision t-104 slices 204-205) -- `h-4 w-4`, the largest
+   * sibling in this family (~100 files) and flagged by every prior slice's
+   * kaizen note as needing further splitting before any slice attempted it.
+   * Slice 204 took `components/art/` (15 files, 47 occurrences). Slice 205
+   * adds `components/navigation/` (9 files, 17 occurrences via
+   * subset-match), splitting the giant family by directory the way the
+   * kaizen notes suggested. Sibling directories still open:
    * `components/dreams` (9 files), `components/user` (7 files), and the
    * rest of the ~100-file family. Distinct from any future
    * `.kr-icon-primary-4` (same size, carries `text-primary`) -- this is the

--- a/components/navigation/account-hub.vue
+++ b/components/navigation/account-hub.vue
@@ -275,7 +275,7 @@
           aria-label="Reload the app"
           @click="requestFullStartupReload"
         >
-          <Icon name="kind-icon:refresh" class="h-4 w-4" />
+          <Icon name="kind-icon:refresh" class="kr-icon-4" />
         </button>
 
         <!--
@@ -303,7 +303,7 @@
           :aria-label="cardHandLabel"
           @click="navStore.toggleWorkspaceHand"
         >
-          <Icon name="kind-icon:cards" class="h-4 w-4" />
+          <Icon name="kind-icon:cards" class="kr-icon-4" />
         </button>
 
         <template v-if="userStore.isLoggedIn">

--- a/components/navigation/card-picker.vue
+++ b/components/navigation/card-picker.vue
@@ -37,7 +37,7 @@
             v-if="back === selected"
             class="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-full bg-primary text-primary-content shadow"
           >
-            <Icon name="kind-icon:check" class="h-4 w-4" />
+            <Icon name="kind-icon:check" class="kr-icon-4" />
           </div>
         </div>
 

--- a/components/navigation/channel-select.vue
+++ b/components/navigation/channel-select.vue
@@ -20,7 +20,7 @@
       >
         <Icon
           :name="activeChannel.icon"
-          class="h-4 w-4 shrink-0 xl:h-5 xl:w-5"
+          class="kr-icon-4 shrink-0 xl:h-5 xl:w-5"
         />
       </span>
 
@@ -90,7 +90,7 @@
               <span
                 class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-base-300/50 bg-base-200 text-base-content xl:h-10 xl:w-10"
               >
-                <Icon :name="channel.icon" class="h-4 w-4 shrink-0" />
+                <Icon :name="channel.icon" class="kr-icon-4 shrink-0" />
               </span>
 
               <span
@@ -117,7 +117,7 @@
             >
               <Icon
                 name="kind-icon:chevron-right"
-                class="h-4 w-4 transition-transform"
+                class="kr-icon-4 transition-transform"
                 :class="
                   expandedChannelKey === channel.channelKey ? 'rotate-90' : ''
                 "

--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -25,7 +25,7 @@
             v-if="channelContentStore.loading"
             class="kr-spinner-xs"
           />
-          <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+          <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
           Reload content
         </button>
       </div>

--- a/components/navigation/server-selector.vue
+++ b/components/navigation/server-selector.vue
@@ -33,7 +33,7 @@
             aria-label="Close server settings"
             @click="closeSelector"
           >
-            <Icon name="kind-icon:x" class="h-4 w-4" />
+            <Icon name="kind-icon:x" class="kr-icon-4" />
           </button>
         </header>
 
@@ -104,7 +104,7 @@
                 type="button"
                 @click="showAddLocal = !showAddLocal"
               >
-                <Icon name="kind-icon:plus" class="h-4 w-4" />
+                <Icon name="kind-icon:plus" class="kr-icon-4" />
                 Add Local
               </button>
             </div>
@@ -341,7 +341,7 @@
                 aria-label="Cancel editing local server"
                 @click="cancelEdit"
               >
-                <Icon name="kind-icon:x" class="h-4 w-4" />
+                <Icon name="kind-icon:x" class="kr-icon-4" />
               </button>
             </div>
 

--- a/components/navigation/tab-select.vue
+++ b/components/navigation/tab-select.vue
@@ -45,7 +45,7 @@
       >
         <Icon
           :name="activeTab?.icon || channel.icon"
-          class="h-4 w-4 shrink-0 xl:h-5 xl:w-5"
+          class="kr-icon-4 shrink-0 xl:h-5 xl:w-5"
         />
       </span>
 

--- a/components/navigation/tutorial-flyer.vue
+++ b/components/navigation/tutorial-flyer.vue
@@ -267,7 +267,7 @@
             @click="close"
           >
             Got it
-            <Icon name="kind-icon:arrow-right" class="h-4 w-4" />
+            <Icon name="kind-icon:arrow-right" class="kr-icon-4" />
           </button>
         </footer>
       </article>

--- a/components/navigation/workspace-narrator.vue
+++ b/components/navigation/workspace-narrator.vue
@@ -304,7 +304,7 @@
                       <span
                         class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-primary/20 bg-primary/10 text-primary"
                       >
-                        <Icon :name="topic.icon" class="h-4 w-4" />
+                        <Icon :name="topic.icon" class="kr-icon-4" />
                       </span>
 
                       <span class="min-w-0 flex-1">
@@ -433,7 +433,7 @@
                       class="btn btn-secondary btn-sm rounded-2xl"
                       @click="showTopics = !showTopics"
                     >
-                      <Icon name="kind-icon:map" class="h-4 w-4" />
+                      <Icon name="kind-icon:map" class="kr-icon-4" />
                       Topics
                     </button>
                   </div>
@@ -448,7 +448,7 @@
                       v-if="isNarratorResponding"
                       class="kr-spinner-xs"
                     />
-                    <Icon v-else name="kind-icon:send" class="h-4 w-4" />
+                    <Icon v-else name="kind-icon:send" class="kr-icon-4" />
                     Ask
                   </button>
                 </div>

--- a/components/navigation/workspace-sheet.vue
+++ b/components/navigation/workspace-sheet.vue
@@ -32,7 +32,7 @@
           <p
             class="kr-text-black-sm inline-flex max-w-full items-center gap-2 rounded-full border border-primary/20 bg-base-100/85 px-3 py-1 uppercase tracking-widest text-primary shadow-sm backdrop-blur"
           >
-            <Icon :name="placeholderIcon" class="h-4 w-4 shrink-0" />
+            <Icon :name="placeholderIcon" class="kr-icon-4 shrink-0" />
             <span class="truncate">{{ label }}</span>
           </p>
         </div>
@@ -143,7 +143,7 @@
               class="btn btn-sm btn-circle absolute right-3 top-3 border-none bg-base-100/80 text-error shadow-sm backdrop-blur hover:bg-base-100"
               @click="builderStore.removeSection(card.key)"
             >
-              <Icon name="kind-icon:trash" class="h-4 w-4" />
+              <Icon name="kind-icon:trash" class="kr-icon-4" />
             </button>
 
             <div class="absolute inset-x-0 bottom-0 flex items-end gap-3 p-4">


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- Continues the `h-4 w-4` -> `.kr-icon-4` directory-by-directory migration (slice 204 took `components/art/`, 15 files).
- This slice takes `components/navigation/` — ran `kr_icon_4_codemod.py --write --root components/navigation`: migrated all 17 occurrences across 9 files (account-hub.vue, card-picker.vue, channel-select.vue, navigation-health.vue, server-selector.vue, tab-select.vue, tutorial-flyer.vue, workspace-narrator.vue, workspace-sheet.vue). Manually reviewed every diff — only static `class="..."` attributes touched, no geometry or behavior change.
- Updated the `.kr-icon-4` doc comment in `assets/css/tailwind.css` to record both slices and the remaining open sibling directories.

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint .`: 333/327/6 — identical to the documented pre-existing baseline
- `test:layout-contract`: holds, 0 new violations
- `test:lint-ratchet`: holds at 333/-59
- `prettier --check`: flags the same 9 files before and after this diff (confirmed via `git stash` comparison against the pre-edit tree) — pre-existing drift, not introduced by this change

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Continue splitting the `h-4 w-4` family by directory — remaining bounded sibling directories: `components/dreams` (9 files), `components/user` (7 files), `components/giftshop` (6 files), `components/scenarios` (5 files), `components/characters` (5 files), and the rest scattered across smaller directories.

### Notes for reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CozBRkNfsKpr6MRBKDqPpa

---
_Generated by [Claude Code](https://claude.ai/code/session_01CozBRkNfsKpr6MRBKDqPpa)_