### PR TITLE
interface-vision/t-104 slice 206: migrate bare h-4 w-4 icon glyphs in components/dreams

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1838,17 +1838,19 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
 
   /* Same bare sizeless-and-colorless icon-glyph shape as `.kr-icon-3`/
    * `.kr-icon-3-5`/`.kr-icon-5`/`.kr-icon-6`/`.kr-icon-7`/`.kr-icon-8`
-   * (interface-vision t-104 slices 204-205) -- `h-4 w-4`, the largest
+   * (interface-vision t-104 slices 204-206) -- `h-4 w-4`, the largest
    * sibling in this family (~100 files) and flagged by every prior slice's
    * kaizen note as needing further splitting before any slice attempted it.
    * Slice 204 took `components/art/` (15 files, 47 occurrences). Slice 205
-   * adds `components/navigation/` (9 files, 17 occurrences via
-   * subset-match), splitting the giant family by directory the way the
+   * added `components/navigation/` (9 files, 17 occurrences via
+   * subset-match). Slice 206 adds `components/dreams/` (9 files, 37
+   * occurrences), splitting the giant family by directory the way the
    * kaizen notes suggested. Sibling directories still open:
-   * `components/dreams` (9 files), `components/user` (7 files), and the
-   * rest of the ~100-file family. Distinct from any future
-   * `.kr-icon-primary-4` (same size, carries `text-primary`) -- this is the
-   * untinted sibling. */
+   * `components/user` (7 files), `components/giftshop` (6 files),
+   * `components/scenarios` (5 files), `components/characters` (5 files),
+   * and the rest of the ~100-file family scattered across smaller
+   * directories. Distinct from any future `.kr-icon-primary-4` (same size,
+   * carries `text-primary`) -- this is the untinted sibling. */
   .kr-icon-4 {
     @apply h-4 w-4;
   }

--- a/components/dreams/dream-art-chooser.vue
+++ b/components/dreams/dream-art-chooser.vue
@@ -32,7 +32,7 @@
         @click="loadAssets(true)"
       >
         <span v-if="isLoadingAssets" class="kr-spinner-xs" />
-        <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+        <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
       </button>
     </div>
 
@@ -42,7 +42,7 @@
       <label
         class="input input-sm input-bordered flex items-center gap-2 rounded-2xl bg-base-100"
       >
-        <Icon name="kind-icon:search" class="h-4 w-4 opacity-60" />
+        <Icon name="kind-icon:search" class="kr-icon-4 opacity-60" />
         <input
           v-model="searchQuery"
           type="search"
@@ -75,7 +75,7 @@
         @click="attachSelectedCollection"
       >
         <span v-if="isSavingCollection" class="kr-spinner-xs" />
-        <Icon v-else name="kind-icon:folder" class="h-4 w-4" />
+        <Icon v-else name="kind-icon:folder" class="kr-icon-4" />
         Attach Collection
       </button>
 
@@ -87,7 +87,7 @@
         @click="useRandomCollectionImage"
       >
         <span v-if="isSavingImage" class="kr-spinner-xs" />
-        <Icon v-else name="kind-icon:dice" class="h-4 w-4" />
+        <Icon v-else name="kind-icon:dice" class="kr-icon-4" />
         Random from Collection
       </button>
 
@@ -97,7 +97,7 @@
         :disabled="!activeCollectionId || isSaving"
         @click="clearDreamCollection"
       >
-        <Icon name="kind-icon:close" class="h-4 w-4" />
+        <Icon name="kind-icon:close" class="kr-icon-4" />
         Detach Collection
       </button>
 
@@ -107,7 +107,7 @@
         :disabled="!activeArtImageId || isSaving"
         @click="clearHighlightImage"
       >
-        <Icon name="kind-icon:close" class="h-4 w-4" />
+        <Icon name="kind-icon:close" class="kr-icon-4" />
         Clear Image
       </button>
 

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -25,7 +25,7 @@
             @click="generateCandidates(false)"
           >
             <span v-if="dreamStore.loading" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
+            <Icon v-else name="kind-icon:sparkles" class="kr-icon-4" />
             Generate
           </button>
 
@@ -35,12 +35,12 @@
             :disabled="dreamStore.loading || !canResubmit"
             @click="generateCandidates(true)"
           >
-            <Icon name="kind-icon:refresh" class="h-4 w-4" />
+            <Icon name="kind-icon:refresh" class="kr-icon-4" />
             Resubmit
           </button>
 
           <button type="button" class="kr-btn-ghost-2xl" @click="resetSession">
-            <Icon name="kind-icon:x" class="h-4 w-4" />
+            <Icon name="kind-icon:x" class="kr-icon-4" />
             Reset
           </button>
         </div>
@@ -78,7 +78,7 @@
           <label
             class="input input-bordered input-sm mt-3 flex items-center gap-2 rounded-2xl bg-base-100"
           >
-            <Icon name="kind-icon:search" class="h-4 w-4 opacity-60" />
+            <Icon name="kind-icon:search" class="kr-icon-4 opacity-60" />
             <input
               v-model="sourceSearch"
               class="grow"

--- a/components/dreams/dream-card.vue
+++ b/components/dreams/dream-card.vue
@@ -59,7 +59,7 @@
           title="Edit Dream"
           @click="emit('edit', dream.id)"
         >
-          <Icon name="kind-icon:edit" class="h-4 w-4" />
+          <Icon name="kind-icon:edit" class="kr-icon-4" />
         </button>
 
         <button
@@ -69,7 +69,7 @@
           title="Archive Dream"
           @click="emit('delete', dream.id)"
         >
-          <Icon name="kind-icon:archive" class="h-4 w-4" />
+          <Icon name="kind-icon:archive" class="kr-icon-4" />
         </button>
       </template>
 

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -117,7 +117,7 @@
             aria-label="All types"
             @click="selectedType = 'all'"
           >
-            <Icon name="kind-icon:cards" class="h-4 w-4" />
+            <Icon name="kind-icon:cards" class="kr-icon-4" />
           </button>
 
           <button
@@ -131,7 +131,7 @@
             :aria-label="dreamTypeLabel(type)"
             @click="selectedType = type"
           >
-            <Icon :name="dreamTypeIcon(type)" class="h-4 w-4" />
+            <Icon :name="dreamTypeIcon(type)" class="kr-icon-4" />
           </button>
         </div>
 
@@ -151,7 +151,7 @@
           aria-label="Show only my Dreams"
           @click="showMineOnly = !showMineOnly"
         >
-          <Icon name="kind-icon:user" class="h-4 w-4" />
+          <Icon name="kind-icon:user" class="kr-icon-4" />
         </button>
 
         <button
@@ -163,7 +163,7 @@
           aria-label="Show archived Dreams"
           @click="showArchived = !showArchived"
         >
-          <Icon name="kind-icon:archive" class="h-4 w-4" />
+          <Icon name="kind-icon:archive" class="kr-icon-4" />
         </button>
 
         <button
@@ -179,7 +179,7 @@
             v-if="isLoading || dreamStore.loading"
             class="kr-spinner-xs"
           />
-          <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+          <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
         </button>
 
         <button
@@ -190,7 +190,7 @@
           aria-label="New Dream"
           @click="startAddingDream"
         >
-          <Icon name="kind-icon:plus" class="h-4 w-4" />
+          <Icon name="kind-icon:plus" class="kr-icon-4" />
         </button>
       </div>
     </header>
@@ -307,7 +307,7 @@
           class="btn btn-error btn-sm rounded-2xl"
           @click="refreshDreams(true)"
         >
-          <Icon name="kind-icon:refresh" class="h-4 w-4" />
+          <Icon name="kind-icon:refresh" class="kr-icon-4" />
           Try Again
         </button>
       </div>
@@ -343,7 +343,7 @@
               type="button"
               @click="startEditingSelectedDream"
             >
-              <Icon name="kind-icon:pencil" class="h-4 w-4" />
+              <Icon name="kind-icon:pencil" class="kr-icon-4" />
               <span class="hidden sm:inline">Edit</span>
             </button>
           </div>
@@ -473,7 +473,7 @@
           type="button"
           @click="startAddingDream"
         >
-          <Icon name="kind-icon:plus" class="h-4 w-4" />
+          <Icon name="kind-icon:plus" class="kr-icon-4" />
           Make the first Dream
         </button>
       </div>

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -31,7 +31,7 @@
             class="kr-btn-ghost-2xl"
             @click="randomizeSeed"
           >
-            <Icon name="kind-icon:dice" class="h-4 w-4" />
+            <Icon name="kind-icon:dice" class="kr-icon-4" />
             Random Seed
           </button>
           <button
@@ -39,7 +39,7 @@
             class="kr-btn-outline-plain rounded-2xl"
             @click="clearForm"
           >
-            <Icon name="kind-icon:x" class="h-4 w-4" />
+            <Icon name="kind-icon:x" class="kr-icon-4" />
             Clear
           </button>
           <button
@@ -52,7 +52,7 @@
               v-if="dreamStore.isSaving"
               class="kr-spinner-xs"
             />
-            <Icon v-else name="kind-icon:save" class="h-4 w-4" />
+            <Icon v-else name="kind-icon:save" class="kr-icon-4" />
             {{ saveLabel }}
           </button>
         </div>
@@ -130,7 +130,7 @@
                 class="btn btn-outline mt-auto rounded-2xl"
                 @click="suggestSlug"
               >
-                <Icon name="kind-icon:wand" class="h-4 w-4" />
+                <Icon name="kind-icon:wand" class="kr-icon-4" />
                 Suggest Slug
               </button>
             </div>
@@ -200,7 +200,7 @@
                 class="btn btn-secondary btn-sm rounded-2xl"
                 @click="copyPitchToArtPrompt"
               >
-                <Icon name="kind-icon:copy" class="h-4 w-4" />
+                <Icon name="kind-icon:copy" class="kr-icon-4" />
                 Use Pitch
               </button>
             </div>

--- a/components/dreams/dream-narration.vue
+++ b/components/dreams/dream-narration.vue
@@ -20,12 +20,12 @@
             title="Start a Storybook story seeded with this Location"
             @click="startStoryWithLocation"
           >
-            <Icon name="kind-icon:book-open" class="h-4 w-4" />
+            <Icon name="kind-icon:book-open" class="kr-icon-4" />
             <span class="hidden sm:inline">Start a story with this</span>
           </button>
 
           <button type="button" class="kr-btn-ghost" @click="backToGallery">
-            <Icon name="kind-icon:arrow-left" class="h-4 w-4" />
+            <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
             All Dreams
           </button>
 
@@ -35,7 +35,7 @@
             :disabled="!dreamStore.selectedDreamId"
             @click="editDream"
           >
-            <Icon name="kind-icon:edit" class="h-4 w-4" />
+            <Icon name="kind-icon:edit" class="kr-icon-4" />
             Edit
           </button>
         </div>
@@ -54,7 +54,7 @@
           "
           @click="workspaceStore.setDreamPanel(panel.key)"
         >
-          <Icon :name="panel.icon" class="h-4 w-4" />
+          <Icon :name="panel.icon" class="kr-icon-4" />
           {{ panel.label }}
         </button>
       </nav>

--- a/components/dreams/dream-pitch-sheet.vue
+++ b/components/dreams/dream-pitch-sheet.vue
@@ -99,7 +99,7 @@
               class="sheet-highlight"
             >
               <span class="sheet-highlight-icon">
-                <Icon :name="highlight.icon || typeIcon" class="h-4 w-4" />
+                <Icon :name="highlight.icon || typeIcon" class="kr-icon-4" />
               </span>
               <p class="min-w-0 text-sm leading-snug text-(--sheet-muted)">
                 <strong class="font-black text-(--sheet-ink)"
@@ -164,7 +164,7 @@
           :disabled="sheetStore.isSaving"
           @click.stop="ensureSheet"
         >
-          <Icon name="kind-icon:file-plus" class="h-4 w-4" />
+          <Icon name="kind-icon:file-plus" class="kr-icon-4" />
           Create Sheet
         </button>
 
@@ -174,7 +174,7 @@
           type="button"
           @click.stop="emit('edit', activeSheet.id)"
         >
-          <Icon name="kind-icon:pencil" class="h-4 w-4" />
+          <Icon name="kind-icon:pencil" class="kr-icon-4" />
           Edit
         </button>
       </footer>

--- a/components/dreams/dream-relationship-gallery.vue
+++ b/components/dreams/dream-relationship-gallery.vue
@@ -35,7 +35,7 @@
           <label
             class="input input-bordered input-xs flex min-w-36 flex-1 items-center gap-2 rounded-2xl bg-base-200"
           >
-            <Icon name="kind-icon:search" class="h-4 w-4 opacity-50" />
+            <Icon name="kind-icon:search" class="kr-icon-4 opacity-50" />
             <input
               v-model="searchQuery"
               type="search"

--- a/components/dreams/dream-sheet-toolbar.vue
+++ b/components/dreams/dream-sheet-toolbar.vue
@@ -4,7 +4,7 @@
     <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div class="min-w-0">
         <p class="kr-text-eyebrow flex items-center gap-2 text-xs tracking-[0.22em] text-primary">
-          <Icon name="kind-icon:file-sparkles" class="h-4 w-4" />
+          <Icon name="kind-icon:file-sparkles" class="kr-icon-4" />
           PitchSheets
         </p>
 
@@ -20,7 +20,7 @@
           :disabled="sheetStore.loading || sheetStore.isSaving"
           @click="refreshSheets"
         >
-          <Icon name="kind-icon:refresh" class="h-4 w-4" />
+          <Icon name="kind-icon:refresh" class="kr-icon-4" />
           Refresh
         </button>
 
@@ -30,7 +30,7 @@
           :disabled="!missingDreams.length || sheetStore.isSaving"
           @click="createMissingSheets"
         >
-          <Icon name="kind-icon:file-plus" class="h-4 w-4" />
+          <Icon name="kind-icon:file-plus" class="kr-icon-4" />
           Create Missing
         </button>
       </div>


### PR DESCRIPTION
Continues the `h-4 w-4` -> `kr-icon-4` directory-by-directory migration (slice 204 took `components/art/`, slice 205 took `components/navigation/`). This slice takes `components/dreams/` (9 files, 37 occurrences) via `kr_icon_4_codemod.py --root components/dreams`.

Only static `class="..."` attributes touched — no geometry or behavior change. Updated the `.kr-icon-4` doc comment in `assets/css/tailwind.css` to record slice 206 and the remaining open sibling directories.

**Verification:**
- `vue-tsc --noEmit` clean
- `eslint .`: 333 problems (327 errors, 6 warnings) — identical to documented baseline
- `test:layout-contract`: holds, 0 new violations
- `test:lint-ratchet`: holds at 333/-59
- `prettier --check`: same 10 pre-existing flagged files in `components/dreams` before and after (confirmed via `git stash` comparison)

Tracked by conductor `interface-vision/t-104` (recurring consistency umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvxMjvDAYEvMyMHjDbQANH

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvxMjvDAYEvMyMHjDbQANH)_