### PR TITLE
interface-vision/t-104 slice 207: migrate bare h-4 w-4 icon glyphs in components/user

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1844,13 +1844,15 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
    * Slice 204 took `components/art/` (15 files, 47 occurrences). Slice 205
    * added `components/navigation/` (9 files, 17 occurrences via
    * subset-match). Slice 206 adds `components/dreams/` (9 files, 37
+   * occurrences). Slice 207 adds `components/user/` (8 files, 23
    * occurrences), splitting the giant family by directory the way the
    * kaizen notes suggested. Sibling directories still open:
-   * `components/user` (7 files), `components/giftshop` (6 files),
-   * `components/scenarios` (5 files), `components/characters` (5 files),
-   * and the rest of the ~100-file family scattered across smaller
-   * directories. Distinct from any future `.kr-icon-primary-4` (same size,
-   * carries `text-primary`) -- this is the untinted sibling. */
+   * `components/giftshop` (6 files), `components/scenarios` (5 files),
+   * `components/characters` (5 files), `components/servers` (4 files),
+   * `components/pages` (4 files), and the rest of the ~100-file family
+   * scattered across smaller directories. Distinct from any future
+   * `.kr-icon-primary-4` (same size, carries `text-primary`) -- this is
+   * the untinted sibling. */
   .kr-icon-4 {
     @apply h-4 w-4;
   }

--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -36,7 +36,7 @@
         title="Close"
         @click="emit('close')"
       >
-        <Icon name="kind-icon:x" class="h-4 w-4" />
+        <Icon name="kind-icon:x" class="kr-icon-4" />
       </button>
     </header>
 
@@ -59,7 +59,7 @@
         :aria-selected="activeTab === tab.value"
         @click="activeTab = tab.value"
       >
-        <Icon :name="tab.icon" class="h-4 w-4" />
+        <Icon :name="tab.icon" class="kr-icon-4" />
         <span class="hidden sm:inline">{{ tab.label }}</span>
       </button>
     </div>
@@ -77,7 +77,7 @@
       >
         <Icon
           :name="statusTone === 'error' ? 'kind-icon:alert' : 'kind-icon:check'"
-          class="h-4 w-4 shrink-0"
+          class="kr-icon-4 shrink-0"
         />
         {{ statusMessage }}
       </div>
@@ -134,7 +134,7 @@
               @click="refreshGallery(true)"
             >
               <span v-if="isLoadingGallery" class="kr-spinner-xs" />
-              <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+              <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
             </button>
           </div>
         </div>
@@ -189,7 +189,7 @@
               @click="chooseFromGallery(selectedGalleryImage)"
             >
               <span v-if="isApplying" class="kr-spinner-sm" />
-              <Icon v-else name="kind-icon:check" class="h-4 w-4" />
+              <Icon v-else name="kind-icon:check" class="kr-icon-4" />
               Use this avatar
             </button>
           </template>

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -22,7 +22,7 @@
           type="button"
           @click="closeThread"
         >
-          <Icon name="kind-icon:arrow-left" class="h-4 w-4" />
+          <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
           Back
         </button>
       </div>
@@ -34,7 +34,7 @@
         <label
           class="input input-bordered flex items-center gap-2 rounded-2xl bg-base-100"
         >
-          <Icon name="kind-icon:search" class="h-4 w-4 opacity-60" />
+          <Icon name="kind-icon:search" class="kr-icon-4 opacity-60" />
           <input
             v-model="searchQuery"
             type="text"
@@ -51,7 +51,7 @@
           @click="refreshChats"
         >
           <span v-if="isLoading" class="kr-spinner-xs" />
-          <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+          <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
           Refresh
         </button>
       </div>
@@ -233,7 +233,7 @@
             @click="sendReply"
           >
             <span v-if="isReplying" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:send" class="h-4 w-4" />
+            <Icon v-else name="kind-icon:send" class="kr-icon-4" />
             Send
           </button>
         </div>

--- a/components/user/first-launch-intro.vue
+++ b/components/user/first-launch-intro.vue
@@ -63,7 +63,7 @@
             class="btn btn-outline btn-sm justify-start rounded-xl"
             @click="dismiss"
           >
-            <Icon :name="link.icon" class="h-4 w-4" />
+            <Icon :name="link.icon" class="kr-icon-4" />
             {{ link.label }}
           </NuxtLink>
         </div>
@@ -101,7 +101,7 @@
           </button>
 
           <button v-else class="kr-btn-primary" type="button" @click="dismiss">
-            <Icon name="kind-icon:check" class="h-4 w-4" />
+            <Icon name="kind-icon:check" class="kr-icon-4" />
             Let's go
           </button>
         </div>

--- a/components/user/google-login.vue
+++ b/components/user/google-login.vue
@@ -6,7 +6,7 @@
       class="btn btn-outline btn-primary flex items-center space-x-3 px-4 sm:px-6 py-2 rounded-lg shadow-md hover:shadow-lg transition-all"
       @click="loginWithGoogle"
     >
-      <Icon name="kind-icon:google" class="w-4 sm:w-5 h-4 sm:h-5" />
+      <Icon name="kind-icon:google" class="kr-icon-4 sm:w-5 sm:h-5" />
       <span class="truncate">Sign in with Google</span>
     </button>
   </div>

--- a/components/user/messenger.vue
+++ b/components/user/messenger.vue
@@ -17,7 +17,7 @@
           :disabled="convo.isLoadingList"
           @click="convo.loadConversations()"
         >
-          <Icon name="kind-icon:refresh" class="h-4 w-4" />
+          <Icon name="kind-icon:refresh" class="kr-icon-4" />
         </button>
       </header>
       <div class="kr-pane-scroll">
@@ -117,7 +117,7 @@
             :disabled="convo.isSending || !draft.trim()"
           >
             <span v-if="convo.isSending" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:send" class="h-4 w-4" />
+            <Icon v-else name="kind-icon:send" class="kr-icon-4" />
           </button>
         </form>
         <p v-if="convo.lastError" class="kr-text-error-xs px-3 pb-2">

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -20,12 +20,12 @@
         type="button"
         @click="introStore.open()"
       >
-        <Icon name="kind-icon:map" class="h-4 w-4" />
+        <Icon name="kind-icon:map" class="kr-icon-4" />
         Replay intro
       </button>
 
       <NuxtLink v-if="isGuest" to="/login" class="kr-btn-primary">
-        <Icon name="kind-icon:login" class="h-4 w-4" />
+        <Icon name="kind-icon:login" class="kr-icon-4" />
         Sign in
       </NuxtLink>
 
@@ -35,7 +35,7 @@
         type="button"
         @click="logout"
       >
-        <Icon name="kind-icon:logout" class="h-4 w-4" />
+        <Icon name="kind-icon:logout" class="kr-icon-4" />
         Sign out
       </button>
     </header>

--- a/components/user/user-galleries.vue
+++ b/components/user/user-galleries.vue
@@ -58,7 +58,7 @@
                 :to="section.to"
                 class="kr-btn-ghost-xs"
               >
-                <Icon name="kind-icon:external-link" class="h-4 w-4" />
+                <Icon name="kind-icon:external-link" class="kr-icon-4" />
                 Open {{ section.label }}
               </NuxtLink>
 
@@ -75,7 +75,7 @@
                       ? 'kind-icon:chevron-up'
                       : 'kind-icon:chevron-down'
                   "
-                  class="h-4 w-4"
+                  class="kr-icon-4"
                 />
                 {{ expandedSections[section.key] ? 'Hide inline' : 'Show inline' }}
               </button>

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -30,7 +30,7 @@
           <option v-for="r in ROLES" :key="r" :value="r">{{ r }}</option>
         </select>
         <button class="kr-btn-primary" @click="openCreate">
-          <Icon name="kind-icon:plus" class="h-4 w-4" /> New user
+          <Icon name="kind-icon:plus" class="kr-icon-4" /> New user
         </button>
       </div>
     </header>
@@ -102,7 +102,7 @@
                   :name="
                     u.emailVerified ? 'kind-icon:check' : 'kind-icon:message'
                   "
-                  class="h-4 w-4 shrink-0"
+                  class="kr-icon-4 shrink-0"
                   :class="u.emailVerified ? 'text-success' : 'text-warning'"
                   :title="
                     u.emailVerified ? 'Verified' : 'Click to force-verify'
@@ -141,7 +141,7 @@
                   title="Reset password"
                   @click="openPassword(u)"
                 >
-                  <Icon name="kind-icon:lock" class="h-4 w-4" />
+                  <Icon name="kind-icon:lock" class="kr-icon-4" />
                 </button>
                 <button
                   class="btn btn-outline btn-xs rounded-lg"
@@ -149,7 +149,7 @@
                   title="Log in as this user"
                   @click="onLoginAs(u)"
                 >
-                  <Icon name="kind-icon:login" class="h-4 w-4" /> Login as
+                  <Icon name="kind-icon:login" class="kr-icon-4" /> Login as
                 </button>
               </div>
             </td>


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Continues the `h-4 w-4` -> `kr-icon-4` directory-by-directory migration (slice 204 took `components/art/`, slice 205 took `components/navigation/`, slice 206 took `components/dreams/`).
- This slice takes `components/user/` (8 files, 23 occurrences via subset-match), migrated with `utils/scripts/codemods/kr_icon_4_codemod.py --root components/user --write`.
- Updated the `.kr-icon-4` doc comment in `assets/css/tailwind.css` to record slice 207 and the remaining open sibling directories.
- No geometry or behavior change — only static `class="..."` attributes touched (dynamic `:class` bindings and any class carrying a `text-*`/`stroke-*`/`fill-*` color token were left alone, per the codemod's documented scope). Responsive-variant tokens preserved verbatim (e.g. `google-login.vue`'s `sm:w-5 sm:h-5`).

### How I verified
- `vue-tsc --noEmit` clean
- `eslint .` → 333 problems (327 errors, 6 warnings) — identical to the documented baseline
- `test:layout-contract` holds (0 new violations)
- `test:lint-ratchet` holds at 333/-59
- `prettier --check components/user/ assets/css/tailwind.css` flags the same 9 pre-existing files before and after this diff (confirmed via `git stash` comparison) — pre-existing drift, not introduced

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Continue splitting the `h-4 w-4` family by directory — remaining bounded sibling directories: `components/giftshop` (6 files), `components/scenarios` (5 files), `components/characters` (5 files), `components/servers` (4 files), `components/pages` (4 files), and the rest scattered across smaller directories.

### Notes for reviewer
Recurring umbrella task; conductor close-out will return `status: ready` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BArgh6NYAduHmdrsnDrgp

---
_Generated by [Claude Code](https://claude.ai/code/session_015BArgh6NYAduHmdrsnDrgp)_