### PR TITLE
interface-vision/t-104 slice 208: migrate bare h-4 w-4 icon glyphs in components/giftshop

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1845,12 +1845,13 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
    * added `components/navigation/` (9 files, 17 occurrences via
    * subset-match). Slice 206 adds `components/dreams/` (9 files, 37
    * occurrences). Slice 207 adds `components/user/` (8 files, 23
+   * occurrences). Slice 208 adds `components/giftshop/` (6 files, 14
    * occurrences), splitting the giant family by directory the way the
    * kaizen notes suggested. Sibling directories still open:
-   * `components/giftshop` (6 files), `components/scenarios` (5 files),
-   * `components/characters` (5 files), `components/servers` (4 files),
-   * `components/pages` (4 files), and the rest of the ~100-file family
-   * scattered across smaller directories. Distinct from any future
+   * `components/scenarios` (5 files), `components/characters` (5 files),
+   * `components/servers` (4 files), `components/pages` (4 files), and the
+   * rest of the ~100-file family scattered across smaller directories.
+   * Distinct from any future
    * `.kr-icon-primary-4` (same size, carries `text-primary`) -- this is
    * the untinted sibling. */
   .kr-icon-4 {

--- a/components/giftshop/checkout-cancel.vue
+++ b/components/giftshop/checkout-cancel.vue
@@ -32,7 +32,7 @@
 
       <div class="mt-6 flex flex-wrap justify-center gap-3">
         <NuxtLink to="/cart" class="kr-btn-primary-md-2xl">
-          <Icon name="kind-icon:cart" class="h-4 w-4" />
+          <Icon name="kind-icon:cart" class="kr-icon-4" />
           Return to cart
         </NuxtLink>
 

--- a/components/giftshop/checkout-success.vue
+++ b/components/giftshop/checkout-success.vue
@@ -31,7 +31,7 @@
 
       <div class="mt-6 flex flex-wrap justify-center gap-3">
         <NuxtLink to="/sanctuary" class="kr-btn-primary-md-2xl">
-          <Icon name="kind-icon:butterfly" class="h-4 w-4" />
+          <Icon name="kind-icon:butterfly" class="kr-icon-4" />
           Return to Sanctuary
         </NuxtLink>
 
@@ -40,7 +40,7 @@
           to="/cart"
           class="kr-btn-outline-md rounded-2xl"
         >
-          <Icon name="kind-icon:cart" class="h-4 w-4" />
+          <Icon name="kind-icon:cart" class="kr-icon-4" />
           Review cart
         </NuxtLink>
       </div>

--- a/components/giftshop/giftshop-interact.vue
+++ b/components/giftshop/giftshop-interact.vue
@@ -28,7 +28,7 @@
           </div>
 
           <button type="button" class="kr-btn-primary-md-2xl" @click="goToCart">
-            <Icon name="kind-icon:cart" class="h-4 w-4" />
+            <Icon name="kind-icon:cart" class="kr-icon-4" />
             Cart
             <span v-if="cartStore.totalItems" class="badge badge-secondary">
               {{ cartStore.totalItems }}
@@ -92,7 +92,7 @@
             to="/giving"
             class="btn btn-primary btn-sm shrink-0 rounded-2xl"
           >
-            <Icon name="kind-icon:gift" class="h-4 w-4" />
+            <Icon name="kind-icon:gift" class="kr-icon-4" />
             Give directly
           </NuxtLink>
         </div>
@@ -123,7 +123,7 @@
                   class="btn btn-sm btn-outline rounded-2xl"
                   @click="addFeaturedPrint(art)"
                 >
-                  <Icon name="kind-icon:plus" class="h-4 w-4" />
+                  <Icon name="kind-icon:plus" class="kr-icon-4" />
                   Add to cart
                 </button>
               </div>
@@ -156,7 +156,7 @@
               class="btn btn-sm btn-outline mt-4 rounded-2xl"
               @click="addShowcaseItem(item)"
             >
-              <Icon name="kind-icon:plus" class="h-4 w-4" />
+              <Icon name="kind-icon:plus" class="kr-icon-4" />
               Add to cart
             </button>
           </article>
@@ -196,7 +196,7 @@
         </div>
 
         <button type="button" class="kr-btn-primary-md-2xl" @click="goToCart">
-          <Icon name="kind-icon:cart" class="h-4 w-4" />
+          <Icon name="kind-icon:cart" class="kr-icon-4" />
           Review cart
         </button>
 
@@ -206,7 +206,7 @@
           :disabled="!cartStore.hasItems"
           @click="cartStore.clearCart()"
         >
-          <Icon name="kind-icon:trash" class="h-4 w-4" />
+          <Icon name="kind-icon:trash" class="kr-icon-4" />
           Release cart butterflies
         </button>
 

--- a/components/giftshop/giftshop-manager.vue
+++ b/components/giftshop/giftshop-manager.vue
@@ -21,7 +21,7 @@
       >
         <Icon
           name="kind-icon:refresh"
-          class="h-4 w-4"
+          class="kr-icon-4"
           :class="isLoadingManager ? 'animate-spin' : ''"
         />
         Refresh

--- a/components/giftshop/mermaids-pdf-purchase.vue
+++ b/components/giftshop/mermaids-pdf-purchase.vue
@@ -40,7 +40,7 @@
         :disabled="downloading"
         @click="download"
       >
-        <Icon name="kind-icon:download" class="h-4 w-4" />
+        <Icon name="kind-icon:download" class="kr-icon-4" />
         {{ downloading ? 'Preparing download...' : 'Download PDF' }}
       </button>
     </div>
@@ -52,7 +52,7 @@
         :disabled="purchasing"
         @click="purchase"
       >
-        <Icon name="kind-icon:cart" class="h-4 w-4" />
+        <Icon name="kind-icon:cart" class="kr-icon-4" />
         {{ purchasing ? 'Redirecting to checkout...' : 'Buy PDF — $9.99' }}
       </button>
     </div>

--- a/components/giftshop/shopping-cart.vue
+++ b/components/giftshop/shopping-cart.vue
@@ -19,7 +19,7 @@
         :disabled="cartStore.loading"
         @click="cartStore.clearCart"
       >
-        <Icon name="kind-icon:trash" class="h-4 w-4" />
+        <Icon name="kind-icon:trash" class="kr-icon-4" />
         Clear cart
       </button>
     </div>
@@ -108,7 +108,7 @@
             :disabled="cartStore.loading"
             @click="cartStore.removeItem(item.id)"
           >
-            <Icon name="kind-icon:trash" class="h-4 w-4" />
+            <Icon name="kind-icon:trash" class="kr-icon-4" />
             Remove
           </button>
         </article>


### PR DESCRIPTION
Continues the `kr-icon-4` directory-by-directory migration (slice 204: `art`, 205: `navigation`, 206: `dreams`, 207: `user`). Migrates all 14 `h-4 w-4` icon-glyph occurrences across 6 files in `components/giftshop/` to `.kr-icon-4`. Only static `class="..."` attributes touched; no geometry or behavior change.

**Verified:**
- `vue-tsc --noEmit` clean
- `eslint .` — 333/327/6, identical to documented baseline
- `test:layout-contract` holds, 0 new violations
- `test:lint-ratchet` holds at 333/-59
- `prettier --check` flags the same 2 pre-existing files (`checkout-cancel.vue`, `shopping-cart.vue`) before and after this diff (confirmed via `git stash` comparison)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qXV6HtfVCwX9CJoZhApZ9

---
_Generated by [Claude Code](https://claude.ai/code/session_013qXV6HtfVCwX9CJoZhApZ9)_