### PR TITLE
interface-vision/t-104 slice 209: migrate bare h-4 w-4 icon glyphs in components/scenarios

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1846,12 +1846,13 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
    * subset-match). Slice 206 adds `components/dreams/` (9 files, 37
    * occurrences). Slice 207 adds `components/user/` (8 files, 23
    * occurrences). Slice 208 adds `components/giftshop/` (6 files, 14
+   * occurrences). Slice 209 adds `components/scenarios/` (5 files, 16
    * occurrences), splitting the giant family by directory the way the
    * kaizen notes suggested. Sibling directories still open:
-   * `components/scenarios` (5 files), `components/characters` (5 files),
-   * `components/servers` (4 files), `components/pages` (4 files), and the
-   * rest of the ~100-file family scattered across smaller directories.
-   * Distinct from any future
+   * `components/characters` (5 files), `components/servers` (4 files),
+   * `components/pages` (4 files), and the rest of the family scattered
+   * across smaller directories (~172 occurrences remain repo-wide as of
+   * slice 209). Distinct from any future
    * `.kr-icon-primary-4` (same size, carries `text-primary`) -- this is
    * the untinted sibling. */
   .kr-icon-4 {

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -174,7 +174,7 @@
           />
 
           <button class="kr-btn-primary-md" type="button" @click="addIntro">
-            <Icon name="kind-icon:plus" class="h-4 w-4" />
+            <Icon name="kind-icon:plus" class="kr-icon-4" />
             Add
           </button>
         </div>

--- a/components/scenarios/scenario-card.vue
+++ b/components/scenarios/scenario-card.vue
@@ -55,7 +55,7 @@
             title="Edit Scenario"
             @click.stop="emit('edit', scenario.id)"
           >
-            <Icon name="kind-icon:pencil" class="h-4 w-4" />
+            <Icon name="kind-icon:pencil" class="kr-icon-4" />
           </button>
 
           <button
@@ -65,7 +65,7 @@
             title="Clone Scenario"
             @click.stop="emit('clone', scenario.id)"
           >
-            <Icon name="kind-icon:copy" class="h-4 w-4" />
+            <Icon name="kind-icon:copy" class="kr-icon-4" />
           </button>
 
           <button
@@ -75,7 +75,7 @@
             title="Delete Scenario"
             @click.stop="deleteScenario"
           >
-            <Icon name="kind-icon:trash" class="h-4 w-4" />
+            <Icon name="kind-icon:trash" class="kr-icon-4" />
           </button>
         </div>
       </template>

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -27,7 +27,7 @@
             type="button"
             @click="startAddingScenario"
           >
-            <Icon name="kind-icon:plus" class="h-4 w-4" />
+            <Icon name="kind-icon:plus" class="kr-icon-4" />
             <span class="hidden sm:inline">Add</span>
           </button>
 
@@ -39,7 +39,7 @@
             @click="refreshScenarios(true)"
           >
             <span v-if="isLoading" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+            <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
           </button>
         </div>
       </div>
@@ -59,7 +59,7 @@
           type="button"
           @click="showScenarioForm = false"
         >
-          <Icon name="kind-icon:x" class="h-4 w-4" />
+          <Icon name="kind-icon:x" class="kr-icon-4" />
         </button>
       </div>
 
@@ -276,7 +276,7 @@
           type="button"
           @click="startAddingScenario"
         >
-          <Icon name="kind-icon:plus" class="h-4 w-4" />
+          <Icon name="kind-icon:plus" class="kr-icon-4" />
           Add Scenario
         </button>
       </div>

--- a/components/scenarios/scenario-relationship-gallery.vue
+++ b/components/scenarios/scenario-relationship-gallery.vue
@@ -38,14 +38,14 @@
             class="kr-btn-primary"
             @click="startAddingScenario"
           >
-            <Icon name="kind-icon:plus" class="h-4 w-4" />
+            <Icon name="kind-icon:plus" class="kr-icon-4" />
             Add
           </button>
 
           <label
             class="input input-bordered input-xs flex min-w-36 flex-1 items-center gap-2 rounded-2xl bg-base-200"
           >
-            <Icon name="kind-icon:search" class="h-4 w-4 opacity-50" />
+            <Icon name="kind-icon:search" class="kr-icon-4 opacity-50" />
             <input
               v-model="searchQuery"
               type="search"
@@ -72,7 +72,7 @@
           class="kr-btn-ghost"
           @click="showScenarioForm = false"
         >
-          <Icon name="kind-icon:x" class="h-4 w-4" />
+          <Icon name="kind-icon:x" class="kr-icon-4" />
         </button>
       </div>
 
@@ -125,7 +125,7 @@
           class="kr-btn-primary"
           @click="startAddingScenario"
         >
-          <Icon name="kind-icon:plus" class="h-4 w-4" />
+          <Icon name="kind-icon:plus" class="kr-icon-4" />
           Add Scenario
         </button>
       </div>

--- a/components/scenarios/scenario-story.vue
+++ b/components/scenarios/scenario-story.vue
@@ -32,7 +32,7 @@
           type="button"
           @click="storyStore.backToBrowse"
         >
-          <Icon name="kind-icon:arrow-left" class="h-4 w-4" />
+          <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
           <span class="hidden sm:inline">All Scenarios</span>
         </button>
 
@@ -65,7 +65,7 @@
           title="Show or hide scenario details"
           @click="sheetStore.toggleSheet()"
         >
-          <Icon name="kind-icon:info" class="h-4 w-4" />
+          <Icon name="kind-icon:info" class="kr-icon-4" />
           <span class="hidden sm:inline">Info</span>
         </button>
       </div>
@@ -235,7 +235,7 @@
           title="Start over with the same scenario"
           @click="storyStore.newStory"
         >
-          <Icon name="kind-icon:refresh" class="h-4 w-4" />
+          <Icon name="kind-icon:refresh" class="kr-icon-4" />
           <span class="hidden sm:inline">New Story</span>
         </button>
 
@@ -246,7 +246,7 @@
           title="End the story and browse scenarios"
           @click="storyStore.endSession"
         >
-          <Icon name="kind-icon:x" class="h-4 w-4" />
+          <Icon name="kind-icon:x" class="kr-icon-4" />
           <span class="hidden sm:inline">End</span>
         </button>
       </div>


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- Slice 209 of the ongoing `h-4 w-4` → `.kr-icon-4` directory-by-directory migration.
- `components/scenarios/` (5 files, 16 occurrences via subset-match): `add-scenario.vue`, `scenario-card.vue`, `scenario-gallery.vue`, `scenario-relationship-gallery.vue`, `scenario-story.vue` now use `kr-icon-4` instead of bare `h-4 w-4`.
- Updated the `.kr-icon-4` doc comment in `assets/css/tailwind.css` to record slice 209 and the remaining open sibling directories.
- No geometry or behavior change — only static `class="..."` attributes touched.

### How I verified
- `npx vue-tsc --noEmit` — clean
- `npx eslint .` — 333/327/6, identical to the documented baseline
- `npm run test:layout-contract` — holds, 0 new violations
- `npm run test:lint-ratchet` — holds at 333 problems (-59)
- `npx prettier --check` — same pre-existing `assets/css/tailwind.css` flag before and after this diff (confirmed via `git stash` comparison); no new files flagged

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Continue splitting the `h-4 w-4` family by directory — remaining bounded sibling directories: `components/characters` (5 files), `components/servers` (4 files), `components/pages` (4 files), and the rest scattered across smaller directories (~172 occurrences remain repo-wide as of this slice).

### Notes for reviewer
Ran via the automated Conductor Agent Routine (scheduled session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QsJd5oxGy6ErJmzxLaCbxc

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsJd5oxGy6ErJmzxLaCbxc)_