### PR TITLE
interface-vision/t-104 slice 210: migrate bare h-4 w-4 icon glyphs in components/characters

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1847,12 +1847,12 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
    * occurrences). Slice 207 adds `components/user/` (8 files, 23
    * occurrences). Slice 208 adds `components/giftshop/` (6 files, 14
    * occurrences). Slice 209 adds `components/scenarios/` (5 files, 16
+   * occurrences). Slice 210 adds `components/characters/` (5 files, 20
    * occurrences), splitting the giant family by directory the way the
    * kaizen notes suggested. Sibling directories still open:
-   * `components/characters` (5 files), `components/servers` (4 files),
-   * `components/pages` (4 files), and the rest of the family scattered
-   * across smaller directories (~172 occurrences remain repo-wide as of
-   * slice 209). Distinct from any future
+   * `components/servers` (4 files), `components/pages` (4 files), and
+   * the rest of the family scattered across smaller directories (~152
+   * occurrences remain repo-wide as of slice 210). Distinct from any future
    * `.kr-icon-primary-4` (same size, carries `text-primary`) -- this is
    * the untinted sibling. */
   .kr-icon-4 {

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -39,7 +39,7 @@
               type="button"
               @click="seedCharacter"
             >
-              <Icon name="kind-icon:dice" class="h-4 w-4" />
+              <Icon name="kind-icon:dice" class="kr-icon-4" />
               Seed
             </button>
           </div>
@@ -182,7 +182,7 @@
                 v-if="characterStore.isGeneratingArt"
                 class="kr-spinner-sm"
               />
-              <Icon v-else name="kind-icon:magic" class="h-4 w-4" />
+              <Icon v-else name="kind-icon:magic" class="kr-icon-4" />
               Generate portrait
             </button>
 
@@ -191,7 +191,7 @@
               type="button"
               @click="useRandomArtImage"
             >
-              <Icon name="kind-icon:dice" class="h-4 w-4" />
+              <Icon name="kind-icon:dice" class="kr-icon-4" />
               Random gallery image
             </button>
           </div>
@@ -293,7 +293,7 @@
             type="button"
             @click="characterStore.rerollCharacterStats"
           >
-            <Icon name="kind-icon:dice" class="h-4 w-4" />
+            <Icon name="kind-icon:dice" class="kr-icon-4" />
             Reroll stats
           </button>
         </div>
@@ -345,7 +345,7 @@
               v-if="isGeneratingFields"
               class="kr-spinner-xs"
             />
-            <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
+            <Icon v-else name="kind-icon:sparkles" class="kr-icon-4" />
             Update selected
           </button>
         </div>

--- a/components/characters/character-card.vue
+++ b/components/characters/character-card.vue
@@ -32,7 +32,7 @@
           title="Edit Character"
           @click.stop="emit('edit', character.id)"
         >
-          <Icon name="kind-icon:pencil" class="h-4 w-4" />
+          <Icon name="kind-icon:pencil" class="kr-icon-4" />
         </button>
 
         <button
@@ -42,7 +42,7 @@
           title="Clone Character"
           @click.stop="emit('clone', character.id)"
         >
-          <Icon name="kind-icon:copy" class="h-4 w-4" />
+          <Icon name="kind-icon:copy" class="kr-icon-4" />
         </button>
 
         <button
@@ -52,7 +52,7 @@
           title="Delete Character"
           @click.stop="deleteCharacter"
         >
-          <Icon name="kind-icon:trash" class="h-4 w-4" />
+          <Icon name="kind-icon:trash" class="kr-icon-4" />
         </button>
       </template>
 
@@ -116,7 +116,7 @@
             type="button"
             @click.stop="toggleMode('chat')"
           >
-            <Icon name="kind-icon:message" class="h-4 w-4" />
+            <Icon name="kind-icon:message" class="kr-icon-4" />
             Chat
           </button>
 
@@ -128,7 +128,7 @@
             type="button"
             @click.stop="toggleMode('adventure')"
           >
-            <Icon name="kind-icon:compass" class="h-4 w-4" />
+            <Icon name="kind-icon:compass" class="kr-icon-4" />
             Adventure
           </button>
         </div>

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -48,7 +48,7 @@
               :disabled="isSendingChat"
               @click="clearSelectedCharacter"
             >
-              <Icon name="kind-icon:x" class="h-4 w-4" />
+              <Icon name="kind-icon:x" class="kr-icon-4" />
               Clear
             </button>
           </div>
@@ -181,7 +181,7 @@
             "
             @click="setActiveMode(tab.key)"
           >
-            <Icon :name="tab.icon" class="h-4 w-4" />
+            <Icon :name="tab.icon" class="kr-icon-4" />
             {{ tab.label }}
           </button>
         </div>
@@ -206,7 +206,7 @@
                 :disabled="chatMessages.length === 0 || isSendingChat"
                 @click="clearChatMessages"
               >
-                <Icon name="kind-icon:x" class="h-4 w-4" />
+                <Icon name="kind-icon:x" class="kr-icon-4" />
                 Clear Chat
               </button>
             </div>

--- a/components/characters/character-flip-card.vue
+++ b/components/characters/character-flip-card.vue
@@ -46,7 +46,7 @@
           "
           @click="setActiveMode(tab.key)"
         >
-          <Icon :name="tab.icon" class="h-4 w-4" />
+          <Icon :name="tab.icon" class="kr-icon-4" />
           {{ tab.label }}
         </button>
 
@@ -56,7 +56,7 @@
           :disabled="isSendingChat"
           @click="clearSelectedCharacter"
         >
-          <Icon name="kind-icon:x" class="h-4 w-4" />
+          <Icon name="kind-icon:x" class="kr-icon-4" />
           Clear Character
         </button>
       </div>
@@ -112,7 +112,7 @@
                 :disabled="chatMessages.length === 0 || isSendingChat"
                 @click="clearChatMessages"
               >
-                <Icon name="kind-icon:x" class="h-4 w-4" />
+                <Icon name="kind-icon:x" class="kr-icon-4" />
                 Clear Chat
               </button>
             </div>

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -19,7 +19,7 @@
         </div>
 
         <button class="kr-btn-ghost" type="button" @click="closeCharacterForm">
-          <Icon name="kind-icon:x" class="h-4 w-4" />
+          <Icon name="kind-icon:x" class="kr-icon-4" />
           <span class="hidden sm:inline">Close</span>
         </button>
       </div>
@@ -170,7 +170,7 @@
                 type="button"
                 @click="cloneSelectedCharacter"
               >
-                <Icon name="kind-icon:copy" class="h-4 w-4" />
+                <Icon name="kind-icon:copy" class="kr-icon-4" />
                 <span class="hidden sm:inline">Clone</span>
               </button>
 
@@ -180,7 +180,7 @@
                 type="button"
                 @click="startEditingSelectedCharacter"
               >
-                <Icon name="kind-icon:pencil" class="h-4 w-4" />
+                <Icon name="kind-icon:pencil" class="kr-icon-4" />
                 <span class="hidden sm:inline">Edit</span>
               </button>
             </div>
@@ -315,7 +315,7 @@
           type="button"
           @click="startAddingCharacter"
         >
-          <Icon name="kind-icon:plus" class="h-4 w-4" />
+          <Icon name="kind-icon:plus" class="kr-icon-4" />
           Make the first weirdo
         </button>
       </div>


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 210 (kind: software, recurring)

### What changed / what I produced
Continues the directory-by-directory `kr-icon-4` migration (slices 204-209 took `components/art`, `components/navigation`, `components/dreams`, `components/user`, `components/giftshop`, `components/scenarios`).

- `components/characters/` (5 files, 20 occurrences): `add-character.vue`, `character-card.vue`, `character-chat.vue`, `character-flip-card.vue`, `character-gallery.vue` now use `kr-icon-4` instead of bare `h-4 w-4`; no geometry or behavior change.
- Updated the `.kr-icon-4` doc comment in `assets/css/tailwind.css` to record slice 210 and the remaining open sibling directories.

### How I verified
- `vue-tsc --noEmit` clean
- `eslint .` 333/327/6 identical to the documented baseline
- `test:layout-contract` holds (0 new violations)
- `test:lint-ratchet` holds at 333/-59
- `prettier --check` flags the same 4 pre-existing-drift files before/after this diff (confirmed via `git stash` comparison)

### Stakes
reversible

### Flags for Reviewer
(none)

### Kaizen suggestion
Remaining bounded sibling directories: `components/servers` (4 files, 9 occurrences), `components/pages` (4 files, 11 occurrences), then the scattered remainder (~152 occurrences repo-wide as of this slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01183nH2Xi83b7Mh3AyyG3DU

---
_Generated by [Claude Code](https://claude.ai/code/session_01183nH2Xi83b7Mh3AyyG3DU)_