### PR TITLE
interface-vision/t-104 slice 211: migrate bare h-4 w-4 icon glyphs in components/servers

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1849,10 +1849,11 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
    * occurrences). Slice 209 adds `components/scenarios/` (5 files, 16
    * occurrences). Slice 210 adds `components/characters/` (5 files, 20
    * occurrences), splitting the giant family by directory the way the
-   * kaizen notes suggested. Sibling directories still open:
-   * `components/servers` (4 files), `components/pages` (4 files), and
-   * the rest of the family scattered across smaller directories (~152
-   * occurrences remain repo-wide as of slice 210). Distinct from any future
+   * kaizen notes suggested. Slice 211 adds `components/servers/` (4 files,
+   * 9 occurrences). Sibling directories still open: `components/pages`
+   * (4 files), and the rest of the family scattered across smaller
+   * directories (143 occurrences remain repo-wide as of slice 211).
+   * Distinct from any future
    * `.kr-icon-primary-4` (same size, carries `text-primary`) -- this is
    * the untinted sibling. */
   .kr-icon-4 {

--- a/components/servers/add-checkpoint.vue
+++ b/components/servers/add-checkpoint.vue
@@ -22,7 +22,7 @@
         type="button"
         @click="emit('close')"
       >
-        <Icon name="kind-icon:x" class="h-4 w-4" />
+        <Icon name="kind-icon:x" class="kr-icon-4" />
         <span class="hidden sm:inline">Close</span>
       </button>
     </div>
@@ -220,7 +220,7 @@
         :disabled="isSaving || !canSubmit"
       >
         <span v-if="isSaving" class="kr-spinner-sm" />
-        <Icon v-else name="kind-icon:plus" class="h-4 w-4" />
+        <Icon v-else name="kind-icon:plus" class="kr-icon-4" />
         Save Checkpoint
       </button>
     </div>

--- a/components/servers/add-server.vue
+++ b/components/servers/add-server.vue
@@ -23,7 +23,7 @@
         title="Close"
         @click="closeForm"
       >
-        <Icon name="kind-icon:x" class="h-4 w-4" />
+        <Icon name="kind-icon:x" class="kr-icon-4" />
       </button>
     </header>
 
@@ -171,7 +171,7 @@
             >
               <Icon
                 :name="showApiKey ? 'kind-icon:eye-off' : 'kind-icon:eye'"
-                class="h-4 w-4"
+                class="kr-icon-4"
               />
               {{ showApiKey ? 'Hide key' : 'Show key' }}
             </button>

--- a/components/servers/checkpoint-card.vue
+++ b/components/servers/checkpoint-card.vue
@@ -59,7 +59,7 @@
         v-if="isActive"
         class="absolute bottom-2 right-2 rounded-full bg-primary p-2 text-primary-content shadow"
       >
-        <Icon name="kind-icon:check" class="h-4 w-4" />
+        <Icon name="kind-icon:check" class="kr-icon-4" />
       </div>
     </div>
 
@@ -113,7 +113,7 @@
         :disabled="!canSelect"
         @click.stop="selectCheckpoint"
       >
-        <Icon name="kind-icon:checkpoint" class="h-4 w-4" />
+        <Icon name="kind-icon:checkpoint" class="kr-icon-4" />
         {{ isActive ? 'Selected' : 'Select' }}
       </button>
     </div>

--- a/components/servers/server-card.vue
+++ b/components/servers/server-card.vue
@@ -21,7 +21,7 @@
           title="Select"
           @click="selectServer"
         >
-          <Icon name="kind-icon:cursor-click" class="h-4 w-4" />
+          <Icon name="kind-icon:cursor-click" class="kr-icon-4" />
         </button>
 
         <button
@@ -31,7 +31,7 @@
           title="Edit"
           @click="editServer"
         >
-          <Icon name="kind-icon:pencil" class="h-4 w-4" />
+          <Icon name="kind-icon:pencil" class="kr-icon-4" />
         </button>
 
         <button
@@ -41,7 +41,7 @@
           title="Test health"
           @click="testServer"
         >
-          <Icon name="kind-icon:activity" class="h-4 w-4" />
+          <Icon name="kind-icon:activity" class="kr-icon-4" />
         </button>
       </div>
 


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 211 (kind: software, recurring)

### What changed / what I produced
Continues the directory-by-directory `kr-icon-4` migration (slices 204-210 took `components/art`, `components/navigation`, `components/dreams`, `components/user`, `components/giftshop`, `components/scenarios`, `components/characters`).

- `components/servers/` (4 files, 9 occurrences): `add-checkpoint.vue`, `add-server.vue`, `checkpoint-card.vue`, `server-card.vue` now use `kr-icon-4` instead of bare `h-4 w-4`; no geometry or behavior change.
- Updated the `.kr-icon-4` doc comment in `assets/css/tailwind.css` to record slice 211 and the remaining open sibling directories.

### How I verified
- `npx vue-tsc --noEmit` — clean
- `npx eslint .` — 333/327/6, identical to the documented baseline
- `npm run test:layout-contract` — holds, 0 new violations
- `npm run test:lint-ratchet` — holds at 333 problems (-59)
- `npx prettier --check` — same pre-existing `components/servers/checkpoint-card.vue` flag before and after this diff (confirmed via `git stash` comparison); no new files flagged

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Remaining bounded sibling directories: `components/pages` (4 files, 11 occurrences), then the scattered remainder (~132 occurrences repo-wide once pages is done).

### Notes for reviewer
Ran via the automated Conductor Agent Routine (scheduled session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pV9wmT4tNMwkr3tj1DRrD

---
_Generated by [Claude Code](https://claude.ai/code/session_018pV9wmT4tNMwkr3tj1DRrD)_