### PR TITLE
interface-vision/t-104 slice 212: migrate bare h-4 w-4 icon glyphs in components/pages

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1850,10 +1850,13 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
    * occurrences). Slice 210 adds `components/characters/` (5 files, 20
    * occurrences), splitting the giant family by directory the way the
    * kaizen notes suggested. Slice 211 adds `components/servers/` (4 files,
-   * 9 occurrences). Sibling directories still open: `components/pages`
-   * (4 files), and the rest of the family scattered across smaller
-   * directories (143 occurrences remain repo-wide as of slice 211).
-   * Distinct from any future
+   * 9 occurrences). Slice 212 adds `components/pages/` (4 files, 11
+   * occurrences), the last bounded sibling directory identified by prior
+   * kaizen notes. The remaining ~124 occurrences (35 files) are scattered
+   * across smaller directories with no single directory large enough to
+   * bound a slice the way the prior ones did -- the next slice should pick
+   * a different splitting strategy (e.g. occurrence-count bands) rather
+   * than directory. Distinct from any future
    * `.kr-icon-primary-4` (same size, carries `text-primary`) -- this is
    * the untinted sibling. */
   .kr-icon-4 {

--- a/components/pages/about-page.vue
+++ b/components/pages/about-page.vue
@@ -30,15 +30,15 @@
 
         <div class="flex flex-wrap gap-2">
           <NuxtLink to="/about" class="btn btn-outline min-w-36 flex-1 justify-start rounded-xl">
-            <Icon name="kind-icon:butterfly" class="h-4 w-4" />
+            <Icon name="kind-icon:butterfly" class="kr-icon-4" />
             About
           </NuxtLink>
           <NuxtLink to="/giving" class="btn btn-outline min-w-36 flex-1 justify-start rounded-xl">
-            <Icon name="kind-icon:hand-heart" class="h-4 w-4" />
+            <Icon name="kind-icon:hand-heart" class="kr-icon-4" />
             Giving
           </NuxtLink>
           <NuxtLink to="/sanctuary" class="btn btn-outline min-w-36 flex-1 justify-start rounded-xl">
-            <Icon name="kind-icon:gift" class="h-4 w-4" />
+            <Icon name="kind-icon:gift" class="kr-icon-4" />
             Gift Shop
           </NuxtLink>
         </div>
@@ -94,7 +94,7 @@
             rel="noopener"
             class="btn btn-outline justify-start rounded-xl"
           >
-            <Icon name="kind-icon:hand-heart" class="h-4 w-4" />
+            <Icon name="kind-icon:hand-heart" class="kr-icon-4" />
             AMIbot fundraiser
           </a>
           <a
@@ -103,14 +103,14 @@
             rel="noopener"
             class="btn btn-outline justify-start rounded-xl"
           >
-            <Icon name="kind-icon:image" class="h-4 w-4" />
+            <Icon name="kind-icon:image" class="kr-icon-4" />
             Cafe Purr
           </a>
           <NuxtLink
             to="/mermaids"
             class="btn btn-outline justify-start rounded-xl"
           >
-            <Icon name="kind-icon:mermaid" class="h-4 w-4" />
+            <Icon name="kind-icon:mermaid" class="kr-icon-4" />
             Mermaids of Venice
           </NuxtLink>
           <a
@@ -119,7 +119,7 @@
             rel="noopener"
             class="btn btn-outline justify-start rounded-xl"
           >
-            <Icon name="kind-icon:magic" class="h-4 w-4" />
+            <Icon name="kind-icon:magic" class="kr-icon-4" />
             Hair by Superkate
           </a>
         </div>

--- a/components/pages/giving-page.vue
+++ b/components/pages/giving-page.vue
@@ -68,7 +68,7 @@
             :disabled="!donationItem"
             @click="addDonationToCart"
           >
-            <Icon name="kind-icon:plus" class="h-4 w-4" />
+            <Icon name="kind-icon:plus" class="kr-icon-4" />
             Add $1 donation to cart
           </button>
 
@@ -78,7 +78,7 @@
             class="kr-btn-primary rounded-2xl"
             @click="openCart"
           >
-            <Icon name="kind-icon:cart" class="h-4 w-4" />
+            <Icon name="kind-icon:cart" class="kr-icon-4" />
             View cart
             <span class="badge badge-secondary">
               {{ cartStore.totalItems }}

--- a/components/pages/mermaids-page.vue
+++ b/components/pages/mermaids-page.vue
@@ -124,7 +124,7 @@
               rel="noopener"
               class="btn btn-primary btn-sm rounded-2xl"
             >
-              <Icon name="kind-icon:external-link" class="h-4 w-4" />
+              <Icon name="kind-icon:external-link" class="kr-icon-4" />
               {{ draft.amazonLabel }}
             </a>
             <input

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -144,7 +144,7 @@
             >
               <Icon
                 :name="effect.icon"
-                class="h-4 w-4"
+                class="kr-icon-4"
                 :style="{ color: effect.color }"
               />
               {{ effect.label }}


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- Replaced hand-rolled `class="h-4 w-4"` with the shared `.kr-icon-4` utility class on 11 `<Icon>` glyphs across 4 files in `components/pages/`: `about-page.vue` (7), `giving-page.vue` (2), `serendipity-page.vue` (1), `mermaids-page.vue` (1). No geometry or behavior change — `.kr-icon-4` is defined as `@apply h-4 w-4`.
- Updated the `.kr-icon-4` doc comment in `assets/css/tailwind.css` to record slice 212 and note that `components/pages` was the last bounded sibling directory in this family; ~124 occurrences (35 files) remain scattered with no single directory large enough to bound a future slice the same way — next slice should switch splitting strategy (e.g. occurrence-count bands).

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint .`: 333 problems (327 errors, 6 warnings) — matches baseline
- `test:layout-contract`: holds, no new violations
- `test:lint-ratchet`: holds at 333/-59
- `prettier --check`: flags the same 4 pre-existing-drift files before/after (confirmed via `git stash`)

### Stakes
reversible

### Kaizen suggestion
The bare `h-4 w-4` family no longer has a bounded sibling directory left to slice by. The next cycle should re-survey the remaining ~124 occurrences and split by occurrence-count band (e.g. files with 3+ occurrences first) instead of by directory.

### Notes for reviewer
Continuation of the recurring interface-vision/t-104 consistency sweep (slice 212 of an ongoing series; see prior slices #2589-#2593).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4kn2V6vgkGUVPcCjTAkYE

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4kn2V6vgkGUVPcCjTAkYE)_