### PR TITLE
fix(nav): restore channel tab submenus

### DIFF
--- a/content.config.ts
+++ b/content.config.ts
@@ -146,7 +146,9 @@ const pageSchema = sharedNavigationSchema.extend({
 const channelSchema = sharedNavigationSchema.extend({
   contentType: z.enum(['channel', 'tab']),
   channelKey: z.string(),
-  navigation: contentNavigationSchema.default(false),
+  // Channel tabs are navigable unless frontmatter explicitly opts them out.
+  // This matches resolveTabItem()'s `item.navigation !== false` contract.
+  navigation: contentNavigationSchema.default(true),
 })
 
 export type ContentType = z.infer<typeof pageSchema>

--- a/utils/scripts/verifyNavigationConsolidation.ts
+++ b/utils/scripts/verifyNavigationConsolidation.ts
@@ -12,6 +12,18 @@ function source(path: string): string {
   return readFileSync(path, 'utf8')
 }
 
+const contentConfig = source('content.config.ts')
+assert.match(
+  contentConfig,
+  /const channelSchema = sharedNavigationSchema\.extend\(\{[\s\S]*?navigation: contentNavigationSchema\.default\(true\),[\s\S]*?\}\)/,
+  'channel content must default navigation to true so ordinary tabs remain in channel submenus unless they explicitly opt out',
+)
+assert.match(
+  contentConfig,
+  /const pageSchema = sharedNavigationSchema\.extend\(\{[\s\S]*?navigation: contentNavigationSchema\.default\(false\),[\s\S]*?\}\)/,
+  'ordinary page content must keep its existing navigation:false default',
+)
+
 // Mirrors the six nested destinations' `navigation: false` frontmatter --
 // resolveTabItem() carries that field onto ResolvedTab.navigation, and these
 // hand-built fixtures stand in for that resolution step for tabs that
@@ -147,4 +159,4 @@ assert.ok(
   'the full navigation directory must honor nested destinations too',
 )
 
-console.log('Navigation consolidation verified: hubs, nested routes, admin composition, access metadata, and ArtJob icon all hold.')
+console.log('Navigation consolidation verified: schema defaults, hubs, nested routes, admin composition, access metadata, and ArtJob icon all hold.')


### PR DESCRIPTION
## Root cause
PR #2570 correctly made `ResolvedTab.navigation` opt-out (`navigation !== false`), but the Nuxt Content `channelSchema` still defaulted `navigation` to `false`. Nuxt therefore materialized every ordinary channel tab that omitted the field as non-navigable. `ChannelTabList` filtered all of those rows out while the flyout shell still rendered, producing the empty submenu sliver visible in the UI.

## Fix
- default `channelSchema.navigation` to `true`, matching the resolver contract
- leave ordinary page-content navigation defaulting to `false`
- preserve explicit `navigation: false` on the six intentionally nested Home/Admin destinations
- add a regression assertion to the navigation-consolidation verifier so schema defaults cannot drift from `ResolvedTab` semantics again

## Scope
Two files only: `content.config.ts` and `utils/scripts/verifyNavigationConsolidation.ts`.