### PR TITLE
interface-vision/t-104 slice 213: migrate bare h-4 w-4 icon glyphs, occurrence-count band

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1852,11 +1852,16 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
    * kaizen notes suggested. Slice 211 adds `components/servers/` (4 files,
    * 9 occurrences). Slice 212 adds `components/pages/` (4 files, 11
    * occurrences), the last bounded sibling directory identified by prior
-   * kaizen notes. The remaining ~124 occurrences (35 files) are scattered
-   * across smaller directories with no single directory large enough to
-   * bound a slice the way the prior ones did -- the next slice should pick
-   * a different splitting strategy (e.g. occurrence-count bands) rather
-   * than directory. Distinct from any future
+   * kaizen notes. Slice 213 switches to the suggested occurrence-count-band
+   * strategy: the top band of files with >=5 occurrences each --
+   * `stage-manager.vue` (17), `bot-gallery.vue` (11), `academy-style-
+   * detail.vue` (10), `coloring-book-manager.vue` (7), `reward-gallery.vue`
+   * (6), `mural-manager.vue` (5), `startup-animation.vue` (5), and
+   * `animation-manager.vue` (5) -- 66 occurrences across 8 files. The
+   * remaining ~64 occurrences (30 files, each with 1-4 occurrences) are
+   * scattered too thinly for another occurrence-count band to bound a
+   * slice the same way -- the next slice should pick an arbitrary
+   * fixed-size batch of files instead. Distinct from any future
    * `.kr-icon-primary-4` (same size, carries `text-primary`) -- this is
    * the untinted sibling. */
   .kr-icon-4 {

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -55,7 +55,7 @@
         aria-label="Close lesson"
         @click="emit('close')"
       >
-        <Icon name="mdi:close" class="h-4 w-4" />
+        <Icon name="mdi:close" class="kr-icon-4" />
       </button>
 
       <div class="absolute inset-x-0 bottom-0 flex flex-col gap-4 p-5 text-white sm:p-7 lg:p-9">
@@ -103,7 +103,7 @@
             rel="noopener noreferrer"
             class="btn rounded-2xl border-white/30 bg-black/35 text-white backdrop-blur hover:bg-black/55"
           >
-            <Icon name="kind-icon:gallery" class="h-4 w-4" />
+            <Icon name="kind-icon:gallery" class="kr-icon-4" />
             View a real work
           </a>
         </div>
@@ -132,7 +132,7 @@
         aria-label="Close lesson"
         @click="emit('close')"
       >
-        <Icon name="mdi:close" class="h-4 w-4" />
+        <Icon name="mdi:close" class="kr-icon-4" />
       </button>
     </header>
 
@@ -143,7 +143,7 @@
       <div class="mb-4 flex flex-wrap items-end justify-between gap-2">
         <div>
           <p class="kr-text-eyebrow flex items-center gap-1.5 text-xs tracking-[0.16em] text-primary">
-            <Icon name="kind-icon:gallery" class="h-4 w-4" />
+            <Icon name="kind-icon:gallery" class="kr-icon-4" />
             Gallery wall
           </p>
           <h4 class="kr-text-black-xl mt-1 text-base-content">Look before you read</h4>
@@ -193,7 +193,7 @@
       <div class="flex min-w-0 flex-col gap-5">
         <section class="kr-panel-section sm:p-6">
           <p class="kr-text-eyebrow flex items-center gap-1.5 text-xs tracking-[0.16em] text-primary">
-            <Icon name="kind-icon:search" class="h-4 w-4" />
+            <Icon name="kind-icon:search" class="kr-icon-4" />
             How to spot it
           </p>
           <h4 class="kr-text-black-xl mt-2 text-base-content">Train your eye</h4>
@@ -217,7 +217,7 @@
           <div class="flex flex-wrap items-end justify-between gap-2">
             <div>
               <p class="kr-text-eyebrow flex items-center gap-1.5 text-xs tracking-[0.16em] text-secondary">
-                <Icon name="kind-icon:user" class="h-4 w-4" />
+                <Icon name="kind-icon:user" class="kr-icon-4" />
                 Meet the masters
               </p>
               <h4 class="kr-text-black-xl mt-2 text-base-content">People behind the movement</h4>
@@ -277,7 +277,7 @@
         <section class="overflow-hidden rounded-3xl border border-primary/25 bg-primary/5 shadow-sm">
           <div class="border-b border-primary/15 bg-primary/10 p-5">
             <p class="kr-text-eyebrow flex items-center gap-1.5 text-xs tracking-[0.16em] text-primary">
-              <Icon name="kind-icon:flask" class="h-4 w-4" />
+              <Icon name="kind-icon:flask" class="kr-icon-4" />
               Try it
             </p>
             <h4 class="kr-text-black-2xl mt-2 leading-tight text-base-content">
@@ -309,7 +309,7 @@
             </div>
 
             <p class="kr-text-dim-xs-55 flex items-start gap-2 leading-relaxed">
-              <Icon name="kind-icon:refresh" class="mt-0.5 h-4 w-4 shrink-0" />
+              <Icon name="kind-icon:refresh" class="kr-icon-4 mt-0.5 shrink-0" />
               Not quite right? Try a different source image, tweak the instruction, or adjust the style strength and remix again.
             </p>
 
@@ -327,7 +327,7 @@
 
         <section class="kr-panel-section">
           <p class="kr-text-eyebrow kr-text-dim-xs-45 flex items-center gap-1.5 tracking-[0.16em]">
-            <Icon name="kind-icon:chat" class="h-4 w-4" />
+            <Icon name="kind-icon:chat" class="kr-icon-4" />
             Reflect
           </p>
           <h4 class="kr-text-black-lg mt-2 text-base-content">Look again after you remix</h4>
@@ -337,7 +337,7 @@
               :key="prompt"
               class="flex items-start gap-2 rounded-xl bg-base-200/45 p-3 text-sm leading-relaxed text-base-content/75"
             >
-              <Icon name="kind-icon:question" class="mt-0.5 h-4 w-4 shrink-0 text-primary/60" />
+              <Icon name="kind-icon:question" class="kr-icon-4 mt-0.5 shrink-0 text-primary/60" />
               {{ prompt }}
             </li>
           </ul>

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -27,7 +27,7 @@
           class="kr-btn btn-outline"
           title="Toggle effects live on-screen"
         >
-          <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+          <Icon name="kind-icon:sparkles" class="kr-icon-4" />
           Screen FX
         </NuxtLink>
         <NuxtLink
@@ -35,7 +35,7 @@
           class="kr-btn btn-outline"
           title="Animation development work lives in Conductor"
         >
-          <Icon name="kind-icon:scroll" class="h-4 w-4" />
+          <Icon name="kind-icon:scroll" class="kr-icon-4" />
           Conductor
         </NuxtLink>
         <button
@@ -44,7 +44,7 @@
           type="button"
           @click="store.clearEffects()"
         >
-          <Icon name="kind-icon:x" class="h-4 w-4" />
+          <Icon name="kind-icon:x" class="kr-icon-4" />
           Clear {{ activeCount }}
         </button>
       </div>
@@ -141,7 +141,7 @@
             title="Close details"
             @click="store.selectSlug(null)"
           >
-            <Icon name="kind-icon:x" class="h-4 w-4" />
+            <Icon name="kind-icon:x" class="kr-icon-4" />
           </button>
         </div>
 
@@ -176,7 +176,7 @@
           type="button"
           @click="store.previewEffect(store.selectedItem.id)"
         >
-          <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+          <Icon name="kind-icon:sparkles" class="kr-icon-4" />
           {{ store.isEffectActive(store.selectedItem.id) ? 'Stop effect' : 'Preview effect' }}
         </button>
 

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -36,7 +36,7 @@
             type="button"
             @click="startAddingBot"
           >
-            <Icon name="kind-icon:plus" class="h-4 w-4" />
+            <Icon name="kind-icon:plus" class="kr-icon-4" />
             <span class="hidden sm:inline">Add</span>
           </button>
 
@@ -48,7 +48,7 @@
             @click="refreshBots(true)"
           >
             <span v-if="isLoading || botStore.loading" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+            <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
             <span class="hidden sm:inline">Refresh</span>
           </button>
         </div>
@@ -71,7 +71,7 @@
         </div>
 
         <button class="kr-btn-ghost" type="button" @click="closeBotForm">
-          <Icon name="kind-icon:x" class="h-4 w-4" />
+          <Icon name="kind-icon:x" class="kr-icon-4" />
           <span class="hidden sm:inline">Close</span>
         </button>
       </div>
@@ -144,7 +144,7 @@
               class="btn btn-outline btn-sm mr-auto rounded-xl"
               @click="cloneInfoBot"
             >
-              <Icon name="kind-icon:copy" class="h-4 w-4" />
+              <Icon name="kind-icon:copy" class="kr-icon-4" />
               Clone
             </button>
 
@@ -154,7 +154,7 @@
               class="btn btn-outline btn-error btn-sm rounded-xl"
               @click="deleteInfoBot"
             >
-              <Icon name="kind-icon:trash" class="h-4 w-4" />
+              <Icon name="kind-icon:trash" class="kr-icon-4" />
               Delete
             </button>
           </template>
@@ -262,7 +262,7 @@
                 type="button"
                 @click="launchSelectedBot"
               >
-                <Icon name="kind-icon:play" class="h-4 w-4" />
+                <Icon name="kind-icon:play" class="kr-icon-4" />
                 <span class="hidden sm:inline">Launch</span>
               </button>
 
@@ -272,7 +272,7 @@
                 type="button"
                 @click="cloneSelectedBot"
               >
-                <Icon name="kind-icon:copy" class="h-4 w-4" />
+                <Icon name="kind-icon:copy" class="kr-icon-4" />
                 <span class="hidden sm:inline">Clone</span>
               </button>
 
@@ -282,7 +282,7 @@
                 type="button"
                 @click="startEditingSelectedBot"
               >
-                <Icon name="kind-icon:pencil" class="h-4 w-4" />
+                <Icon name="kind-icon:pencil" class="kr-icon-4" />
                 <span class="hidden sm:inline">Edit</span>
               </button>
             </div>
@@ -370,7 +370,7 @@
           type="button"
           @click="startAddingBot"
         >
-          <Icon name="kind-icon:plus" class="h-4 w-4" />
+          <Icon name="kind-icon:plus" class="kr-icon-4" />
           Build Bot
         </button>
       </div>
@@ -469,7 +469,7 @@
                 <Icon
                   v-if="segment.icon"
                   :name="segment.icon"
-                  class="h-4 w-4"
+                  class="kr-icon-4"
                   aria-hidden="true"
                 />
                 <span :class="segment.icon ? 'sr-only' : 'text-xs font-bold'">
@@ -542,7 +542,7 @@
               type="button"
               @click="clearSelectedBot"
             >
-              <Icon name="kind-icon:x" class="h-4 w-4" />
+              <Icon name="kind-icon:x" class="kr-icon-4" />
               Clear
             </button>
           </div>

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -105,7 +105,7 @@
             class="kr-btn-ghost-2xl"
             @click="closePage"
           >
-            <Icon name="mdi:arrow-left" class="h-4 w-4" />
+            <Icon name="mdi:arrow-left" class="kr-icon-4" />
             Library
           </button>
           <h2 class="kr-text-black-sm text-base-content">
@@ -120,7 +120,7 @@
             title="Undo last fill"
             @click="coloringStore.undo()"
           >
-            <Icon name="mdi:undo" class="h-4 w-4" />
+            <Icon name="mdi:undo" class="kr-icon-4" />
             Undo
           </button>
           <button
@@ -129,7 +129,7 @@
             title="Clear all fills"
             @click="coloringStore.resetPage()"
           >
-            <Icon name="mdi:restore" class="h-4 w-4" />
+            <Icon name="mdi:restore" class="kr-icon-4" />
             Reset
           </button>
           <button
@@ -143,7 +143,7 @@
               v-if="isExporting"
               class="kr-spinner-xs"
             />
-            <Icon v-else name="kind-icon:image" class="h-4 w-4" />
+            <Icon v-else name="kind-icon:image" class="kr-icon-4" />
             Save image
           </button>
           <button
@@ -152,7 +152,7 @@
             title="Download your color assignments as JSON"
             @click="downloadAssignments"
           >
-            <Icon name="mdi:download" class="h-4 w-4" />
+            <Icon name="mdi:download" class="kr-icon-4" />
             Save file
           </button>
         </div>
@@ -200,7 +200,7 @@
               title="Paint blank (eraser)"
               @click="coloringStore.setActiveColor(BLANK_COLOR_ID)"
             >
-              <Icon name="mdi:eraser" class="h-4 w-4" />
+              <Icon name="mdi:eraser" class="kr-icon-4" />
             </button>
           </div>
 
@@ -216,7 +216,7 @@
               class="btn btn-outline btn-sm flex-1 rounded-2xl"
               @click="addCustomColor"
             >
-              <Icon name="mdi:plus" class="h-4 w-4" />
+              <Icon name="mdi:plus" class="kr-icon-4" />
               Add color
             </button>
           </div>

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -53,7 +53,7 @@
             type="button"
             @click="startAddingReward"
           >
-            <Icon name="kind-icon:plus" class="h-4 w-4" />
+            <Icon name="kind-icon:plus" class="kr-icon-4" />
             <span class="hidden sm:inline">Add</span>
           </button>
 
@@ -65,7 +65,7 @@
             @click="refreshRewards(true)"
           >
             <span v-if="isLoading" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+            <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
             <span class="hidden sm:inline">Refresh</span>
           </button>
         </div>
@@ -88,7 +88,7 @@
         </div>
 
         <button class="kr-btn-ghost" type="button" @click="closeRewardForm">
-          <Icon name="kind-icon:x" class="h-4 w-4" />
+          <Icon name="kind-icon:x" class="kr-icon-4" />
           <span class="hidden sm:inline">Close</span>
         </button>
       </div>
@@ -230,7 +230,7 @@
               type="button"
               @click="startEditingReward"
             >
-              <Icon name="kind-icon:pencil" class="h-4 w-4" />
+              <Icon name="kind-icon:pencil" class="kr-icon-4" />
               <span class="hidden sm:inline">Edit</span>
             </button>
           </div>
@@ -314,7 +314,7 @@
           type="button"
           @click="startAddingReward"
         >
-          <Icon name="kind-icon:plus" class="h-4 w-4" />
+          <Icon name="kind-icon:plus" class="kr-icon-4" />
           Add Reward
         </button>
       </div>
@@ -424,7 +424,7 @@
               type="button"
               @click="clearSelectedReward"
             >
-              <Icon name="kind-icon:x" class="h-4 w-4" />
+              <Icon name="kind-icon:x" class="kr-icon-4" />
               Clear
             </button>
           </div>

--- a/components/screenfx/startup-animation.vue
+++ b/components/screenfx/startup-animation.vue
@@ -49,7 +49,7 @@
             :disabled="!hasSelectableEffects"
             @click="selectPreviousEffect"
           >
-            <Icon name="kind-icon:chevron-left" class="h-4 w-4" />
+            <Icon name="kind-icon:chevron-left" class="kr-icon-4" />
           </button>
 
           <button
@@ -59,7 +59,7 @@
             :disabled="!hasSelectableEffects"
             @click="selectRandomEffect"
           >
-            <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+            <Icon name="kind-icon:sparkles" class="kr-icon-4" />
             <span class="hidden sm:inline">Random</span>
           </button>
 
@@ -71,7 +71,7 @@
             :disabled="!hasSelectableEffects"
             @click="selectNextEffect"
           >
-            <Icon name="kind-icon:chevron-right" class="h-4 w-4" />
+            <Icon name="kind-icon:chevron-right" class="kr-icon-4" />
           </button>
         </div>
 
@@ -93,7 +93,7 @@
           aria-label="Leave startup animation"
           @click="startupStore.requestExit()"
         >
-          <Icon name="kind-icon:x" class="h-4 w-4" />
+          <Icon name="kind-icon:x" class="kr-icon-4" />
         </button>
       </template>
 
@@ -108,7 +108,7 @@
           title="Pause the launch and explore animations"
           @click="startupStore.enterControlMode()"
         >
-          <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+          <Icon name="kind-icon:sparkles" class="kr-icon-4" />
           <span>Pause &amp; explore</span>
         </button>
       </template>

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -300,7 +300,7 @@
                       ? 'mdi:chevron-down'
                       : 'mdi:chevron-right'
                   "
-                  class="h-4 w-4"
+                  class="kr-icon-4"
                 />
                 Performer Gallery ({{ store.performers.length }} preset
                 performers)
@@ -344,7 +344,7 @@
                       class="btn btn-primary btn-sm rounded-xl gap-1.5"
                       @click="openPerformerCreator()"
                     >
-                      <Icon name="mdi:account-plus" class="h-4 w-4" />
+                      <Icon name="mdi:account-plus" class="kr-icon-4" />
                       Create Custom Performer
                     </button>
 
@@ -354,7 +354,7 @@
                       class="btn btn-ghost btn-sm rounded-xl gap-1.5"
                       @click="pendingCustomPerformer = null"
                     >
-                      <Icon name="mdi:close" class="h-4 w-4" />
+                      <Icon name="mdi:close" class="kr-icon-4" />
                       Clear Custom
                     </button>
                   </div>
@@ -489,7 +489,7 @@
                 @click="activeCard = 'settings'"
               >
                 Cast ready — configure show
-                <Icon name="mdi:arrow-right" class="h-4 w-4" />
+                <Icon name="mdi:arrow-right" class="kr-icon-4" />
               </button>
             </div>
           </template>
@@ -641,7 +641,7 @@
               class="kr-btn-outline-md"
               @click="activeCard = 'cast'"
             >
-              <Icon name="mdi:arrow-left" class="h-4 w-4" /> Back
+              <Icon name="mdi:arrow-left" class="kr-icon-4" /> Back
             </button>
             <button
               type="button"
@@ -649,7 +649,7 @@
               :disabled="!store.castReady"
               @click="goToRun"
             >
-              <Icon name="mdi:play" class="h-4 w-4" />
+              <Icon name="mdi:play" class="kr-icon-4" />
               Start the show
             </button>
           </div>
@@ -702,7 +702,7 @@
                   class="kr-btn btn-outline"
                   @click="activeCard = 'cast'"
                 >
-                  <Icon name="mdi:account-multiple-plus" class="h-4 w-4" /> Cast
+                  <Icon name="mdi:account-multiple-plus" class="kr-icon-4" /> Cast
                   Roles
                 </button>
                 <button
@@ -711,7 +711,7 @@
                   :disabled="!store.castReady"
                   @click="store.start()"
                 >
-                  <Icon name="mdi:play" class="h-4 w-4" /> Start Show
+                  <Icon name="mdi:play" class="kr-icon-4" /> Start Show
                 </button>
               </div>
             </div>
@@ -730,7 +730,7 @@
                 :disabled="!store.castReady"
                 @click="store.start()"
               >
-                <Icon name="mdi:play" class="h-4 w-4" /> Start
+                <Icon name="mdi:play" class="kr-icon-4" /> Start
               </button>
             </template>
             <template v-else-if="!store.isPaused">
@@ -739,7 +739,7 @@
                 class="btn btn-warning btn-sm rounded-2xl"
                 @click="store.pause()"
               >
-                <Icon name="mdi:pause" class="h-4 w-4" /> Pause
+                <Icon name="mdi:pause" class="kr-icon-4" /> Pause
               </button>
             </template>
             <template v-else>
@@ -748,7 +748,7 @@
                 class="btn btn-primary btn-sm rounded-2xl"
                 @click="store.resume()"
               >
-                <Icon name="mdi:play" class="h-4 w-4" /> Resume
+                <Icon name="mdi:play" class="kr-icon-4" /> Resume
               </button>
             </template>
 
@@ -758,7 +758,7 @@
               class="kr-btn-ghost-2xl"
               @click="store.stop()"
             >
-              <Icon name="mdi:stop" class="h-4 w-4" />
+              <Icon name="mdi:stop" class="kr-icon-4" />
             </button>
             <button
               type="button"
@@ -766,7 +766,7 @@
               :disabled="store.isGenerating || !store.transcript.length"
               @click="store.regenerateLastTurn()"
             >
-              <Icon name="mdi:refresh" class="h-4 w-4" />
+              <Icon name="mdi:refresh" class="kr-icon-4" />
             </button>
             <button
               type="button"
@@ -774,7 +774,7 @@
               :disabled="store.isGenerating"
               @click="store.generateNextTurn()"
             >
-              <Icon name="mdi:skip-next" class="h-4 w-4" />
+              <Icon name="mdi:skip-next" class="kr-icon-4" />
             </button>
 
             <span class="kr-text-dim-xs flex-1">
@@ -809,7 +809,7 @@
                 :disabled="!interjection.trim()"
                 @click="submitInterjection"
               >
-                <Icon name="mdi:send" class="h-4 w-4" />
+                <Icon name="mdi:send" class="kr-icon-4" />
               </button>
             </div>
             <div class="flex gap-2">
@@ -826,7 +826,7 @@
                 :disabled="!narratorBeat.trim()"
                 @click="submitNarratorBeat"
               >
-                <Icon name="mdi:script-text" class="h-4 w-4" />
+                <Icon name="mdi:script-text" class="kr-icon-4" />
               </button>
             </div>
           </div>
@@ -885,7 +885,7 @@
             class="h-full w-full object-cover opacity-80"
           />
           <div v-else class="flex h-full items-center justify-center">
-            <Icon :name="card.icon" class="h-4 w-4 opacity-40" />
+            <Icon :name="card.icon" class="kr-icon-4 opacity-40" />
           </div>
           <div
             v-if="activeCard === card.key"

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -27,7 +27,7 @@
             type="button"
             @click="coloringStore.undo()"
           >
-            <Icon name="mdi:undo" class="h-4 w-4" />
+            <Icon name="mdi:undo" class="kr-icon-4" />
             Undo
           </button>
 
@@ -36,7 +36,7 @@
             type="button"
             @click="coloringStore.resetPage()"
           >
-            <Icon name="kind-icon:refresh" class="h-4 w-4" />
+            <Icon name="kind-icon:refresh" class="kr-icon-4" />
             Reset
           </button>
 
@@ -48,7 +48,7 @@
             @click="saveImage"
           >
             <span v-if="isExporting" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:image" class="h-4 w-4" />
+            <Icon v-else name="kind-icon:image" class="kr-icon-4" />
             Save image
           </button>
 
@@ -123,7 +123,7 @@
                 "
                 @click="coloringStore.removeColor(color.id)"
               >
-                <Icon name="kind-icon:trash" class="h-4 w-4" />
+                <Icon name="kind-icon:trash" class="kr-icon-4" />
               </button>
             </div>
           </div>
@@ -158,7 +158,7 @@
               class="btn btn-sm btn-primary rounded-xl text-white"
               type="submit"
             >
-              <Icon name="kind-icon:plus" class="h-4 w-4" />
+              <Icon name="kind-icon:plus" class="kr-icon-4" />
               Save Color
             </button>
           </div>


### PR DESCRIPTION
### Task
interface-vision/t-104 (recurring consistency umbrella) — slice 213.

### What changed
Replaces hand-rolled `class="h-4 w-4"` with the shared `.kr-icon-4` utility class on 66 Icon glyphs across 8 files, switching to the occurrence-count-band splitting strategy the prior slice's kaizen note suggested (no single directory was large enough to bound a slice anymore):

- `components/stages/stage-manager.vue` (17)
- `components/bots/bot-gallery.vue` (11)
- `components/academy/academy-style-detail.vue` (10)
- `components/coloring/coloring-book-manager.vue` (7)
- `components/rewards/reward-gallery.vue` (6)
- `components/wonderlab/mural-manager.vue` (5)
- `components/screenfx/startup-animation.vue` (5)
- `components/animation/animation-manager.vue` (5)

The top band of files with >=5 occurrences each. No geometry or behavior change — `.kr-icon-4` is defined as `@apply h-4 w-4` in `assets/css/tailwind.css`. Combined-class instances (e.g. `mt-0.5 h-4 w-4 shrink-0`) keep their sibling utilities, moving `kr-icon-4` to the front. Left three non-glyph `h-4 w-4` badge-dot `<span>` elements in `stage-manager.vue` untouched (out of scope — not Icon glyphs).

Updates the `.kr-icon-4` doc comment to record slice 213 and the remaining scattered count (~64 occurrences, 30 files, each 1-4 occurrences).

### How I verified
- `vue-tsc --noEmit`: clean
- `eslint`: 333 problems (327 errors, 6 warnings) — matches baseline
- `test:layout-contract`: holds, no new violations
- `test:lint-ratchet`: holds at 333/-59
- `prettier --check`: flags the same 6 pre-existing-drift files before/after (confirmed via `git stash`)

### Stakes
Reversible, scoped, mechanical class-name swap only.

### Flags for Reviewer
None.

### Kaizen suggestion
The remaining ~64 occurrences (30 files, each 1-4 occurrences) are scattered too thinly for another occurrence-count band to bound a slice the same way — the next slice should pick an arbitrary fixed-size batch of files instead (e.g. alphabetical, or grouped by subdirectory regardless of size).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HnYZpkvMXRncKa4gf8cfu

---
_Generated by [Claude Code](https://claude.ai/code/session_017HnYZpkvMXRncKa4gf8cfu)_