### PR TITLE
refactor(ui): use kr-icon-4 in bot card actions

### DIFF
--- a/components/bots/bot-card.vue
+++ b/components/bots/bot-card.vue
@@ -78,7 +78,7 @@
             type="button"
             @click.stop="launchBot"
           >
-            <Icon name="kind-icon:message" class="h-4 w-4" />
+            <Icon name="kind-icon:message" class="kr-icon-4" />
             Chat
           </button>
 
@@ -87,7 +87,7 @@
             type="button"
             @click.stop="selectBot"
           >
-            <Icon name="kind-icon:check" class="h-4 w-4" />
+            <Icon name="kind-icon:check" class="kr-icon-4" />
             Select
           </button>
         </div>


### PR DESCRIPTION
## Summary
- migrate the two bare `h-4 w-4` Bot card action glyphs to the shared `kr-icon-4` primitive
- no behavior, layout, or color change

## Verification
- branch diff against current `main`: 1 file, +2/-2, branch 0 commits behind
- this is the same mechanical icon-size substitution used by interface-vision/t-104 slices 204-213
- full repository CI is authoritative and must complete green before merge

## Flags for Reviewer
None. Reversible presentation-token cleanup only; no schema, API, data, deployment, or outward-facing action.