### PR TITLE
interface-vision/t-104 slice 214: migrate 33 bare h-4 w-4 icon glyphs, alphabetical batch

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1861,7 +1861,16 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
    * remaining ~64 occurrences (30 files, each with 1-4 occurrences) are
    * scattered too thinly for another occurrence-count band to bound a
    * slice the same way -- the next slice should pick an arbitrary
-   * fixed-size batch of files instead. Distinct from any future
+   * fixed-size batch of files instead. Slice 214 takes the first
+   * alphabetical batch of 14 files (33 occurrences): academy-styles-
+   * browser.vue, academy-timeline.vue, achievement-gallery.vue,
+   * add-bot.vue, brainstorm-manager.vue, kr-card-back.vue,
+   * kr-entity-card-body.vue, kr-search-field.vue, add-lora.vue,
+   * lora-discover.vue, kr-manager.vue, model-builder-item-panel.vue,
+   * model-builder-recipe-selector.vue, model-builder-source-picker.vue.
+   * 13 files / 29 occurrences remain, alphabetically after
+   * model-builder-source-picker.vue -- the next slice can keep taking
+   * arbitrary alphabetical batches the same way. Distinct from any future
    * `.kr-icon-primary-4` (same size, carries `text-primary`) -- this is
    * the untinted sibling. */
   .kr-icon-4 {

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -6,7 +6,7 @@
     >
       <div class="min-w-0 max-w-2xl">
         <p class="kr-text-eyebrow flex items-center gap-1.5 text-xs tracking-[0.16em] text-primary">
-          <Icon name="kind-icon:palette" class="h-4 w-4" aria-hidden="true" />
+          <Icon name="kind-icon:palette" class="kr-icon-4" aria-hidden="true" />
           Browse the collection
         </p>
         <h2 class="kr-text-black-2xl mt-2 text-base-content sm:text-3xl">Style Gallery</h2>
@@ -52,7 +52,7 @@
               title="Clear search"
               @click="clearSearch"
             >
-              <Icon name="mdi:close" class="h-4 w-4" aria-hidden="true" />
+              <Icon name="mdi:close" class="kr-icon-4" aria-hidden="true" />
             </button>
           </div>
         </div>
@@ -82,7 +82,7 @@
       <button type="button" class="kr-btn-primary rounded-2xl" @click="openNextLesson">
         <Icon
           :name="nextLesson ? 'kind-icon:arrow-right' : 'kind-icon:refresh'"
-          class="h-4 w-4"
+          class="kr-icon-4"
           aria-hidden="true"
         />
         {{ nextLesson ? 'Continue learning' : 'Review from the start' }}

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -119,7 +119,7 @@
               class="absolute right-3 top-3 flex h-8 w-8 items-center justify-center rounded-full bg-success text-success-content shadow-md"
               title="Lesson explored"
             >
-              <Icon name="kind-icon:check" class="h-4 w-4" aria-hidden="true" />
+              <Icon name="kind-icon:check" class="kr-icon-4" aria-hidden="true" />
               <span class="sr-only">Lesson explored</span>
             </div>
 
@@ -138,7 +138,7 @@
               <span>Enter the gallery</span>
               <Icon
                 name="kind-icon:arrow-right"
-                class="h-4 w-4 transition-transform group-hover:translate-x-1"
+                class="kr-icon-4 transition-transform group-hover:translate-x-1"
                 aria-hidden="true"
               />
             </div>

--- a/components/achievements/achievement-gallery.vue
+++ b/components/achievements/achievement-gallery.vue
@@ -29,7 +29,7 @@
         type="button"
         @click="resetAchievements"
       >
-        <Icon name="kind-icon:refresh" class="h-4 w-4" />
+        <Icon name="kind-icon:refresh" class="kr-icon-4" />
         Reset
       </button>
     </header>
@@ -44,7 +44,7 @@
           <span
             class="flex h-7 w-7 items-center justify-center rounded-lg bg-success/15 text-success"
           >
-            <Icon name="kind-icon:check" class="h-4 w-4" />
+            <Icon name="kind-icon:check" class="kr-icon-4" />
           </span>
           <h2 class="kr-text-black-sm text-base-content">Earned</h2>
           <span class="ml-auto badge badge-success badge-sm">{{
@@ -86,7 +86,7 @@
           <span
             class="flex h-7 w-7 items-center justify-center rounded-lg bg-secondary/15 text-secondary"
           >
-            <Icon name="kind-icon:trophy" class="h-4 w-4" />
+            <Icon name="kind-icon:trophy" class="kr-icon-4" />
           </span>
           <h2 class="kr-text-black-sm text-base-content">Leaderboard</h2>
         </div>
@@ -101,7 +101,7 @@
           <span
             class="flex h-7 w-7 items-center justify-center rounded-lg bg-base-300 text-base-content/50"
           >
-            <Icon name="kind-icon:question" class="h-4 w-4" />
+            <Icon name="kind-icon:question" class="kr-icon-4" />
           </span>
           <h2 class="kr-text-black-sm text-base-content">Undiscovered</h2>
           <span class="kr-badge-ghost-sm ml-auto">{{

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -39,7 +39,7 @@
               type="button"
               @click="seedBot"
             >
-              <Icon name="kind-icon:dice" class="h-4 w-4" />
+              <Icon name="kind-icon:dice" class="kr-icon-4" />
               Seed
             </button>
           </div>
@@ -199,7 +199,7 @@
               type="button"
               @click="useRandomArtImage"
             >
-              <Icon name="kind-icon:dice" class="h-4 w-4" />
+              <Icon name="kind-icon:dice" class="kr-icon-4" />
               Random Art Image
             </button>
           </div>
@@ -231,7 +231,7 @@
               v-if="isGeneratingFields"
               class="kr-spinner-xs"
             />
-            <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
+            <Icon v-else name="kind-icon:sparkles" class="kr-icon-4" />
             Update Selected
           </button>
         </div>

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -629,7 +629,7 @@
           data-testid="brainstorm-copy-kept"
           @click="copySelectedKept"
         >
-          <Icon name="kind-icon:copy" class="h-4 w-4" />
+          <Icon name="kind-icon:copy" class="kr-icon-4" />
           Copy selected
         </button>
         <button
@@ -639,7 +639,7 @@
           data-testid="brainstorm-export-kept"
           @click="exportSelectedKept"
         >
-          <Icon name="kind-icon:download" class="h-4 w-4" />
+          <Icon name="kind-icon:download" class="kr-icon-4" />
           Export .md
         </button>
         <span v-if="keptExportMessage" class="kr-text-dim-xs">{{
@@ -739,7 +739,7 @@
             v-if="isGeneratingArt"
             class="kr-spinner-xs"
           />
-          <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
+          <Icon v-else name="kind-icon:sparkles" class="kr-icon-4" />
           {{
             isGeneratingArt
               ? artProgressLabel

--- a/components/gallery/kr-card-back.vue
+++ b/components/gallery/kr-card-back.vue
@@ -138,7 +138,7 @@
         class="btn btn-sm absolute right-2 top-2 rounded-xl border-none bg-black/55 text-white hover:bg-black/75"
         @click="emit('back')"
       >
-        <Icon name="kind-icon:arrow-left" class="h-4 w-4" />
+        <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
         Back
       </button>
     </header>
@@ -246,7 +246,7 @@
         :aria-expanded="reviewsOpen"
         @click="reviewsOpen = !reviewsOpen"
       >
-        <Icon name="kind-icon:comment" class="h-4 w-4" />
+        <Icon name="kind-icon:comment" class="kr-icon-4" />
         Reviews
       </button>
 
@@ -256,7 +256,7 @@
         class="kr-btn btn-outline"
         @click="editing = true"
       >
-        <Icon name="kind-icon:edit" class="h-4 w-4" />
+        <Icon name="kind-icon:edit" class="kr-icon-4" />
         Edit
       </button>
 
@@ -267,7 +267,7 @@
         @click="emit('interact')"
       >
         {{ interactLabel }}
-        <Icon name="kind-icon:arrow-right" class="h-4 w-4" />
+        <Icon name="kind-icon:arrow-right" class="kr-icon-4" />
       </button>
     </footer>
   </section>

--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -203,7 +203,7 @@
           v-if="selected"
           class="absolute right-2 top-9 rounded-full bg-primary p-1.5 text-primary-content shadow-lg"
         >
-          <Icon name="kind-icon:check" class="h-4 w-4" aria-hidden="true" />
+          <Icon name="kind-icon:check" class="kr-icon-4" aria-hidden="true" />
         </div>
       </template>
     </kr-art-plate>

--- a/components/gallery/kr-search-field.vue
+++ b/components/gallery/kr-search-field.vue
@@ -62,7 +62,7 @@
       :aria-expanded="false"
       @click="expand"
     >
-      <Icon name="kind-icon:search" class="h-4 w-4" />
+      <Icon name="kind-icon:search" class="kr-icon-4" />
 
       <!-- A filter you cannot see is the failure mode this whole component has
            to avoid; the dot is the collapsed state admitting it is doing
@@ -85,7 +85,7 @@
       v-else
       class="kr-input-sm flex w-full min-w-0 items-center gap-2 bg-base-200"
     >
-      <Icon name="kind-icon:search" class="h-4 w-4 shrink-0 opacity-50" />
+      <Icon name="kind-icon:search" class="kr-icon-4 shrink-0 opacity-50" />
 
       <input
         ref="inputEl"

--- a/components/lora/add-lora.vue
+++ b/components/lora/add-lora.vue
@@ -29,7 +29,7 @@
         type="button"
         @click="emit('close')"
       >
-        <Icon name="kind-icon:x" class="h-4 w-4" />
+        <Icon name="kind-icon:x" class="kr-icon-4" />
         <span class="hidden sm:inline">Close</span>
       </button>
     </div>
@@ -215,7 +215,7 @@
         :disabled="isSaving || !canSubmit"
       >
         <span v-if="isSaving" class="kr-spinner-sm" />
-        <Icon v-else name="kind-icon:check" class="h-4 w-4" />
+        <Icon v-else name="kind-icon:check" class="kr-icon-4" />
         {{ isEditing ? 'Save Changes' : 'Add LoRA' }}
       </button>
     </div>

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -69,7 +69,7 @@
           :disabled="loading"
         >
           <span v-if="loading" class="kr-spinner-sm" />
-          <Icon v-else name="kind-icon:search" class="h-4 w-4" />
+          <Icon v-else name="kind-icon:search" class="kr-icon-4" />
           {{ source === 'civarchive' ? 'Look up' : 'Search' }}
         </button>
       </form>
@@ -156,7 +156,7 @@
               v-if="queuing === card.civitaiModelVersionId"
               class="kr-spinner-xs"
             />
-            <Icon v-else :name="downloadButtonIcon(card)" class="h-4 w-4" />
+            <Icon v-else :name="downloadButtonIcon(card)" class="kr-icon-4" />
             {{ downloadButtonLabel(card) }}
           </button>
         </div>

--- a/components/manager/kr-manager.vue
+++ b/components/manager/kr-manager.vue
@@ -87,7 +87,7 @@
         @click="emit('refresh')"
       >
         <span v-if="loading" class="kr-spinner-xs" />
-        <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+        <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
         Refresh
       </button>
     </div>
@@ -170,7 +170,7 @@
           type="button"
           @click="goToDefaultTab"
         >
-          <Icon name="kind-icon:arrow-left" class="h-4 w-4" />
+          <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
           <span class="hidden sm:inline">{{ defaultTabLabel }}</span>
         </button>
       </header>

--- a/components/model-builder/model-builder-item-panel.vue
+++ b/components/model-builder/model-builder-item-panel.vue
@@ -282,7 +282,7 @@
               aria-hidden="true"
             />
             <template v-else>
-              <Icon name="kind-icon:sparkles" class="h-4 w-4" />
+              <Icon name="kind-icon:sparkles" class="kr-icon-4" />
               {{
                 item.imagePath ? 'Regenerate candidate' : 'Generate candidate'
               }}
@@ -302,7 +302,7 @@
             "
             @click="store.generateItemAssetAsync(item.id)"
           >
-            <Icon name="kind-icon:clock" class="h-4 w-4" />
+            <Icon name="kind-icon:clock" class="kr-icon-4" />
           </button>
         </div>
 

--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -41,7 +41,7 @@
         @click="store.selectRecipe(recipe.key)"
       >
         <span class="kr-text-bold-xs flex items-center gap-1.5">
-          <Icon :name="recipe.icon" class="h-4 w-4" />
+          <Icon :name="recipe.icon" class="kr-icon-4" />
           {{ recipe.label }}
         </span>
       </button>
@@ -166,7 +166,7 @@
           aria-hidden="true"
         />
         <template v-else>
-          <Icon name="kind-icon:play" class="h-4 w-4" />
+          <Icon name="kind-icon:play" class="kr-icon-4" />
           Start build run
         </template>
       </button>

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -47,7 +47,7 @@
         :aria-pressed="store.sourceType === type.key"
         @click="store.selectSourceType(type.key)"
       >
-        <Icon :name="type.icon" class="h-4 w-4" />
+        <Icon :name="type.icon" class="kr-icon-4" />
         {{ type.label }}
       </button>
     </div>


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring umbrella)

### What changed / what I produced
Continues the `.kr-icon-4` untinted-glyph migration. Slices 204-212 split the ~100-file backlog by directory; slice 213 switched to occurrence-count bands once no directory was large enough to bound a slice. With both strategies exhausted, this slice takes the kaizen-suggested arbitrary alphabetical batch: the first 14 files (of the remaining 27) still carrying a bare `h-4 w-4` Icon class with no color tint.

Files (33 occurrences):
- components/academy/academy-styles-browser.vue
- components/academy/academy-timeline.vue
- components/achievements/achievement-gallery.vue
- components/bots/add-bot.vue
- components/brainstorm/brainstorm-manager.vue
- components/gallery/kr-card-back.vue
- components/gallery/kr-entity-card-body.vue
- components/gallery/kr-search-field.vue
- components/lora/add-lora.vue
- components/lora/lora-discover.vue
- components/manager/kr-manager.vue
- components/model-builder/model-builder-item-panel.vue
- components/model-builder/model-builder-recipe-selector.vue
- components/model-builder/model-builder-source-picker.vue

No geometry or behavior change — `.kr-icon-4` is `h-4 w-4` verbatim. Other modifier classes on the same element (`shrink-0`, `opacity-40`, `transition-transform`, etc.) are preserved in their original relative order. Tinted variants (`text-*`) are out of scope, matching the untinted/tinted split earlier slices established between `.kr-icon-4` and `.kr-icon-primary-4`.

13 files / 29 occurrences remain, alphabetically after `model-builder-source-picker.vue` — noted in the `tailwind.css` doc comment for the next slice.

### How I verified
- `vue-tsc --noEmit` — clean
- `eslint` on the 14 changed files — 2 pre-existing baseline errors (`achievement-gallery.vue:179` no-explicit-any, `add-bot.vue:680` no-extra-boolean-cast), confirmed via `git stash` to predate this change
- `npm run test:layout-contract` — holds, no new violations
- `npm run test:lint-ratchet` — holds at 333/-59, unchanged from the prior slice
- `prettier --check` — flags the same 10 pre-existing-drift files before and after (confirmed via `git stash`)
- `add-bot.vue` originally had CRLF line endings; caught and fixed a naive-script clobber to LF before committing (verified `git diff --stat` shows only the 3 intended line changes, not the whole file)

### Stakes
reversible

### Flags for Reviewer
- None — same pattern as slices 204-213, mechanical class-token substitution only.

### Kaizen suggestion
Keep taking arbitrary alphabetical batches of ~10-15 files per slice until the pool empties; at that point do one final sweep to catch stragglers (e.g. non-`<Icon>` bare `h-4 w-4` elements that were intentionally out of scope, or spans/images) and confirm the `.kr-icon-4` doc comment's running total matches a fresh grep.

### Notes for reviewer
Cross-repo task tracked in conductor's `projects/interface-vision/roadmap.yaml` (t-104, recurring). Conductor-side claim/review/re-arm bookkeeping is being handled in the companion conductor session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FgHtvgTbdV4qKmYbgfoxxT

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgHtvgTbdV4qKmYbgfoxxT)_