### PR TITLE
refactor(ui): use shared 16px icon primitive in reward card

### DIFF
--- a/components/rewards/reward-card.vue
+++ b/components/rewards/reward-card.vue
@@ -32,7 +32,7 @@
           title="Start Reward Story"
           @click.stop="interactWithReward"
         >
-          <Icon name="kind-icon:story" class="h-4 w-4" />
+          <Icon name="kind-icon:story" class="kr-icon-4" />
         </button>
 
         <button
@@ -42,7 +42,7 @@
           title="Edit Reward"
           @click.stop="emit('edit', reward.id)"
         >
-          <Icon name="kind-icon:pencil" class="h-4 w-4" />
+          <Icon name="kind-icon:pencil" class="kr-icon-4" />
         </button>
 
         <button
@@ -52,7 +52,7 @@
           title="Delete Reward"
           @click.stop="deleteReward"
         >
-          <Icon name="kind-icon:trash" class="h-4 w-4" />
+          <Icon name="kind-icon:trash" class="kr-icon-4" />
         </button>
       </template>
 
@@ -110,7 +110,7 @@
           type="button"
           @click.stop="selectReward"
         >
-          <Icon name="kind-icon:check" class="h-4 w-4" />
+          <Icon name="kind-icon:check" class="kr-icon-4" />
           {{ activeSelected ? 'Selected' : 'Select' }}
         </button>
 


### PR DESCRIPTION
### Task
interface-vision/t-104: bounded kr-icon-4 consistency slice (kind: software)

### What changed / what I produced
- Replaced four bare `h-4 w-4` Reward card glyphs with the existing `kr-icon-4` primitive.
- Covers story, edit, delete, and select actions in `components/rewards/reward-card.vue`.
- No behavior, color, or geometry change; `kr-icon-4` is the established 16px colorless glyph primitive.

### How I verified
- Inspected the complete one-file diff against current main.
- Conductor claim was applied and verified for session `2026-09-10T231747Z-interface-vision-t-104-c2f7`.
- Conductor review transition was processed successfully before this PR opened.
- Awaiting exact-head GitHub Actions checks; merge only after they complete successfully.

### Stakes
reversible

### Kaizen suggestion
Continue the `kr-icon-4` family in small component-bounded slices rather than a repo-wide 95-file migration; `components/model/add-model.vue` and `components/wonderlab/reaction-card.vue` are visible remaining candidates from the current search.

### Notes for reviewer
Mechanical shared-primitive substitution only; no production data, schema, secrets, billing, or deployment changes.