### PR TITLE
interface-vision/t-104 slice 216: migrate remaining bare h-4 w-4 icon glyphs to kr-icon-4

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -102,7 +102,7 @@
                 aria-label="Close workspace"
                 @click="setWorkspaceSheetOpen(false)"
               >
-                <Icon name="kind-icon:close" class="h-4 w-4" />
+                <Icon name="kind-icon:close" class="kr-icon-4" />
               </button>
             </div>
 

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -19,7 +19,7 @@
               v-if="persona?.avatarImage && !personaAvatarFailed"
               :src="persona.avatarImage"
               :alt="persona.name"
-              class="h-4 w-4 rounded-full object-cover"
+              class="kr-icon-4 rounded-full object-cover"
               loading="lazy"
               @error="personaAvatarFailed = true"
             />

--- a/components/model/add-model.vue
+++ b/components/model/add-model.vue
@@ -29,7 +29,7 @@
         type="button"
         @click="emit('close')"
       >
-        <Icon name="kind-icon:x" class="h-4 w-4" />
+        <Icon name="kind-icon:x" class="kr-icon-4" />
         <span class="hidden sm:inline">Close</span>
       </button>
     </div>
@@ -163,7 +163,7 @@
         :disabled="isSaving || !canSubmit"
       >
         <span v-if="isSaving" class="kr-spinner-sm" />
-        <Icon v-else name="kind-icon:check" class="h-4 w-4" />
+        <Icon v-else name="kind-icon:check" class="kr-icon-4" />
         {{ isEditing ? 'Save Changes' : 'Add Model' }}
       </button>
     </div>

--- a/components/narrative/kr-narrator-stage.vue
+++ b/components/narrative/kr-narrator-stage.vue
@@ -96,7 +96,7 @@
             v-if="isNarratorResponding"
             class="kr-spinner-xs"
           />
-          <Icon v-else name="kind-icon:send" class="h-4 w-4" />
+          <Icon v-else name="kind-icon:send" class="kr-icon-4" />
         </button>
       </div>
     </div>

--- a/components/projects/project-placement-manager.vue
+++ b/components/projects/project-placement-manager.vue
@@ -21,7 +21,7 @@
         </div>
 
         <span class="badge badge-warning badge-lg shrink-0 gap-1 font-black">
-          <Icon name="kind-icon:shield" class="h-4 w-4" />
+          <Icon name="kind-icon:shield" class="kr-icon-4" />
           Admin
         </span>
       </div>
@@ -89,7 +89,7 @@
               @click="loadProjects"
             >
               <span v-if="projectStore.loading" class="kr-spinner-xs" />
-              <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+              <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
               Load projects
             </button>
 
@@ -100,7 +100,7 @@
               @click="applyPlacements"
             >
               <span v-if="applying" class="kr-spinner-xs" />
-              <Icon v-else name="kind-icon:wand" class="h-4 w-4" />
+              <Icon v-else name="kind-icon:wand" class="kr-icon-4" />
               Apply placements
             </button>
           </div>

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -529,7 +529,7 @@ onMounted(async () => {
                 v-if="activePreviewResourceId === infoResource.id"
                 class="kr-spinner-xs"
               />
-              <Icon v-else name="kind-icon:sparkles" class="h-4 w-4" />
+              <Icon v-else name="kind-icon:sparkles" class="kr-icon-4" />
               {{ infoResourceArt ? 'Regenerate art' : 'Generate art' }}
             </button>
 
@@ -538,7 +538,7 @@ onMounted(async () => {
               class="kr-btn-primary"
               @click="addToGeneration(infoResource)"
             >
-              <Icon name="kind-icon:plus" class="h-4 w-4" />
+              <Icon name="kind-icon:plus" class="kr-icon-4" />
               Add to build
             </button>
           </template>

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -36,7 +36,7 @@
         :disabled="isStarting"
         @click="backToGallery"
       >
-        <Icon name="kind-icon:arrow-left" class="h-4 w-4" />
+        <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
         <span class="hidden sm:inline">Rewards</span>
       </button>
 
@@ -65,7 +65,7 @@
         title="Start a Storybook story seeded with this Reward"
         @click="startStoryWithReward"
       >
-        <Icon name="kind-icon:book-open" class="h-4 w-4" />
+        <Icon name="kind-icon:book-open" class="kr-icon-4" />
         <span class="hidden sm:inline">Start a story with this</span>
       </button>
     </header>
@@ -429,7 +429,7 @@
               :disabled="isStarting"
               @click="characterStore.deselectCharacter?.()"
             >
-              <Icon name="kind-icon:x" class="h-4 w-4" />
+              <Icon name="kind-icon:x" class="kr-icon-4" />
               Remove character
             </button>
           </div>

--- a/components/screenfx/animation-interact.vue
+++ b/components/screenfx/animation-interact.vue
@@ -17,7 +17,7 @@
           title="Previous effect"
           @click="animationStore.prevEffect()"
         >
-          <Icon name="kind-icon:chevron-left" class="h-4 w-4" />
+          <Icon name="kind-icon:chevron-left" class="kr-icon-4" />
         </button>
 
         <span
@@ -32,7 +32,7 @@
           title="Next effect"
           @click="animationStore.nextEffect()"
         >
-          <Icon name="kind-icon:chevron-right" class="h-4 w-4" />
+          <Icon name="kind-icon:chevron-right" class="kr-icon-4" />
         </button>
 
         <div class="mx-1 h-4 w-px bg-white/20" />
@@ -43,7 +43,7 @@
           title="Stop animation"
           @click="animationStore.stop()"
         >
-          <Icon name="kind-icon:x" class="h-4 w-4" />
+          <Icon name="kind-icon:x" class="kr-icon-4" />
         </button>
       </div>
 

--- a/components/screenfx/animation-selector.vue
+++ b/components/screenfx/animation-selector.vue
@@ -56,7 +56,7 @@
           type="button"
           @click="preview"
         >
-          <Icon name="kind-icon:play" class="h-4 w-4" />
+          <Icon name="kind-icon:play" class="kr-icon-4" />
           Preview
         </button>
 

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -33,7 +33,7 @@
           class="kr-btn-ghost"
           @click="emit('close')"
         >
-          <Icon name="mdi:close" class="h-4 w-4" />
+          <Icon name="mdi:close" class="kr-icon-4" />
         </button>
       </div>
 
@@ -418,7 +418,7 @@
                 <!-- Selected check badge -->
                 <div
                   v-if="isTraitSelected(choice.value)"
-                  class="absolute right-1 top-1 flex h-4 w-4 items-center justify-center rounded-full bg-primary shadow"
+                  class="kr-icon-4 absolute right-1 top-1 flex items-center justify-center rounded-full bg-primary shadow"
                 >
                   <Icon
                     name="mdi:check"
@@ -496,7 +496,7 @@
             :disabled="!form.name.trim()"
             @click="handleAssign"
           >
-            <Icon name="mdi:account-plus" class="h-4 w-4" />
+            <Icon name="mdi:account-plus" class="kr-icon-4" />
             Add to Cast
           </button>
         </div>

--- a/components/stages/stage-message.vue
+++ b/components/stages/stage-message.vue
@@ -34,7 +34,7 @@
     <div
       class="kr-icon-8 rounded-full bg-secondary/20 flex items-center justify-center shrink-0"
     >
-      <Icon name="mdi:account" class="w-4 h-4" />
+      <Icon name="mdi:account" class="kr-icon-4" />
     </div>
     <div class="bg-secondary/20 rounded-2xl px-3 py-2 text-sm">
       <div class="text-xs opacity-60 mb-0.5">{{ entry.speakerLabel }}</div>

--- a/components/themes/theme-gallery.vue
+++ b/components/themes/theme-gallery.vue
@@ -85,7 +85,7 @@
 
     <section v-if="themeError" class="shrink-0 kr-note kr-note-error p-3">
       <div class="flex items-start gap-2">
-        <Icon name="kind-icon:alert" class="mt-0.5 h-4 w-4 shrink-0" />
+        <Icon name="kind-icon:alert" class="kr-icon-4 mt-0.5 shrink-0" />
         <p class="whitespace-pre-wrap">{{ themeError }}</p>
       </div>
     </section>

--- a/components/wonderlab/reactable-card.vue
+++ b/components/wonderlab/reactable-card.vue
@@ -42,7 +42,7 @@
         title="React"
         @click.stop="toggleReaction"
       >
-        <Icon name="kind-icon:star" class="h-4 w-4" />
+        <Icon name="kind-icon:star" class="kr-icon-4" />
       </button>
     </div>
 
@@ -66,7 +66,7 @@
             type="button"
             @click="reactionOpen = false"
           >
-            <Icon name="kind-icon:x" class="h-4 w-4" />
+            <Icon name="kind-icon:x" class="kr-icon-4" />
           </button>
         </div>
 

--- a/components/wonderlab/reaction-card.vue
+++ b/components/wonderlab/reaction-card.vue
@@ -112,7 +112,7 @@
             type="button"
             @click="toggleComment"
           >
-            <Icon name="kind-icon:comment" class="h-4 w-4" />
+            <Icon name="kind-icon:comment" class="kr-icon-4" />
             {{ showComment ? 'Hide Comment' : 'Comment' }}
           </button>
 
@@ -122,7 +122,7 @@
             type="button"
             @click="clearReaction"
           >
-            <Icon name="kind-icon:x" class="h-4 w-4" />
+            <Icon name="kind-icon:x" class="kr-icon-4" />
             Clear
           </button>
         </div>
@@ -139,7 +139,7 @@
             class="kr-spinner-sm"
           />
 
-          <Icon v-else name="kind-icon:check" class="h-4 w-4" />
+          <Icon v-else name="kind-icon:check" class="kr-icon-4" />
           Submit
         </button>
       </div>
@@ -155,7 +155,7 @@
           type="button"
           @click="share(platform.key)"
         >
-          <Icon :name="platform.icon" class="h-4 w-4" />
+          <Icon :name="platform.icon" class="kr-icon-4" />
           {{ platform.label }}
         </button>
       </div>


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

### What changed / what I produced
- Ran `utils/scripts/codemods/kr_icon_4_codemod.py --root . --write` repo-wide, migrating the last 28 bare `h-4 w-4` icon-glyph occurrences (14 files) to the existing `.kr-icon-4` primitive: `app.vue`, `components/brainstorm/brainstorm-manager.vue`, `components/model/add-model.vue`, `components/narrative/kr-narrator-stage.vue`, `components/projects/project-placement-manager.vue`, `components/resources/resource-gallery.vue`, `components/rewards/reward-encounter.vue`, `components/screenfx/animation-interact.vue`, `components/screenfx/animation-selector.vue`, `components/stages/performer-creator.vue`, `components/stages/stage-message.vue`, `components/themes/theme-gallery.vue`, `components/wonderlab/reactable-card.vue`, `components/wonderlab/reaction-card.vue`.
- This closes out the `h-4 w-4` bare-glyph family for the repo — the codemod's own dry run now reports 0 remaining candidates.
- `.kr-icon-4` is a pure `@apply h-4 w-4` alias (see `assets/css/tailwind.css`), so no geometry, color, or behavior change anywhere.

### How I verified
- `npm run test` (vue-tsc --noEmit): clean, no new type errors.
- `npx eslint .`: 333 problems (327 errors, 6 warnings) — matches the documented baseline exactly, no new errors introduced.
- `npx tsx utils/scripts/verifyLayoutContract.ts`: holds, no new violations.
- `npx tsx utils/scripts/verifyLintRatchet.ts`: 333 problems / -59, ratchet holds.
- `npx prettier --check` on the 14 changed files: 7 flagged, confirmed via `git stash`/`git stash pop` to be the same pre-existing drift before and after this change (not introduced by it).
- Codemod dry run (`--root .` without `--write`) after applying: 0 remaining `kr-icon-4` candidates repo-wide.

### Stakes
reversible

### Flags for Reviewer
- None — this is a pure class-token substitution with an existing, previously-reviewed codemod, following the exact pattern of slices 198-215.

### Kaizen suggestion
The `h-4 w-4` family is now fully migrated repo-wide. The next interface-vision slice should move to the next-most-common hand-rolled shape still outstanding (check `interface-vision`'s allow-list/adoption-tracking script for the current top offender) rather than re-scanning this family.

### Notes for reviewer
Recurring consistency-umbrella task (interface-vision/t-104) — same pattern as prior slices 198-215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StSTuFNzSjpiRh2PZ82ZQb

---
_Generated by [Claude Code](https://claude.ai/code/session_01StSTuFNzSjpiRh2PZ82ZQb)_