### PR TITLE
style(interface): use kr-icon-4 in model builder source list

### DIFF
--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -233,7 +233,7 @@
             <Icon
               v-else
               :name="activeType?.icon || 'kind-icon:blueprint'"
-              class="h-4 w-4 text-base-content/30"
+              class="kr-icon-4 text-base-content/30"
             />
           </div>
           <span class="kr-text-bold-sm shrink-0 truncate text-base-content">


### PR DESCRIPTION
### Task
interface-vision/t-104: bounded consistency slice (kind: software)

### What changed / what I produced
- Replaced the remaining hand-rolled `h-4 w-4` source-list fallback glyph in `components/model-builder/model-builder-source-picker.vue` with the geometry-equivalent shared `kr-icon-4` primitive.
- Preserved the existing `text-base-content/30` tint and all behavior.

### How I verified
- Inspected the complete one-file branch diff against current `main`; this is one class-token substitution only.
- Conductor claim and `status: review` were processed and verified before opening this PR.
- CI on this exact PR head is the merge gate; merge only after all required checks complete successfully.

### Stakes
reversible

### Kaizen suggestion
Continue the `h-4 w-4` family in bounded per-file slices, prioritizing live components whose extra tokens are purely tint/shrink utilities and leaving responsive-size or structural icon classes alone.

### Notes for reviewer
No schema, API, store, route, or behavior changes.