### PR TITLE
style(sample): use shared kr-icon-4 primitive

### DIFF
--- a/sample/sample-card.vue.txt
+++ b/sample/sample-card.vue.txt
@@ -27,7 +27,7 @@
         title="Interact with Sample"
         @click.stop="interactWithSample"
       >
-        <Icon name="kind-icon:play" class="h-4 w-4" />
+        <Icon name="kind-icon:play" class="kr-icon-4" />
       </button>
 
       <button
@@ -37,7 +37,7 @@
         title="Edit Sample"
         @click.stop="emit('edit', sample.id)"
       >
-        <Icon name="kind-icon:pencil" class="h-4 w-4" />
+        <Icon name="kind-icon:pencil" class="kr-icon-4" />
       </button>
 
       <button
@@ -47,7 +47,7 @@
         title="Delete Sample"
         @click.stop="deleteSample"
       >
-        <Icon name="kind-icon:trash" class="h-4 w-4" />
+        <Icon name="kind-icon:trash" class="kr-icon-4" />
       </button>
     </template>
 
@@ -76,7 +76,7 @@
         v-if="activeSelected"
         class="absolute bottom-2 right-2 rounded-full bg-primary p-2 text-primary-content shadow"
       >
-        <Icon name="kind-icon:check" class="h-4 w-4" />
+        <Icon name="kind-icon:check" class="kr-icon-4" />
       </div>
     </div>
 

--- a/sample/sample-gallery.vue.txt
+++ b/sample/sample-gallery.vue.txt
@@ -44,7 +44,7 @@
             type="button"
             @click="startAddingSample"
           >
-            <Icon name="kind-icon:plus" class="h-4 w-4" />
+            <Icon name="kind-icon:plus" class="kr-icon-4" />
             <span class="hidden sm:inline">Add</span>
           </button>
 
@@ -56,7 +56,7 @@
             @click="refreshSamples(true)"
           >
             <span v-if="isLoading" class="loading loading-spinner loading-xs" />
-            <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+            <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
             <span class="hidden sm:inline">Refresh</span>
           </button>
         </div>
@@ -117,7 +117,7 @@
           :disabled="!sampleStore.selectedSample"
           @click="clearSelectedSample"
         >
-          <Icon name="kind-icon:x" class="h-4 w-4" />
+          <Icon name="kind-icon:x" class="kr-icon-4" />
           Clear
         </button>
       </div>
@@ -139,7 +139,7 @@
           type="button"
           @click="closeSampleForm"
         >
-          <Icon name="kind-icon:x" class="h-4 w-4" />
+          <Icon name="kind-icon:x" class="kr-icon-4" />
           <span class="hidden sm:inline">Close</span>
         </button>
       </div>
@@ -186,7 +186,7 @@
           type="button"
           @click="startAddingSample"
         >
-          <Icon name="kind-icon:plus" class="h-4 w-4" />
+          <Icon name="kind-icon:plus" class="kr-icon-4" />
           Add Sample
         </button>
       </div>

--- a/sample/sample-manager.vue.txt
+++ b/sample/sample-manager.vue.txt
@@ -26,7 +26,7 @@
           v-if="isLoadingManager"
           class="loading loading-spinner loading-xs"
         />
-        <Icon v-else name="kind-icon:refresh" class="h-4 w-4" />
+        <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
         Refresh
       </button>
     </div>
@@ -56,7 +56,7 @@
           type="button"
           @click="goToGallery"
         >
-          <Icon name="kind-icon:arrow-left" class="h-4 w-4" />
+          <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
           <span class="hidden sm:inline">Gallery</span>
         </button>
       </div>


### PR DESCRIPTION
## Summary
- migrate the scaffold sample card, gallery, and manager templates from bare `h-4 w-4` icon sizing to the geometry-equivalent `kr-icon-4` primitive
- keep larger icon sizes and all surrounding color/behavior classes unchanged
- this is scaffold/template consistency only; no production route, API, schema, or behavior change

## Conductor
- project: `interface-vision`
- task: `t-104`
- session: `2026-09-11T011527Z-interface-vision-t-104-r4x9`
- claim and review transitions were processed and verified before opening this PR

## Verification
- diff is restricted to `sample/*.vue.txt` scaffold templates
- replacements are exact `h-4 w-4` -> `kr-icon-4`, whose primitive is the same 1rem x 1rem geometry
- rely on repository PR checks for contract/type safety before merge

## Flags for Reviewer
None. Reversible consistency-only change.