### PR TITLE
style(inputs): use shared kr-input-sm primitive

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1606,6 +1606,18 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply input w-full bg-base-200;
   }
 
+  /* The small (not full-width) sibling of .kr-input (interface-vision t-104
+   * slice 219): DaisyUI's compact `input-sm` size, previously hand-rolled as
+   * `input input-bordered input-sm` -- `input-bordered` is a dead legacy v4
+   * class in this repo's daisyUI v5 (dropped here the same way .kr-input
+   * already drops it), leaving `input input-sm` as the real applied shape.
+   * 54 occurrences across 25 files, almost always a filter/search-bar or
+   * compact inline field rather than a full form input -- distinct from
+   * .kr-input/.kr-input-muted's `w-full` shape, so not folded into either. */
+  .kr-input-sm {
+    @apply input input-sm;
+  }
+
   /* The page-header icon badge: a tinted `h-12 w-12` square housing a
    * page-header `<Icon>`, sitting beside the page title (interface-vision
    * t-104 slice 149) -- previously hand-rolled identically across 8

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -33,7 +33,7 @@
           </div>
 
           <div class="flex min-w-0 flex-1 items-center gap-2 lg:flex-none">
-            <label class="input input-bordered input-sm flex min-w-0 flex-1 items-center gap-1.5 bg-base-100 lg:w-72">
+            <label class="kr-input-sm flex min-w-0 flex-1 items-center gap-1.5 bg-base-100 lg:w-72">
               <Icon name="kind-icon:search" class="h-3.5 w-3.5 shrink-0 text-base-content/40" aria-hidden="true" />
               <input
                 ref="searchInputRef"

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -179,7 +179,7 @@
         v-model="store.state.note"
         type="text"
         placeholder="Notes on this matchup (why the winner won)…"
-        class="input input-bordered input-sm flex-1"
+        class="kr-input-sm flex-1"
       />
       <button class="kr-btn-plain" @click="store.saveMatchup">Save matchup</button>
     </div>

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -155,7 +155,7 @@
               <input
                 v-model.trim="imageForm.designer"
                 type="text"
-                class="input input-bordered input-sm"
+                class="kr-input-sm"
                 :disabled="isUploading"
                 placeholder="who made this beautiful little menace?"
               />
@@ -166,7 +166,7 @@
               <input
                 v-model.trim="imageForm.genres"
                 type="text"
-                class="input input-bordered input-sm"
+                class="kr-input-sm"
                 :disabled="isUploading"
                 placeholder="gothic, surreal, sci-fi"
               />
@@ -197,7 +197,7 @@
               <input
                 v-model.trim="imageForm.checkpoint"
                 type="text"
-                class="input input-bordered input-sm"
+                class="kr-input-sm"
                 :disabled="isUploading"
                 placeholder="model checkpoint"
               />
@@ -208,7 +208,7 @@
               <input
                 v-model.trim="imageForm.sampler"
                 type="text"
-                class="input input-bordered input-sm"
+                class="kr-input-sm"
                 :disabled="isUploading"
                 placeholder="Euler a, DPM++ 2M, etc."
               />
@@ -219,7 +219,7 @@
               <input
                 v-model.number="imageForm.seed"
                 type="number"
-                class="input input-bordered input-sm"
+                class="kr-input-sm"
                 :disabled="isUploading"
               />
             </label>
@@ -230,7 +230,7 @@
                 v-model.number="imageForm.steps"
                 type="number"
                 min="1"
-                class="input input-bordered input-sm"
+                class="kr-input-sm"
                 :disabled="isUploading"
               />
             </label>
@@ -241,7 +241,7 @@
                 v-model.number="imageForm.cfg"
                 type="number"
                 min="0"
-                class="input input-bordered input-sm"
+                class="kr-input-sm"
                 :disabled="isUploading"
               />
             </label>
@@ -252,7 +252,7 @@
                 v-model.number="imageForm.rarity"
                 type="number"
                 min="0"
-                class="input input-bordered input-sm"
+                class="kr-input-sm"
                 :disabled="isUploading"
               />
             </label>
@@ -262,7 +262,7 @@
               <input
                 v-model.trim="imageForm.serverName"
                 type="text"
-                class="input input-bordered input-sm"
+                class="kr-input-sm"
                 :disabled="isUploading"
                 placeholder="A1111, Comfy, Flux…"
               />
@@ -273,7 +273,7 @@
               <input
                 v-model.trim="imageForm.serverUrl"
                 type="text"
-                class="input input-bordered input-sm"
+                class="kr-input-sm"
                 :disabled="isUploading"
                 placeholder="optional source endpoint"
               />

--- a/components/art/stylist-calculator.vue
+++ b/components/art/stylist-calculator.vue
@@ -19,7 +19,7 @@
           type="text"
           list="calculator-client-suggestions"
           placeholder="Client name"
-          class="input input-sm input-bordered w-full"
+          class="kr-input-sm w-full"
         />
         <datalist id="calculator-client-suggestions">
           <option
@@ -32,7 +32,7 @@
 
       <label class="flex flex-col gap-1">
         <span class="kr-text-black-xs text-base-content">Date</span>
-        <input v-model="date" type="date" class="input input-sm input-bordered w-full" />
+        <input v-model="date" type="date" class="kr-input-sm w-full" />
       </label>
 
       <label class="flex flex-col gap-1">
@@ -42,7 +42,7 @@
           type="number"
           min="0"
           step="5"
-          class="input input-sm input-bordered w-full"
+          class="kr-input-sm w-full"
         />
       </label>
 
@@ -53,7 +53,7 @@
           type="number"
           min="0"
           step="1"
-          class="input input-sm input-bordered w-full"
+          class="kr-input-sm w-full"
         />
       </label>
     </div>

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -10,11 +10,11 @@
     <form class="flex flex-wrap items-end gap-2 kr-panel-compact" @submit.prevent="save">
       <label class="flex min-w-40 flex-1 flex-col gap-1">
         <span class="kr-text-black-xs">Name</span>
-        <input v-model="name" type="text" placeholder="Client name" class="input input-sm input-bordered w-full" />
+        <input v-model="name" type="text" placeholder="Client name" class="kr-input-sm w-full" />
       </label>
       <label class="flex min-w-40 flex-1 flex-col gap-1">
         <span class="kr-text-black-xs">Email (optional)</span>
-        <input v-model="email" type="email" placeholder="For receipt prefill" class="input input-sm input-bordered w-full" />
+        <input v-model="email" type="email" placeholder="For receipt prefill" class="kr-input-sm w-full" />
       </label>
       <button type="submit" class="kr-btn-primary-plain" :disabled="!name.trim()">
         {{ editingId ? 'Update' : 'Add client' }}

--- a/components/art/stylist-history.vue
+++ b/components/art/stylist-history.vue
@@ -16,9 +16,9 @@
         v-model="query"
         type="text"
         placeholder="Search by client"
-        class="input input-sm input-bordered min-w-40 flex-1"
+        class="kr-input-sm min-w-40 flex-1"
       />
-      <input v-model="date" type="date" class="input input-sm input-bordered" />
+      <input v-model="date" type="date" class="kr-input-sm" />
       <button
         v-if="query || date"
         type="button"

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -36,7 +36,7 @@
           type="text"
           list="stylist-client-suggestions"
           placeholder="Whose hair are we styling?"
-          class="input input-sm input-bordered w-full"
+          class="kr-input-sm w-full"
         />
         <datalist id="stylist-client-suggestions">
           <option

--- a/components/art/stylist-settings.vue
+++ b/components/art/stylist-settings.vue
@@ -17,7 +17,7 @@
         <input
           v-model="salonName"
           type="text"
-          class="input input-sm input-bordered w-full"
+          class="kr-input-sm w-full"
           @change="save"
         />
       </label>
@@ -28,7 +28,7 @@
           v-model="bookingLink"
           type="text"
           placeholder="Booking URL, phone, or however clients should reach out"
-          class="input input-sm input-bordered w-full"
+          class="kr-input-sm w-full"
           @change="save"
         />
       </label>
@@ -39,7 +39,7 @@
           v-model="replyContact"
           type="text"
           placeholder="Where replies should go"
-          class="input input-sm input-bordered w-full"
+          class="kr-input-sm w-full"
           @change="save"
         />
       </label>

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -255,7 +255,7 @@
 
             <input
               v-model="modelName"
-              class="input input-bordered input-sm bg-base-200"
+              class="kr-input-sm bg-base-200"
               placeholder="Optional model override"
             />
           </label>
@@ -267,7 +267,7 @@
 
             <input
               v-model.number="maxTokens"
-              class="input input-bordered input-sm bg-base-200"
+              class="kr-input-sm bg-base-200"
               type="number"
               min="128"
               step="128"

--- a/components/brainstorm/brainstorm-candidate-card.vue
+++ b/components/brainstorm/brainstorm-candidate-card.vue
@@ -65,7 +65,7 @@
             :id="`${candidate.id}-title`"
             ref="editTitleInput"
             v-model="draftTitle"
-            class="input input-bordered input-sm w-full font-bold"
+            class="kr-input-sm w-full font-bold"
             maxlength="120"
             placeholder="Optional title"
             :disabled="disabled"

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -236,7 +236,7 @@
                 :max="BRAINSTORM_MAX_RESULTS"
                 :value="returnTypeCount(option.id) ?? ''"
                 placeholder="Auto"
-                class="input input-bordered input-sm w-24 bg-base-100"
+                class="kr-input-sm w-24 bg-base-100"
                 :disabled="isGenerating"
                 @input="updateReturnTypeCount(option.id, $event)"
               />

--- a/components/conductor/packmaker-pack-editor.vue
+++ b/components/conductor/packmaker-pack-editor.vue
@@ -62,7 +62,7 @@
         <input
           v-model="draft.title"
           type="text"
-          class="input input-bordered input-sm"
+          class="kr-input-sm"
           @input="syncIdFromTitle"
         />
       </label>
@@ -71,7 +71,7 @@
         <input
           v-model="draft.id"
           type="text"
-          class="input input-bordered input-sm font-mono"
+          class="kr-input-sm font-mono"
           :disabled="editingExisting"
           @input="idTouched = true"
         />
@@ -165,7 +165,7 @@
             <input
               v-model="item.draftPayload.title"
               type="text"
-              class="input input-bordered input-sm"
+              class="kr-input-sm"
               @input="item.id = slugify(item.draftPayload.title)"
             />
           </label>

--- a/components/dreams/dream-art-chooser.vue
+++ b/components/dreams/dream-art-chooser.vue
@@ -40,7 +40,7 @@
       class="mt-3 grid gap-2 lg:grid-cols-[minmax(0,1fr)_minmax(12rem,18rem)]"
     >
       <label
-        class="input input-sm input-bordered flex items-center gap-2 rounded-2xl bg-base-100"
+        class="kr-input-sm flex items-center gap-2 rounded-2xl bg-base-100"
       >
         <Icon name="kind-icon:search" class="kr-icon-4 opacity-60" />
         <input

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -76,7 +76,7 @@
           </div>
 
           <label
-            class="input input-bordered input-sm mt-3 flex items-center gap-2 rounded-2xl bg-base-100"
+            class="kr-input-sm mt-3 flex items-center gap-2 rounded-2xl bg-base-100"
           >
             <Icon name="kind-icon:search" class="kr-icon-4 opacity-60" />
             <input
@@ -393,7 +393,7 @@
                 type="number"
                 min="1"
                 max="10"
-                class="input input-bordered input-sm rounded-2xl bg-base-100"
+                class="kr-input-sm rounded-2xl bg-base-100"
               />
             </label>
             <label class="form-control">
@@ -406,7 +406,7 @@
                 min="300"
                 max="4000"
                 step="100"
-                class="input input-bordered input-sm rounded-2xl bg-base-100"
+                class="kr-input-sm rounded-2xl bg-base-100"
               />
             </label>
             <label class="form-control">

--- a/components/giftshop/shopping-cart.vue
+++ b/components/giftshop/shopping-cart.vue
@@ -91,7 +91,7 @@
                 type="number"
                 min="1"
                 max="25"
-                class="input input-sm input-bordered w-20"
+                class="kr-input-sm w-20"
                 :disabled="cartStore.loading"
                 @change="updateQuantity(item.id, item.quantity)"
               />

--- a/components/narrative/kr-narrator-stage.vue
+++ b/components/narrative/kr-narrator-stage.vue
@@ -81,7 +81,7 @@
         <input
           v-model="narratorMessage"
           type="text"
-          class="input input-bordered input-sm min-w-0 flex-1 rounded-2xl bg-base-100 text-sm"
+          class="kr-input-sm min-w-0 flex-1 rounded-2xl bg-base-100 text-sm"
           :placeholder="narratorPlaceholder"
           :disabled="!canUseNarrator || isNarratorResponding"
           @keydown.enter.prevent="sendNarratorMessage"

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -76,7 +76,7 @@
 
     <div class="flex min-h-0 flex-1 flex-col gap-3 p-3 sm:p-4">
       <div class="kr-toolbar">
-        <label class="input input-bordered input-sm flex min-w-52 flex-1 items-center gap-2 rounded-2xl bg-base-100">
+        <label class="kr-input-sm flex min-w-52 flex-1 items-center gap-2 rounded-2xl bg-base-100">
           <Icon name="kind-icon:search" class="size-4 text-base-content/35" />
           <input
             v-model="query"

--- a/components/pages/mermaids-page.vue
+++ b/components/pages/mermaids-page.vue
@@ -131,7 +131,7 @@
               v-if="editing"
               v-model="draft.amazonLabel"
               aria-label="Amazon button label"
-              class="input input-bordered input-sm min-w-48 flex-1"
+              class="kr-input-sm min-w-48 flex-1"
             />
           </div>
 

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -60,7 +60,7 @@
         </span>
         <input
           v-model="relayInput"
-          class="input input-bordered input-sm w-full"
+          class="kr-input-sm w-full"
           placeholder="http://localhost:4173"
           @change="saveRelay"
         />
@@ -89,7 +89,7 @@
       <form class="mt-3 flex gap-2" @submit.prevent="send(utterance)">
         <input
           v-model="utterance"
-          class="input input-bordered input-sm flex-1"
+          class="kr-input-sm flex-1"
           placeholder="Serendipity, turn butterflies on"
         />
         <button class="kr-btn-primary-plain" type="submit">Send</button>

--- a/components/ruler-hooked/ruler-hooked-slots.vue
+++ b/components/ruler-hooked/ruler-hooked-slots.vue
@@ -26,7 +26,7 @@
       <div class="flex flex-wrap items-end gap-2">
         <label class="form-control">
           <span class="kr-label-xs">Ruler name</span>
-          <input v-model="rulerName" type="text" placeholder="Mo" class="input input-bordered input-sm w-28" />
+          <input v-model="rulerName" type="text" placeholder="Mo" class="kr-input-sm w-28" />
         </label>
         <label class="form-control">
           <span class="kr-label-xs">Title</span>
@@ -35,7 +35,7 @@
             type="text"
             list="ruler-honorific-suggestions"
             placeholder="Queen"
-            class="input input-bordered input-sm w-32"
+            class="kr-input-sm w-32"
           />
           <datalist id="ruler-honorific-suggestions">
             <option v-for="h in honorificSuggestions" :key="h" :value="h" />

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -799,7 +799,7 @@
               <input
                 v-model="interjection"
                 type="text"
-                class="input input-bordered input-sm flex-1 rounded-2xl bg-base-100 focus:border-primary"
+                class="kr-input-sm flex-1 rounded-2xl bg-base-100 focus:border-primary"
                 placeholder="Jump in as yourself…"
                 @keydown.enter.prevent="submitInterjection"
               />
@@ -816,7 +816,7 @@
               <input
                 v-model="narratorBeat"
                 type="text"
-                class="input input-bordered input-sm flex-1 rounded-2xl bg-base-100 focus:border-primary"
+                class="kr-input-sm flex-1 rounded-2xl bg-base-100 focus:border-primary"
                 placeholder="Add a stage direction or scene beat…"
                 @keydown.enter.prevent="submitNarratorBeat"
               />

--- a/components/video-lora-picker.vue
+++ b/components/video-lora-picker.vue
@@ -132,7 +132,7 @@
             min="-2"
             max="2"
             step="0.05"
-            class="input input-bordered input-sm w-full"
+            class="kr-input-sm w-full"
             :aria-label="`${resourceLabel(entry.resource)} strength value`"
             @input="setStrength(entry.resourceId, $event)"
           />
@@ -163,7 +163,7 @@
         <input
           v-model="search"
           type="search"
-          class="input input-bordered input-sm min-w-52 flex-1"
+          class="kr-input-sm min-w-52 flex-1"
           placeholder="Search LoRAs by name, path, or trigger word…"
         />
         <span class="kr-text-faded-xs-55">

--- a/components/wonderlab/mural-manager.vue
+++ b/components/wonderlab/mural-manager.vue
@@ -133,7 +133,7 @@
           <div class="grid gap-2">
             <input
               v-model="newColorName"
-              class="input input-bordered input-sm bg-base-200"
+              class="kr-input-sm bg-base-200"
               type="text"
               placeholder="Color name"
             />
@@ -141,7 +141,7 @@
             <div class="grid grid-cols-[1fr_auto] gap-2">
               <input
                 v-model="newColorValue"
-                class="input input-bordered input-sm bg-base-200 font-mono"
+                class="kr-input-sm bg-base-200 font-mono"
                 type="text"
                 placeholder="#55a9b5"
               />

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -94,7 +94,7 @@
               <div class="join w-full max-w-xl">
                 <input
                   v-model="newSetName"
-                  class="input input-bordered input-sm join-item min-w-0 flex-1"
+                  class="kr-input-sm join-item min-w-0 flex-1"
                   placeholder="Work phrases"
                   maxlength="80"
                 />
@@ -130,7 +130,7 @@
               <span class="label-text mb-1 font-semibold">Find Hanzi, pinyin, or English</span>
               <input
                 v-model="searchQuery"
-                class="input input-bordered input-sm w-full"
+                class="kr-input-sm w-full"
                 placeholder="说, shuō, speak, casino…"
                 autocomplete="off"
               />

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -267,7 +267,7 @@
               min="64"
               max="2048"
               step="8"
-              class="input input-bordered input-sm w-full"
+              class="kr-input-sm w-full"
             />
           </div>
           <div class="space-y-1">
@@ -278,7 +278,7 @@
               min="64"
               max="2048"
               step="8"
-              class="input input-bordered input-sm w-full"
+              class="kr-input-sm w-full"
             />
           </div>
           <div class="space-y-1">
@@ -299,7 +299,7 @@
               v-model="seedInput"
               type="number"
               min="0"
-              class="input input-bordered input-sm w-full"
+              class="kr-input-sm w-full"
             />
           </div>
         </div>

--- a/utils/scripts/codemods/kr_input_sm_codemod.py
+++ b/utils/scripts/codemods/kr_input_sm_codemod.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `input input-bordered input-sm` shapes to
+`kr-input-sm`.
+
+The small (not full-width) sibling of `.kr-input`/`.kr-input-muted`
+(interface-vision t-104 slice 219) -- DaisyUI v5's compact `input-sm` size.
+`input-bordered` is a dead legacy v4 class in this repo's daisyUI v5 (the
+base `input` class already carries a border), dropped here the same way
+`.kr-input` already drops it from its own `@apply`. Distinct from
+`.kr-input`/`.kr-input-muted`, which both require `w-full`: this family is
+the compact inline/filter-bar shape, not a full-width form field, so it is
+not folded into either existing primitive even where a source also happens
+to carry `w-full` as an extra token.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+class strings containing all three base tokens (`input`, `input-bordered`,
+`input-sm`) are touched, and only in static `class="..."` attributes --
+never `:class`/`v-bind:class` bindings (see _class_attr.py). A source that
+already carries `kr-input-sm`, or is missing any one of the three base
+tokens, is left untouched. Extra tokens beyond the base set (w-full, flex-1,
+rounded-2xl, bg-base-100, ...) are preserved verbatim after the primitive
+class, matching every other kr-*-codemod's subset-match convention -- pass
+--exact-only to restrict a slice to sources with no extra tokens at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-input-sm"
+BASE_TOKENS = {"input", "input-bordered", "input-sm"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim (no
+        # universal-newline translation) -- a handful of source files carry
+        # CRLF, and translating those to LF on write would turn a one-line
+        # class-attribute change into a whole-file rewrite (kind_robots
+        # add-bot.vue, caught during interface-vision t-104 slice 214).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"{PRIMITIVE} {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software)

Slice 219 of this recurring consistency umbrella.

### What changed / what I produced
- Added `.kr-input-sm { @apply input input-sm; }` to `assets/css/tailwind.css` — the compact (not full-width) sibling of the existing `.kr-input`/`.kr-input-muted` primitives. `input-bordered` is a dead legacy daisyUI v4 class in this repo's v5 (base `input` already carries a border), dropped the same way `.kr-input` already drops it from its own `@apply`.
- New codemod `utils/scripts/codemods/kr_input_sm_codemod.py`, sibling of `kr_input_codemod.py`'s subset-match convention: matches class strings carrying all three base tokens (`input`, `input-bordered`, `input-sm`), folds them into `kr-input-sm`, preserves any extra tokens (`w-full`, `flex-1`, `rounded-2xl`, `bg-base-100`, `min-w-*`, etc.) verbatim after the primitive.
- Ran it `--write` repo-wide: migrated 54 occurrences across 25 files. Dry run afterward confirms 0 remaining candidates repo-wide.
- No geometry, color, or behavior change anywhere in this diff.

### How I verified
- `vue-tsc --noEmit` — clean.
- `eslint .` — 333 problems (327 errors, 6 warnings), identical to the documented baseline.
- `npm run test:layout-contract` — holds, 0 new violations.
- `npm run test:lint-ratchet` — holds at 333/-59.
- `prettier --check` on the 26 touched files — same 18 files flagged before and after (confirmed by running prettier against each file's `origin/main` version vs. the working-tree version), no new drift introduced.
- Manually spot-checked several diffs (`image-upload.vue`, `mermaids-page.vue`) — only static `class="..."` attributes touched, extra tokens preserved.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
The bare `kr-icon-*` family (sizes 3/3.5/4/5/6/7/8) is now fully closed repo-wide (all codemods report 0 candidates). The *colored* icon-glyph variants (`h-N w-N text-{color}`) are too fragmented to bound a slice the same way (max 7 occurrences for any single size+color pair, spread across `text-primary`/`text-secondary`/`text-warning`/`text-base-content/NN`/etc.) — the next slice should either pick a different shape entirely, or make a deliberate decision on how to group colored icon glyphs (e.g. by size only, tolerating mixed colors as a preserved extra token) before attempting that family.

### Notes for reviewer
Conductor task interface-vision/t-104 will be closed via a follow-up `close_task.py` PR once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HoM7WEoABN1UwgYj4rxFbB

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoM7WEoABN1UwgYj4rxFbB)_