### PR TITLE
fix(mobile): restore Gift Shop scrolling

### DIFF
--- a/components/giftshop/giftshop-manager.vue
+++ b/components/giftshop/giftshop-manager.vue
@@ -100,7 +100,9 @@
       </section>
 
       <section v-else-if="activeTab === 'giftshop'" class="kr-stage h-full">
-        <giftshop-interact class="h-full min-h-0 flex-1 overflow-hidden" />
+        <div class="kr-scroll">
+          <giftshop-interact />
+        </div>
       </section>
 
       <div

--- a/utils/scripts/verify-giftshop-checkout.mjs
+++ b/utils/scripts/verify-giftshop-checkout.mjs
@@ -17,6 +17,7 @@ const [
   accountHub,
   givingPage,
   giftshop,
+  giftshopManager,
   shoppingCart,
   checkoutRoute,
   statusRoute,
@@ -29,6 +30,7 @@ const [
   source('components/navigation/account-hub.vue'),
   source('components/pages/giving-page.vue'),
   source('components/giftshop/giftshop-interact.vue'),
+  source('components/giftshop/giftshop-manager.vue'),
   source('components/giftshop/shopping-cart.vue'),
   source('server/api/stripe/checkout.post.ts'),
   source('server/api/stripe/checkout-status.get.ts'),
@@ -99,6 +101,16 @@ assert.doesNotMatch(
   /setDashboardTab\?\.\('giftshop', 'cart'\)/,
   'giftshop must not target an unregistered dashboard tab',
 )
+assert.match(
+  giftshopManager,
+  /v-else-if="activeTab === 'giftshop'"[\s\S]*?<div class="kr-scroll">[\s\S]*?<giftshop-interact\s*\/>/,
+  'giftshop tab must put its long storefront inside a reachable scroll owner',
+)
+assert.doesNotMatch(
+  giftshopManager,
+  /<giftshop-interact[^>]*overflow-hidden/,
+  'giftshop storefront must not be clipped by an overflow-hidden component mount',
+)
 
 assert.match(
   shoppingCart,
@@ -150,5 +162,5 @@ assert.match(
 )
 
 console.log(
-  '✅ Giftshop checkout contract passed: visible cart, real Stripe redirect, verified return, preserved cancellation.',
+  '✅ Giftshop checkout contract passed: visible cart, reachable storefront scroll, real Stripe redirect, verified return, preserved cancellation.',
 )


### PR DESCRIPTION
## Root cause
The outer app shell intentionally locks the viewport (`h-dvh` + `overflow-hidden`), so each tall page surface needs a reachable inner scroll owner. The Gift Shop manager handled community/mana/forum with `.kr-scroll`, but the actual `giftshop` branch mounted a long normal-flow `giftshop-interact` surface as `h-full ... overflow-hidden` with no scroller. On mobile, the lower storefront existed below the fold but could not be reached.

## Fix
- put the Gift Shop branch inside `.kr-scroll`
- stop forcing `overflow-hidden` onto `giftshop-interact`
- extend the Giftshop Checkout Contract to pin this scroll ownership so the storefront cannot silently become unscrollable again

## Same-pattern audit
I checked the comparable `h-full/min-h-0/overflow-hidden` manager mounts. The other obvious cases are bounded interaction shells with their own scroll surfaces: Art Gallery owns `overflow-auto`; Theme Gallery owns `overflow-y-auto`; Dream Brainstorm uses `kr-panes`/`kr-pane-scroll`; Bot, Reward, Scenario, and Character interact surfaces route into gallery/chat/encounter surfaces designed for bounded scrolling. Gift Shop was the outlier because `giftshop-interact` itself is plain long-flow grid content.

## Scope
Two changed files. No route, data, schema, billing, or navigation behavior changes.