### PR TITLE
style(sample): use shared kr-icon-4 primitive in scaffold template

### DIFF
--- a/sample/sample-interact.vue.txt
+++ b/sample/sample-interact.vue.txt
@@ -16,7 +16,7 @@
         type="button"
         @click="backToGallery"
       >
-        <Icon name="kind-icon:arrow-left" class="h-4 w-4" />
+        <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
         <span class="hidden sm:inline">Gallery</span>
       </button>
 
@@ -171,7 +171,7 @@
               :disabled="!interactionPreview"
               @click="copyPreview"
             >
-              <Icon name="kind-icon:copy" class="h-4 w-4" />
+              <Icon name="kind-icon:copy" class="kr-icon-4" />
               Copy
             </button>
           </div>


### PR DESCRIPTION
### Task
interface-vision/t-104: bounded consistency slice (kind: software)

### What changed / what I produced
- `sample/sample-interact.vue.txt`'s two bare `h-4 w-4` icon glyphs (the arrow-left back-button glyph and the copy-button glyph) now use the shared `.kr-icon-4` primitive instead.
- This scaffold template is a `.vue.txt` file, outside `utils/scripts/codemods/kr_icon_4_codemod.py`'s `*.vue`-only scope, so it was left over after the codemod's family closed and flagged in interface-vision t-104 slice 221's kaizen note as a separate bounded follow-up rather than folded into the "closed family" claim.
- No behavior, geometry, or color change — `kr-icon-4` is exactly `@apply h-4 w-4;`.

### How I verified
- `grep -rln "h-4 w-4" --include="*.vue.txt" .` confirms this was the only remaining file with this shape, and both occurrences were exact `class="h-4 w-4"` matches (no `:class` bindings, no extra tokens).
- Confirmed no source/test/build file references `sample/sample-interact.vue.txt` (pure scaffold reference template, not compiled or exercised by CI).
- `git diff --stat`: 1 file changed, +2/-2, matches intended scope exactly.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
The `.kr-icon-4` doc comment in `assets/css/tailwind.css` is stale (still says "13 files / 29 occurrences remain" from an earlier slice, predating slices 214-220 which closed the family for live `*.vue` files). A future slice should refresh that comment to reflect the family's current closed state.

### Notes for reviewer
None.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEqFjQTSCmUAeTmGkrNXK6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEqFjQTSCmUAeTmGkrNXK6)_