### PR TITLE
interface-vision/t-104 slice 223: refresh stale kr-icon-4 doc comment

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1880,11 +1880,16 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
    * kr-entity-card-body.vue, kr-search-field.vue, add-lora.vue,
    * lora-discover.vue, kr-manager.vue, model-builder-item-panel.vue,
    * model-builder-recipe-selector.vue, model-builder-source-picker.vue.
-   * 13 files / 29 occurrences remain, alphabetically after
-   * model-builder-source-picker.vue -- the next slice can keep taking
-   * arbitrary alphabetical batches the same way. Distinct from any future
-   * `.kr-icon-primary-4` (same size, carries `text-primary`) -- this is
-   * the untinted sibling. */
+   * Slices 215-220 continued taking arbitrary alphabetical batches the
+   * same way; slice 221 audited the remaining GitHub code-search hits and
+   * found only fragmented `h-4 w-4 text-<color>` variants too scattered to
+   * justify a combined primitive (no new `.kr-icon-<color>-4` created).
+   * Slice 222 migrated the last two bare glyphs, in a `.vue.txt` scaffold
+   * template outside this codemod's `*.vue`-only scope. This family is now
+   * fully migrated repo-wide for live `*.vue` files: a slice-223 dry run of
+   * `kr_icon_4_codemod.py` reports 0 remaining candidates. Distinct from
+   * any future `.kr-icon-primary-4` (same size, carries `text-primary`) --
+   * this is the untinted sibling. */
   .kr-icon-4 {
     @apply h-4 w-4;
   }


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 223: doc-only follow-up flagged by slice 222's kaizen note.

### What changed
- The doc comment above `.kr-icon-4` in `assets/css/tailwind.css` said "13 files / 29 occurrences remain, alphabetically after model-builder-source-picker.vue", predating slices 215-220 (further alphabetical batches), slice 221 (audited remaining fragmented `h-4 w-4 text-<color>` hits, decided against a combined primitive), and slice 222 (migrated the last two glyphs, in a `.vue.txt` scaffold template outside the codemod's `*.vue`-only scope).
- Refreshed the comment to reflect that this family is now fully migrated repo-wide for live `*.vue` files, and to summarize what slices 215-222 actually did.
- No product code changed — comment only, no geometry or behavior change.

### How I verified
- Re-ran `utils/scripts/codemods/kr_icon_4_codemod.py --root .`: 0 remaining candidates repo-wide, confirming the comment's new claim.
- `vue-tsc --noEmit`: clean.
- `verifyLintRatchet.ts` (test:lint-ratchet): 333 problems / -59, matching baseline exactly.
- `verifyLayoutContract.ts` (test:layout-contract): holds, no new violations.
- `prettier --check assets/css/tailwind.css`: flags pre-existing drift in this file — confirmed via `git stash` that the same warning fires identically before my change, so this is baseline drift, not something I introduced.
- `git diff --stat`: single file, comment-only, +10/-5.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
No further work is queued for the `kr-icon-4` family. The next slice should run a fresh full-repo class-frequency audit (per slice 181's original suggestion) to find the next largest hand-rolled shape not yet covered by a `kr-*` primitive, rather than continuing to poke at already-closed families.

### Notes for reviewer

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApezrfrWUYhaHhm83a9vfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApezrfrWUYhaHhm83a9vfT)_