### PR TITLE
style(interface-vision): compose shared icon sizing in animation layer

### DIFF
--- a/components/screenfx/animation-layer.vue
+++ b/components/screenfx/animation-layer.vue
@@ -28,7 +28,7 @@
 
           <Icon
             :name="animationStore.activeEffect?.icon || 'kind-icon:sparkles'"
-            class="h-5 w-5 shrink-0 text-secondary"
+            class="kr-icon-5 shrink-0 text-secondary"
           />
 
           <animation-interact class="pointer-events-auto shrink-0" />


### PR DESCRIPTION
### Task
interface-vision/t-104: bounded consistency slice 224 (kind: software)

### What changed / what I produced
- Replaced the animation status glyph's hand-rolled `h-5 w-5` sizing with `kr-icon-5`.
- Preserved `shrink-0 text-secondary`, following slice 221's recorded rule that colored glyphs compose a shared size primitive with their semantic color utility.
- No behavior, color, layout geometry, API, store, or schema change.

### How I verified
- Inspected the complete one-file change against current main.
- Confirmed `.kr-icon-5` is the established geometry-equivalent shared primitive for `h-5 w-5` glyph sizing.
- Conductor review transition processed successfully in Process task events run 34565625721 before opening this PR.
- Awaiting this exact head's GitHub Actions checks before merge.

### Stakes
reversible

### Kaizen suggestion
Continue the bounded colored-glyph pass by composing existing `kr-icon-*` size primitives with semantic `text-*` utilities, without adding combined size+color primitives unless a genuinely repeated semantic family justifies one.

### Notes for reviewer
This is intentionally one mechanical substitution in a live component, chosen from the remaining `h-5 w-5` colored-glyph pool after slice 221 explicitly settled the composition rule.