### PR TITLE
interface-vision/t-104 slice 224: migrate plain size-4 icon shorthand to kr-icon-4

### DIFF
--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -46,7 +46,7 @@
                 to="/play/challenges/leaderboard"
                 class="kr-btn btn-outline"
               >
-                <Icon name="kind-icon:trophy" class="size-4" />
+                <Icon name="kind-icon:trophy" class="kr-icon-4" />
                 Rankings
               </NuxtLink>
               <button
@@ -60,7 +60,7 @@
                   v-if="loading"
                   class="kr-spinner-sm"
                 />
-                <Icon v-else name="kind-icon:refresh" class="size-4" />
+                <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
               </button>
             </div>
           </div>
@@ -213,7 +213,7 @@
                   <div
                     class="grid size-8 shrink-0 place-items-center rounded-xl bg-primary/10 text-primary"
                   >
-                    <Icon name="kind-icon:trophy" class="size-4" />
+                    <Icon name="kind-icon:trophy" class="kr-icon-4" />
                   </div>
                   <div class="min-w-0 flex-1">
                     <p

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -200,7 +200,7 @@
           :disabled="anyBusy"
           @click="onGenerateAll"
         >
-          <Icon name="kind-icon:sparkles" class="size-4" />
+          <Icon name="kind-icon:sparkles" class="kr-icon-4" />
           Create all remaining records
         </button>
         <button
@@ -209,7 +209,7 @@
           :disabled="!packStore.isPackComplete(selectedPack.id)"
           @click="onMarkReady"
         >
-          <Icon name="kind-icon:check" class="size-4" />
+          <Icon name="kind-icon:check" class="kr-icon-4" />
           Mark pack ready
         </button>
         <button

--- a/components/conductor/project-front-page.vue
+++ b/components/conductor/project-front-page.vue
@@ -67,7 +67,7 @@
             :rel="launch.external ? 'noopener noreferrer' : undefined"
             class="btn btn-primary btn-sm gap-1.5 rounded-2xl sm:btn-md"
           >
-            <Icon :name="launch.icon || 'kind-icon:sparkles'" class="size-4" />
+            <Icon :name="launch.icon || 'kind-icon:sparkles'" class="kr-icon-4" />
             {{ launch.label }}
           </a>
           <a
@@ -80,7 +80,7 @@
           >
             <Icon
               :name="link.icon || 'kind-icon:external-link'"
-              class="size-4"
+              class="kr-icon-4"
             />
             {{ link.label }}
           </a>
@@ -184,7 +184,7 @@
         >
           <Icon
             :name="launch.icon || 'kind-icon:external-link'"
-            class="size-4"
+            class="kr-icon-4"
           />
           {{ launch.label }}
         </a>

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -55,7 +55,7 @@
           class="kr-btn-primary"
           @click="store.finishStory()"
         >
-          <Icon name="kind-icon:moon" class="size-4" /> Finish this tale
+          <Icon name="kind-icon:moon" class="kr-icon-4" /> Finish this tale
         </button>
         <!-- New story — arms on first click, fires on second, so an in-progress
              or finished tale can't be discarded by a single stray click. -->
@@ -66,7 +66,7 @@
           :disabled="store.isWeaving"
           @click="newStoryArmed = true"
         >
-          <Icon name="kind-icon:plus" class="size-4" /> New story
+          <Icon name="kind-icon:plus" class="kr-icon-4" /> New story
         </button>
         <button
           v-else
@@ -75,7 +75,7 @@
           @click="startAnother"
           @blur="newStoryArmed = false"
         >
-          <Icon name="kind-icon:alert" class="size-4" /> Discard this tale?
+          <Icon name="kind-icon:alert" class="kr-icon-4" /> Discard this tale?
         </button>
       </div>
     </header>
@@ -505,7 +505,7 @@
             :disabled="setupStep === 0 || store.isWeaving"
             @click="setupStep -= 1"
           >
-            <Icon name="kind-icon:chevron-left" class="size-4" /> Back
+            <Icon name="kind-icon:chevron-left" class="kr-icon-4" /> Back
           </button>
           <div class="flex flex-wrap gap-2">
             <button
@@ -523,7 +523,7 @@
               :disabled="!canAdvance"
               @click="advanceSetup"
             >
-              Continue <Icon name="kind-icon:chevron-right" class="size-4" />
+              Continue <Icon name="kind-icon:chevron-right" class="kr-icon-4" />
             </button>
             <button
               v-else
@@ -537,7 +537,7 @@
                 class="loading loading-dots loading-sm"
               />
               <template v-else>
-                <Icon name="kind-icon:sparkles" class="size-4" /> Write the
+                <Icon name="kind-icon:sparkles" class="kr-icon-4" /> Write the
                 opening scene
               </template>
             </button>

--- a/components/conductor/voice-lab-page.vue
+++ b/components/conductor/voice-lab-page.vue
@@ -47,7 +47,7 @@
               :name="
                 voice.sending ? 'kind-icon:spinner' : 'kind-icon:microphone'
               "
-              class="size-4"
+              class="kr-icon-4"
               :class="{ 'animate-spin': voice.sending }"
             />
             {{ voice.sending ? 'Sending…' : 'Try it' }}
@@ -75,7 +75,7 @@
           to="/serendipity"
           class="btn btn-ghost btn-sm w-fit gap-1.5 rounded-xl border border-base-300"
         >
-          <Icon name="kind-icon:external-link" class="size-4" />
+          <Icon name="kind-icon:external-link" class="kr-icon-4" />
           Open the full Serendipity view
         </NuxtLink>
       </section>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -48,7 +48,7 @@
           <img
             :src="projectIconPath(selectedProject.slug)"
             :alt="selectedProject.name"
-            class="size-4 shrink-0 rounded-sm object-cover"
+            class="kr-icon-4 shrink-0 rounded-sm object-cover"
           />
           <span class="kr-text-bold-xs min-w-0 break-words leading-tight">{{
             selectedProject.name || selectedProject.slug
@@ -302,7 +302,7 @@
                   class="btn btn-primary btn-sm ml-auto rounded-xl"
                   :disabled="!newTodoTitle.trim() || todoStore.loading"
                 >
-                  <Icon name="kind-icon:plus" class="size-4" /> Add
+                  <Icon name="kind-icon:plus" class="kr-icon-4" /> Add
                 </button>
               </div>
             </form>

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -9,7 +9,7 @@
           class="kr-btn-ghost-2xl"
           @click="goBack"
         >
-          <Icon name="kind-icon:chevron-left" class="size-4" />
+          <Icon name="kind-icon:chevron-left" class="kr-icon-4" />
           Projects
         </button>
 
@@ -43,7 +43,7 @@
             @click="refresh"
           >
             <span v-if="isLoading" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:refresh" class="size-4" />
+            <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
             Refresh
           </button>
         </div>
@@ -62,7 +62,7 @@
             class="flex size-8 shrink-0 items-center justify-center rounded-xl"
             :class="tab.iconClass"
           >
-            <Icon :name="tab.icon" class="size-4" />
+            <Icon :name="tab.icon" class="kr-icon-4" />
           </span>
           <span class="min-w-0 flex-1">
             <span class="kr-text-eyebrow block truncate text-xs tracking-wide">
@@ -189,7 +189,7 @@
                 class="rounded-2xl border border-warning/30 bg-warning/8 p-3"
               >
                 <div class="kr-text-eyebrow flex items-center gap-2 text-xs tracking-wide text-warning">
-                  <Icon name="kind-icon:warning" class="size-4" />
+                  <Icon name="kind-icon:warning" class="kr-icon-4" />
                   Existing-work check
                 </div>
                 <div class="mt-2 flex flex-wrap gap-2">
@@ -294,7 +294,7 @@
             @click="requestPitchRun"
           >
             <span v-if="requestingPitches" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:sparkles" class="size-4" />
+            <Icon v-else name="kind-icon:sparkles" class="kr-icon-4" />
             Queue a fresh pitch run
           </button>
         </div>

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -71,7 +71,7 @@
               @click="conductorStore.fetchProjects(true)"
             >
               <span v-if="conductorStore.pending" class="kr-spinner-xs" />
-              <Icon v-else name="kind-icon:refresh-cw" class="size-4" />
+              <Icon v-else name="kind-icon:refresh-cw" class="kr-icon-4" />
               Refresh
             </button>
           </div>
@@ -199,7 +199,7 @@
                     Context from Conductor
                     <Icon
                       name="kind-icon:chevron-down"
-                      class="size-4 transition-transform group-open:rotate-180"
+                      class="kr-icon-4 transition-transform group-open:rotate-180"
                     />
                   </summary>
                   <p
@@ -222,7 +222,7 @@
                       v-if="taskIsUpdating(gate.project.slug, gate.task.id)"
                       class="kr-spinner-xs"
                     />
-                    <Icon v-else name="kind-icon:check" class="size-4" />
+                    <Icon v-else name="kind-icon:check" class="kr-icon-4" />
                     Approve
                   </button>
 
@@ -230,11 +230,11 @@
                     <summary
                       class="btn btn-outline btn-sm w-full list-none rounded-xl marker:hidden"
                     >
-                      <Icon name="kind-icon:message-square" class="size-4" />
+                      <Icon name="kind-icon:message-square" class="kr-icon-4" />
                       Reply or send back
                       <Icon
                         name="kind-icon:chevron-down"
-                        class="ml-auto size-4 transition-transform group-open:rotate-180"
+                        class="kr-icon-4 ml-auto transition-transform group-open:rotate-180"
                       />
                     </summary>
                     <div

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -24,7 +24,7 @@
           :aria-expanded="libraryOpen"
           @click="libraryOpen = !libraryOpen"
         >
-          <Icon name="kind-icon:book" class="size-4" />
+          <Icon name="kind-icon:book" class="kr-icon-4" />
           {{ libraryOpen ? 'Hide library' : 'Recent stories' }}
         </button>
 
@@ -35,7 +35,7 @@
             :disabled="storyStore.isWeaving"
             @click="duplicateCurrent"
           >
-            <Icon name="kind-icon:copy" class="size-4" /> Duplicate
+            <Icon name="kind-icon:copy" class="kr-icon-4" /> Duplicate
           </button>
 
           <div class="dropdown dropdown-end">
@@ -45,7 +45,7 @@
               class="btn btn-ghost btn-sm rounded-xl border border-base-300"
               aria-haspopup="menu"
             >
-              <Icon name="kind-icon:download" class="size-4" /> Export
+              <Icon name="kind-icon:download" class="kr-icon-4" /> Export
             </button>
             <ul
               tabindex="0"
@@ -69,7 +69,7 @@
             :disabled="storyStore.isWeaving"
             @click="restartArmed = true"
           >
-            <Icon name="kind-icon:refresh" class="size-4" /> Restart
+            <Icon name="kind-icon:refresh" class="kr-icon-4" /> Restart
           </button>
           <button
             v-else
@@ -79,7 +79,7 @@
             @click="restartCurrent"
             @blur="restartArmed = false"
           >
-            <Icon name="kind-icon:alert" class="size-4" /> Restart from the
+            <Icon name="kind-icon:alert" class="kr-icon-4" /> Restart from the
             beginning?
           </button>
 
@@ -90,7 +90,7 @@
             :disabled="storyStore.isWeaving"
             @click="newStoryArmed = true"
           >
-            <Icon name="kind-icon:plus" class="size-4" /> New story
+            <Icon name="kind-icon:plus" class="kr-icon-4" /> New story
           </button>
           <button
             v-else
@@ -100,7 +100,7 @@
             @click="startNewStory"
             @blur="newStoryArmed = false"
           >
-            <Icon name="kind-icon:alert" class="size-4" /> Discard this tale?
+            <Icon name="kind-icon:alert" class="kr-icon-4" /> Discard this tale?
           </button>
         </template>
       </div>

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -39,7 +39,7 @@
             <span
               class="kr-text-eyebrow inline-flex items-center gap-2 rounded-full border border-secondary/30 bg-base-100/80 px-3 py-1.5 text-[0.68rem] tracking-[0.16em] text-secondary shadow-sm backdrop-blur"
             >
-              <Icon name="kind-icon:gearhammer" class="size-4" />
+              <Icon name="kind-icon:gearhammer" class="kr-icon-4" />
               The Quest Desk
             </span>
             <h2
@@ -209,7 +209,7 @@
                 </span>
                 <Icon
                   name="kind-icon:chevron-down"
-                  class="size-4 transition-transform group-open:rotate-180"
+                  class="kr-icon-4 transition-transform group-open:rotate-180"
                 />
               </summary>
 
@@ -352,7 +352,7 @@
                 <span
                   class="flex size-9 shrink-0 items-center justify-center rounded-xl bg-secondary text-secondary-content"
                 >
-                  <Icon name="kind-icon:magic" class="size-4" />
+                  <Icon name="kind-icon:magic" class="kr-icon-4" />
                 </span>
                 <div>
                   <p
@@ -389,7 +389,7 @@
             :disabled="store.isWeaving || !canBegin"
             @click="begin(true)"
           >
-            <Icon name="kind-icon:wand" class="size-4" />
+            <Icon name="kind-icon:wand" class="kr-icon-4" />
             Surprise me
           </button>
           <button
@@ -401,7 +401,7 @@
             <span v-if="store.isWeaving" class="loading loading-dots loading-sm" />
             <template v-else>
               Build my quest
-              <Icon name="kind-icon:chevron-right" class="size-4" />
+              <Icon name="kind-icon:chevron-right" class="kr-icon-4" />
             </template>
           </button>
           <p
@@ -436,7 +436,7 @@
               :disabled="store.isWeaving"
               @click="startOver"
             >
-              <Icon name="kind-icon:wand" class="size-4" />
+              <Icon name="kind-icon:wand" class="kr-icon-4" />
               Edit setup
             </button>
           </div>
@@ -592,7 +592,7 @@
               :disabled="store.isWeaving || !store.session.checkpoints.length"
               @click="store.startQuest()"
             >
-              <Icon name="kind-icon:story" class="size-4" />
+              <Icon name="kind-icon:story" class="kr-icon-4" />
               Start the adventure
             </button>
           </aside>

--- a/utils/scripts/codemods/kr_icon_4_size_shorthand_codemod.py
+++ b/utils/scripts/codemods/kr_icon_4_size_shorthand_codemod.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Find or migrate the `size-4` Tailwind shorthand to `kr-icon-4`.
+
+`size-4` is a plain alias for `h-4 w-4` (Tailwind's `size-*` utility sets
+both axes at once) -- CSS-identical to the bare icon-glyph shape
+`kr-icon_4_codemod.py` already migrated repo-wide (interface-vision t-104
+slice 223: a dry run of that script now reports 0 remaining `h-4 w-4`
+candidates). `size-4` is a separate source spelling of the exact same
+primitive, not a new shape: `.kr-icon-4 { @apply h-4 w-4; }` in
+tailwind.css covers both verbatim. Grepping the codebase for
+`class="size-4"` shows the same usage as the `h-4 w-4` family it mirrors --
+overwhelmingly a bare `<Icon ... class="size-4" />` glyph, e.g.
+`components/bots/bot-manager.vue`'s `<Icon name="kind-icon:brain"
+class="size-4" />`.
+
+Excludes any class string carrying a `text-*`/`stroke-*`/`fill-*` token --
+that is the `kr-icon-primary-4` (or another future colored sibling) shape,
+not this one -- same convention as `kr_icon_4_codemod.py`.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+static `class="..."` attributes are touched, never `:class`/`v-bind:class`
+bindings (see _class_attr.py). Pass --exact-only to restrict a slice to
+sources with no extra tokens beyond `size-4` itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-4"
+BASE_TOKEN = "size-4"
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or BASE_TOKEN not in tokens:
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token != BASE_TOKEN]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly `size-4` (no "
+        "extra utility tokens preserved).",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-4 (size-4 shorthand) {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring)

### What changed / what I produced
- New codemod `utils/scripts/codemods/kr_icon_4_size_shorthand_codemod.py`: migrates the Tailwind `size-4` shorthand (CSS-identical to `h-4 w-4`) onto the existing `.kr-icon-4` primitive, same convention as `kr_icon_4_codemod.py` (excludes any `text-*`/`stroke-*`/`fill-*`-tinted class strings, which are a different colored-sibling shape).
- Ran it scoped to `components/conductor` and `components/pages` (the two directories accounting for the largest share of the 50-file/123-occurrence `size-4` family repo-wide): 16 + 26 = 42 occurrences across 10 files migrated.
- No behavior/geometry change — `.kr-icon-4` applies the same `h-4 w-4` either way.

### How I verified
- Dry run before/after: 0 remaining `size-4` candidates in the two scoped directories after `--write`.
- Manual diff review of every changed file — each hit is a bare `<Icon ... class="size-4" />` glyph (or the class alone on the icon element), consistent with the family this mirrors.
- Local `vue-tsc`/`eslint`/`prettier` could not be run this session (sandbox `npm ci` hit a flaky/corrupted-cache extraction failure on this large dependency tree, even after a cache clear + reduced-concurrency retry) — relying on this PR's CI (which includes TypeScript, layout contract, and lint-ratchet checks) to confirm. Will monitor and fix promptly if anything comes back red.

### Stakes
reversible

### Flags for Reviewer
- Local verification gap noted above — CI is the real confirmation this session has for this change; will actively watch it.
- 108 exact-match + 15 subset-match `size-4` occurrences remain in the other ~40 files repo-wide (plus 34 colored `size-4` occurrences, mostly one-off colors not yet worth a new primitive, though `text-primary` ones — 8 total — could fold into the existing `kr-icon-primary-4` in a future slice) — left for the next slice(s), split by directory per this family's established convention.

### Kaizen suggestion
Next interface-vision/t-104 slice: continue the `size-4` family in the remaining directories (`components/dreams`, `components/cthulhuquarium`, `components/newsfeed`, `components/narrative`, `components/art`, `components/home`, `pages/play`, etc., roughly ordered by occurrence count), or fold the 8 `text-primary size-4` occurrences into `kr-icon-primary-4`.

### Notes for reviewer
Conductor task interface-vision/t-104 claimed this session (session `claude-scheduled-20260911T053434Z-iv-t104-size4`); will close out to `review`/`done` in the conductor roadmap once this PR is green and merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BXVSZQuPzg8nzXVdeTGr9


---
_Generated by [Claude Code](https://claude.ai/code/session_011BXVSZQuPzg8nzXVdeTGr9)_