### PR TITLE
style(interface): use shared login lock icon sizing

### DIFF
--- a/components/user/login-page.vue
+++ b/components/user/login-page.vue
@@ -128,7 +128,7 @@
             >
               <Icon
                 name="kind-icon:lock"
-                class="h-5 w-5 shrink-0 text-secondary"
+                class="kr-icon-5 shrink-0 text-secondary"
               />
               <input
                 id="password"


### PR DESCRIPTION
### Task
interface-vision/t-104: bounded consistency slice 225 (kind: software)

### What changed / what I produced
- Replaced the login password lock glyph's hand-rolled `h-5 w-5` sizing with the geometry-equivalent `kr-icon-5` primitive.
- Preserved `shrink-0` and semantic `text-secondary`; no color, behavior, or layout geometry change.

### How I verified
- Inspected the complete one-file change and confirmed `kr-icon-5` is the established 20px shared sizing primitive used elsewhere in this component/repo.
- Conductor claim and review transitions were processed successfully before PR creation.
- Awaiting this PR's exact-head GitHub Actions checks before merge.

### Stakes
reversible

### Kaizen suggestion
Continue the remaining live colored `h-5 w-5 text-*` glyph pool as small composition-only slices, preferring `kr-icon-5` + semantic `text-*` over new combined color-size primitives.

### Notes for reviewer
No API, schema, store, route, or deployment changes.