### PR TITLE
style(interface): use shared icon sizing on first-launch step icon

### DIFF
--- a/components/user/first-launch-intro.vue
+++ b/components/user/first-launch-intro.vue
@@ -47,7 +47,7 @@
             :key="item.label"
             class="flex flex-col items-center gap-1 kr-panel-muted-compact-xs text-center"
           >
-            <Icon :name="item.icon" class="h-5 w-5 text-secondary" />
+            <Icon :name="item.icon" class="kr-icon-5 text-secondary" />
             <span class="kr-text-bold-xs">{{ item.label }}</span>
           </li>
         </ul>


### PR DESCRIPTION
### Task
interface-vision/t-104: bounded consistency slice 226 (kind: software)

### What changed / what I produced
- `components/user/first-launch-intro.vue`'s per-step icon now composes the shared `kr-icon-5` sizing primitive with its existing semantic `text-secondary` utility, replacing hand-rolled `h-5 w-5` sizing.
- No color, behavior, or geometry change — `kr-icon-5` is CSS-identical to `h-5 w-5`.

### How I verified
- `vue-tsc --noEmit` clean.
- `eslint` on the changed file: clean.
- `npm run test:layout-contract`: holds, no new violations.
- `npm run test:lint-ratchet`: 333 problems / 24 rules (-59), unchanged baseline.
- `prettier --check` on the changed file: passes.

### Stakes
reversible

### Kaizen suggestion
Continue the remaining live colored `h-5 w-5 text-*` glyph pool (text-accent, text-success, text-warning, text-info, text-error, text-base-content variants) as small composition-only slices, preferring `kr-icon-5` + the existing semantic `text-*` utility over new combined color-size primitives, per slice 224/225's established rule.

### Notes for reviewer
No API, schema, store, route, or deployment changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tA3rve4e9QfTntA6nK84W

---
_Generated by [Claude Code](https://claude.ai/code/session_014tA3rve4e9QfTntA6nK84W)_