### PR TITLE
style(navigation): use shared icon sizing on shared-route groups header

### DIFF
--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -80,7 +80,7 @@
       class="rounded-2xl border border-secondary/30 bg-secondary/5 p-4 shadow-sm"
     >
       <div class="flex items-center gap-2">
-        <Icon name="kind-icon:link" class="h-5 w-5 text-secondary" />
+        <Icon name="kind-icon:link" class="kr-icon-5 text-secondary" />
         <h2 class="font-black">Shared-route groups</h2>
       </div>
       <div class="mt-3 flex flex-wrap gap-2">


### PR DESCRIPTION
### Task
interface-vision/t-104: bounded consistency slice 227 (kind: software)

### What changed / what I produced
- `components/navigation/navigation-health.vue`'s shared-route groups header icon now composes the shared `kr-icon-5` sizing primitive with its existing semantic `text-secondary` utility, replacing hand-rolled `h-5 w-5` sizing.
- No color, behavior, or geometry change — `kr-icon-5` is CSS-identical to `h-5 w-5`.

### How I verified
- `vue-tsc --noEmit` clean.
- `eslint` on the changed file: clean.
- `npm run test:layout-contract`: holds, no new violations.
- `npm run test:lint-ratchet`: 333 problems / 24 rules (-59), unchanged baseline.
- `prettier --check` on the changed file: flags pre-existing drift, confirmed via `git stash` to be unrelated to this change (present before and after).

### Stakes
reversible

### Kaizen suggestion
Continue the remaining live colored `h-5 w-5 text-*` glyph pool (user-dashboard.vue has 4 more: text-accent, text-success, text-warning, text-info; plus text-error in this same file, text-base-content variants elsewhere, and text-primary-content in art-styler.vue) as small composition-only slices.

### Notes for reviewer
No API, schema, store, route, or deployment changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tA3rve4e9QfTntA6nK84W

---
_Generated by [Claude Code](https://claude.ai/code/session_014tA3rve4e9QfTntA6nK84W)_