### PR TITLE
style(navigation): use shared error icon sizing

### DIFF
--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -101,7 +101,7 @@
       class="rounded-2xl border border-error/30 bg-error/5 p-4 shadow-sm"
     >
       <div class="flex items-center gap-2">
-        <Icon name="kind-icon:error" class="h-5 w-5 text-error" />
+        <Icon name="kind-icon:error" class="kr-icon-5 text-error" />
         <h2 class="font-black">Nav manifest issues</h2>
       </div>
       <ul class="mt-3 flex flex-col gap-1.5">


### PR DESCRIPTION
### Task
interface-vision/t-104: bounded consistency slice 228 (kind: software, recurring)

### What changed
- `components/navigation/navigation-health.vue`'s Nav manifest issues header now composes the existing `kr-icon-5` geometry primitive with its existing semantic `text-error` utility.
- Replaces hand-rolled `h-5 w-5` sizing only. No color, behavior, API, schema, store, route, or layout geometry change.

### Verification
- Conductor claim event processed successfully and roadmap ownership verified for session `2026-09-11T071607Z-interface-vision-t-104-p8m2` before implementation.
- Conductor review transition processed successfully before opening this PR.
- Complete branch diff inspected: one intended icon-sizing substitution plus an end-of-file newline normalization from the connector write. No other source changes.
- Await exact-head GitHub Actions before merge.

### Kaizen
Continue the remaining live colored `h-5 w-5 text-*` glyph pool as small composition-only slices, especially the grouped user-dashboard accent/secondary/success/warning/info set.

### Stakes
reversible