### PR TITLE
style(user): use shared icon sizing for dashboard glyph pool

### DIFF
--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -145,7 +145,7 @@
                   <div class="flex items-center gap-2">
                     <Icon
                       name="kind-icon:jellybean"
-                      class="h-5 w-5 text-accent"
+                      class="kr-icon-5 text-accent"
                     />
                     <span class="kr-text-black-sm">Karma</span>
                   </div>
@@ -173,7 +173,7 @@
                   <div class="flex items-center gap-2">
                     <Icon
                       name="kind-icon:sparkles"
-                      class="h-5 w-5 text-secondary"
+                      class="kr-icon-5 text-secondary"
                     />
                     <span class="kr-text-black-sm">Mana</span>
                   </div>
@@ -204,7 +204,7 @@
                   <div class="flex items-center gap-2">
                     <Icon
                       name="kind-icon:trophy"
-                      class="h-5 w-5 text-success"
+                      class="kr-icon-5 text-success"
                     />
                     <span class="kr-text-black-sm">Achievements</span>
                   </div>
@@ -266,7 +266,7 @@
 
                 <div class="flex flex-col gap-2 kr-panel-flat p-4">
                   <label class="flex cursor-pointer items-center gap-2">
-                    <Icon name="kind-icon:eye" class="h-5 w-5 text-warning" />
+                    <Icon name="kind-icon:eye" class="kr-icon-5 text-warning" />
                     <span class="kr-text-black-sm">Show mature content</span>
                   </label>
 
@@ -292,7 +292,7 @@
 
                 <div class="flex flex-col gap-2 kr-panel-flat p-4">
                   <div class="flex items-center gap-2">
-                    <Icon name="kind-icon:server" class="h-5 w-5 text-info" />
+                    <Icon name="kind-icon:server" class="kr-icon-5 text-info" />
                     <span class="kr-text-black-sm">Server preferences</span>
                   </div>
 


### PR DESCRIPTION
### Task
interface-vision/t-104: bounded consistency slice 229 (kind: software, recurring)

### What changed / what I produced
- `components/user/user-dashboard.vue`'s karma/mana/achievements/mature-toggle/server-preferences icons now compose the shared `kr-icon-5` size primitive instead of hand-rolled `h-5 w-5`, keeping each icon's existing semantic color utility (`text-accent`/`text-secondary`/`text-success`/`text-warning`/`text-info`) as-is.
- No color, behavior, API, schema, store, route, or layout geometry change — a pure class-string substitution, same composition-only rule as slices 226-228.

### How I verified
- `npx vue-tsc --noEmit` — clean.
- `npx eslint components/user/user-dashboard.vue` — clean.
- `npx prettier --check components/user/user-dashboard.vue` — passing.
- `npm run test:layout-contract` — holds, no new violations.
- `npm run test:lint-ratchet` — 333 problems / 24 rules (-59), unchanged baseline.
- Grepped the file post-edit to confirm zero remaining `h-5 w-5` occurrences and that the nearby `text-error` reference is an unrelated button class, not an icon.

### Stakes
reversible

### Flags for Reviewer
- None.

### Kaizen suggestion
`user-dashboard.vue`'s grouped colored `h-5 w-5` pool (the file the last two slices' kaizen notes pointed at) is now fully migrated. Next slice can resume the general `h-5 w-5 text-*` sweep elsewhere in the repo, or pick another file with multiple colored occurrences if one exists.

### Notes for reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195iqk1iJ8LE2BZSTmC1Y8K

---
_Generated by [Claude Code](https://claude.ai/code/session_0195iqk1iJ8LE2BZSTmC1Y8K)_