### PR TITLE
fix(conductor): answerable roadmap tasks and a readable one-image art panel

### DIFF
--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -33,9 +33,9 @@
       </div>
     </header>
 
-    <div v-if="slots.length > 1" class="mt-3 flex flex-wrap gap-1.5">
+    <div v-if="editableSlots.length > 1" class="mt-3 flex flex-wrap gap-1.5">
       <button
-        v-for="slot in slots"
+        v-for="slot in editableSlots"
         :key="slot.field"
         type="button"
         class="kr-btn-xs-lg"
@@ -46,34 +46,83 @@
       </button>
     </div>
 
-    <div class="mt-3 grid gap-3" :class="history.length ? 'lg:grid-cols-[minmax(0,1fr)_minmax(12rem,0.8fr)]' : ''">
-      <div
-        class="relative min-h-48 overflow-hidden rounded-xl border border-base-300 bg-base-200"
-        :style="{ aspectRatio: selectedSlot.aspect || undefined }"
-      >
+    <div
+      class="art-stage group relative mt-3 touch-pan-y select-none overflow-hidden rounded-xl border border-base-300 bg-base-200"
+      :style="{ '--art-stage-aspect': selectedSlot.aspect || '1 / 1' }"
+      @mouseenter="carouselPaused = true"
+      @mouseleave="carouselPaused = false"
+      @pointerdown="beginCarouselSwipe"
+      @pointerup="endCarouselSwipe"
+      @pointercancel="cancelCarouselSwipe"
+    >
+      <template v-if="activeCarouselSlide.src && !activeSlideFailed">
         <img
-          v-if="currentSrc && !currentFailed"
-          :key="currentSrc"
-          :src="currentSrc"
-          :alt="`${title} ${selectedSlot.label}`"
-          class="absolute inset-0 size-full object-cover"
-          @error="currentFailed = true"
+          :src="activeCarouselSlide.src"
+          alt=""
+          aria-hidden="true"
+          draggable="false"
+          class="art-stage-backdrop"
         />
-        <div
-          v-else
-          class="absolute inset-0 flex flex-col items-center justify-center gap-2 p-4 text-center text-base-content/40"
-        >
-          <Icon name="kind-icon:image" class="size-10 opacity-40" />
-          <p class="text-xs font-semibold">No {{ selectedSlot.label.toLowerCase() }} yet.</p>
-        </div>
+        <Transition name="entity-carousel-fade">
+          <img
+            :key="activeCarouselSlide.src"
+            :src="activeCarouselSlide.src"
+            :alt="`${title} ${activeCarouselSlide.label}`"
+            draggable="false"
+            class="art-stage-image"
+            @error="markSlideFailed(activeCarouselSlide.src)"
+          />
+        </Transition>
+      </template>
+      <div
+        v-else
+        class="absolute inset-0 flex flex-col items-center justify-center gap-2 p-4 text-center text-base-content/40"
+      >
+        <Icon name="kind-icon:image" class="size-10 opacity-40" />
+        <p class="text-xs font-semibold">
+          No {{ activeCarouselSlide.label.toLowerCase() }} yet.
+        </p>
+      </div>
 
-        <div
-          class="absolute inset-x-0 bottom-0 flex flex-wrap items-center justify-between gap-2 bg-linear-to-t from-base-300/95 to-transparent p-3 pt-10"
+      <div
+        class="pointer-events-none absolute inset-x-0 top-0 flex flex-wrap items-center gap-2 bg-linear-to-b from-base-300/90 to-transparent p-2"
+      >
+        <Icon name="kind-icon:image" class="size-3.5 text-secondary" />
+        <span class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide">
+          Artwork &amp; inspirations
+        </span>
+        <span v-if="inspirationCount" class="kr-badge-info-xs">
+          {{ inspirationCount }} inspiration{{ inspirationCount === 1 ? '' : 's' }}
+        </span>
+        <span v-if="collectionSlides.length" class="kr-badge-secondary-xs">
+          {{ collectionSlides.length }} collection
+        </span>
+        <span v-if="hasCarousel" class="kr-text-dim-xs ml-auto">
+          {{ carouselIndex + 1 }} / {{ carouselSlides.length }}
+        </span>
+      </div>
+
+      <div
+        class="absolute inset-x-0 bottom-0 flex flex-wrap items-center justify-between gap-2 bg-linear-to-t from-base-300/95 to-transparent p-3 pt-10"
+      >
+        <span
+          class="badge badge-sm border-0 bg-base-100/85 font-bold backdrop-blur"
         >
-          <span class="badge badge-sm border-0 bg-base-100/85 font-bold backdrop-blur">
-            Current {{ selectedSlot.label }}
-          </span>
-          <div v-if="mayEdit" class="flex gap-1">
+          {{ activeSlideCaption }}
+        </span>
+        <div v-if="mayEdit" class="flex flex-wrap gap-1">
+          <button
+            v-if="canPromoteActiveSlide"
+            type="button"
+            class="btn btn-primary btn-xs gap-1 rounded-lg"
+            :disabled="promoting"
+            @click="promoteActiveSlide"
+          >
+            <span v-if="promoting" class="kr-spinner-xs" />
+            <Icon v-else name="kind-icon:star" class="size-3" />
+            Set as {{ primarySlot.label.toLowerCase() }}
+          </button>
+          <template v-else>
             <button
               type="button"
               class="btn btn-secondary btn-xs gap-1 rounded-lg"
@@ -90,103 +139,10 @@
               <Icon name="kind-icon:upload" class="size-3" />
               Upload
             </button>
-          </div>
+          </template>
         </div>
       </div>
 
-      <aside v-if="history.length" class="kr-panel-tint-compact-50">
-        <div class="mb-2 flex items-center gap-2">
-          <Icon name="kind-icon:history" class="size-3.5 text-base-content/50" />
-          <h4 class="kr-text-eyebrow kr-text-dim-xs-55 tracking-wide">
-            Inspiration history
-          </h4>
-          <span class="kr-badge-ghost-xs ml-auto">{{ filteredHistory.length }}</span>
-        </div>
-        <div v-if="filteredHistory.length" class="grid max-h-72 grid-cols-2 gap-2 overflow-y-auto">
-          <article
-            v-for="item in filteredHistory"
-            :key="item.id"
-            class="group relative overflow-hidden rounded-lg border border-base-300 bg-base-100"
-          >
-            <img
-              :src="historySrc(item)"
-              :alt="item.fileName || 'Previous artwork'"
-              class="aspect-square size-full object-cover"
-            />
-            <button
-              v-if="mayEdit"
-              type="button"
-              class="btn btn-circle btn-error btn-xs absolute right-1 top-1 opacity-0 shadow transition-opacity group-hover:opacity-100"
-              title="Remove from inspiration history"
-              :disabled="removingHistoryId === item.id"
-              @click="removeHistory(item.id)"
-            >
-              <span v-if="removingHistoryId === item.id" class="kr-spinner-xs" />
-              <Icon v-else name="kind-icon:trash" class="size-3" />
-            </button>
-            <p class="truncate px-2 py-1 text-[0.65rem] text-base-content/50">
-              {{ item.fieldLabel || item.fileName || `Image ${item.id}` }}
-            </p>
-          </article>
-        </div>
-        <p v-else class="kr-text-dim-xs-40 py-6 text-center">
-          No saved {{ selectedSlot.label.toLowerCase() }} versions.
-        </p>
-      </aside>
-    </div>
-
-    <div
-      v-if="hasCarousel"
-      class="group relative mt-3 min-h-40 touch-pan-y select-none overflow-hidden rounded-xl border border-dashed border-primary/40 bg-primary/5"
-      @mouseenter="carouselPaused = true"
-      @mouseleave="carouselPaused = false"
-      @pointerdown="beginCarouselSwipe"
-      @pointerup="endCarouselSwipe"
-      @pointercancel="cancelCarouselSwipe"
-    >
-      <Transition name="entity-carousel-fade">
-        <img
-          :key="activeCarouselSlide.src"
-          :src="activeCarouselSlide.src"
-          :alt="activeCarouselSlide.label"
-          draggable="false"
-          class="absolute inset-0 size-full object-cover"
-        />
-      </Transition>
-      <div
-        class="pointer-events-none absolute inset-x-0 top-0 flex flex-wrap items-center gap-2 bg-linear-to-b from-base-300/90 to-transparent p-2"
-      >
-        <Icon name="kind-icon:image" class="size-3.5 text-secondary" />
-        <span
-          class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide"
-        >
-          Artwork &amp; inspirations
-        </span>
-        <span
-          v-if="history.length"
-          class="kr-badge-info-xs"
-        >
-          {{ history.length }} inspiration{{ history.length === 1 ? '' : 's' }}
-        </span>
-        <span
-          v-if="collectionSlides.length"
-          class="kr-badge-secondary-xs"
-        >
-          {{ collectionSlides.length }} collection
-        </span>
-        <span class="kr-text-dim-xs ml-auto">
-          {{ carouselIndex + 1 }} / {{ carouselSlides.length }}
-        </span>
-      </div>
-      <div
-        class="pointer-events-none absolute inset-x-0 bottom-0 bg-linear-to-t from-base-300/90 to-transparent p-2 pt-8"
-      >
-        <span
-          class="badge badge-sm border-0 bg-base-100/85 font-semibold backdrop-blur"
-        >
-          {{ activeCarouselSlide.label }}
-        </span>
-      </div>
       <template v-if="carouselSlides.length > 1">
         <button
           type="button"
@@ -208,30 +164,59 @@
         </button>
       </template>
     </div>
+
     <div
-      v-if="hasCarousel && carouselSlides.length > 1"
-      class="mt-2 flex flex-wrap justify-center gap-1.5"
+      v-if="carouselSlides.length > 1"
+      class="mt-2 flex gap-1.5 overflow-x-auto pb-1"
     >
-      <button
+      <div
         v-for="(slide, index) in carouselSlides"
-        :key="slide.src"
-        type="button"
-        class="relative size-10 overflow-hidden rounded-lg border transition-all"
-        :class="
-          index === carouselIndex
-            ? 'border-primary ring-2 ring-primary/40'
-            : 'border-base-300 opacity-60 hover:opacity-100'
-        "
-        :aria-label="`Show ${slide.label}`"
-        :title="slide.label"
-        @click="selectCarouselSlide(index)"
+        :key="slide.key"
+        class="group/thumb relative shrink-0"
       >
-        <img
-          :src="slide.src"
-          :alt="slide.label"
-          class="size-full object-cover"
-        />
-      </button>
+        <button
+          type="button"
+          class="relative block size-14 overflow-hidden rounded-lg border transition-all"
+          :class="
+            index === carouselIndex
+              ? 'border-primary ring-2 ring-primary/40'
+              : 'border-base-300 opacity-70 hover:opacity-100'
+          "
+          :aria-label="`Show ${slide.label}`"
+          :title="slide.label"
+          @click="selectCarouselSlide(index)"
+        >
+          <img
+            v-if="slide.src"
+            :src="slide.src"
+            :alt="slide.label"
+            class="size-full object-cover"
+          />
+          <span
+            v-else
+            class="flex size-full items-center justify-center text-base-content/30"
+          >
+            <Icon name="kind-icon:image" class="size-4" />
+          </span>
+          <span
+            v-if="slide.kind === 'slot'"
+            class="absolute inset-x-0 bottom-0 truncate bg-base-300/85 px-1 text-[0.55rem] font-bold leading-4"
+          >
+            {{ slide.label }}
+          </span>
+        </button>
+        <button
+          v-if="mayEdit && slide.kind === 'inspiration' && slide.artImageId"
+          type="button"
+          class="btn btn-circle btn-error btn-xs absolute -right-1 -top-1 opacity-0 shadow transition-opacity group-hover/thumb:opacity-100"
+          title="Remove from inspiration history"
+          :disabled="removingHistoryId === slide.artImageId"
+          @click="removeHistory(slide.artImageId)"
+        >
+          <span v-if="removingHistoryId === slide.artImageId" class="kr-spinner-xs" />
+          <Icon v-else name="kind-icon:trash" class="size-3" />
+        </button>
+      </div>
     </div>
 
     <form
@@ -545,13 +530,35 @@ type GenerationPreset = {
   steps?: number
 }
 type CollectionSlide = { src: string; label: string }
-type CarouselSlide = { src: string; label: string; field?: string }
+type CarouselSlide = {
+  key: string
+  src: string
+  label: string
+  kind: 'slot' | 'inspiration' | 'collection'
+  field?: string
+  artImageId?: number
+}
+type ServerArtSlot = {
+  field: string
+  label: string
+  width: number
+  height: number
+  primary: boolean
+  retired: boolean
+}
+type ResolvedSlot = ServerArtSlot & { aspect: string }
 
 const props = withDefaults(
   defineProps<{
     entityType: EntityArtType
     entity: EntityRecord
-    slots: EntityArtSlot[]
+    /**
+     * Optional override. The slot roster normally arrives from the entity art
+     * endpoint, which reads the same table that refuses generation for retired
+     * slots -- hardcoding a list here is how every call site ended up offering
+     * Hero, Card and Icon as peer tabs after all three were retired.
+     */
+    slots?: EntityArtSlot[]
     canEdit?: boolean
     /**
      * Extra read-only slides (e.g. a linked ArtCollection). Canonical entity
@@ -561,6 +568,7 @@ const props = withDefaults(
     collectionSlides?: CollectionSlide[]
   }>(),
   {
+    slots: () => [],
     canEdit: false,
     collectionSlides: () => [],
   },
@@ -573,7 +581,8 @@ const emit = defineEmits<{
 
 const userStore = useUserStore()
 const resourceStore = useResourceStore()
-const selectedField = ref(props.slots[0]?.field || 'imagePath')
+const serverSlots = ref<ServerArtSlot[]>([])
+const selectedField = ref(defaultFieldName())
 const history = ref<HistoryItem[]>([])
 const showGenerate = ref(false)
 const showUpload = ref(false)
@@ -587,7 +596,8 @@ const uploadFile = ref<File | null>(null)
 const submitting = ref(false)
 const loadingResources = ref(false)
 const removingHistoryId = ref<number | null>(null)
-const currentFailed = ref(false)
+const promoting = ref(false)
+const failedSrcs = ref<string[]>([])
 const message = ref('')
 const messageTone = ref<'info' | 'success' | 'error'>('info')
 let pollTimer: ReturnType<typeof setTimeout> | null = null
@@ -611,16 +621,61 @@ const mayEdit = computed(
     userStore.isAdmin ||
     Number(props.entity.userId) === Number(userStore.userId),
 )
-const selectedSlot = computed(() => {
-  const configured = props.slots.find((slot) => slot.field === selectedField.value)
+function defaultFieldName(): string {
+  return props.entityType === 'bot' ? 'avatarImage' : 'imagePath'
+}
+
+function fallbackSlot(): ResolvedSlot {
   return {
-    field: configured?.field || props.slots[0]?.field || 'imagePath',
-    label: configured?.label || 'Image',
-    aspect: configured?.aspect || '1 / 1',
-    width: configured?.width || 1024,
-    height: configured?.height || 1024,
+    field: defaultFieldName(),
+    label: 'Image',
+    aspect: '1 / 1',
+    width: 1024,
+    height: 1024,
+    primary: true,
+    retired: false,
   }
+}
+
+/**
+ * Server roster first, the `slots` prop as an override, and a single synthetic
+ * primary while the first fetch is in flight so the panel never renders an
+ * empty frame.
+ */
+const resolvedSlots = computed<ResolvedSlot[]>(() => {
+  if (props.slots.length) {
+    return props.slots.map((slot, index) => ({
+      field: slot.field,
+      label: slot.label,
+      aspect: slot.aspect || '1 / 1',
+      width: slot.width || 1024,
+      height: slot.height || 1024,
+      primary: index === 0,
+      retired: false,
+    }))
+  }
+  if (serverSlots.value.length) {
+    return serverSlots.value.map((slot) => ({
+      ...slot,
+      aspect: `${slot.width} / ${slot.height}`,
+    }))
+  }
+  return [fallbackSlot()]
 })
+const editableSlots = computed(() =>
+  resolvedSlots.value.filter((slot) => !slot.retired),
+)
+const primarySlot = computed(
+  () =>
+    editableSlots.value.find((slot) => slot.primary) ||
+    editableSlots.value[0] ||
+    fallbackSlot(),
+)
+const selectedSlot = computed<ResolvedSlot>(
+  () =>
+    editableSlots.value.find((slot) => slot.field === selectedField.value) ||
+    primarySlot.value,
+)
 /**
  * A Project's own DB columns (heroPath/cardPath/imagePath) are only one of
  * two places its art can live: conductor's art pipeline commits hero/card/
@@ -640,12 +695,26 @@ const PROJECT_ART_KIND_BY_FIELD: Record<string, 'hero' | 'card' | 'icon'> = {
   imagePath: 'icon',
 }
 
-function projectFallbackSrc(field: string): string {
-  if (props.entityType !== 'project') return ''
-  const kind = PROJECT_ART_KIND_BY_FIELD[field]
+/**
+ * The primary slot reaches for the LARGEST conductor render first and steps
+ * down only when one is missing. One image now serves every view, and the
+ * primary field for a project is still the one conductor delivers its 256px
+ * icon into -- resolving the primary straight to that icon would put a
+ * thumbnail on the main stage for every project whose art lives in the
+ * conductor repo rather than in an ArtImage row.
+ */
+function projectFallbackCandidates(field: string): string[] {
+  if (props.entityType !== 'project') return []
   const slug = props.entity.conductorSlug as string | null | undefined
-  if (!kind || !slug) return ''
-  return projectAssetFallback(slug, kind)
+  if (!slug) return []
+  const own = PROJECT_ART_KIND_BY_FIELD[field]
+  const kinds: ('hero' | 'card' | 'icon')[] =
+    field === primarySlot.value.field
+      ? ['hero', 'card', 'icon']
+      : own
+        ? [own]
+        : []
+  return kinds.map((kind) => projectAssetFallback(slug, kind))
 }
 
 function slotSrc(field: string): string {
@@ -654,14 +723,14 @@ function slotSrc(field: string): string {
   if (props.entity.artImageId && ['imagePath', 'avatarImage'].includes(field)) {
     return `/api/art/images/${props.entity.artImageId}/file`
   }
-  return projectFallbackSrc(field)
+  const candidates = projectFallbackCandidates(field)
+  return (
+    candidates.find((src) => !failedSrcs.value.includes(src)) ||
+    candidates[0] ||
+    ''
+  )
 }
 const currentSrc = computed(() => slotSrc(selectedSlot.value.field))
-const filteredHistory = computed(() =>
-  history.value.filter(
-    (item) => !item.field || item.field === selectedField.value,
-  ),
-)
 const checkpointOptions = computed(() =>
   resourceStore.resources
     .filter((resource) => {
@@ -757,24 +826,76 @@ function historySrc(item: HistoryItem): string {
   return normalizeSrc(item.imagePath || item.path) || `/api/art/images/${item.id}/file`
 }
 
+/**
+ * One loop, every image: the editable slots (empty ones included, so a slot
+ * with no art yet is still reachable), then whatever a retired slot is still
+ * holding, then inspiration history, then the linked collection.
+ *
+ * Retired slots ride along as inspirations rather than as their own tabs. The
+ * art they hold is real and still rendered elsewhere on the site, so hiding it
+ * would lose it, but nothing new is generated into them -- the way back into
+ * circulation is `Set as main`.
+ */
 const carouselSlides = computed<CarouselSlide[]>(() => {
   const out: CarouselSlide[] = []
-  const seen = new Set<string>()
-  const push = (src: string, label: string, field?: string) => {
-    if (!src || seen.has(src)) return
-    seen.add(src)
-    out.push({ src, label, field })
+  const seenSrcs = new Set<string>()
+  const seenIds = new Set<number>()
+  /*
+   * Deduped by ArtImage id as well as by URL. Promoting an inspiration leaves
+   * its history link in place and stamps a cache-busting `?v=` onto the slot
+   * path, so the same image reaches here under two different URLs and would
+   * otherwise show up twice -- once as the main image and once as an
+   * inspiration of itself.
+   */
+  const push = (slide: CarouselSlide) => {
+    if (slide.artImageId) {
+      if (seenIds.has(slide.artImageId)) return
+      seenIds.add(slide.artImageId)
+    }
+    if (slide.src) {
+      if (seenSrcs.has(slide.src)) return
+      seenSrcs.add(slide.src)
+    }
+    out.push(slide)
   }
-  for (const slot of props.slots) push(slotSrc(slot.field), slot.label, slot.field)
+  for (const slot of editableSlots.value) {
+    push({
+      key: `slot:${slot.field}`,
+      src: slotSrc(slot.field),
+      label: slot.label,
+      kind: 'slot',
+      field: slot.field,
+      artImageId: slotArtImageId(slot.field) ?? undefined,
+    })
+  }
+  for (const slot of resolvedSlots.value) {
+    if (!slot.retired) continue
+    const src = slotSrc(slot.field)
+    if (!src) continue
+    push({
+      key: `retired:${slot.field}`,
+      src,
+      label: `Retired · ${slot.label}`,
+      kind: 'inspiration',
+      artImageId: slotArtImageId(slot.field) ?? undefined,
+    })
+  }
   for (const item of history.value) {
-    push(
-      historySrc(item),
-      `Inspiration · ${item.fieldLabel || item.fileName || `Image ${item.id}`}`,
-      item.field,
-    )
+    push({
+      key: `history:${item.id}`,
+      src: historySrc(item),
+      label: `Inspiration · ${item.fieldLabel || item.fileName || `Image ${item.id}`}`,
+      kind: 'inspiration',
+      artImageId: item.id,
+    })
   }
   for (const slide of props.collectionSlides) {
-    push(normalizeSrc(slide.src), slide.label)
+    push({
+      key: `collection:${slide.src || slide.label}`,
+      src: normalizeSrc(slide.src),
+      label: slide.label,
+      kind: 'collection',
+    })
   }
   return out
 })
@@ -782,8 +903,34 @@ const hasCarousel = computed(() => carouselSlides.value.length > 1)
 const activeCarouselSlide = computed<CarouselSlide>(
   () =>
     carouselSlides.value[carouselIndex.value] ??
-    carouselSlides.value[0] ?? { src: '', label: '' },
+    carouselSlides.value[0] ?? {
+      key: 'empty',
+      src: '',
+      label: primarySlot.value.label,
+      kind: 'slot',
+    },
 )
+const activeSlideFailed = computed(() =>
+  failedSrcs.value.includes(activeCarouselSlide.value.src),
+)
+const inspirationCount = computed(
+  () =>
+    carouselSlides.value.filter((slide) => slide.kind === 'inspiration').length,
+)
+const activeSlideCaption = computed(() => {
+  const slide = activeCarouselSlide.value
+  return slide.kind === 'slot' ? `Current ${slide.label}` : slide.label
+})
+/**
+ * Only an image that is not already serving a slot can be promoted, and only
+ * when the endpoint has an id to promote -- a collection slide carries a URL
+ * and nothing else.
+ */
+const canPromoteActiveSlide = computed(() => {
+  const slide = activeCarouselSlide.value
+  if (slide.kind !== 'inspiration' || !slide.artImageId) return false
+  return slotArtImageId(primarySlot.value.field) !== slide.artImageId
+})
 
 function stepCarousel(direction: number) {
   const count = carouselSlides.value.length
@@ -820,8 +967,31 @@ function selectCarouselSlide(index: number) {
 
 function selectSlot(field: string) {
   selectedField.value = field
-  currentFailed.value = false
   message.value = ''
+}
+
+function markSlideFailed(src: string) {
+  if (!src || failedSrcs.value.includes(src)) return
+  failedSrcs.value = [...failedSrcs.value, src]
+}
+
+/**
+ * The ArtImage id behind a slot, resolved the same way the server does it: the
+ * slot's own id column, then the id embedded in an /api/art/images/<id>/file
+ * path, and the record's primary artImageId only for the primary slot.
+ */
+function slotArtImageId(field: string): number | null {
+  const slotIdField = field.match(/^(card|hero|icon)Path$/)
+  const columnValue = slotIdField
+    ? props.entity[`${slotIdField[1]}ArtImageId`]
+    : props.entity.artImageId
+  const columnId = Number(columnValue)
+  if (Number.isInteger(columnId) && columnId > 0) return columnId
+  const raw = props.entity[field]
+  const embedded = Number(
+    typeof raw === 'string' ? raw.match(/\/api\/art\/images\/(\d+)\/file/)?.[1] : NaN,
+  )
+  return Number.isInteger(embedded) && embedded > 0 ? embedded : null
 }
 
 function openGenerate() {
@@ -855,7 +1025,7 @@ function handleFile(event: Event) {
 function applyEntity(entity: EntityRecord | null | undefined) {
   if (!entity) return
   Object.assign(props.entity, entity)
-  currentFailed.value = false
+  failedSrcs.value = []
   emit('updated', props.entity)
 }
 
@@ -864,6 +1034,7 @@ async function fetchEntityArt(force = false) {
   const response = await performFetch<{
     entity: EntityRecord
     history: HistoryItem[]
+    slots?: ServerArtSlot[]
   }>(
     `/api/art/entities/${props.entityType}/${props.entity.id}${query}`,
     force ? { cache: 'no-store' } : {},
@@ -873,6 +1044,48 @@ async function fetchEntityArt(force = false) {
   }
   applyEntity(response.data.entity)
   history.value = response.data.history || []
+  serverSlots.value = response.data.slots || []
+  if (!editableSlots.value.some((slot) => slot.field === selectedField.value)) {
+    selectedField.value = primarySlot.value.field
+  }
+}
+
+async function promoteActiveSlide() {
+  const slide = activeCarouselSlide.value
+  if (!slide.artImageId || promoting.value) return
+  promoting.value = true
+  message.value = ''
+  try {
+    const response = await performFetch<{
+      entity: EntityRecord
+      history: HistoryItem[]
+    }>(`/api/art/entities/${props.entityType}/${props.entity.id}/promote`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        field: primarySlot.value.field,
+        artImageId: slide.artImageId,
+        preserveOriginal: true,
+      }),
+    })
+    if (!response.success || !response.data) {
+      throw new Error(response.message || 'That image could not be set as the main image.')
+    }
+    applyEntity(response.data.entity)
+    history.value = response.data.history || []
+    selectedField.value = primarySlot.value.field
+    carouselIndex.value = 0
+    message.value = response.message || 'Main image updated.'
+    messageTone.value = 'success'
+  } catch (error) {
+    message.value =
+      error instanceof Error
+        ? error.message
+        : 'That image could not be set as the main image.'
+    messageTone.value = 'error'
+  } finally {
+    promoting.value = false
+  }
 }
 
 async function ensureResources() {
@@ -1058,8 +1271,9 @@ watch(generationEngine, () => {
 watch(
   () => [props.entityType, props.entity.id],
   async () => {
-    selectedField.value = props.slots[0]?.field || 'imagePath'
-    currentFailed.value = false
+    serverSlots.value = []
+    selectedField.value = defaultFieldName()
+    failedSrcs.value = []
     history.value = []
     carouselIndex.value = 0
     cancelCarouselSwipe()
@@ -1070,7 +1284,10 @@ watch(
   },
 )
 watch(selectedField, () => {
-  currentFailed.value = false
+  const index = carouselSlides.value.findIndex(
+    (slide) => slide.kind === 'slot' && slide.field === selectedField.value,
+  )
+  if (index >= 0) carouselIndex.value = index
 })
 watch(carouselSlides, (next) => {
   if (carouselIndex.value >= next.length) carouselIndex.value = 0
@@ -1098,6 +1315,37 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
+/*
+ * One stage, sized by the slot's own aspect and clamped so a tall card frame
+ * cannot push the rest of the panel off screen. The image is contained rather
+ * than cropped -- the loop mixes 16:9, 2:3 and square art, and cover hid the
+ * subject of whichever one did not match the frame -- over a blurred copy of
+ * itself so the letterboxing still reads as artwork.
+ */
+.art-stage {
+  aspect-ratio: var(--art-stage-aspect, 1 / 1);
+  min-height: 12rem;
+  max-height: min(50vh, 24rem);
+}
+
+.art-stage-backdrop,
+.art-stage-image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.art-stage-backdrop {
+  object-fit: cover;
+  filter: blur(1.5rem) saturate(1.1);
+  transform: scale(1.1);
+}
+
+.art-stage-image {
+  object-fit: contain;
+}
+
 .entity-carousel-fade-enter-active,
 .entity-carousel-fade-leave-active {
   transition: opacity 400ms ease;

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -989,9 +989,9 @@ function markSlideFailed(src: string) {
  * path, and the record's primary artImageId only for the primary slot.
  */
 function slotArtImageId(field: string): number | null {
-  const slotIdField = field.match(/^(card|hero|icon)Path$/)
-  const columnValue = slotIdField
-    ? props.entity[`${slotIdField[1]}ArtImageId`]
+  const slotName = field.match(/^(card|hero|icon)Path$/)?.[1]
+  const columnValue = slotName
+    ? props.entity[`${slotName}ArtImageId`]
     : props.entity.artImageId
   const columnId = Number(columnValue)
   if (Number.isInteger(columnId) && columnId > 0) return columnId

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -242,10 +242,14 @@
       </div>
 
       <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <label class="form-control gap-1">
+        <label v-if="editableSlots.length > 1" class="form-control gap-1">
           <span class="kr-text-dim-xs-60 font-semibold">Target</span>
           <select v-model="selectedField" class="kr-select-sm" :disabled="submitting">
-            <option v-for="slot in slots" :key="slot.field" :value="slot.field">
+            <option
+              v-for="slot in editableSlots"
+              :key="slot.field"
+              :value="slot.field"
+            >
               {{ slot.label }}
             </option>
           </select>
@@ -405,10 +409,14 @@
       </div>
 
       <div class="grid gap-3 sm:grid-cols-2">
-        <label class="form-control gap-1">
+        <label v-if="editableSlots.length > 1" class="form-control gap-1">
           <span class="kr-text-dim-xs-60 font-semibold">Target</span>
           <select v-model="selectedField" class="kr-select-sm" :disabled="submitting">
-            <option v-for="slot in slots" :key="slot.field" :value="slot.field">
+            <option
+              v-for="slot in editableSlots"
+              :key="slot.field"
+              :value="slot.field"
+            >
               {{ slot.label }}
             </option>
           </select>

--- a/components/bots/bot-chat.vue
+++ b/components/bots/bot-chat.vue
@@ -315,36 +315,6 @@
         v-if="botStore.currentBot"
         entity-type="bot"
         :entity="botStore.currentBot"
-        :slots="[
-          {
-            field: 'avatarImage',
-            label: 'Avatar',
-            aspect: '1 / 1',
-            width: 1024,
-            height: 1024,
-          },
-          {
-            field: 'iconPath',
-            label: 'Icon',
-            aspect: '1 / 1',
-            width: 256,
-            height: 256,
-          },
-          {
-            field: 'cardPath',
-            label: 'Card',
-            aspect: '2 / 3',
-            width: 512,
-            height: 768,
-          },
-          {
-            field: 'heroPath',
-            label: 'Hero',
-            aspect: '16 / 9',
-            width: 1280,
-            height: 720,
-          },
-        ]"
       />
 
       <!--

--- a/components/characters/character-chat.vue
+++ b/components/characters/character-chat.vue
@@ -70,36 +70,6 @@
           v-if="characterStore.selectedCharacter"
           entity-type="character"
           :entity="characterStore.selectedCharacter"
-          :slots="[
-            {
-              field: 'imagePath',
-              label: 'Portrait',
-              aspect: '1 / 1',
-              width: 1024,
-              height: 1024,
-            },
-            {
-              field: 'iconPath',
-              label: 'Icon',
-              aspect: '1 / 1',
-              width: 256,
-              height: 256,
-            },
-            {
-              field: 'cardPath',
-              label: 'Card',
-              aspect: '2 / 3',
-              width: 512,
-              height: 768,
-            },
-            {
-              field: 'heroPath',
-              label: 'Hero',
-              aspect: '16 / 9',
-              width: 1280,
-              height: 720,
-            },
-          ]"
         />
 
         <section

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -140,7 +140,6 @@
         entity-type="project"
         :entity="linkedProject"
         :collection-slides="projectCollectionSlides"
-        :slots="projectArtSlots"
       />
 
       <div class="flex min-w-0 flex-col gap-2">
@@ -371,6 +370,12 @@
               {{ task.status }}
             </span>
           </div>
+
+          <TaskResponder
+            :project-slug="selectedProject.slug"
+            :task="task"
+            :project-id="linkedProject?.id ?? null"
+          />
         </div>
 
         <details
@@ -507,6 +512,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import EntityArtManager from '@/components/art/entity-art-manager.vue'
+import TaskResponder from '@/components/conductor/task-responder.vue'
 import type {
   ConductorProject,
   ConductorTask,
@@ -542,30 +548,6 @@ const projectTaskCategory = ref<TodoCategory>('AGENT')
 const projectTaskPriority = ref<ProjectPriorityLevel>('NORMAL')
 const projectTaskSubmitting = ref(false)
 let saveMessageTimer: ReturnType<typeof setTimeout> | null = null
-
-const projectArtSlots = [
-  {
-    field: 'heroPath',
-    label: 'Hero',
-    aspect: '16 / 9',
-    width: 1280,
-    height: 720,
-  },
-  {
-    field: 'cardPath',
-    label: 'Card',
-    aspect: '2 / 3',
-    width: 512,
-    height: 768,
-  },
-  {
-    field: 'imagePath',
-    label: 'Icon',
-    aspect: '1 / 1',
-    width: 256,
-    height: 256,
-  },
-]
 
 type ProjectPatch = {
   description?: string | null
@@ -963,37 +945,13 @@ onBeforeUnmount(() => {
   }
 }
 
-:deep(.project-art-compact header p),
-:deep(.project-art-compact header .badge),
-:deep(.project-art-compact .mt-2.flex.flex-wrap.justify-center) {
-  display: none;
-}
-
-:deep(
-  .project-art-compact:has(.group.relative.mt-3.min-h-40) .mt-3.grid.gap-3
-) {
-  display: none;
-}
-
-:deep(.project-art-compact .mt-3.grid.gap-3) {
-  margin-top: 0.5rem;
-}
-
-:deep(.project-art-compact .mt-3.grid.gap-3 > div) {
-  height: 20vh;
-  min-height: 8rem;
-  max-height: 12rem;
-  aspect-ratio: auto !important;
-}
-
-:deep(.project-art-compact .mt-3.grid.gap-3 aside) {
-  display: none;
-}
-
-:deep(.project-art-compact .group.relative.mt-3.min-h-40) {
-  height: 20vh;
-  min-height: 8rem;
-  max-height: 12rem;
-  margin-top: 0.5rem;
-}
+/*
+ * The Artwork panel owns its own layout. This block used to reach into
+ * entity-art-manager.vue by Tailwind utility-class selector to hide one of its
+ * two image viewers and clamp the other to a fifth of the viewport height.
+ * That is what left project images too small to read with dead space under
+ * them (Silas, 2026-09-11), and it broke silently whenever a utility class in
+ * the child changed. The child renders a single stage now, so there is nothing
+ * to hide -- see verifyEntityArtManager.ts, which keeps those selectors out.
+ */
 </style>

--- a/components/conductor/task-responder.vue
+++ b/components/conductor/task-responder.vue
@@ -1,0 +1,203 @@
+<!-- /components/conductor/task-responder.vue -->
+<template>
+  <div v-if="userStore.isAdmin" class="mt-2">
+    <button
+      type="button"
+      class="kr-btn-ghost-xs-lg gap-1 border border-base-300"
+      :aria-expanded="open"
+      @click="toggle"
+    >
+      <Icon name="kind-icon:comment" class="size-3" />
+      {{ isGated ? 'Answer this gate' : 'Respond' }}
+    </button>
+
+    <div
+      v-if="open"
+      class="mt-2 rounded-lg border border-base-300 bg-base-200/50 p-2"
+    >
+      <label class="sr-only" :for="`task-reply-${taskKey}`">
+        Your response for {{ task.title }}
+      </label>
+      <textarea
+        :id="`task-reply-${taskKey}`"
+        v-model="reply"
+        rows="3"
+        class="textarea textarea-bordered w-full rounded-lg text-sm leading-snug"
+        :placeholder="
+          isGated
+            ? 'Answer this, and the next agent picks the task up carrying what you said.'
+            : 'This reaches the project worker as a new task on this roadmap item.'
+        "
+        :disabled="busy"
+      />
+
+      <div class="mt-1.5 flex flex-wrap items-center gap-1">
+        <template v-if="isGated">
+          <button
+            type="button"
+            class="btn btn-primary btn-xs gap-1 rounded-lg"
+            :disabled="busy || !replyText"
+            title="Answer and release the gate for the next agent"
+            @click="runTaskAction('answer')"
+          >
+            <span v-if="busy" class="kr-spinner-xs" />
+            <Icon v-else name="kind-icon:send" class="size-3" />
+            Send to agent
+          </button>
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs rounded-lg border border-base-300 text-success"
+            :disabled="busy"
+            title="Close this gate as approved"
+            @click="runTaskAction('approve')"
+          >
+            Approve
+          </button>
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs rounded-lg border border-base-300 text-error"
+            :disabled="busy || !replyText"
+            title="Send the work back for another pass"
+            @click="runTaskAction('reject')"
+          >
+            Send back
+          </button>
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs rounded-lg border border-base-300"
+            :disabled="busy || !replyText"
+            title="Add this note but leave the gate open"
+            @click="runTaskAction('comment')"
+          >
+            Note only
+          </button>
+        </template>
+        <button
+          v-else
+          type="button"
+          class="btn btn-primary btn-xs gap-1 rounded-lg"
+          :disabled="busy || !replyText || !props.projectId"
+          @click="sendTaskNote"
+        >
+          <span v-if="busy" class="kr-spinner-xs" />
+          <Icon v-else name="kind-icon:send" class="size-3" />
+          Send to worker
+        </button>
+      </div>
+
+      <p v-if="error" class="mt-1 text-[0.65rem] font-bold text-error">
+        {{ error }}
+      </p>
+      <p v-else-if="sent" class="mt-1 text-[0.65rem] font-bold text-success">
+        {{ sent }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { ConductorTask } from '@/server/api/conductor/projects.get'
+import {
+  useConductorStore,
+  type ConductorTaskAction,
+} from '@/stores/conductorStore'
+import { useTodoStore } from '@/stores/todoStore'
+import { useUserStore } from '@/stores/userStore'
+
+/*
+ * Responding to a roadmap item, in the place the item is actually read.
+ *
+ * Silas, 2026-09-11: "I cannot actually respond to tasks, I can't clear tasks
+ * that are human gated." The gate composer already existed on the For You home
+ * surface (home-attention.vue) and the conductor task-action endpoint already
+ * supported all four verbs -- the two conductor surfaces that actually SHOW a
+ * roadmap were the ones with no way to act on it, so a gate opened here had to
+ * be answered somewhere else. This is the shared composer both of them mount.
+ *
+ * A gate gets the four conductor verbs. Anything else gets a project Todo
+ * tagged with the task id, because conductor's task-action endpoint only
+ * accepts a task already parked at needs-human (409 otherwise) and inventing a
+ * second write path into the roadmap from here would be a worse answer than
+ * using the queue the workers already read.
+ */
+const props = defineProps<{
+  projectSlug: string
+  task: ConductorTask
+  projectId?: number | null
+}>()
+
+const conductorStore = useConductorStore()
+const todoStore = useTodoStore()
+const userStore = useUserStore()
+
+const open = ref(false)
+const reply = ref('')
+const sent = ref('')
+const error = ref('')
+const noteSubmitting = ref(false)
+
+const taskKey = computed(() => `${props.projectSlug}/${props.task.id}`)
+const isGated = computed(() => props.task.status === 'needs-human')
+const replyText = computed(() => reply.value.trim())
+const busy = computed(
+  () =>
+    noteSubmitting.value ||
+    conductorStore.updatingTaskKeys.includes(taskKey.value),
+)
+
+function toggle(): void {
+  open.value = !open.value
+  sent.value = ''
+  error.value = ''
+  conductorStore.taskUpdateError = null
+}
+
+async function runTaskAction(action: ConductorTaskAction): Promise<void> {
+  error.value = ''
+  const completed = await conductorStore.submitTaskAction(
+    props.projectSlug,
+    props.task.id,
+    action,
+    reply.value,
+  )
+  if (!completed) {
+    error.value =
+      conductorStore.taskUpdateError || 'Conductor task update failed.'
+    return
+  }
+  reply.value = ''
+  sent.value =
+    action === 'comment'
+      ? 'Note queued. The gate stays open.'
+      : 'Queued for conductor. It reaches the roadmap on the next task-events run.'
+}
+
+async function sendTaskNote(): Promise<void> {
+  const body = replyText.value
+  if (!body || !props.projectId) return
+  noteSubmitting.value = true
+  error.value = ''
+  try {
+    const created = await todoStore.createTodo({
+      title: `${props.task.id}: ${props.task.title}`.slice(0, 160),
+      description: [
+        `Project: ${props.projectSlug}`,
+        `Roadmap task: ${props.task.id} (${props.task.status})`,
+        body,
+      ].join('\n\n'),
+      category: 'AGENT',
+      priority: 'NORMAL',
+      projectId: props.projectId,
+    })
+    if (!created) {
+      error.value = 'That response could not be saved.'
+      return
+    }
+    reply.value = ''
+    sent.value = 'Sent to the project worker queue.'
+  } finally {
+    noteSubmitting.value = false
+  }
+}
+</script>

--- a/components/facets/facet-editor.vue
+++ b/components/facets/facet-editor.vue
@@ -38,19 +38,7 @@
   <section v-if="facet" class="space-y-4">
     <FacetProfileEditor v-model="editForm" />
 
-    <EntityArtManager
-      entity-type="facet"
-      :entity="facet"
-      :slots="[
-        {
-          field: 'imagePath',
-          label: 'Image',
-          aspect: '1 / 1',
-          width: 1024,
-          height: 1024,
-        },
-      ]"
-    />
+    <EntityArtManager entity-type="facet" :entity="facet" />
 
     <p v-if="errorMessage" class="text-sm text-error">{{ errorMessage }}</p>
 

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -786,29 +786,6 @@
                 entity-type="project"
                 :entity="linkedProject"
                 :collection-slides="projectCollectionSlides"
-                :slots="[
-                  {
-                    field: 'heroPath',
-                    label: 'Hero',
-                    aspect: '16 / 9',
-                    width: 1280,
-                    height: 720,
-                  },
-                  {
-                    field: 'cardPath',
-                    label: 'Card',
-                    aspect: '2 / 3',
-                    width: 512,
-                    height: 768,
-                  },
-                  {
-                    field: 'imagePath',
-                    label: 'Icon',
-                    aspect: '1 / 1',
-                    width: 256,
-                    height: 256,
-                  },
-                ]"
               />
             </div>
 
@@ -1003,6 +980,12 @@
                         >{{ task.status }}</span
                       >
                     </div>
+
+                    <TaskResponder
+                      :project-slug="selectedProject.slug"
+                      :task="task"
+                      :project-id="linkedProject?.id ?? null"
+                    />
                   </div>
                 </div>
 
@@ -1176,6 +1159,7 @@ import type { BuilderCard } from '@/stores/helpers/builderCards'
 import type { GalleryItem } from '@/components/gallery/kr-gallery.vue'
 import { IS_GALLERY_MODE, type GalleryMode } from '@/utils/galleryVocabulary'
 import EntityArtManager from '@/components/art/entity-art-manager.vue'
+import TaskResponder from '@/components/conductor/task-responder.vue'
 import SnapshotModeBanner from '@/components/navigation/snapshot-mode-banner.vue'
 
 type ProjectPatch = {

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -268,36 +268,6 @@
           v-if="rewardStore.selectedReward"
           entity-type="reward"
           :entity="rewardStore.selectedReward"
-          :slots="[
-            {
-              field: 'imagePath',
-              label: 'Reward image',
-              aspect: '1 / 1',
-              width: 1024,
-              height: 1024,
-            },
-            {
-              field: 'iconPath',
-              label: 'Icon',
-              aspect: '1 / 1',
-              width: 256,
-              height: 256,
-            },
-            {
-              field: 'cardPath',
-              label: 'Card',
-              aspect: '2 / 3',
-              width: 512,
-              height: 768,
-            },
-            {
-              field: 'heroPath',
-              label: 'Hero',
-              aspect: '16 / 9',
-              width: 1280,
-              height: 720,
-            },
-          ]"
         />
         <section class="shrink-0 kr-panel-flat p-4 shadow-md">
           <h2 class="kr-text-bold-lg mb-3 text-base-content">The Encounter</h2>

--- a/components/scenarios/scenario-story.vue
+++ b/components/scenarios/scenario-story.vue
@@ -75,36 +75,6 @@
       v-if="selectedScenario"
       entity-type="scenario"
       :entity="selectedScenario"
-      :slots="[
-        {
-          field: 'imagePath',
-          label: 'Scenario image',
-          aspect: '16 / 9',
-          width: 1536,
-          height: 864,
-        },
-        {
-          field: 'iconPath',
-          label: 'Icon',
-          aspect: '1 / 1',
-          width: 256,
-          height: 256,
-        },
-        {
-          field: 'cardPath',
-          label: 'Card',
-          aspect: '2 / 3',
-          width: 512,
-          height: 768,
-        },
-        {
-          field: 'heroPath',
-          label: 'Hero',
-          aspect: '16 / 9',
-          width: 1280,
-          height: 720,
-        },
-      ]"
     />
 
     <article

--- a/plugins/entity-art-prompt-suggest.client.ts
+++ b/plugins/entity-art-prompt-suggest.client.ts
@@ -43,10 +43,20 @@ type ScenarioStore = ReturnType<typeof useScenarioStore>
 
 const BUTTON_MARKER = 'data-entity-art-prompt-suggest'
 const attached = new WeakSet<HTMLTextAreaElement>()
+/*
+ * Primary first in both rosters. entity-art-manager.vue hides its Target
+ * select once an entity has a single generatable slot -- which the slot
+ * collapse made true for every entity -- so there is no longer a select for
+ * `selectedSlot` to read, and it falls through to the head of this list. The
+ * head therefore has to be the primary: taking heroPath for a project (or a
+ * generic 1024 square for a scenario) frames the suggested prompt for a slot
+ * the enqueue gate will not accept. The retired entries stay because a
+ * still-visible Target select on an override call site can select them.
+ */
 const PROJECT_ART_SLOTS: EntityArtSlot[] = [
+  { field: 'imagePath', label: 'Image', width: 1024, height: 1024 },
   { field: 'heroPath', label: 'Hero', width: 1280, height: 720 },
   { field: 'cardPath', label: 'Card', width: 512, height: 768 },
-  { field: 'imagePath', label: 'Icon', width: 256, height: 256 },
 ]
 const SCENARIO_ART_SLOTS: EntityArtSlot[] = [
   { field: 'imagePath', label: 'Scenario image', width: 1536, height: 864 },
@@ -65,8 +75,8 @@ function positiveInteger(value: unknown): number | undefined {
 }
 
 function managerContextFromVue(element: HTMLElement): ManagerContext | null {
-  let instance: VueInstanceLike | null | undefined =
-    (element as VueElement).__vueParentComponent
+  let instance: VueInstanceLike | null | undefined = (element as VueElement)
+    .__vueParentComponent
 
   while (instance) {
     const props = instance.props ?? {}
@@ -246,8 +256,9 @@ function selectedValue(
   predicate: (select: HTMLSelectElement) => boolean,
 ): string {
   return (
-    Array.from(form.querySelectorAll<HTMLSelectElement>('select')).find(predicate)
-      ?.value || ''
+    Array.from(form.querySelectorAll<HTMLSelectElement>('select')).find(
+      predicate,
+    )?.value || ''
   )
 }
 
@@ -259,7 +270,8 @@ function selectedSlot(
     context.slots.some((slot) => slot.field === select.value),
   )
   return (
-    context.slots.find((slot) => slot.field === field) || {
+    context.slots.find((slot) => slot.field === field) ||
+    context.slots[0] || {
       field: field || 'imagePath',
       label: 'Image',
       width: 1024,
@@ -410,11 +422,14 @@ function addSuggestButton(
     } catch (error) {
       const detail =
         error instanceof Error ? cleanString(error.message).slice(0, 72) : ''
-      button.textContent = detail ? `Suggestion failed · ${detail}` : 'Suggestion failed'
+      button.textContent = detail
+        ? `Suggestion failed · ${detail}`
+        : 'Suggestion failed'
       button.title = detail || 'Prompt suggestion failed.'
       window.setTimeout(() => {
         button.textContent = initialLabel
-        button.title = 'Generate an editable art prompt from the canonical record'
+        button.title =
+          'Generate an editable art prompt from the canonical record'
       }, 5000)
     } finally {
       button.dataset.loading = 'false'
@@ -455,12 +470,7 @@ export default defineNuxtPlugin((nuxtApp) => {
               scenarioStore,
             )
           }
-          scanForEntityArtPrompts(
-            node,
-            pageStore,
-            projectStore,
-            scenarioStore,
-          )
+          scanForEntityArtPrompts(node, pageStore, projectStore, scenarioStore)
         }
       }
     })

--- a/server/api/art/entities/[entityType]/[id].get.ts
+++ b/server/api/art/entities/[entityType]/[id].get.ts
@@ -5,6 +5,7 @@ import { errorHandler } from '~/server/utils/error'
 import { requireApiUser } from '~/server/utils/authGuard'
 import {
   listEntityArtHistory,
+  listEntityArtSlots,
   resolveEntityArtTarget,
 } from '~/server/utils/entityArt'
 
@@ -36,6 +37,7 @@ export default defineEventHandler(async (event) => {
       data: {
         entity: target.record,
         history,
+        slots: listEntityArtSlots(target.entityType),
       },
       statusCode: 200,
     }

--- a/server/api/art/entities/[entityType]/[id]/promote.post.ts
+++ b/server/api/art/entities/[entityType]/[id]/promote.post.ts
@@ -1,0 +1,158 @@
+// /server/api/art/entities/[entityType]/[id]/promote.post.ts
+import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
+import prisma from '~/server/utils/prisma'
+import { errorHandler } from '~/server/utils/error'
+import { requireApiUser } from '~/server/utils/authGuard'
+import {
+  applyEntityArtImage,
+  listEntityArtHistory,
+  listEntityArtSlots,
+  resolveEntityArtTarget,
+  slotArtImageIdField,
+} from '~/server/utils/entityArt'
+
+type PromoteBody = {
+  field?: string
+  artImageId?: number | string
+  preserveOriginal?: boolean
+}
+
+/**
+ * Make an image the entity's current art for a slot without regenerating it.
+ *
+ * Silas, 2026-09-11: "I should be able to set one of the inspiration images to
+ * be the main image, but that doesn't seem to be an option". Every path into a
+ * slot went through a render or an upload, so an image already sitting in the
+ * inspiration gallery -- including the ones the slot collapse left behind in
+ * the retired card and hero columns -- could only be reinstated by uploading
+ * it again from disk.
+ *
+ * The candidate has to already be reachable from this entity, so promoting
+ * cannot pull an arbitrary ArtImage row in by id: either it is in this
+ * entity's inspiration history, or it is the current image of one of the
+ * entity's own slots (which is what makes "use the old hero as the main
+ * image" work).
+ */
+export default defineEventHandler(async (event) => {
+  try {
+    const auth = await requireApiUser(event)
+    const entityType = getRouterParam(event, 'entityType')
+    const id = getRouterParam(event, 'id')
+    const body = await readBody<PromoteBody>(event)
+    const artImageId = Number(body?.artImageId)
+    if (!Number.isInteger(artImageId) || artImageId <= 0) {
+      throw createError({ statusCode: 400, message: 'Invalid image ID.' })
+    }
+
+    const target = await resolveEntityArtTarget(
+      prisma,
+      entityType,
+      id,
+      body?.field,
+      auth,
+    )
+    if (target.config.retired) {
+      throw createError({
+        statusCode: 400,
+        message:
+          `The ${target.config.label} slot is no longer generated, so it cannot be set as ` +
+          'the main image. Promote into the primary slot instead.',
+      })
+    }
+
+    const link = await prisma.entityArtImage.findUnique({
+      where: {
+        entityType_entityId_artImageId: {
+          entityType: target.entityType,
+          entityId: target.entityId,
+          artImageId,
+        },
+      },
+      select: { artImageId: true },
+    })
+    if (!link && !holdsArtImage(target.record, artImageId, target.entityType)) {
+      throw createError({
+        statusCode: 404,
+        message: 'That image is not part of this item’s artwork.',
+      })
+    }
+
+    if (currentSlotArtImageId(target.record, target.field) === artImageId) {
+      throw createError({
+        statusCode: 409,
+        message: `That image is already the current ${target.config.label.toLowerCase()}.`,
+      })
+    }
+
+    const preserveOriginal = body?.preserveOriginal !== false
+    const result = await prisma.$transaction((tx) =>
+      applyEntityArtImage(tx, {
+        entityType: target.entityType,
+        entityId: target.entityId,
+        field: target.field,
+        artImageId,
+        preserveOriginal,
+      }),
+    )
+    const history = await listEntityArtHistory(
+      prisma,
+      target.entityType,
+      target.entityId,
+    )
+
+    return {
+      success: true,
+      message: preserveOriginal
+        ? `${target.config.label} updated; the previous image was kept as inspiration.`
+        : `${target.config.label} updated without retaining the previous image.`,
+      data: {
+        entity: result.entity,
+        history,
+        artImageId,
+        archivedArtImageId: result.archivedArtImageId,
+      },
+      statusCode: 200,
+    }
+  } catch (error: unknown) {
+    const handled = errorHandler(error)
+    const statusCode = handled.statusCode || 500
+    event.node.res.statusCode = statusCode
+    return {
+      success: false,
+      message: handled.message || 'Failed to set that image as the main image.',
+      data: null,
+      statusCode,
+    }
+  }
+})
+
+const IMAGE_API_PATTERN = /\/api\/art\/images\/(\d+)\/file/
+
+/*
+ * Mirrors entityArt.ts's own resolution order: the slot's id column first, the
+ * id embedded in an /api/art/images/<id>/file path second (rows the 2026-08-06
+ * backfill has not reached), and the record's primary artImageId only for the
+ * primary field.
+ */
+function currentSlotArtImageId(
+  record: Record<string, unknown>,
+  field: string,
+): number | null {
+  const slotField = slotArtImageIdField(field)
+  const columnId = Number(slotField ? record[slotField] : record.artImageId)
+  if (Number.isInteger(columnId) && columnId > 0) return columnId
+  const path =
+    typeof record[field] === 'string' ? (record[field] as string) : ''
+  const embedded = Number(path.match(IMAGE_API_PATTERN)?.[1])
+  return Number.isInteger(embedded) && embedded > 0 ? embedded : null
+}
+
+function holdsArtImage(
+  record: Record<string, unknown>,
+  artImageId: number,
+  entityType: Parameters<typeof listEntityArtSlots>[0],
+): boolean {
+  return listEntityArtSlots(entityType).some(
+    (slot) => currentSlotArtImageId(record, slot.field) === artImageId,
+  )
+}

--- a/server/utils/entityArt.ts
+++ b/server/utils/entityArt.ts
@@ -91,10 +91,13 @@ export const ENTITY_FIELDS: Record<
    * Kind Robots set (e.g. 'kind-icon:bot'); it is never an art slot and never
    * generated. `iconPath` points at a fully developed logo image and IS an art
    * slot, rendered at 256x256 so small grid cells stop reusing a 1024px
-   * portrait. `project` still labels its `imagePath` 'Icon' for backward
-   * compatibility -- see server/api/conductor/project-art-complete.post.ts,
-   * which maps that field onto the ArtImage `iconPath` variant. Migrating
-   * project onto a real iconPath column is deliberately left for t-009.
+   * portrait. `project` renders its `imagePath` primary at the same 1024x1024
+   * as every other collapsed entity, so the one main image is large enough to
+   * be re-cropped into a hero or card frame; the 256x256 icon variant it used
+   * to be could not. server/api/conductor/project-art-complete.post.ts still
+   * maps that field onto the ArtImage `iconPath` variant, so conductor's own
+   * icon deliveries keep landing. Migrating project onto a real iconPath
+   * column is deliberately left for t-009.
    */
   bot: {
     avatarImage: {
@@ -259,9 +262,9 @@ export const ENTITY_FIELDS: Record<
   },
   project: {
     imagePath: {
-      label: 'Icon',
-      width: 256,
-      height: 256,
+      label: 'Image',
+      width: 1024,
+      height: 1024,
       primary: true,
     },
     cardPath: {
@@ -372,6 +375,41 @@ export function getEntityArtFieldConfig(
     })
   }
   return { field, ...config }
+}
+
+export type EntityArtSlotInfo = {
+  field: string
+  label: string
+  width: number
+  height: number
+  primary: boolean
+  retired: boolean
+}
+
+/**
+ * The slot roster for an entity type, primary first.
+ *
+ * Call sites used to hardcode their own slot arrays, which is how
+ * project-detail.vue and conductor-page.vue ended up offering Hero, Card and
+ * Icon as three peer tabs months after the slot collapse retired all three
+ * (Silas, 2026-09-11: "we're still displaying as if they are expecting a three
+ * way card hero icon set"). Serving the roster from the same table that
+ * `prepareEntityArtEnqueue` refuses retired work from means a client cannot
+ * offer to generate a slot the server will reject.
+ */
+export function listEntityArtSlots(
+  entityType: EntityArtType,
+): EntityArtSlotInfo[] {
+  return Object.entries(ENTITY_FIELDS[entityType])
+    .map(([field, config]) => ({
+      field,
+      label: config.label,
+      width: config.width,
+      height: config.height,
+      primary: config.primary,
+      retired: config.retired === true,
+    }))
+    .sort((left, right) => Number(right.primary) - Number(left.primary))
 }
 
 export function entityArtHistoryPrefix(

--- a/utils/scripts/verifyEntityArtManager.ts
+++ b/utils/scripts/verifyEntityArtManager.ts
@@ -60,6 +60,51 @@ expectContains('server/utils/entityArt.ts', [
   'entityArtHistoryPrefix',
 ])
 
+/*
+ * The slot collapse, enforced from the client side. ENTITY_FIELDS retires
+ * card/hero/icon and prepareEntityArtEnqueue refuses to generate them, so a
+ * call site that hands over its own slot array offers tabs the server will
+ * reject -- which is exactly what every project surface was still doing months
+ * later. The roster comes from the endpoint, retired slots ride in the
+ * inspiration loop, and an inspiration can be promoted back into the primary.
+ */
+expectContains('components/art/entity-art-manager.vue', [
+  'serverSlots.value = response.data.slots || []',
+  'const editableSlots = computed(() =>',
+  "slide.kind === 'inspiration'",
+  '/promote`',
+  'canPromoteActiveSlide',
+  '.art-stage-image',
+  'object-fit: contain;',
+])
+
+expectContains('server/utils/entityArt.ts', [
+  'export function listEntityArtSlots(',
+  'retired: config.retired === true,',
+])
+
+expectContains('server/api/art/entities/[entityType]/[id].get.ts', [
+  'slots: listEntityArtSlots(target.entityType)',
+])
+
+expectContains('server/api/art/entities/[entityType]/[id]/promote.post.ts', [
+  'applyEntityArtImage',
+  'entityType_entityId_artImageId',
+  'target.config.retired',
+])
+
+for (const callSite of [
+  'components/bots/bot-chat.vue',
+  'components/characters/character-chat.vue',
+  'components/rewards/reward-encounter.vue',
+  'components/facets/facet-editor.vue',
+  'components/scenarios/scenario-story.vue',
+  'components/conductor/project-detail.vue',
+  'components/pages/conductor-page.vue',
+]) {
+  expectOmits(callSite, [':slots="['])
+}
+
 expectContains('components/art/entity-art-manager.vue', [
   'Queued as ArtJob',
   'startPolling(activeJobId)',
@@ -90,7 +135,6 @@ expectContains('components/conductor/project-detail.vue', [
   'data-project-notes',
   '@container (min-width: 72rem)',
   'grid-template-columns: minmax(0, 3fr) minmax(22rem, 2fr);',
-  'height: 20vh;',
   'v-model="projectTaskText"',
   'taskStatusSummary(selectedProject)',
   '<progress',
@@ -113,7 +157,8 @@ const projectDetailOrder = [
 if (
   projectDetailOrder.some((index) => index < 0) ||
   projectDetailOrder.some(
-    (index, position) => position > 0 && index <= projectDetailOrder[position - 1]!,
+    (index, position) =>
+      position > 0 && index <= projectDetailOrder[position - 1]!,
   )
 ) {
   throw new Error(
@@ -126,7 +171,9 @@ if (
     projectDetailSource,
   )
 ) {
-  throw new Error('Project roadmap must be an expandable container open by default.')
+  throw new Error(
+    'Project roadmap must be an expandable container open by default.',
+  )
 }
 
 for (const marker of ['data-project-milestones', 'data-project-notes']) {
@@ -136,16 +183,53 @@ for (const marker of ['data-project-milestones', 'data-project-notes']) {
   if (
     detailsStart < 0 ||
     detailsEnd < 0 ||
-    /\sopen(?:\s|>)/.test(projectDetailSource.slice(detailsStart, detailsEnd + 1))
+    /\sopen(?:\s|>)/.test(
+      projectDetailSource.slice(detailsStart, detailsEnd + 1),
+    )
   ) {
     throw new Error(`${marker} must remain collapsed by default.`)
   }
 }
 
-if (!/<section class="kr-panel-flat overflow-hidden" data-project-profile>/.test(projectDetailSource)) {
-  throw new Error('Project Profile must stay always open rather than returning to a disclosure.')
+if (
+  !/<section class="kr-panel-flat overflow-hidden" data-project-profile>/.test(
+    projectDetailSource,
+  )
+) {
+  throw new Error(
+    'Project Profile must stay always open rather than returning to a disclosure.',
+  )
 }
 
+/*
+ * Every conductor surface that renders a roadmap has to be able to act on the
+ * task it is showing. A gate opened on either one used to be answerable only
+ * from the For You home surface (Silas, 2026-09-11: "I cannot actually respond
+ * to tasks, I can't clear tasks that are human gated").
+ */
+expectContains('components/conductor/task-responder.vue', [
+  'conductorStore.submitTaskAction(',
+  "runTaskAction('answer')",
+  "runTaskAction('approve')",
+  "runTaskAction('reject')",
+  "runTaskAction('comment')",
+  'sendTaskNote',
+  'todoStore.createTodo(',
+])
+
+for (const roadmapSurface of [
+  'components/conductor/project-detail.vue',
+  'components/pages/conductor-page.vue',
+]) {
+  expectContains(roadmapSurface, ['<TaskResponder', ':task="task"'])
+}
+
+/*
+ * project-detail.vue used to reach into entity-art-manager.vue by Tailwind
+ * class string to hide one of its two image viewers and clamp the other to
+ * 20vh, which is what left project art unreadable with dead space under it.
+ * The child owns one stage now; these selectors must not come back.
+ */
 expectOmits('components/conductor/project-detail.vue', [
   'Feature Wishlist',
   'projectTaskTitle',
@@ -154,6 +238,11 @@ expectOmits('components/conductor/project-detail.vue', [
   'min-h-[200px]',
   'sm:grid-cols-2',
   'xl:grid-cols-',
+  '.mt-3.grid.gap-3',
+  '.group.relative.mt-3.min-h-40',
+  'aspect-ratio: auto !important',
+  "field: 'heroPath'",
+  "field: 'cardPath'",
 ])
 
 expectContains('components/pages/conductor-manager.vue', [

--- a/utils/scripts/verifyFacetArtworkMigration.ts
+++ b/utils/scripts/verifyFacetArtworkMigration.ts
@@ -292,16 +292,29 @@ async function main(): Promise<void> {
     '<FacetProfileEditor v-model="createForm" />',
   )
 
-  // The art slots were imagePath + iconPath + cardPath + heroPath. Only the
-  // primary is generated now; the retired fields are rejected at enqueue, so
-  // offering their upload slots here would have been three buttons that 400.
+  /*
+   * The art slots were imagePath + iconPath + cardPath + heroPath. Only the
+   * primary is generated now; the retired fields are rejected at enqueue, so
+   * offering their upload slots here would have been three buttons that 400.
+   * The editor no longer names a slot at all -- the roster arrives from the
+   * entity art endpoint, which is the same table the enqueue gate reads, so
+   * the two cannot drift. Per this file's own rule above, assert the structure
+   * (which editor, mounted for which entity) rather than a spelling of the
+   * inputs.
+   */
   for (const field of [
     '<FacetProfileEditor v-model="editForm" />',
     'entity-type="facet"',
-    "field: 'imagePath'",
-    "aspect: '1 / 1'",
+    ':entity="facet"',
   ]) {
     requireText('components/facets/facet-editor.vue', facetEditor, field)
+  }
+  if (facetEditor.includes(':slots="[')) {
+    throw new Error(
+      'components/facets/facet-editor.vue hardcodes an art slot array again; ' +
+        'the roster must come from the entity art endpoint so a retired slot ' +
+        'cannot be offered after the enqueue gate starts rejecting it.',
+    )
   }
 
   // Was the literal chain `facet.cardPath || facet.imagePath || facet.heroPath`.

--- a/utils/scripts/verifyFacetCatalogCutover.ts
+++ b/utils/scripts/verifyFacetCatalogCutover.ts
@@ -215,9 +215,15 @@ async function main(): Promise<void> {
   requireText(files.facetManager, text.facetManager, 'FacetProfileEditor')
   requireText(files.facetManager, text.facetManager, 'facetProfilePayload')
   requireText(files.facetEditor, text.facetEditor, 'EntityArtManager')
-  // Was field: 'iconPath'. The slot collapse retired icon/card/hero, so the
-  // editor offers the one slot that still enqueues.
-  requireText(files.facetEditor, text.facetEditor, "field: 'imagePath'")
+  /*
+   * Was field: 'iconPath', then field: 'imagePath'. The slot collapse retired
+   * icon/card/hero, and the editor no longer names any slot: the roster comes
+   * from the entity art endpoint (listEntityArtSlots), which reads the same
+   * table the enqueue gate rejects retired slots from. Forbidding the literal
+   * array is the stronger guard -- a hardcoded list is exactly how the project
+   * surfaces kept offering three retired slots for months after the collapse.
+   */
+  forbidText(files.facetEditor, text.facetEditor, ':slots="[')
   forbidText(files.facetManager, text.facetManager, 'requestPrimaryArtwork')
   forbidText(files.facetManager, text.facetManager, 'useFacetArtRequestStore')
   forbidText(files.facetEditor, text.facetEditor, 'requestPrimaryArtwork')

--- a/utils/scripts/verifyFacetCatalogMaintenance.ts
+++ b/utils/scripts/verifyFacetCatalogMaintenance.ts
@@ -272,20 +272,21 @@ for (const required of [
   assert.ok(entityArt.includes(required), `Entity art is missing ${required}`)
 }
 
-// Was "must expose canonical icon, card, and hero variants" (256/512/1280).
-// Those slots are rejected at enqueue now, so the editor offers the primary
-// alone; entityArt.ts still declares the retired configs above because
-// completion and history reads share them.
+// Was "must expose canonical icon, card, and hero variants" (256/512/1280),
+// then a literal imagePath/1024 slot. Those retired slots are rejected at
+// enqueue now, and the editor names no slot at all: its roster comes from the
+// entity art endpoint via listEntityArtSlots, which reads the same table the
+// enqueue gate reads. entityArt.ts still declares the retired configs above
+// because completion and history reads share them.
 assert.ok(
-  editor.includes("field: 'imagePath'") && editor.includes('width: 1024'),
-  'Facet editor must expose the primary art slot.',
+  editor.includes('entity-type="facet"') && editor.includes(':entity="facet"'),
+  'Facet editor must mount the entity art manager for the Facet.',
 )
-for (const retired of ["field: 'iconPath'", "field: 'cardPath'", "field: 'heroPath'"]) {
-  assert.ok(
-    !editor.includes(retired),
-    `Facet editor still offers ${retired}, which the enqueue gate rejects.`,
-  )
-}
+assert.ok(
+  !editor.includes(':slots="['),
+  'Facet editor hardcodes an art slot array again; the roster must come from ' +
+    'the endpoint so a retired slot cannot outlive the enqueue gate.',
+)
 assert.ok(
   !manager.includes('useFacetArtRequestStore') &&
     !editor.includes('useFacetArtRequestStore') &&

--- a/utils/scripts/verifyFacetLibraryAdvanced.ts
+++ b/utils/scripts/verifyFacetLibraryAdvanced.ts
@@ -50,9 +50,12 @@ async function main(): Promise<void> {
   // than an editor expanding inside a grid cell. The Library tab keeps
   // creation and the catalog fetch.
   requireText(files.facetEditor, facetEditor, 'EntityArtManager')
-  // Was field: 'iconPath'. Icon/card/hero are rejected at enqueue since the
-  // slot collapse, so the primary is the slot the editor still offers.
-  requireText(files.facetEditor, facetEditor, "field: 'imagePath'")
+  /*
+   * Was field: 'iconPath', then field: 'imagePath'. Icon/card/hero are
+   * rejected at enqueue since the slot collapse, and the editor now takes its
+   * roster from the entity art endpoint rather than naming a slot at all.
+   */
+  requireText(files.facetEditor, facetEditor, 'entity-type="facet"')
   requireText(files.facetEditor, facetEditor, 'Save canonical profile')
   for (const [label, text] of [
     [files.manager, manager],

--- a/utils/scripts/verifyProjectArtPromptSuggest.ts
+++ b/utils/scripts/verifyProjectArtPromptSuggest.ts
@@ -8,7 +8,9 @@ function expectContains(path: string, needles: string[]): void {
   const source = read(path)
   for (const needle of needles) {
     if (!source.includes(needle)) {
-      throw new Error(`${path} is missing Project prompt suggestion contract: ${needle}`)
+      throw new Error(
+        `${path} is missing Project prompt suggestion contract: ${needle}`,
+      )
     }
   }
 }
@@ -31,9 +33,14 @@ expectContains('plugins/entity-art-prompt-suggest.client.ts', [
   "element.closest('.project-art-compact')",
   'projectStore.projectForSlug(workspaceSlug)',
   "entityType: 'project'",
-  "{ field: 'imagePath', label: 'Icon', width: 256, height: 256 }",
-  "{ field: 'cardPath', label: 'Card', width: 512, height: 768 }",
+  // Primary FIRST, and at the collapsed 1024 size. entity-art-manager.vue
+  // hides its Target select when an entity has one generatable slot, so
+  // selectedSlot() falls through to the head of this roster -- a heroPath or
+  // 256px icon head would frame the suggestion for a slot enqueue rejects.
+  "{ field: 'imagePath', label: 'Image', width: 1024, height: 1024 }",
   "{ field: 'heroPath', label: 'Hero', width: 1280, height: 720 }",
+  "{ field: 'cardPath', label: 'Card', width: 512, height: 768 }",
+  'context.slots[0]',
   "button.textContent = '✨ Suggest prompt'",
   'entityRef: entityRef(context)',
   'current: textarea.value',


### PR DESCRIPTION
Fixes the four things Silas reported on the conductor project page (2026-09-11).

## 1. "I cannot actually respond to tasks, I can't clear tasks that are human gated"

`/api/conductor/task-action` already supported **approve / reject / comment / answer**, and the For You home surface (`home-attention.vue`) already had a composer for them. The two surfaces that actually *render* a roadmap — `project-detail.vue` and the tasks tab in `conductor-page.vue` — were read-only, so a gate you read on the project page had to be answered somewhere else.

New shared `components/conductor/task-responder.vue`, mounted by both:

- **needs-human task** → *Send to agent* (`answer`, releases the gate carrying your text), *Approve*, *Send back* (`reject`), *Note only* (`comment`, stays gated).
- **any other task** → *Send to worker*, which files a project Todo titled with the task id. `task-action` returns 409 for a task not parked at `needs-human`, and adding a second write path into the roadmap would be worse than using the queue the workers already read.

## 2. Weird formatting and empty space below images

`project-detail.vue` reached into `entity-art-manager.vue` by Tailwind utility-class selector (`.mt-3.grid.gap-3`, `.group.relative.mt-3.min-h-40`) to hide one of the child's **two** image viewers and clamp the other to `20vh` / `max-height: 12rem`. That clamp is what left the images unreadable with ~230px of dead space under the column — and it broke silently any time a utility class in the child changed.

The child now renders **one** stage:

- sized by its slot's aspect, capped at `min(50vh, 24rem)`
- `object-fit: contain` over a blurred copy of itself, so mixed 16:9 / 2:3 / square art is fully visible instead of cropped
- the inspiration aside and the duplicate carousel collapse into a single thumbnail strip

The `:deep()` block is gone, and `verifyEntityArtManager.ts` now asserts those selectors stay gone.

## 3. "I should be able to set one of the inspiration images to be the main image"

New `POST /api/art/entities/:entityType/:id/promote`. It reuses `applyEntityArtImage` to move an image the entity **already holds** — an inspiration, or whatever a retired slot is still carrying — into the primary slot, keeping the outgoing image as inspiration. The candidate must already be reachable from the entity (history link, or the current image of one of its own slots), so an arbitrary `ArtImage` id can't be pulled in. Surfaces as a **Set as image** button on any non-primary slide.

## 4. "Still displaying as if they are expecting a three way card hero icon set"

`ENTITY_FIELDS` retired `cardPath` / `heroPath` / `iconPath` on 2026-09-05 and `prepareEntityArtEnqueue` refuses to generate them — but all seven call sites handed the component their own hardcoded slot array, so the UI kept offering three peer tabs the server would reject with *"The Hero slot is no longer generated."*

The roster now comes from the endpoint via `listEntityArtSlots()`. Retired slots ride along in the inspiration loop (their art is real and still rendered by the gallery and front pages, so hiding it would lose it), are no longer generatable or uploadable targets, and the call sites drop their arrays.

Related: a project's primary render moves from **256×256 to 1024×1024**, matching every other collapsed entity. One image now serves the hero, card and icon crops, and the icon-sized primary it used to be could not. Its conductor-repo fallback reaches for the largest available render first for the same reason.

## Checks

| check | result |
|---|---|
| `npm run test` (vue-tsc) | clean, exit 0 |
| `verifyEntityArtManager.ts` | pass (contract updated for the new shape) |
| `verifyEntityArtPrimaryCrop` / `PromptFraming` / `PromptSuggest` / `verifyProjectArtPromptSuggest` | pass |
| `verifyConductorApiAuthGuards` / `ProgressParity` / `SlugImmutabilityGuard` | pass |
| `verifyLintRatchet` | holds, no rule got worse |
| `auditIcons` | every referenced icon exists |

ESLint on the touched files reports the same 3 pre-existing errors in `entity-art-manager.vue` as `main` — no new ones.

## Worth a look

- Collection slides carry a URL and no `ArtImage` id, so they show in the loop but can't be promoted yet.
- The stage still auto-advances every 6s (existing behaviour), pausing on hover. Say the word if you'd rather it hold on the main image until you click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122Jqy2w6wUgpJriLCrhTS9