### PR TITLE
interface-vision/t-104 slice 230: use shared icon sizing on model-builder source-picker fallback glyphs

### DIFF
--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -111,7 +111,7 @@
       >
         <Icon
           :name="activeType?.icon || 'kind-icon:blueprint'"
-          class="h-6 w-6 text-base-content/30"
+          class="kr-icon-6 text-base-content/30"
         />
         No {{ activeType?.plural.toLowerCase() }} yet.
       </div>
@@ -139,7 +139,7 @@
             <Icon
               v-else
               :name="activeType?.icon || 'kind-icon:blueprint'"
-              class="h-7 w-7 text-base-content/25"
+              class="kr-icon-7 text-base-content/25"
             />
           </div>
           <div class="min-w-0 p-2">
@@ -178,7 +178,7 @@
             <Icon
               v-else
               :name="activeType?.icon || 'kind-icon:blueprint'"
-              class="h-5 w-5 text-base-content/30"
+              class="kr-icon-5 text-base-content/30"
             />
           </div>
 


### PR DESCRIPTION
### Task
`interface-vision/t-104` — the recurring live front-end-consistency umbrella (slice-based, `recurring: true`). This is slice 230, continuing the composition-only `kr-icon-N` + existing semantic color rule established across slices 225-229.

### Change
`components/model-builder/model-builder-source-picker.vue` has three fallback-icon glyphs (rendered when a source record has no thumbnail/art):

- empty-state icon: `h-6 w-6 text-base-content/30` → `kr-icon-6 text-base-content/30`
- gallery-view tile fallback: `h-7 w-7 text-base-content/25` → `kr-icon-7 text-base-content/25`
- grid-view row fallback: `h-5 w-5 text-base-content/30` → `kr-icon-5 text-base-content/30`

All three sizes are CSS-identical to the primitives (`.kr-icon-5`/`.kr-icon-6`/`.kr-icon-7` already exist in `assets/css/tailwind.css`). No color, behavior, geometry, or icon-name change — composition only.

### How I verified
- `vue-tsc --noEmit` — clean.
- `eslint components/model-builder/model-builder-source-picker.vue` — clean.
- `prettier --check` flags the same file before and after this change (confirmed via `git stash`) — pre-existing drift, not introduced here.
- `npm run test:layout-contract` — holds, 0 new violations.

### Stakes
reversible — one file, composition-only class swap, no store/API/schema/route change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZoM2ktyY7eyLWZjLo4tVM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZoM2ktyY7eyLWZjLo4tVM)_