### PR TITLE
style(model-builder): use shared grid fallback icon sizing

### DIFF
--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -178,7 +178,7 @@
             <Icon
               v-else
               :name="activeType?.icon || 'kind-icon:blueprint'"
-              class="h-5 w-5 text-base-content/30"
+              class="kr-icon-5 text-base-content/30"
             />
           </div>
 


### PR DESCRIPTION
## Summary
- migrate the remaining Model Builder grid fallback glyph from hand-rolled `h-5 w-5` geometry to `kr-icon-5`
- preserve the existing `text-base-content/30` semantic tint
- no behavior, API, schema, store, route, or layout geometry change

## Conductor
- project: `interface-vision`
- task: `t-104`
- session: `2026-09-11T082035Z-interface-vision-t-104-m3q8`
- review transition verified via Process task events run 34583504478

## Verification
- complete diff is one scoped class substitution in `components/model-builder/model-builder-source-picker.vue`
- CI required before merge

## Flags for Reviewer
None. Reversible consistency-only change applying the established shared-geometry + semantic-color composition rule.