### PR TITLE
fix(audit): fail the responsive audit when a route never loaded

### DIFF
--- a/utils/scripts/auditResponsiveLayout.mjs
+++ b/utils/scripts/auditResponsiveLayout.mjs
@@ -34,9 +34,16 @@
  *
  *     npm run audit:responsive -- --base http://localhost:3000
  *
- * Exits non-zero when any route/viewport has a defect. Do not pipe the command
- * in CI — that replaces this exit status with the last pipeline stage's, which
- * is how interface-vision t-063's verifier stayed dead for weeks.
+ * THE DEFAULT BASE IS LOCALHOST. Forgetting `--base` while intending to audit a
+ * deployment used to print a full sheet of `✅` against nothing at all, because
+ * a route that could not be reached was not counted (fixed 2026-09-11 — see the
+ * note at the `!loaded` branch). It is counted now, so a wrong or unreachable
+ * base fails instead of flattering.
+ *
+ * Exits non-zero when any route/viewport has a defect, including one that could
+ * not be loaded. Do not pipe the command in CI — that replaces this exit status
+ * with the last pipeline stage's, which is how interface-vision t-063's verifier
+ * stayed dead for weeks.
  */
 
 const args = process.argv.slice(2)
@@ -366,10 +373,35 @@ for (const vp of VIEWPORTS) {
     const m = await page.evaluate(collect, MIN_FLEX_WIDTH).catch(() => null)
     const label = `${vp.name.padEnd(7)} ${route.padEnd(14)}`
 
-    if (!m) {
+    /*
+     * A ROUTE THAT NEVER LOADED IS A FAILURE, NOT A PASS.
+     *
+     * This reported `✅` for every route and viewport while the browser was
+     * sitting on Chrome's own ERR_CONNECTION_RESET page (2026-09-11, auditing
+     * production from a sandbox with no egress to it). The navigation `.catch`
+     * below already recorded `loaded = false`, but nothing consumed it: a
+     * failed navigation leaves a real error DOCUMENT in place, so
+     * `page.evaluate(collect)` succeeds against it and returns measurements of
+     * the error page -- which has no spill, no crushed elements and no broken
+     * art. The `(navigation failed)` message underneath only fires when
+     * `evaluate` itself throws, which it does not.
+     *
+     * This is the failure mode the header warns about two ways over: a
+     * verifier that stays green while measuring nothing, and a result believed
+     * because it was printed rather than because it was looked at. It took
+     * `--shots` and opening the PNGs to notice. So the check fails loudly now,
+     * which also means a CI run against an unreachable deployment reports the
+     * outage instead of a clean bill of health.
+     */
+    if (!loaded) {
+      failures += 1
       console.log(
-        `${label} ⚠️  could not measure${loaded ? '' : ' (navigation failed)'}`,
+        `${label} ❌ navigation failed — nothing was measured. ` +
+          `Is ${BASE} reachable from here?`,
       )
+    } else if (!m) {
+      failures += 1
+      console.log(`${label} ❌ could not measure the page`)
     } else if (
       m.horizontalScroll ||
       m.spill.length ||


### PR DESCRIPTION
Found while trying to verify #2617. `audit:responsive` reported:

```
phone   /              ✅
tablet  /              ✅
desktop /              ✅

✅ Responsive layout audit clean across all routes and viewports.
```

…while every single viewport was actually showing this:

> **This site can't be reached** — The connection was reset. `ERR_CONNECTION_RESET`

I only caught it by passing `--shots` and opening the PNGs. I had already written the green result into a PR description as evidence.

## Root cause

The navigation `.catch` already recorded `loaded = false`, but **nothing consumed it**:

```js
await page.goto(BASE + route, ...).catch(() => { loaded = false })
...
const m = await page.evaluate(collect, MIN_FLEX_WIDTH).catch(() => null)
if (!m) {
  console.log(`${label} ⚠️  could not measure${loaded ? '' : ' (navigation failed)'}`)
}
```

A failed navigation leaves a real error **document** in place, so `page.evaluate(collect)` succeeds against it and returns measurements of Chrome's error page — which has no spill, no crushed elements and no broken art, so the route falls through to the `✅` branch. The `(navigation failed)` message only reachable via `if (!m)` requires `evaluate` itself to throw, which it never does.

Compounding it: `--base` defaults to `http://127.0.0.1:3000`. Forgetting it while intending to audit a deployment produces the same full sheet of green against nothing listening.

This is precisely the failure mode the file's own header warns about, twice over — a verifier that stays green while measuring nothing ("how interface-vision t-063's verifier stayed dead for weeks"), and a layout result trusted because it was printed rather than because it was measured.

It also means the hourly `responsive-layout-audit.yml` run reports a clean bill of health whenever production is unreachable from the runner, which is the opposite of what you'd want from that signal.

## The fix

An unloaded route is a failure, not a pass — and so is a page that loads but can't be measured. Plus a header note about the localhost default.

## Verified both directions

| scenario | result |
|---|---|
| reachable page (local static server on :3000) | `✅` all three viewports, **exit 0** |
| unreachable base (`https://kindrobots.org` from this sandbox) | `❌ navigation failed — nothing was measured` per viewport, **exit 1** |

The agent proxy independently confirmed the cause during that run: `kindrobots.org:443 — ws_closed_mid_exchange ×9`.

Split out of #2617 rather than bundled into it — that one is a dashboard layout change and this is tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122Jqy2w6wUgpJriLCrhTS9

---
_Generated by [Claude Code](https://claude.ai/code/session_0122Jqy2w6wUgpJriLCrhTS9)_