### PR TITLE
fix(conductor): stop rendering raw Conductor pitch text as player-facing copy

### DIFF
--- a/components/conductor/project-front-page.vue
+++ b/components/conductor/project-front-page.vue
@@ -234,7 +234,20 @@ const view = computed(() => {
   return {
     title: p?.title || f.title,
     tagline: p?.flavorText || f.tagline,
-    description: p?.description || f.description,
+    // Prefer the page's own authored copy over the live Project.description
+    // field: it is seeded (server/api/conductor/sync.post.ts) from Conductor's
+    // notesFromSilas -- Silas's raw internal planning dictation, not player-
+    // facing copy -- and never refreshed after a Project row first exists.
+    // cthulhuquarium/t-066: /play/aquarium was rendering that pitch text
+    // verbatim ("Long time silly project planned... my inspiration is the
+    // absolutely excellent mobile game insaniquarium...") because it happened
+    // to have no authored fallback description at the time. Every current
+    // caller of this component supplies one, so falling back to the live
+    // value only when the page genuinely has no authored description of its
+    // own keeps this component usable for a future page that hasn't written
+    // one yet, without risking raw internal notes leaking onto any surface
+    // that already has real copy.
+    description: f.description || p?.description || undefined,
     icon: p?.icon || f.icon,
     status: p?.status ?? null,
     links: f.links,


### PR DESCRIPTION
## Summary
- `/play/aquarium` was rendering Silas's raw internal pitch dictation ("Long
  time silly project planned that I've never made happen... my inspiration
  is the absolutely excellent mobile game insaniquarium...") verbatim as
  page copy, instead of `components/conductor/aquarium-page.vue`'s own
  short authored description.
- Root cause: `server/api/conductor/sync.post.ts` seeds
  `Project.description` from `notesFromSilas ?? goal` only on first create,
  and never refreshes it afterward — so once a Project row exists, that
  field is effectively a frozen copy of whatever Conductor's internal notes
  happened to say at creation time, not curated player-facing copy.
- `components/conductor/project-front-page.vue`'s `view.description`
  computed read that live field ahead of the page's own authored
  `fallback.description`, so every `conductor/*-page.vue` front page using
  this shared wrapper was one stale/raw live value away from the same
  leak, not just aquarium.
- Fix: flip the precedence — `fallback.description` wins whenever the page
  supplies one (every current caller already does), falling back to the
  live value only when a future page hasn't written its own yet.

## Conductor
- project: `cthulhuquarium`
- task: `t-066`
- session: `claude-blissful-curie-s0dmr5-20260911T114500Z-cq-t066`

## Verification
- `vue-tsc --noEmit` — clean (required an `?? undefined` on the merged
  value since the live field is nullable and the fallback type is not).
- `eslint components/conductor/project-front-page.vue` — clean.
- Read every current caller of `project-front-page.vue`
  (`components/conductor/*-page.vue`, `components/coloring/coloring-book-page.vue`)
  and confirmed each already supplies a non-empty authored `description` in
  its fallback config, so this change is a no-op for all of them except
  removing the risk of the live field ever showing through — and confirmed
  `tagline`/`p?.flavorText` is untouched and unaffected (that field is not
  populated by the Conductor sync at all).

## Flags for Reviewer
No dedicated regression-guard test added (the repo has a precedent pattern
for this exact class of bug — `utils/scripts/verifyAppmakerFleetDescriptionGuard.ts`
— but wiring a new one up means a new npm script + a new GitHub Actions
workflow file, which felt like more ceremony than this one-line precedence
fix warranted). Worth adding later if this class of regression recurs.

## Kaizen suggestion
`server/api/conductor/sync.post.ts`'s `existing` update branch never
touches `description` after first create, so any project's stale seed
value (correct or not) is permanently frozen. Consider refreshing
`description` on every sync from `goal ?? notesFromSilas` (goal first —
it's the curated one-liner; `notesFromSilas` is raw dictation) so the DB
field stays a reasonable value for any *other* consumer besides
`project-front-page.vue` (e.g. an admin list view) without depending on
every future consumer independently reinventing this same fallback
precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QE2SBkqSazbsKZhMuJynT

---
_Generated by [Claude Code](https://claude.ai/code/session_013QE2SBkqSazbsKZhMuJynT)_