### PR TITLE
kontext: allow overriding the base UNet, so the noise defect can be bisected

### DIFF
--- a/server/api/art/enqueue.post.ts
+++ b/server/api/art/enqueue.post.ts
@@ -113,6 +113,11 @@ type ArtEnqueueRequest = {
   }> | null
   checkpointResourceId?: number | null
   loraResourceIds?: number[] | null
+  // Kontext base-UNet override (coloring-book/t-039). `.gguf` keeps the
+  // UnetLoaderGGUF path, `.safetensors` switches to core UNETLoader. Unset
+  // preserves the previous hardcoded default.
+  unetName?: string | null
+  unetWeightDtype?: string | null
   designer?: string | null
   isPublic?: boolean | null
   isMature?: boolean | null
@@ -669,6 +674,12 @@ function buildJobPayload(
       loraName: body.loraName ?? null,
       loraStrength: body.loraStrength ?? null,
       loras: body.loras ?? null,
+      // Optional base-UNet override. Exists so the Kontext checkpoint can be
+      // swapped without a deploy while the corrupted-noise defect
+      // (coloring-book/t-039) is bisected -- the UNet was hardcoded, so "is the
+      // GGUF quant the cause?" was untestable. Unset keeps the default.
+      unetName: body.unetName ?? null,
+      unetWeightDtype: body.unetWeightDtype ?? null,
     })
     return {
       jobEngine: 'COMFY',

--- a/server/api/comfy/kontext/utils/workflow.ts
+++ b/server/api/comfy/kontext/utils/workflow.ts
@@ -59,6 +59,22 @@ export type KontextWorkflowInput = {
   loraStrength?: number | null
   // Multiple stacked LoRAs, applied in order. Supersedes the pair above.
   loras?: LoraSelectionInput[] | null
+  // Optional base-UNet override (cthulhuquarium art audit / coloring-book t-039,
+  // ai-art-academy t-079). The Kontext UNet was hardcoded to the GGUF-quantised
+  // flux1-kontext-dev-Q5_K_M.gguf, which made it impossible to answer the one
+  // question that matters about the corrupted-noise defect: is the quantised
+  // checkpoint the cause? A plain Kontext call with no LoRA at all renders pure
+  // static (ArtJob 21693), so the fault is upstream of the LoRA branch and the
+  // quantised UNet is the leading suspect -- but it could not be swapped out to
+  // check.
+  //
+  // Pass a `.gguf` name to keep the UnetLoaderGGUF path, or a `.safetensors`
+  // name to load through core ComfyUI's UNETLoader instead. Unset preserves the
+  // exact previous behaviour, so no existing caller changes.
+  unetName?: string | null
+  // Weight dtype for the non-GGUF UNETLoader path. Defaults to fp8_e4m3fn,
+  // which matches the fp8-scaled Kontext checkpoint in the Resource library.
+  unetWeightDtype?: string | null
 }
 
 export const DEFAULT_KONTEXT_WIDTH = 1024
@@ -85,6 +101,43 @@ function resolveSeed(seed?: number | null): number {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value))
+}
+
+const DEFAULT_KONTEXT_UNET = 'flux1-kontext-dev-Q5_K_M.gguf'
+const DEFAULT_KONTEXT_UNET_WEIGHT_DTYPE = 'fp8_e4m3fn'
+
+/**
+ * Node 59, the base UNet the whole Kontext graph hangs off.
+ *
+ * GGUF checkpoints need the ComfyUI-GGUF node pack's `UnetLoaderGGUF`; ordinary
+ * `.safetensors` weights need core ComfyUI's `UNETLoader`, which additionally
+ * wants a weight dtype. Feeding a `.safetensors` name to the GGUF loader (or the
+ * reverse) fails at graph execution, so the file extension picks the node rather
+ * than the caller having to know which is which.
+ *
+ * Default is unchanged from when this was inlined, so callers that pass nothing
+ * get exactly the previous graph.
+ */
+function buildKontextUnetLoader(input: KontextWorkflowInput): ComfyWorkflowNode {
+  const unetName = input.unetName?.trim() || DEFAULT_KONTEXT_UNET
+
+  if (unetName.toLowerCase().endsWith('.gguf')) {
+    return {
+      inputs: { unet_name: unetName },
+      class_type: 'UnetLoaderGGUF',
+      _meta: { title: 'Unet Loader (GGUF)' },
+    }
+  }
+
+  return {
+    inputs: {
+      unet_name: unetName,
+      weight_dtype:
+        input.unetWeightDtype?.trim() || DEFAULT_KONTEXT_UNET_WEIGHT_DTYPE,
+    },
+    class_type: 'UNETLoader',
+    _meta: { title: 'Load Diffusion Model' },
+  }
 }
 
 export function buildKontextWorkflow(
@@ -224,11 +277,7 @@ export function buildKontextWorkflow(
       class_type: 'ReferenceLatent',
       _meta: { title: 'ReferenceLatent' },
     },
-    '59': {
-      inputs: { unet_name: 'flux1-kontext-dev-Q5_K_M.gguf' },
-      class_type: 'UnetLoaderGGUF',
-      _meta: { title: 'Unet Loader (GGUF)' },
-    },
+    '59': buildKontextUnetLoader(input),
     '60': {
       inputs: {
         detail_amount: 0.06,


### PR DESCRIPTION
### Task
`coloring-book/t-039` (and the now-closed `ai-art-academy/t-079`). Diagnostic plumbing for the Kontext corrupted-noise defect.

### Why
The Kontext UNet was **hardcoded** in node 59 to `flux1-kontext-dev-Q5_K_M.gguf`, which made the one question that matters untestable: **is the GGUF quantisation the cause?**

What's already established: a plain kontext image-to-image call with **no LoRA fields at all** renders pure multicoloured static — ArtJob 21693, valid PNG, DONE, no error. That **rules out t-079's LoRA-branch hypothesis**; the fault is upstream and shared by every kontext call, leaving the quantised UNet as the leading suspect.

The Resource library holds **exactly one** non-GGUF Kontext base model — `diffusion_models/flux1-dev-kontext_fp8_scaled.safetensors` (id 3837) — but nothing could point a job at it.

### What changed
`buildKontextWorkflow` takes an optional **`unetName`**, and the file extension picks the loader node:
- `.gguf` → ComfyUI-GGUF's `UnetLoaderGGUF`
- anything else → core ComfyUI's `UNETLoader` with a `weight_dtype` (default `fp8_e4m3fn`, matching that checkpoint)

Mixing them fails at graph execution, so inferring the node from the extension keeps callers from needing to know which is which. **`unetWeightDtype`** overrides the dtype. Both threaded through `/api/art/enqueue`.

### Unset preserves previous behaviour exactly
Verified by building the graph and inspecting node 59 across all three paths:

| input | node 59 |
|---|---|
| *(default)* | `{unet_name: flux1-kontext-dev-Q5_K_M.gguf}` · `UnetLoaderGGUF` |
| `...fp8_scaled.safetensors` | `{unet_name: …, weight_dtype: fp8_e4m3fn}` · `UNETLoader` |
| `other.gguf` | `{unet_name: other.gguf}` · `UnetLoaderGGUF` |

The default is byte-identical to the old inlined literal, so **no existing caller changes**.

### How I verified
- `vue-tsc --noEmit` — clean.
- `eslint` — clean on both changed files.
- Built all three graph variants and diffed node 59 (table above).

### Stakes
reversible — two optional, defaulted parameters. No schema, route-shape, or behaviour change for any current caller; every existing enqueue produces the identical workflow it did before.

### Notes for reviewer
**This is diagnostic plumbing, not a fix.** It makes the comparison run possible; whether the quant is at fault remains open on `coloring-book/t-039`. I'll run the fp8 comparison against this once deployed and record the result there.

Worth knowing regardless of the outcome: `art_quality.assess_file` returned **`ok=True`, `reasons=[]`** on the noise image under the `color` variant. Static is saturated and busy, so it scores as a healthy colour image — the earlier coloring-book rejections only caught it because the `bw` variant's `white_fraction` check fails on static by coincidence. Any colour art from a broken path can currently pass the mechanical gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4LGW6k2vqnFtaDEMWp8GW

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4LGW6k2vqnFtaDEMWp8GW)_