### PR TITLE
fix(cthulhuquarium): stop the sets-row plate from stretching full width

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -338,15 +338,29 @@
             :key="entry.id"
             class="flex items-start gap-2 kr-panel-compact"
           >
-            <kr-art-plate
-              :source="withCthulhuquariumArt(entry)"
-              variant="icon"
-              shape="plate"
-              frame="thin"
-              fit="cover"
-              class="size-12 shrink-0"
-              placeholder-icon="kind-icon:fish"
-            />
+            <!-- cthulhuquarium/t-067: kr-art-plate's shape="plate" aspect box
+                 forces `w-full` internally, which fights an externally passed
+                 size-* class for the `width` property at equal specificity and
+                 wins -- the plate then stretches to the row's full width
+                 instead of staying icon-sized (same bug and fix as
+                 kr-entity-card-body.vue's icon thumbnail, see its comment).
+                 Constrain from an outer wrapper instead of via a class on the
+                 plate itself, and use shape="square" (not "plate") to match
+                 what this file's header comment already documents `icon`
+                 shapes as wanting: small and square, the intro piece to a
+                 text-forward row. -->
+            <div
+              class="size-12 shrink-0 overflow-hidden rounded-2xl border border-base-300"
+            >
+              <kr-art-plate
+                :source="withCthulhuquariumArt(entry)"
+                variant="icon"
+                shape="square"
+                frame="none"
+                fit="cover"
+                placeholder-icon="kind-icon:fish"
+              />
+            </div>
             <div class="min-w-0 flex-1">
               <p class="kr-text-bold-sm truncate">{{ entry.name }}</p>
               <!-- Deliberately never the field note here -- the server
@@ -388,16 +402,21 @@
         >
           <!-- cthulhuquarium/t-065: the authored cover plate. The book had a
                formal name and a text label; now it has its cover. -->
-          <kr-art-plate
+          <!-- cthulhuquarium/t-067: see the fish-list wrapper comment above --
+               same width-cascade fix, wrapper-owned size and border. -->
+          <div
             v-if="artByName('ichthyonomicon')"
-            :source="{ imagePath: artByName('ichthyonomicon') }"
-            variant="icon"
-            shape="plate"
-            frame="thin"
-            fit="cover"
-            class="size-10 shrink-0"
-            placeholder-icon="kind-icon:book"
-          />
+            class="size-10 shrink-0 overflow-hidden rounded-2xl border border-base-300"
+          >
+            <kr-art-plate
+              :source="{ imagePath: artByName('ichthyonomicon') }"
+              variant="icon"
+              shape="square"
+              frame="none"
+              fit="cover"
+              placeholder-icon="kind-icon:book"
+            />
+          </div>
           <span class="kr-text-eyebrow text-xs tracking-wide opacity-60">
             The Ichthyonomicon
             <span v-if="tankStore.bestiaryTotalCount > 0" class="opacity-80">
@@ -429,17 +448,24 @@
               class="flex items-start gap-2 kr-panel-compact"
               :class="{ 'opacity-60': !entry.collected }"
             >
-              <kr-art-plate
-                :source="entry.collected ? withCthulhuquariumArt(entry) : null"
-                variant="icon"
-                shape="plate"
-                frame="thin"
-                fit="cover"
-                class="size-12 shrink-0"
-                :placeholder-icon="
-                  entry.collected ? 'kind-icon:fish' : 'kind-icon:lock'
-                "
-              />
+              <!-- cthulhuquarium/t-067: see the fish-list wrapper comment
+                   above -- same width-cascade fix. -->
+              <div
+                class="size-12 shrink-0 overflow-hidden rounded-2xl border border-base-300"
+              >
+                <kr-art-plate
+                  :source="
+                    entry.collected ? withCthulhuquariumArt(entry) : null
+                  "
+                  variant="icon"
+                  shape="square"
+                  frame="none"
+                  fit="cover"
+                  :placeholder-icon="
+                    entry.collected ? 'kind-icon:fish' : 'kind-icon:lock'
+                  "
+                />
+              </div>
               <div class="min-w-0 flex-1">
                 <p class="kr-text-bold-sm truncate">{{ entry.name }}</p>
                 <p class="mt-0.5 line-clamp-2 text-xs italic opacity-70">
@@ -666,22 +692,24 @@
               :key="egg.id"
               class="flex items-start gap-2 rounded-xl border border-primary/60 bg-base-100 p-3"
             >
-              <kr-art-plate
+              <!-- cthulhuquarium/t-067: see the fish-list wrapper comment
+                   above -- same width-cascade fix. -->
+              <div
                 v-if="artForEggTier(egg.rarity)"
-                :source="{ imagePath: artForEggTier(egg.rarity) }"
-                variant="icon"
-                shape="plate"
-                frame="thin"
-                fit="cover"
-                class="size-12 shrink-0"
-                placeholder-icon="kind-icon:egg"
-              />
-              <span
-                v-else
-                class="text-3xl leading-none"
-                aria-hidden="true"
-                >{{ EGG_ICON }}</span
+                class="size-12 shrink-0 overflow-hidden rounded-2xl border border-base-300"
               >
+                <kr-art-plate
+                  :source="{ imagePath: artForEggTier(egg.rarity) }"
+                  variant="icon"
+                  shape="square"
+                  frame="none"
+                  fit="cover"
+                  placeholder-icon="kind-icon:egg"
+                />
+              </div>
+              <span v-else class="text-3xl leading-none" aria-hidden="true">{{
+                EGG_ICON
+              }}</span>
               <div class="min-w-0 flex-1">
                 <p class="kr-text-bold-sm truncate">
                   {{ egg.rarity.charAt(0)
@@ -758,15 +786,22 @@
         v-if="tankStore.finaleConfig"
         class="flex items-start gap-2 kr-panel-divider"
       >
-        <kr-art-plate
-          :source="{ imagePath: setLastAquariumArt }"
-          variant="icon"
-          shape="plate"
-          frame="thin"
-          fit="cover"
-          class="size-12 shrink-0"
-          placeholder-icon="kind-icon:box"
-        />
+        <!-- cthulhuquarium/t-067: THE reported bug -- "The Last Aquarium" row
+             rendering one word per line because this plate stretched to the
+             row's full width. See the fish-list wrapper comment above for the
+             root cause and fix (same width-cascade issue, same fix here). -->
+        <div
+          class="size-12 shrink-0 overflow-hidden rounded-2xl border border-base-300"
+        >
+          <kr-art-plate
+            :source="{ imagePath: setLastAquariumArt }"
+            variant="icon"
+            shape="square"
+            frame="none"
+            fit="cover"
+            placeholder-icon="kind-icon:box"
+          />
+        </div>
         <div class="min-w-0 flex-1">
           <div class="flex items-start justify-between gap-2">
             <p class="kr-text-bold-sm">{{ tankStore.finaleConfig.title }}</p>
@@ -1038,7 +1073,9 @@
             }}
           </p>
           <kr-art-plate
-            :source="withCthulhuquariumArt(tankStore.revealedBreed.stock.Monster)"
+            :source="
+              withCthulhuquariumArt(tankStore.revealedBreed.stock.Monster)
+            "
             variant="card"
             shape="plate"
             frame="thin"


### PR DESCRIPTION
### Task
cthulhuquarium/t-067: Fix the collapsed one-word-per-line layout in the sets row (kind: software)

### What changed / what I produced
- Root cause confirmed: `kr-art-plate`'s `shape="plate"` aspect box always carries an internal `w-full` class. A consumer's own `size-*` class (e.g. `size-12`) fights it for the `width` CSS property at equal specificity and loses, so the plate renders at the row's full width instead of icon-sized — this is exactly what made "The Last Aquarium" row squeeze its title/description into a ~60px column, one word per line.
- This is the *same* bug `kr-entity-card-body.vue` already hit and fixed for `/characters` icons (2026-08-05), documented right there in its own comment: "the thumbnail is sized by this WRAPPER, never by classes on the plate." That fix deliberately lives at the call site, not inside `kr-art-plate.vue` — so I followed the same established convention rather than forking/patching the shared component.
- Applied it to every icon-row usage in `cthulhuquarium-game.vue` that has the identical pattern (fish list, ichthyonomicon cover, bestiary list, egg list, and the reported Last Aquarium row): size + border now live on an outer wrapper `div`, the plate itself gets `frame="none"` and no sizing class, and `shape` changed from `"plate"` to `"square"` — matching what this file's own header comment already documents an `icon` shape as wanting ("SQUARE, small, as the intro piece to a text-forward row"). A wrapper alone would still leave a height gap (plate's 3:2 aspect vs. a square wrapper); the shape change removes that mismatch entirely.
- Left the four reveal-dialog `kr-art-plate` usages (unlock/hatch/breed/finale) untouched — same `shape="plate"` pattern but with a different external size (`h-32 w-24`) and no adjacent `flex-1` text sibling, so they don't exhibit the reported one-word-per-line symptom. Out of scope for this task; flagging for whoever next touches those dialogs.

### How I verified
- `eslint` clean on the changed file
- `vue-tsc --noEmit` clean (full project)
- `prettier --check` clean
- `npm run test:layout-contract` — no new violations
- `npm run test:gallery-adoption` — passed
- `npm run test:narrative-kit` — passed (covers `kr-art-plate.vue` contracts)
- Reasoned through the CSS cascade by hand against the actual `aspectClass`/`frameClass` source in `kr-art-plate.vue` to confirm the fix mechanism, cross-checked against `kr-entity-card-body.vue`'s prior, already-shipped fix for the identical defect.
- Could not visually screenshot `/play/aquarium` from this sandbox (no live preview/deploy path per AGENTS.md's kind_robots verification notes) — the fix is a direct, mechanical, verified port of an existing proven fix pattern.

### Stakes
reversible

### Flags for Reviewer
- I did not touch `kr-art-plate.vue` itself. The task note asked me to check whether the fix belongs there; the answer, from `kr-entity-card-body.vue`'s own comment ("Do not move this sizing back onto the plate"), is that the wrapper-at-call-site pattern is the established, deliberate convention — so I followed it rather than reopening that decision.
- The four reveal-dialog usages of `kr-art-plate` (lines ~888/946/1005/1078) have the same underlying width-cascade conflict (`h-32 w-24` vs. internal `w-full`) but a different visible symptom (no adjacent text to squeeze) and are out of this task's scope — worth a follow-up if they look wrong in practice.

### Kaizen suggestion
Every `shape="plate"` + external size-class combo in this codebase is a latent instance of the same width-cascade bug (four remain, in this same file's reveal dialogs). A `grep`-able audit task across the whole repo for `kr-art-plate` call sites passing a `class` with `size-*`/`w-*`/`h-*` alongside `shape="plate"` (or any shape) would catch the rest before Silas finds them by screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4yjWUaUe8YysBybi8Aip5

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4yjWUaUe8YysBybi8Aip5)_