### PR TITLE
cthulhuquarium/t-070: real fish art in the swim-canvas renderer

### DIFF
--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -14,13 +14,17 @@
      drifting motes as a VISUAL reveal of coins the server already credited;
      clicking one just dismisses it. No extra request, no new balance path.
 
-     Fish are still hand-drawn shapes, not art -- t-015 (full art pass) is
-     the task that changes that. What's real now is the swim behavior itself:
-     each occupant's Monster.behavior (the fish bible's own vocabulary --
-     drift/dart/lurk/school/anchor/surface/hover/tumble/cling) selects a
-     movement profile instead of a hardcoded three-value switch, and hue
-     comes from Monster.hue when a balance pass has set it, falling back to
-     a slug-derived hue so an unassigned species still reads consistently
+     Fish render as real art where a species has a delivered plate
+     (cthulhuquarium/t-070, following t-065's bestiary/catalog delivery --
+     see drawFish/getFishImage below), falling back to the original
+     hand-drawn primitives for the ~32/151 species with no plate yet or
+     while an image is still loading. What's real regardless of which draw
+     path fires is the swim behavior: each occupant's Monster.behavior (the
+     fish bible's own vocabulary -- drift/dart/lurk/school/anchor/surface/
+     hover/tumble/cling) selects a movement profile instead of a hardcoded
+     three-value switch, and hue (used by the primitive fallback only) comes
+     from Monster.hue when a balance pass has set it, falling back to a
+     slug-derived hue so an unassigned species still reads consistently
      rather than defaulting to one color. -->
 <template>
   <ClientOnly>
@@ -1283,6 +1287,7 @@ import setLastAquariumArt from '~/assets/images/cthulhuquarium/cthulhuquarium-se
 import {
   artByName,
   artForEggTier,
+  artForSpecies,
   withCthulhuquariumArt,
 } from '~/utils/cthulhuquariumArt'
 
@@ -1661,6 +1666,36 @@ function stockFor(swimmer: Swimmer): TankStock | undefined {
   return tankStore.stock.find((entry) => entry.id === swimmer.stockId)
 }
 
+// cthulhuquarium/t-070: real fish art in the swim view. t-065 delivered 119
+// of 151 species' plates, but only into the bestiary/catalog/reveal panels
+// (see withCthulhuquariumArt) -- the swim canvas kept drawing the hand-drawn
+// primitives below regardless, which the audit (t-068's
+// FULL-GAME-GAP-AUDIT.md) flagged as the most visible remaining gap. This
+// preloads and caches one HTMLImageElement per species slug the first time
+// it's needed and draws it in place of the primitives once loaded; a species
+// with no plate (32/151, mostly *-common starters) or an image still in
+// flight falls back to the original primitive draw, so nothing ever renders
+// blank.
+const fishImageCache = new Map<string, HTMLImageElement | null>()
+
+function getFishImage(slug: string): HTMLImageElement | null {
+  if (fishImageCache.has(slug)) return fishImageCache.get(slug) ?? null
+  const url = artForSpecies(slug)
+  if (!url) {
+    fishImageCache.set(slug, null)
+    return null
+  }
+  // Reserve the slot immediately so a swimmer drawn on the next few frames
+  // (before onload fires) doesn't kick off a duplicate Image() for the same
+  // slug -- the primitive fallback below covers those frames instead.
+  fishImageCache.set(slug, null)
+  const image = new Image()
+  image.onload = () => fishImageCache.set(slug, image)
+  image.onerror = () => fishImageCache.set(slug, null)
+  image.src = url
+  return null
+}
+
 function drawFish(
   context: CanvasRenderingContext2D,
   swimmer: Swimmer,
@@ -1673,10 +1708,27 @@ function drawFish(
   // Hungry occupants desaturate and dim rather than vanishing, so a
   // neglected tank reads as neglected at a glance.
   const life = 0.3 + (hunger / 100) * 0.7
+  const image = getFishImage(monster.slug)
 
   context.save()
   context.translate(swimmer.x, swimmer.y)
   context.scale(facing, 1)
+
+  if (image) {
+    // Art plates are square, subject-centered portraits -- draw one square,
+    // scaled to roughly the same footprint the primitive silhouette used
+    // (nose-to-tail span below is about 2.7x `size`). Hunger still dims the
+    // occupant via alpha, same signal the primitive draw gives.
+    context.globalAlpha = life
+    context.filter = hunger < 100 ? `saturate(${40 + hunger * 0.6}%)` : 'none'
+    const d = size * 2.6
+    context.drawImage(image, -d / 2, -d / 2, d, d)
+    context.filter = 'none'
+    context.globalAlpha = 1
+    context.restore()
+    return
+  }
+
   context.fillStyle = `hsla(${hue}, ${28 + hunger * 0.35}%, ${20 + hunger * 0.14}%, ${life})`
 
   context.beginPath()


### PR DESCRIPTION
### Task
cthulhuquarium/t-070: Wire real fish art into the swim-canvas renderer, not just the bestiary/catalog panels (kind: software)

### What changed / what I produced
- `components/cthulhuquarium/cthulhuquarium-game.vue`: added `getFishImage()`, which lazily resolves and caches one `HTMLImageElement` per species slug via `artForSpecies()` (the same bundled-Vite-asset delivery t-065 already shipped for the bestiary/catalog/reveal panels), and wired it into `drawFish()` — when a loaded image is available it draws that instead of the hand-drawn ellipse+triangle silhouette; hunger still dims the occupant via alpha plus a light `saturate()` filter, same signal the primitive draw gives. A species with no delivered plate (32/151, mostly `*-common` starters) or an image still mid-load falls straight back to the unchanged primitive draw, so nothing ever renders blank.
- Updated the component's own header comment, which still said fish were "still hand-drawn shapes, not art" — stale since t-065 shipped the bestiary/catalog art.

### How I verified
- `npx eslint components/cthulhuquarium/cthulhuquarium-game.vue` — clean.
- `npx vue-tsc --noEmit` (full project) — clean, no errors in this file or anywhere else.
- `npx prettier --check` — clean (ran `--write` once to match project style before committing).
- Read-verified the image cache logic against the existing `waterGradient`-style module-scope caching convention already used elsewhere in this file, and against `withCthulhuquariumArt`'s own "fill nulls only, DB wins" precedent — `artForSpecies` is a pure lookup with no DB write, so there's no risk of this overwriting anything.
- Did not have a way to visually confirm the rendered canvas in this sandbox (no browser preview available here); relying on type/lint correctness plus the same asset-resolution path (`artForSpecies`) that's already proven live in production for the bestiary/catalog panels (confirmed via a live `curl` against `kindrobots.org` in the conductor session that filed this task).

### Stakes
reversible

### Flags for Reviewer
- No visual/browser verification was possible from this sandbox — the change reuses a proven asset-resolution path but a human/CI screenshot check of `/play/aquarium`'s tank canvas would be the strongest confirmation this actually looks right.
- The `saturate()` CSS filter on `drawImage` is a new technique in this file (existing hunger-dimming was pure `fillStyle` alpha/HSL math on primitives) — flagging in case there's a project convention against canvas `filter` for performance reasons on lower-end devices; it's applied per-fish per-frame, same order of cost as the existing per-frame `fillStyle` string interpolation it replaces for hungry fish.

### Kaizen suggestion
The remaining 32/151 species without a delivered art plate (t-073) will keep showing primitives in the swim view forever until that art lands — worth confirming t-073 actually closes the loop rather than leaving a permanent minority of "still hand-drawn" fish once the more prominent 119 are visibly fixed.

### Notes for reviewer
Filed and implemented from `silasfelinus/conductor`'s cthulhuquarium/t-068 gap audit (`projects/cthulhuquarium/FULL-GAME-GAP-AUDIT.md`), which flagged this as the most likely driver of Silas's "barest of bones" verdict on 2026-09-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fH2VsBpfRr1QuT5AGW4TK

---
_Generated by [Claude Code](https://claude.ai/code/session_014fH2VsBpfRr1QuT5AGW4TK)_