### PR TITLE
media-watchlist/t-019: fix the watchlist failing to load and the masked error

### DIFF
--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -543,6 +543,7 @@ type MediaEntrySummary = MediaEntryDetail
 
 type MediaEntriesResponse = {
   success: boolean
+  message?: string
   data: MediaEntrySummary[]
   count: number
   total: number
@@ -579,6 +580,7 @@ type MediaEntryStats = {
 
 type MediaEntryStatsResponse = {
   success: boolean
+  message?: string
   data: MediaEntryStats
 }
 
@@ -647,6 +649,35 @@ const MONTH_LABELS: { value: number; label: string }[] = [
 
 const userStore = useUserStore()
 const isAdmin = computed(() => userStore.isAdmin === true)
+
+// media-watchlist/t-019: every route in this feature is admin-gated
+// (requireAdminApiUser), but none of these $fetch calls ever attached an
+// Authorization header -- every request arrived at the server looking
+// anonymous, so the admin check rejected it regardless of who was actually
+// signed in. This was "the load fails" half of the bug, not a stale/
+// mis-scoped session as first suspected.
+function authHeaders(): Record<string, string> | undefined {
+  const token = userStore.token || userStore.user?.token || ''
+  return token ? { Authorization: `Bearer ${token}` } : undefined
+}
+
+// media-watchlist/t-019 (the error-lies half): the API answers a rejection
+// with HTTP 200 and {success:false, message}, or -- now that the backend
+// sets a real status code -- $fetch/ofetch throws instead and carries the
+// real body on `error.data`. Prefer that real message over a hardcoded
+// string either way, so a user who needs to sign in again is actually told
+// that instead of a generic "failed to load" banner.
+function extractApiErrorMessage(error: unknown, fallback: string): string {
+  if (error && typeof error === 'object') {
+    const data = (error as { data?: unknown }).data
+    if (data && typeof data === 'object') {
+      const message = (data as { message?: unknown }).message
+      if (typeof message === 'string' && message) return message
+    }
+  }
+  if (error instanceof Error && error.message) return error.message
+  return fallback
+}
 
 const search = ref('')
 const activeYear = ref<number | null>(null)
@@ -818,7 +849,10 @@ async function loadStats(): Promise<void> {
   try {
     const res = await $fetch<MediaEntryStatsResponse, string>(
       '/api/media-entries/stats',
-      { query: { year: activeYear.value || undefined } },
+      {
+        query: { year: activeYear.value || undefined },
+        headers: authHeaders(),
+      },
     )
     if (res?.success) stats.value = res.data
   } catch {
@@ -832,7 +866,7 @@ async function loadRecentEntries(): Promise<void> {
   try {
     const res = await $fetch<MediaEntriesResponse, string>(
       '/api/media-entries',
-      { query: { take: 10, sort: 'date_desc' } },
+      { query: { take: 10, sort: 'date_desc' }, headers: authHeaders() },
     )
     if (res?.success) recentEntries.value = res.data
   } catch {
@@ -866,19 +900,22 @@ async function loadEntries(): Promise<void> {
           take,
           skip: skip.value,
         },
+        headers: authHeaders(),
       },
     )
 
     if (!res?.success) {
-      throw new Error('Failed to load the watchlist.')
+      throw new Error(res?.message || 'Failed to load the watchlist.')
     }
 
     entries.value =
       skip.value === 0 ? res.data : [...entries.value, ...res.data]
     total.value = res.total
   } catch (error) {
-    errorMessage.value =
-      error instanceof Error ? error.message : 'Failed to load the watchlist.'
+    errorMessage.value = extractApiErrorMessage(
+      error,
+      'Failed to load the watchlist.',
+    )
   } finally {
     isLoading.value = false
   }

--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -183,6 +183,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import type { MediaType } from '~/prisma/generated/prisma/client'
+import { useUserStore } from '@/stores/userStore'
 
 export type MediaEntryDetail = {
   id: number
@@ -213,16 +214,41 @@ type RelatedEntry = {
 
 type MediaEntryPatchResponse = {
   success: boolean
+  message?: string
   data: MediaEntryDetail
 }
 
 type MediaEntryRelatedResponse = {
   success: boolean
+  message?: string
   data: RelatedEntry[]
 }
 
 const props = defineProps<{ entry: MediaEntryDetail }>()
 const emit = defineEmits<{ (e: 'updated', entry: MediaEntryDetail): void }>()
+
+const userStore = useUserStore()
+
+// media-watchlist/t-019: same missing-Authorization-header bug as
+// watchlist-browse.vue -- every route here is admin-gated, but nothing ever
+// attached the signed-in user's token, so requests looked anonymous
+// regardless of who was actually signed in.
+function authHeaders(): Record<string, string> | undefined {
+  const token = userStore.token || userStore.user?.token || ''
+  return token ? { Authorization: `Bearer ${token}` } : undefined
+}
+
+function extractApiErrorMessage(error: unknown, fallback: string): string {
+  if (error && typeof error === 'object') {
+    const data = (error as { data?: unknown }).data
+    if (data && typeof data === 'object') {
+      const message = (data as { message?: unknown }).message
+      if (typeof message === 'string' && message) return message
+    }
+  }
+  if (error instanceof Error && error.message) return error.message
+  return fallback
+}
 
 const draft = ref(props.entry.review ?? '')
 const saveState = ref<'idle' | 'saving' | 'saved'>('idle')
@@ -238,6 +264,7 @@ async function fetchRelated(id: number) {
   try {
     const res = await $fetch<MediaEntryRelatedResponse, string>(
       `/api/media-entries/${id}/related`,
+      { headers: authHeaders() },
     )
     relatedEntries.value = res?.success ? res.data : []
   } catch {
@@ -309,14 +336,13 @@ async function patch(
   try {
     const res = await $fetch<MediaEntryPatchResponse, string>(
       `/api/media-entries/${props.entry.id}`,
-      { method: 'PATCH', body },
+      { method: 'PATCH', body, headers: authHeaders() },
     )
-    if (!res?.success) throw new Error('Update failed.')
+    if (!res?.success) throw new Error(res?.message || 'Update failed.')
     emit('updated', res.data)
     return res.data
   } catch (error) {
-    errorMessage.value =
-      error instanceof Error ? error.message : 'Failed to save.'
+    errorMessage.value = extractApiErrorMessage(error, 'Failed to save.')
     return null
   }
 }

--- a/server/api/media-entries/[id].patch.ts
+++ b/server/api/media-entries/[id].patch.ts
@@ -12,7 +12,13 @@
 //   publish   boolean         — true sets reviewPublic = true (one-way per the
 //                                MVP rule: "Publish" only sets the flag, no UI
 //                                exposes un-publishing)
-import { defineEventHandler, readBody, getRouterParam, createError } from 'h3'
+import {
+  defineEventHandler,
+  readBody,
+  getRouterParam,
+  createError,
+  setResponseStatus,
+} from 'h3'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireAdminApiUser } from '~/server/utils/authGuard'
@@ -101,6 +107,8 @@ export default defineEventHandler(async (event) => {
 
     return { success: true, data: updated }
   } catch (error) {
-    return errorHandler(error)
+    const result = errorHandler(error)
+    setResponseStatus(event, result.statusCode || 500)
+    return result
   }
 })

--- a/server/api/media-entries/[id]/related.get.ts
+++ b/server/api/media-entries/[id]/related.get.ts
@@ -3,7 +3,12 @@
 // "Related entries — same title, other years or formats" for the Entry
 // Detail panel (media-watchlist/t-006, BROWSE-UX.md §3). Admin-gated, same
 // convention as the other media-entries routes.
-import { defineEventHandler, getRouterParam, createError } from 'h3'
+import {
+  defineEventHandler,
+  getRouterParam,
+  createError,
+  setResponseStatus,
+} from 'h3'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireAdminApiUser } from '~/server/utils/authGuard'
@@ -50,6 +55,8 @@ export default defineEventHandler(async (event) => {
 
     return { success: true, data: related }
   } catch (error) {
-    return errorHandler(error)
+    const result = errorHandler(error)
+    setResponseStatus(event, result.statusCode || 500)
+    return result
   }
 })

--- a/server/api/media-entries/export.get.ts
+++ b/server/api/media-entries/export.get.ts
@@ -11,7 +11,7 @@
 //
 // Query: search, mediaType, starred, sort, year, month, season (all
 // optional, same semantics as index.get.ts).
-import { defineEventHandler, getQuery, setHeader } from 'h3'
+import { defineEventHandler, getQuery, setHeader, setResponseStatus } from 'h3'
 import type { MediaEntry, Prisma } from '~/prisma/generated/prisma/client'
 import { MediaType } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
@@ -170,6 +170,8 @@ export default defineEventHandler(async (event) => {
 
     return csv
   } catch (error) {
-    return errorHandler(error)
+    const result = errorHandler(error)
+    setResponseStatus(event, result.statusCode || 500)
+    return result
   }
 })

--- a/server/api/media-entries/index.get.ts
+++ b/server/api/media-entries/index.get.ts
@@ -6,7 +6,7 @@
 // Admin-gated: this is Silas's private personal log (BROWSE-UX.md — "Private
 // by default; no social features at MVP"), same convention as
 // server/api/art/queue/stats.get.ts.
-import { defineEventHandler, getQuery } from 'h3'
+import { defineEventHandler, getQuery, setResponseStatus } from 'h3'
 import type { Prisma } from '~/prisma/generated/prisma/client'
 import { MediaType } from '~/prisma/generated/prisma/client'
 import prisma from '~/server/utils/prisma'
@@ -131,6 +131,8 @@ export default defineEventHandler(async (event) => {
       total,
     }
   } catch (error) {
-    return errorHandler(error)
+    const result = errorHandler(error)
+    setResponseStatus(event, result.statusCode || 500)
+    return result
   }
 })

--- a/server/api/media-entries/stats.get.ts
+++ b/server/api/media-entries/stats.get.ts
@@ -5,7 +5,7 @@
 // server/api/art/queue/stats.get.ts. Admin-gated, same as the browse route.
 //
 // Query: ?year=<int> (optional; omit for all-time totals)
-import { defineEventHandler, getQuery } from 'h3'
+import { defineEventHandler, getQuery, setResponseStatus } from 'h3'
 import prisma from '~/server/utils/prisma'
 import { errorHandler } from '~/server/utils/error'
 import { requireAdminApiUser } from '~/server/utils/authGuard'
@@ -171,6 +171,8 @@ export default defineEventHandler(async (event) => {
       },
     }
   } catch (error) {
-    return errorHandler(error)
+    const result = errorHandler(error)
+    setResponseStatus(event, result.statusCode || 500)
+    return result
   }
 })


### PR DESCRIPTION
### Task
media-watchlist/t-019: Fix the Media Watchlist failing to load, and stop masking the real cause (kind: software)

### What changed / what I produced
Two root causes, both in the same feature:

1. **THE LOAD FAILS.** Every `$fetch` call in `watchlist-browse.vue` and
   `watchlist-entry-detail.vue` was missing the `Authorization` header entirely,
   even though every `media-entries` route is admin-gated (`requireAdminApiUser`).
   Every request arrived at the server looking anonymous, regardless of who was
   actually signed in — not a stale/mis-scoped session as first suspected. Added
   the same `userStore.token`-based header this codebase already uses elsewhere
   (`stores/artStore.ts`, `components/art/stylist-clients.vue`, etc.) to all five
   `media-entries` `$fetch` calls across both components.
2. **THE ERROR LIES.** `server/utils/error.ts`'s `errorHandler()` computes a
   `statusCode` but every `media-entries` route just returned its result object
   directly from a `catch` block, so h3 always answered HTTP 200 — every
   distinguishable backend failure rendered as the same generic banner, and the
   frontend discarded the real message that was in the response body. Fixed by
   adding `setResponseStatus(event, result.statusCode || 500)` after
   `errorHandler(error)` in all five `media-entries` routes (`index`, `stats`,
   `export`, `[id].patch`, `[id]/related`), matching the convention already used
   in `server/api/achievements/index.get.ts` and
   `server/api/brainstorm/generate.post.ts`. Both frontend components now extract
   the real message from the thrown fetch error's body (or the `success:false`
   payload as a fallback) instead of a hardcoded string.

### How I verified
- `npx eslint` on all 7 changed files: clean.
- `npx vue-tsc --noEmit`: clean.
- `npx prettier --check`: clean (one `--write` pass needed for formatting, then
  re-verified).
- Read every media-entries route and both watchlist components end-to-end to
  confirm the auth-header gap and the status-masking pattern by code inspection,
  cross-checked against the working `Authorization: Bearer` pattern used
  elsewhere in this codebase.

### Stakes
reversible

### Flags for Reviewer
- No existing test coverage for this feature to extend, and no live DB/site
  access from this sandbox to reproduce the original failure end-to-end — this
  is a code-reading-verified fix, not one confirmed against a running instance.
  A human spot-check of `/plan/watchlist` after deploy is the strongest
  remaining confirmation.
- `components/watchlist/watchlist-browse.vue`'s CSV export button still
  navigates via a plain `<a>` click (`link.href = '/api/media-entries/export?...'`),
  which can't carry an `Authorization` header the way `$fetch` can. Whether that
  path is also broken (same admin-gate, no cookie-based auth in this app) wasn't
  in Silas's original report and wasn't touched here — flagging in case export
  turns out to have the same root cause once the two items above are confirmed
  fixed in production.
- Filed `kind-robots/t-096` in conductor separately for the wider house-wide
  finding: this same `errorHandler`-never-sets-status pattern exists at ~432
  call sites across `server/api`, not just these 5. Fixing the utility itself
  (`errorHandler(error, event)`) would need a real audit + codemod across the
  whole API and was deliberately out of scope for this task.

### Kaizen suggestion
See `kind-robots/t-096` (already filed) — fix `errorHandler()` at the root
instead of patching each of the ~400 remaining call sites individually.

### Notes for reviewer
None beyond the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZXSBYeuGgMpYHocw5oMbi

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZXSBYeuGgMpYHocw5oMbi)_