### PR TITLE
cthulhuquarium/t-076: add bulk Monster art-linker script

### DIFF
--- a/scripts/link_cthulhuquarium_monster_art.ts
+++ b/scripts/link_cthulhuquarium_monster_art.ts
@@ -1,0 +1,131 @@
+import 'dotenv/config'
+import { cp, mkdir, readdir } from 'node:fs/promises'
+import { basename, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { PrismaClient } from '../prisma/generated/prisma/client'
+import { createDatabaseAdapter } from '../server/utils/databaseAdapterConfig'
+
+const SOURCE_DIR = fileURLToPath(new URL('../assets/images/cthulhuquarium/', import.meta.url))
+const PUBLIC_DIR = fileURLToPath(new URL('../public/images/cthulhuquarium/', import.meta.url))
+const FISH_PREFIX = 'cthulhuquarium-fish-'
+const PUBLIC_PREFIX = '/images/cthulhuquarium/'
+
+export type FishPlate = {
+  slug: string
+  fileName: string
+  imagePath: string
+  sourcePath: string
+  publicPath: string
+}
+
+export function plateFromFileName(fileName: string): FishPlate | null {
+  if (!fileName.startsWith(FISH_PREFIX) || !fileName.endsWith('.webp')) return null
+  const slug = fileName.slice(FISH_PREFIX.length, -'.webp'.length)
+  if (!slug) return null
+  return {
+    slug,
+    fileName,
+    imagePath: `${PUBLIC_PREFIX}${fileName}`,
+    sourcePath: join(SOURCE_DIR, fileName),
+    publicPath: join(PUBLIC_DIR, fileName),
+  }
+}
+
+export async function discoverFishPlates(): Promise<FishPlate[]> {
+  const files = await readdir(SOURCE_DIR)
+  return files
+    .map(plateFromFileName)
+    .filter((plate): plate is FishPlate => plate !== null)
+    .sort((a, b) => a.slug.localeCompare(b.slug))
+}
+
+async function preparePublicFiles(plates: FishPlate[]) {
+  await mkdir(PUBLIC_DIR, { recursive: true })
+  await Promise.all(plates.map((plate) => cp(plate.sourcePath, plate.publicPath)))
+}
+
+function createPrismaClient(): PrismaClient {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) throw new Error('DATABASE_URL is missing')
+  return new PrismaClient({ adapter: createDatabaseAdapter(databaseUrl) })
+}
+
+async function linkDatabaseRows(plates: FishPlate[]) {
+  const prisma = createPrismaClient()
+  try {
+    const monsters = await prisma.monster.findMany({
+      where: { slug: { in: plates.map((plate) => plate.slug) } },
+      select: { id: true, slug: true },
+    })
+    const monsterBySlug = new Map(monsters.map((monster) => [monster.slug, monster]))
+    const missing = plates.filter((plate) => !monsterBySlug.has(plate.slug))
+    if (missing.length) {
+      throw new Error(`Missing Monster rows for: ${missing.map((plate) => plate.slug).join(', ')}`)
+    }
+
+    let created = 0
+    let updated = 0
+    for (const plate of plates) {
+      const monster = monsterBySlug.get(plate.slug)!
+      const existing = await prisma.artImage.findFirst({
+        where: { fileName: plate.fileName },
+        select: { id: true },
+      })
+      const data = {
+        userId: 10,
+        fileName: plate.fileName,
+        imagePath: plate.imagePath,
+        path: plate.imagePath,
+        isPublic: true,
+        isMature: false,
+        isActive: true,
+        promptString: `Cthulhuquarium species plate: ${plate.slug}`,
+      }
+      const artImage = existing
+        ? await prisma.artImage.update({ where: { id: existing.id }, data })
+        : await prisma.artImage.create({ data })
+      existing ? updated++ : created++
+
+      await prisma.monster.update({
+        where: { id: monster.id },
+        data: {
+          artImageId: artImage.id,
+          iconPath: plate.imagePath,
+          cardPath: plate.imagePath,
+        },
+      })
+    }
+
+    console.log(`Linked ${plates.length} Monster rows (${created} ArtImage rows created, ${updated} updated).`)
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+async function main() {
+  const write = process.argv.includes('--write')
+  const preparePublic = process.argv.includes('--prepare-public') || write
+  const plates = await discoverFishPlates()
+
+  console.log(`Found ${plates.length} bundled Cthulhuquarium fish plates.`)
+  console.log(`Stable URL root: ${PUBLIC_PREFIX}`)
+
+  if (preparePublic) {
+    await preparePublicFiles(plates)
+    console.log(`Copied ${plates.length} plates into ${basename(PUBLIC_DIR)}/images/cthulhuquarium for stable public URLs.`)
+  }
+
+  if (!write) {
+    console.log('[dry run] No database rows changed. Re-run with --write against the intended DATABASE_URL to link ArtImage and Monster rows.')
+    return
+  }
+
+  await linkDatabaseRows(plates)
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
### Task
cthulhuquarium/t-076: Bulk-create real ArtImage records and link them to the 119 Monster rows that have art (kind: software)

### What changed / what I produced
- `scripts/link_cthulhuquarium_monster_art.ts` — a dry-run-by-default bulk linker:
  - Discovers delivered `cthulhuquarium-fish-*.webp` plates already bundled under `assets/images/cthulhuquarium/` (from cthulhuquarium/t-065, kind_robots#2620).
  - `--prepare-public` (implied by `--write`) copies them into `public/images/cthulhuquarium/` for a stable, non-fingerprinted `/images/cthulhuquarium/...` URL — required because `ArtImage.imagePath` is rendered verbatim as an `<img src>` (`utils/artImageSrc.ts`), not resolved through Vite asset fingerprinting.
  - `--write` idempotently creates/updates one `ArtImage` row per plate (keyed by `fileName`, `userId: 10` — the established system/guest owner, matching `ArtImage`'s own `@default(10)` and the `seed_kr_logo_art_image.ts` precedent) and links `Monster.artImageId`/`iconPath`/`cardPath` by slug.
  - Verifies every discovered plate has a matching `Monster.slug` before writing anything; throws rather than partially linking.
  - With no flags: reports discovered plate count and exits — no filesystem or database writes.

### How I verified
- This is intentionally **not** run with `--write` from this session: the sandbox has no reachable `DATABASE_URL` (dummy-only, per `docs/runbooks/migration-credential-boundary.md`), so a live linking pass needs a session with real production DB access. The task note documents this explicitly.
- Reviewed the script by reading: mirrors the discovery/idempotent-upsert idiom of `scripts/seed_bestiary.ts` and `scripts/seed_kr_logo_art_image.ts`, and the FK-existence pattern of `server/api/monsters/[id].patch.ts` (kind_robots#2138).
- No destructive operations anywhere in the script — plate copy is additive, `ArtImage`/`Monster` writes are create-or-update only, never delete.

### Stakes
reversible — new script file only; `--write` (the only path that touches the database) is never invoked by CI or this PR, and even then only creates/updates rows, never deletes.

### Flags for Reviewer
- This PR only adds the tool. The actual `--write` run (creating real `ArtImage` rows for the 119 already-delivered species) still needs a session with live `DATABASE_URL` access — tracked as the remainder of cthulhuquarium/t-076 in conductor's roadmap.
- This closes a process gap: the roadmap task had already moved to `status: review` with a note describing this script, but the commit was left sitting on an un-PR'd branch (`worker/cthulhuquarium-t-076-20260911T141847Z-r4m9`) with no open PR. Opening it now to land the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QV51GgrpquXhAB8mwv5Fja

---
_Generated by [Claude Code](https://claude.ai/code/session_01QV51GgrpquXhAB8mwv5Fja)_