### PR TITLE
feat(aquarium): establish rivalry rule engine

### DIFF
--- a/server/utils/aquariumRivalry.ts
+++ b/server/utils/aquariumRivalry.ts
@@ -1,0 +1,92 @@
+// /server/utils/aquariumRivalry.ts
+// Pure rivalry rules for Cthulhuquarium. Persistence and tick settlement stay in
+// aquarium.ts/aquariumEconomy.ts; this module only answers which occupants are
+// squabbling and the production multiplier each one receives.
+
+export const RIVALRY_PREDATOR_PREY_MULTIPLIER = 0.7
+export const RIVALRY_SCHOOL_ANCHOR_MULTIPLIER = 0.85
+export const RIVALRY_AUTHORED_MULTIPLIER = 0.6
+export const RIVALRY_SAME_SPECIES_MULTIPLIER = 0.85
+
+export interface RivalryFish {
+  id: number
+  slug: string
+  dietRole?: string | null
+  schoolRole?: string | null
+  rivals?: readonly string[] | null
+}
+
+export type RivalryReason =
+  | 'predator-prey'
+  | 'school-anchor'
+  | 'authored'
+  | 'same-species'
+
+export interface RivalryPair {
+  aId: number
+  bId: number
+  multiplierEach: number
+  reasons: readonly RivalryReason[]
+}
+
+export interface RivalryResult {
+  active: boolean
+  pairs: readonly RivalryPair[]
+  multiplierByFishId: ReadonlyMap<number, number>
+}
+
+function isPair(a: string | null | undefined, b: string | null | undefined, x: string, y: string): boolean {
+  return (a === x && b === y) || (a === y && b === x)
+}
+
+export function evaluateRivalry(
+  fish: readonly RivalryFish[],
+  peaceWardActive = false,
+): RivalryResult {
+  const multiplierByFishId = new Map<number, number>(fish.map((entry) => [entry.id, 1]))
+  if (peaceWardActive || fish.length < 2) {
+    return { active: false, pairs: [], multiplierByFishId }
+  }
+
+  const pairs: RivalryPair[] = []
+  for (let i = 0; i < fish.length; i += 1) {
+    const a = fish[i]
+    if (!a) continue
+    for (let j = i + 1; j < fish.length; j += 1) {
+      const b = fish[j]
+      if (!b) continue
+
+      const reasons: RivalryReason[] = []
+      const penalties: number[] = []
+
+      if (isPair(a.dietRole, b.dietRole, 'predator', 'prey')) {
+        reasons.push('predator-prey')
+        penalties.push(RIVALRY_PREDATOR_PREY_MULTIPLIER)
+      }
+      if (isPair(a.schoolRole, b.schoolRole, 'school', 'anchor')) {
+        reasons.push('school-anchor')
+        penalties.push(RIVALRY_SCHOOL_ANCHOR_MULTIPLIER)
+      }
+      if (a.rivals?.includes(b.slug) || b.rivals?.includes(a.slug)) {
+        reasons.push('authored')
+        penalties.push(RIVALRY_AUTHORED_MULTIPLIER)
+      }
+      if (a.slug === b.slug) {
+        reasons.push('same-species')
+        penalties.push(RIVALRY_SAME_SPECIES_MULTIPLIER)
+      }
+
+      if (penalties.length === 0) continue
+
+      // Multiple reasons describe one squabble, not several simultaneous fights.
+      // The strongest applicable rule wins, preventing pair-order or tag-count from
+      // multiplying a fish all the way toward zero production.
+      const multiplierEach = Math.min(...penalties)
+      pairs.push({ aId: a.id, bId: b.id, multiplierEach, reasons })
+      multiplierByFishId.set(a.id, Math.min(multiplierByFishId.get(a.id) ?? 1, multiplierEach))
+      multiplierByFishId.set(b.id, Math.min(multiplierByFishId.get(b.id) ?? 1, multiplierEach))
+    }
+  }
+
+  return { active: pairs.length > 0, pairs, multiplierByFishId }
+}

--- a/utils/scripts/verifyAquariumRivalry.test.ts
+++ b/utils/scripts/verifyAquariumRivalry.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { evaluateRivalry } from '../../server/utils/aquariumRivalry'
+
+describe('Cthulhuquarium rivalry', () => {
+  it('applies predator/prey and school/anchor emergent rules', () => {
+    const result = evaluateRivalry([
+      { id: 1, slug: 'hunter', dietRole: 'predator', schoolRole: 'school' },
+      { id: 2, slug: 'grazer', dietRole: 'prey', schoolRole: 'anchor' },
+    ])
+    assert.equal(result.active, true)
+    assert.equal(result.pairs.length, 1)
+    assert.equal(result.multiplierByFishId.get(1), 0.7)
+    assert.deepEqual(result.pairs[0]?.reasons, ['predator-prey', 'school-anchor'])
+  })
+
+  it('honors authored rivals and same-species territorial pressure', () => {
+    const authored = evaluateRivalry([
+      { id: 1, slug: 'a', rivals: ['b'] },
+      { id: 2, slug: 'b' },
+    ])
+    assert.equal(authored.multiplierByFishId.get(1), 0.6)
+
+    const territorial = evaluateRivalry([
+      { id: 3, slug: 'rustfish' },
+      { id: 4, slug: 'rustfish' },
+    ])
+    assert.equal(territorial.multiplierByFishId.get(3), 0.85)
+    assert.deepEqual(territorial.pairs[0]?.reasons, ['same-species'])
+  })
+
+  it('uses the strongest rule once per pair rather than multiplying penalties', () => {
+    const result = evaluateRivalry([
+      { id: 1, slug: 'a', dietRole: 'predator', rivals: ['b'] },
+      { id: 2, slug: 'b', dietRole: 'prey' },
+    ])
+    assert.equal(result.multiplierByFishId.get(1), 0.6)
+    assert.equal(result.pairs[0]?.multiplierEach, 0.6)
+  })
+
+  it('peace ward suppresses every rivalry source', () => {
+    const result = evaluateRivalry(
+      [
+        { id: 1, slug: 'a', dietRole: 'predator', rivals: ['b'] },
+        { id: 2, slug: 'b', dietRole: 'prey' },
+      ],
+      true,
+    )
+    assert.equal(result.active, false)
+    assert.equal(result.pairs.length, 0)
+    assert.equal(result.multiplierByFishId.get(1), 1)
+  })
+
+  it('keeps unrelated fish at full production', () => {
+    const result = evaluateRivalry([
+      { id: 1, slug: 'a', dietRole: 'neutral', schoolRole: 'solitary' },
+      { id: 2, slug: 'b', dietRole: 'neutral', schoolRole: 'solitary' },
+    ])
+    assert.equal(result.active, false)
+    assert.equal(result.multiplierByFishId.get(1), 1)
+    assert.equal(result.multiplierByFishId.get(2), 1)
+  })
+})


### PR DESCRIPTION
## Summary
- add a pure rivalry evaluator for Cthulhuquarium
- encode economy.yaml's predator/prey and school/anchor rules
- support authored rival overrides, same-species territorial pressure, and Peace Ward suppression
- add focused node:test coverage for composition and non-rival cases

## Scope
This is the first bounded slice of conductor cthulhuquarium/t-075. It deliberately does not yet wire rivalry into tick settlement or fire `first_rivalry_resolved`; the roadmap review note records those continuation steps.

## Verification
GitHub Actions is the available execution environment for this connector-only run. Complete branch diff inspected before opening: 2 new files, 155 lines, no schema or production mutation.

## Flags for Reviewer
The authored `rivals` list is accepted by the pure evaluator but is not yet persisted on Monster rows. Runtime wiring should pass the existing dietRole/schoolRole immediately and add authored data only when its canonical storage path is available. Multiple rivalry reasons for one pair use the strongest penalty rather than multiplying toward zero, preserving rivalry as a rate constraint rather than degradation.