### PR TITLE
interface-vision/t-104 slice 232: close remaining bare h-5 w-5 colored glyph pool

### DIFF
--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -350,7 +350,10 @@
                     {{ selectedCollectionSummary }}
                   </p>
                 </div>
-                <Icon name="kind-icon:folder" class="h-5 w-5 text-secondary" />
+                <Icon
+                  name="kind-icon:folder"
+                  class="kr-icon-5 text-secondary"
+                />
               </div>
 
               <button

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -204,7 +204,7 @@
             >
               <Icon
                 name="mdi:check-circle"
-                class="h-5 w-5 text-primary-content drop-shadow"
+                class="kr-icon-5 text-primary-content drop-shadow"
               />
             </div>
           </button>
@@ -258,7 +258,7 @@
               <Icon
                 v-if="!isLoadingStarterImage"
                 name="mdi:check-circle"
-                class="h-5 w-5 text-primary-content drop-shadow"
+                class="kr-icon-5 text-primary-content drop-shadow"
               />
               <span
                 v-else

--- a/components/navigation/navigation-trimmed.vue
+++ b/components/navigation/navigation-trimmed.vue
@@ -83,7 +83,7 @@
               >
                 <Icon
                   :name="tab.icon || channel.icon"
-                  class="h-5 w-5 text-base-100 drop-shadow"
+                  class="kr-icon-5 text-base-100 drop-shadow"
                 />
               </span>
             </span>

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -294,7 +294,7 @@
                 <div v-else class="flex h-full items-center justify-center">
                   <Icon
                     name="mdi:pencil"
-                    class="h-5 w-5 text-base-content/20"
+                    class="kr-icon-5 text-base-content/20"
                   />
                 </div>
                 <!-- Selected overlay -->


### PR DESCRIPTION
### What changed
Migrates the last 5 hand-rolled `h-5 w-5` icon-glyph occurrences repo-wide to compose the shared `.kr-icon-5` size primitive with each glyph's existing semantic color utility — same composition-only rule established by slices 224–231 (per slice 221's decision not to create combined `kr-icon-<color>-*` primitives for fragmented color pairs).

- `components/navigation/navigation-trimmed.vue` — channel tab icon (`text-base-100 drop-shadow`)
- `components/stages/performer-creator.vue` — pencil edit icon (`text-base-content/20`)
- `components/art/art-interact.vue` — folder icon (`text-secondary`)
- `components/art/art-styler.vue` — check-circle selected-state icon, 2 occurrences (`text-primary-content drop-shadow`)

No color, behavior, API, schema, store, route, or layout geometry change. `art-interact.vue` needed one `prettier --write` pass afterward — the class string got slightly longer, pushing that line past print width, so Prettier re-wrapped the `<Icon>` tag onto multiple lines.

A repo-wide `grep -rn 'h-5 w-5 text-' components/ pages/` now returns nothing outside `sample/` scaffold templates (out of the `.vue`-only codemod scope, consistent with the earlier `kr-icon-4` precedent).

### How I verified
- `npx vue-tsc --noEmit` — clean
- `npx eslint` on the 4 changed files — 0 errors (2 pre-existing unrelated warnings in `performer-creator.vue`, confirmed unrelated to my lines)
- `npx prettier --check` — only the same pre-existing `performer-creator.vue` drift before/after (confirmed via `git stash`)
- `npm run test:layout-contract` — holds, 0 new violations
- `npm run test:lint-ratchet` — holds, no rule regression (334/-58)

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
The bare, colored `h-N w-N text-*` glyph pool is now fully closed for every size interface-vision has touched (4/5/6/7/8/10/12 sizeless, plus 5/6/primary-4/5/6/7/10/12 for common colors). The next bounded slice should run a fresh full-repo class-frequency survey outside all now-closed families to find the next target, per the established convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pk7WdziPmxbcjJacsHGyxU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk7WdziPmxbcjJacsHGyxU)_