### PR TITLE
feat(aquarium): persist rivalry milestone lifecycle decision

### DIFF
--- a/server/utils/aquariumRivalryMilestone.ts
+++ b/server/utils/aquariumRivalryMilestone.ts
@@ -1,0 +1,29 @@
+export const RIVALRY_OBSERVED_EVENT_KIND = 'rivalry-observed'
+export const FIRST_RIVALRY_RESOLVED_MILESTONE_ID = 'first_rivalry_resolved'
+
+export interface RivalryMilestoneState {
+  shouldRecordObserved: boolean
+  shouldFireResolved: boolean
+}
+
+export function rivalryMilestoneState(
+  rivalryActive: boolean,
+  rivalryWasObserved: boolean,
+  rivalryResolvedAlready: boolean,
+): RivalryMilestoneState {
+  if (rivalryResolvedAlready) {
+    return { shouldRecordObserved: false, shouldFireResolved: false }
+  }
+
+  if (rivalryActive) {
+    return {
+      shouldRecordObserved: !rivalryWasObserved,
+      shouldFireResolved: false,
+    }
+  }
+
+  return {
+    shouldRecordObserved: false,
+    shouldFireResolved: rivalryWasObserved,
+  }
+}

--- a/utils/scripts/verifyAquariumRivalryMilestone.test.ts
+++ b/utils/scripts/verifyAquariumRivalryMilestone.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  rivalryMilestoneState,
+} from '../../server/utils/aquariumRivalryMilestone'
+
+test('records the first observed active rivalry', () => {
+  assert.deepEqual(rivalryMilestoneState(true, false, false), {
+    shouldRecordObserved: true,
+    shouldFireResolved: false,
+  })
+})
+
+test('does not repeatedly record an ongoing rivalry', () => {
+  assert.deepEqual(rivalryMilestoneState(true, true, false), {
+    shouldRecordObserved: false,
+    shouldFireResolved: false,
+  })
+})
+
+test('fires the milestone only after an observed rivalry clears', () => {
+  assert.deepEqual(rivalryMilestoneState(false, true, false), {
+    shouldRecordObserved: false,
+    shouldFireResolved: true,
+  })
+})
+
+test('does not fire for a tank that has never had rivalry', () => {
+  assert.deepEqual(rivalryMilestoneState(false, false, false), {
+    shouldRecordObserved: false,
+    shouldFireResolved: false,
+  })
+})
+
+test('resolved milestone is permanently idempotent', () => {
+  assert.deepEqual(rivalryMilestoneState(true, true, true), {
+    shouldRecordObserved: false,
+    shouldFireResolved: false,
+  })
+  assert.deepEqual(rivalryMilestoneState(false, true, true), {
+    shouldRecordObserved: false,
+    shouldFireResolved: false,
+  })
+})


### PR DESCRIPTION
## Summary
- adds the pure lifecycle decision for first rivalry observation and later resolution
- makes the `first_rivalry_resolved` transition idempotent before it is wired into Prisma tick settlement
- adds focused node:test coverage for observe, ongoing, clear, never-observed, and already-resolved states

## Scope
Cthulhuquarium t-077 incremental runtime-wiring slice. This deliberately does not yet alter tick production; the remaining task work is to call `evaluateRivalry()` from settlement, persist the observation/resolution events, and apply the per-fish production multipliers.

## Verification
Complete diff inspected: two new files, 73 lines, no schema/API/UI/deploy changes. CI is the executable verification transport for this connector-only run.