### PR TITLE
style(media): introduce kr-img-cover, migrate 40 hand-rolled occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -2423,6 +2423,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply text-sm text-base-content/50;
   }
 
+  /* New family opened per slice 232's kaizen note (the bare colored/sizeless
+   * h-N w-N icon-glyph pool interface-vision has touched is now fully
+   * closed; time for a fresh full-repo class-frequency survey outside it).
+   * `h-full w-full object-cover` is the exact, verbatim hand-rolled shape
+   * for an <img>/<video> filling its container -- 30 files, 30 occurrences,
+   * all exact matches with no extra tokens riding along (no rounded-*,
+   * shrink-0, or other modifier folded in at any site). Purely a sizing/
+   * object-fit primitive: no color and no behavior, so this is the same
+   * composition-only substitution as `kr-container`/`kr-icon-*` -- no
+   * geometry or rendering change at any of the 30 sites. */
+  .kr-img-cover {
+    @apply h-full w-full object-cover;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -12,7 +12,7 @@
         <img
           :src="lesson.previewImageSrc"
           :alt="`${lesson.name} visual style study`"
-          class="h-full w-full object-cover"
+          class="kr-img-cover"
         />
         <div class="absolute inset-0 bg-linear-to-t from-black/80 via-transparent to-transparent" />
         <div class="absolute inset-x-0 bottom-0 p-4 text-white">
@@ -245,7 +245,7 @@
                   :src="artist.portrait.imageSrc"
                   :alt="artistPortraitAlt(artist)"
                   loading="lazy"
-                  class="h-full w-full object-cover"
+                  class="kr-img-cover"
                 />
               </a>
               <div

--- a/components/academy/academy-timeline.vue
+++ b/components/academy/academy-timeline.vue
@@ -44,7 +44,7 @@
             v-if="style.previewImageSrc"
             :src="style.previewImageSrc"
             alt=""
-            class="h-full w-full object-cover"
+            class="kr-img-cover"
             :class="index === 1 ? 'scale-110' : ''"
           />
           <div v-else class="flex h-full items-center justify-center bg-base-200">

--- a/components/achievements/achievement-popup.vue
+++ b/components/achievements/achievement-popup.vue
@@ -22,7 +22,7 @@
             v-if="achievement.imagePath"
             :src="achievement.imagePath"
             :alt="achievement.label"
-            class="h-full w-full object-cover"
+            class="kr-img-cover"
           />
           <Icon
             v-else

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -81,7 +81,7 @@
             <img
               :src="sourceImageSrc"
               :alt="selectedSourceImage.fileName || 'Source'"
-              class="h-full w-full object-cover"
+              class="kr-img-cover"
             />
           </div>
           <div class="min-w-0 flex-1">
@@ -297,7 +297,7 @@
             v-if="sourceImageSrc"
             :src="sourceImageSrc"
             :alt="selectedSourceImage?.fileName || 'Source image'"
-            class="h-full w-full object-cover"
+            class="kr-img-cover"
           />
           <div
             v-else
@@ -324,7 +324,7 @@
             <img
               :src="resultImageSrc"
               alt="Styled result"
-              class="h-full w-full object-cover"
+              class="kr-img-cover"
             />
             <div
               class="absolute inset-0 flex items-center justify-center bg-success/40 backdrop-blur-sm"

--- a/components/art/stylist-client-gallery.vue
+++ b/components/art/stylist-client-gallery.vue
@@ -113,7 +113,7 @@
                   photoById.get(Number(item.id))!.caption ||
                   `${client.name} ${photoById.get(Number(item.id))!.kind}`
                 "
-                class="h-full w-full object-cover"
+                class="kr-img-cover"
                 decoding="async"
               />
               <div

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -39,7 +39,7 @@
               v-if="photoUrls[customer.id]"
               :src="photoUrls[customer.id]"
               :alt="`${customer.name} primary client photo`"
-              class="h-full w-full object-cover"
+              class="kr-img-cover"
             />
             <Icon v-else name="kind-icon:user" class="size-7 text-base-content/25" />
           </div>

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -62,7 +62,7 @@
                 v-if="pageRef.thumb"
                 :src="pageRef.thumb"
                 :alt="pageRef.title"
-                class="h-full w-full object-cover"
+                class="kr-img-cover"
               />
               <Icon
                 v-else

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -108,7 +108,7 @@
             v-if="card.previewImageUrl"
             :src="card.previewImageUrl"
             :alt="card.name"
-            class="h-full w-full object-cover"
+            class="kr-img-cover"
             loading="lazy"
           />
           <div

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -65,7 +65,7 @@
           v-if="sourceImage"
           :src="sourceImage"
           :alt="run?.sourceLabel"
-          class="h-full w-full object-cover"
+          class="kr-img-cover"
           loading="lazy"
         />
         <Icon v-else name="kind-icon:blueprint" class="h-6 w-6 text-base-content/30" />

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -172,7 +172,7 @@
               v-if="recordImage(record)"
               :src="recordImage(record)"
               alt=""
-              class="h-full w-full object-cover"
+              class="kr-img-cover"
               loading="lazy"
             />
             <Icon
@@ -227,7 +227,7 @@
               v-if="recordImage(record)"
               :src="recordImage(record)"
               alt=""
-              class="h-full w-full object-cover"
+              class="kr-img-cover"
               loading="lazy"
             />
             <Icon

--- a/components/navigation/channel-tab-list.vue
+++ b/components/navigation/channel-tab-list.vue
@@ -39,7 +39,7 @@
                 v-if="tab.image"
                 :src="tab.image"
                 :alt="tab.title || tab.label"
-                class="h-full w-full object-cover"
+                class="kr-img-cover"
               />
               <span
                 class="absolute inset-0 flex items-center justify-center bg-base-content/20"

--- a/components/navigation/navigation-artwork.vue
+++ b/components/navigation/navigation-artwork.vue
@@ -6,7 +6,7 @@
       :src="resolvedSrc"
       :alt="alt"
       loading="lazy"
-      class="h-full w-full object-cover"
+      class="kr-img-cover"
     />
   </span>
 </template>

--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -174,7 +174,7 @@
                 v-if="tab.image"
                 :src="tab.image"
                 :alt="tab.title"
-                class="h-full w-full object-cover"
+                class="kr-img-cover"
                 @error="markBroken(tab.image)"
               />
               <span

--- a/components/navigation/tutorial-flyer.vue
+++ b/components/navigation/tutorial-flyer.vue
@@ -117,7 +117,7 @@
                 :src="heroImage"
                 :alt="`${config.title} tutorial`"
                 loading="lazy"
-                class="h-full w-full object-cover"
+                class="kr-img-cover"
               />
               <Icon v-else name="kind-icon:info" class="kr-icon-primary-7" />
             </div>

--- a/components/navigation/workspace-hand.vue
+++ b/components/navigation/workspace-hand.vue
@@ -134,7 +134,7 @@
                 <img
                   :src="cardBackSrc(cardBack)"
                   :alt="`Card back ${cardBack}`"
-                  class="h-full w-full object-cover"
+                  class="kr-img-cover"
                 />
               </div>
 

--- a/components/navigation/workspace-narrator.vue
+++ b/components/navigation/workspace-narrator.vue
@@ -89,7 +89,7 @@
                       <img
                         :src="displayedNarratorImage"
                         :alt="narratorName"
-                        class="h-full w-full object-cover"
+                        class="kr-img-cover"
                         loading="lazy"
                       />
                     </template>
@@ -98,7 +98,7 @@
                       <img
                         :src="narratorCardBackSrc"
                         :alt="`Card back ${cardBack}`"
-                        class="h-full w-full object-cover"
+                        class="kr-img-cover"
                         loading="lazy"
                       />
                     </template>
@@ -254,7 +254,7 @@
                       <img
                         :src="displayedNarratorImage"
                         :alt="narratorName"
-                        class="h-full w-full object-cover"
+                        class="kr-img-cover"
                         loading="lazy"
                       />
                     </template>
@@ -263,7 +263,7 @@
                       <img
                         :src="narratorCardBackSrc"
                         :alt="`Card back ${cardBack}`"
-                        class="h-full w-full object-cover"
+                        class="kr-img-cover"
                         loading="lazy"
                       />
                     </template>
@@ -524,7 +524,7 @@
             <img
               :src="narratorCardBackSrc"
               :alt="`Card back ${cardBack}`"
-              class="h-full w-full object-cover"
+              class="kr-img-cover"
               loading="lazy"
             />
           </template>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -541,7 +541,7 @@
                       v-if="!iconFailed"
                       :src="projectIconPath(selectedProject.slug)"
                       :alt="selectedProject.name"
-                      class="h-full w-full object-cover"
+                      class="kr-img-cover"
                       @error="iconFailed = true"
                     />
                     <div

--- a/components/reviews/review-list.vue
+++ b/components/reviews/review-list.vue
@@ -49,7 +49,7 @@
           v-if="avatarFor(review)"
           :src="avatarFor(review) as string"
           :alt="nameFor(review)"
-          class="h-full w-full object-cover"
+          class="kr-img-cover"
           loading="lazy"
         />
         <Icon

--- a/components/rewards/reward-encounter.vue
+++ b/components/rewards/reward-encounter.vue
@@ -94,7 +94,7 @@
                   v-if="rewardHeroSrc"
                   :src="rewardHeroSrc"
                   :alt="selectedRewardName"
-                  class="h-full w-full object-cover"
+                  class="kr-img-cover"
                   @error="handleHeroImageError"
                 />
 

--- a/components/scenarios/scenario-story.vue
+++ b/components/scenarios/scenario-story.vue
@@ -182,7 +182,7 @@
           <img
             :src="selectedScenarioImage"
             :alt="selectedScenarioTitle"
-            class="h-full w-full object-cover"
+            class="kr-img-cover"
           />
         </div>
 

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -197,7 +197,7 @@
                   v-if="form.imagePath"
                   :src="String(form.imagePath)"
                   alt="Avatar"
-                  class="h-full w-full object-cover"
+                  class="kr-img-cover"
                 />
                 <Icon
                   v-else

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -160,7 +160,7 @@
                   v-else-if="slotImage(slot)"
                   :src="slotImage(slot)!"
                   alt=""
-                  class="h-full w-full object-cover"
+                  class="kr-img-cover"
                 />
                 <Icon
                   v-else

--- a/components/stages/stage-preset.vue
+++ b/components/stages/stage-preset.vue
@@ -15,7 +15,7 @@
       <img
         :src="preset.imagePath"
         :alt="preset.label"
-        class="h-full w-full object-cover"
+        class="kr-img-cover"
       />
       <div
         class="absolute inset-0 bg-linear-to-t from-base-100/90 to-transparent"

--- a/components/stages/stage-slot.vue
+++ b/components/stages/stage-slot.vue
@@ -12,7 +12,7 @@
             v-if="imageUrl"
             :src="imageUrl"
             :alt="displayName || 'participant'"
-            class="h-full w-full object-cover"
+            class="kr-img-cover"
           />
           <Icon v-else :name="typeIcon" class="kr-icon-5 opacity-60" />
         </div>

--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -14,7 +14,7 @@
           v-if="previewUrl"
           :src="previewUrl"
           alt="Current avatar preview"
-          class="h-full w-full object-cover"
+          class="kr-img-cover"
           @error="onPreviewError"
         />
         <Icon v-else name="kind-icon:user" class="kr-icon-primary-6" />
@@ -162,7 +162,7 @@
               <img
                 :src="thumbFor(selectedGalleryImage)"
                 :alt="selectedGalleryImage.promptString || `Image ${selectedGalleryImage.id}`"
-                class="h-full w-full object-cover"
+                class="kr-img-cover"
                 loading="lazy"
                 decoding="async"
                 @error="onThumbError($event, selectedGalleryImage)"

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -111,7 +111,7 @@
                 v-if="thread.otherAvatar"
                 :src="thread.otherAvatar"
                 :alt="thread.otherLabel"
-                class="h-full w-full object-cover"
+                class="kr-img-cover"
                 @error="onAvatarError(thread)"
               />
               <span v-else>{{ getInitials(thread.otherLabel) }}</span>
@@ -186,7 +186,7 @@
             v-if="activeThread.otherAvatar"
             :src="activeThread.otherAvatar"
             :alt="activeThread.otherLabel"
-            class="h-full w-full object-cover"
+            class="kr-img-cover"
             @error="onAvatarError(activeThread)"
           />
           <span v-else>{{ getInitials(activeThread.otherLabel) }}</span>

--- a/pages/play/aquarium/browse/[username]/[slug].vue
+++ b/pages/play/aquarium/browse/[username]/[slug].vue
@@ -56,7 +56,7 @@
                 v-if="tank.User.avatarImage"
                 :src="normalizeImagePath(tank.User.avatarImage)"
                 :alt="tank.User.username"
-                class="h-full w-full object-cover"
+                class="kr-img-cover"
               />
               <Icon
                 v-else

--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -79,7 +79,7 @@
                   v-if="tank.User.avatarImage"
                   :src="normalizeImagePath(tank.User.avatarImage)"
                   :alt="tank.User.username"
-                  class="h-full w-full object-cover"
+                  class="kr-img-cover"
                 />
                 <Icon
                   v-else

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -81,7 +81,7 @@
                 v-if="entry.avatarImage"
                 :src="normalizeImagePath(entry.avatarImage)"
                 :alt="entry.username"
-                class="h-full w-full object-cover"
+                class="kr-img-cover"
               />
               <Icon
                 v-else

--- a/pages/users/[id].vue
+++ b/pages/users/[id].vue
@@ -25,7 +25,7 @@
               v-if="user.avatarImage"
               :src="normalizeImagePath(user.avatarImage)"
               :alt="displayName"
-              class="h-full w-full object-cover"
+              class="kr-img-cover"
             />
             <Icon
               v-else


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules — slice 233 (kind: software)

### What changed / what I produced
- Opened a new family per slice 232's kaizen note (the bare colored/sizeless `h-N w-N` icon-glyph pool is now fully closed; time for a fresh full-repo class-frequency survey outside it).
- Added `.kr-img-cover` (`h-full w-full object-cover`) to `assets/css/tailwind.css`, documented in the same style as the existing `kr-icon-*`/`kr-container` families.
- Migrated all 40 exact, verbatim occurrences of `class="h-full w-full object-cover"` across 30 files (`components/**`, `pages/**`) to `class="kr-img-cover"`. Only exact-string matches were touched — no rounded-*, shrink-0, or other modifier riding along at any site was altered.
- No color, behavior, API, schema, store, route, or layout geometry change at any of the 40 sites.

### How I verified
- `npm run test` (vue-tsc --noEmit): clean.
- `npx eslint` on all 30 changed `.vue` files: 7 pre-existing findings, confirmed identical before/after via `git stash` (unrelated to this diff).
- `npx prettier --check` on the same files + `tailwind.css`: same 20-file pre-existing drift before/after, confirmed via `git stash`.
- `npm run test:layout-contract`: holds, 0 new violations.
- `npm run test:lint-ratchet`: holds at 334/-58, no rule regression.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Next candidates from the same survey worth a future slice: `input input-bordered input-xs` (11 exact occurrences) and `select select-bordered w-full bg-base-200` (10 exact occurrences) — DaisyUI form-control size/variant combos, same shape of purely-cosmetic composition opportunity as this slice.

### Notes for reviewer
Rebased onto current `origin/main` (includes `#2633`) before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018khu5fGSS8f7LktonGU9bR

---
_Generated by [Claude Code](https://claude.ai/code/session_018khu5fGSS8f7LktonGU9bR)_