### PR TITLE
style(forms): introduce kr-input-xs and kr-select-muted, migrate 21 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1618,6 +1618,27 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply input input-sm;
   }
 
+  /* The compact `input-xs` sibling of .kr-input-sm (interface-vision t-104
+   * slice 234): previously hand-rolled as `input input-bordered input-xs` --
+   * `input-bordered` is the same dead legacy v4 class .kr-input-sm already
+   * drops, leaving `input input-xs` as the real applied shape. 11
+   * occurrences across 2 files (build-bench.vue's per-side inference
+   * config fields, stylist-client-gallery.vue's compact filters). */
+  .kr-input-xs {
+    @apply input input-xs;
+  }
+
+  /* The `select` counterpart to .kr-input-muted (interface-vision t-104
+   * slice 234): the same full-width DaisyUI select shape on the muted
+   * base-200 background -- previously hand-rolled as `select
+   * select-bordered w-full bg-base-200`; `select-bordered` is the same dead
+   * legacy v4 class .kr-input/.kr-input-sm already drop from their input
+   * counterparts, leaving `select w-full bg-base-200` as the real applied
+   * shape. 10 occurrences across 8 files. */
+  .kr-select-muted {
+    @apply select w-full bg-base-200;
+  }
+
   /* The page-header icon badge: a tinted `h-12 w-12` square housing a
    * page-header `<Icon>`, sitting beside the page title (interface-vision
    * t-104 slice 149) -- previously hand-rolled identically across 8

--- a/components/art/build-bench.vue
+++ b/components/art/build-bench.vue
@@ -88,15 +88,15 @@
           <div class="mt-2 grid grid-cols-3 gap-2">
             <label class="flex flex-col gap-1">
               <span>Steps</span>
-              <input v-model.number="cfg(side).steps" type="number" min="1" class="input input-bordered input-xs" @change="store.persist" />
+              <input v-model.number="cfg(side).steps" type="number" min="1" class="kr-input-xs" @change="store.persist" />
             </label>
             <label class="flex flex-col gap-1">
               <span>CFG</span>
-              <input v-model.number="cfg(side).cfg" type="number" step="0.1" class="input input-bordered input-xs" @change="store.persist" />
+              <input v-model.number="cfg(side).cfg" type="number" step="0.1" class="kr-input-xs" @change="store.persist" />
             </label>
             <label class="flex flex-col gap-1">
               <span>Guidance</span>
-              <input v-model.number="cfg(side).guidance" type="number" step="0.1" class="input input-bordered input-xs" @change="store.persist" />
+              <input v-model.number="cfg(side).guidance" type="number" step="0.1" class="kr-input-xs" @change="store.persist" />
             </label>
             <label class="flex flex-col gap-1">
               <span>Seed</span>
@@ -104,29 +104,29 @@
                 :value="cfg(side).seed ?? ''"
                 type="number"
                 placeholder="random"
-                class="input input-bordered input-xs"
+                class="kr-input-xs"
                 @change="onSeed(side, $event)"
               />
             </label>
             <label class="flex flex-col gap-1">
               <span>Width</span>
-              <input v-model.number="cfg(side).width" type="number" step="8" class="input input-bordered input-xs" @change="store.persist" />
+              <input v-model.number="cfg(side).width" type="number" step="8" class="kr-input-xs" @change="store.persist" />
             </label>
             <label class="flex flex-col gap-1">
               <span>Height</span>
-              <input v-model.number="cfg(side).height" type="number" step="8" class="input input-bordered input-xs" @change="store.persist" />
+              <input v-model.number="cfg(side).height" type="number" step="8" class="kr-input-xs" @change="store.persist" />
             </label>
             <label class="flex flex-col gap-1">
               <span>Sampler</span>
-              <input v-model="cfg(side).sampler" type="text" class="input input-bordered input-xs" @change="store.persist" />
+              <input v-model="cfg(side).sampler" type="text" class="kr-input-xs" @change="store.persist" />
             </label>
             <label class="flex flex-col gap-1">
               <span>Scheduler</span>
-              <input v-model="cfg(side).scheduler" type="text" class="input input-bordered input-xs" @change="store.persist" />
+              <input v-model="cfg(side).scheduler" type="text" class="kr-input-xs" @change="store.persist" />
             </label>
             <label class="flex flex-col gap-1">
               <span>LoRA</span>
-              <input v-model="cfg(side).loraName" type="text" placeholder="none" class="input input-bordered input-xs" @change="store.persist" />
+              <input v-model="cfg(side).loraName" type="text" placeholder="none" class="kr-input-xs" @change="store.persist" />
             </label>
           </div>
         </details>

--- a/components/art/stylist-client-gallery.vue
+++ b/components/art/stylist-client-gallery.vue
@@ -33,7 +33,7 @@
         <span class="kr-text-bold-xs">Folder</span>
         <input
           v-model="uploadFolder"
-          class="input input-bordered input-xs"
+          class="kr-input-xs"
           placeholder="general"
         />
       </label>
@@ -51,7 +51,7 @@
         <span class="kr-text-bold-xs">Caption</span>
         <input
           v-model="uploadCaption"
-          class="input input-bordered input-xs"
+          class="kr-input-xs"
           placeholder="Color, formula, date, or notes"
         />
       </label>

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -107,7 +107,7 @@
 
               <select
                 v-model="botStore.botForm.BotType"
-                class="select select-bordered w-full bg-base-200"
+                class="kr-select-muted"
               >
                 <option value="assistant">assistant</option>
                 <option value="character">character</option>

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -289,7 +289,7 @@
           </div>
 
           <select
-            class="select select-bordered w-full bg-base-200"
+            class="kr-select-muted"
             :value="botStore.currentBot?.id ?? ''"
             aria-label="Select bot"
             @change="selectBotFromEvent"

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -187,7 +187,7 @@
           </div>
 
           <select
-            class="select select-bordered w-full bg-base-200"
+            class="kr-select-muted"
             :value="characterStore.selectedCharacter?.id ?? ''"
             aria-label="Select character"
             @change="selectCharacterFromEvent"

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -349,7 +349,7 @@
           </div>
 
           <select
-            class="select select-bordered w-full bg-base-200"
+            class="kr-select-muted"
             :value="dreamStore.selectedDream?.id ?? ''"
             aria-label="Select Dream"
             @change="selectDreamFromEvent"

--- a/components/lora/add-lora.vue
+++ b/components/lora/add-lora.vue
@@ -78,7 +78,7 @@
 
         <select
           v-model="form.resourceType"
-          class="select select-bordered w-full bg-base-200"
+          class="kr-select-muted"
         >
           <option value="LORA">LoRA</option>
           <option value="LYCORIS">LyCORIS</option>
@@ -92,7 +92,7 @@
 
         <select
           v-model="form.supportedServer"
-          class="select select-bordered w-full bg-base-200"
+          class="kr-select-muted"
         >
           <option value="SDXL">SDXL</option>
           <option value="SD15">SD15</option>

--- a/components/model/add-model.vue
+++ b/components/model/add-model.vue
@@ -77,7 +77,7 @@
 
       <select
         v-model="form.supportedServer"
-        class="select select-bordered w-full bg-base-200"
+        class="kr-select-muted"
       >
         <option v-for="server in SERVER_OPTIONS" :key="server" :value="server">
           {{ server }}

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -236,7 +236,7 @@
           </div>
 
           <select
-            class="select select-bordered w-full bg-base-200"
+            class="kr-select-muted"
             :value="rewardStore.selectedReward?.id ?? ''"
             aria-label="Select reward"
             @change="selectRewardFromEvent"

--- a/components/servers/add-checkpoint.vue
+++ b/components/servers/add-checkpoint.vue
@@ -68,10 +68,7 @@
           <span class="kr-label-bold">Resource Type</span>
         </span>
 
-        <select
-          v-model="form.resourceType"
-          class="select select-bordered w-full bg-base-200"
-        >
+        <select v-model="form.resourceType" class="kr-select-muted">
           <option value="CHECKPOINT">Checkpoint</option>
           <option value="LORA">LoRA</option>
           <option value="LYCORIS">LyCORIS</option>
@@ -89,10 +86,7 @@
           <span class="kr-label-bold">Supported Server</span>
         </span>
 
-        <select
-          v-model="form.supportedServer"
-          class="select select-bordered w-full bg-base-200"
-        >
+        <select v-model="form.supportedServer" class="kr-select-muted">
           <option value="SDXL">SDXL</option>
           <option value="SD15">SD15</option>
           <option value="FLUX">FLUX</option>


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules — slice 234 (kind: software)

### What changed / what I produced
- Per slice 233's kaizen note, ran the next full-repo class-frequency survey for the remaining DaisyUI form-control candidates.
- Added `.kr-input-xs` (`input input-xs`) — the compact sibling of `.kr-input-sm`. Previously hand-rolled as `input input-bordered input-xs`; `input-bordered` is the same dead legacy v4 class `.kr-input-sm` already drops in this repo's daisyUI v5. Migrated all 11 exact occurrences across 2 files (build-bench.vue, stylist-client-gallery.vue).
- Added `.kr-select-muted` (`select w-full bg-base-200`) — the select counterpart of `.kr-input-muted`. Previously hand-rolled as `select select-bordered w-full bg-base-200`; `select-bordered` is the same dead legacy v4 class, dropped the same way. Migrated all 10 exact occurrences across 8 files.
- Only exact-string `class="..."` matches migrated; 13 near-miss sites with extra riding classes (`flex-1`, `rounded-xl`, etc.) intentionally left out of scope, same convention as every prior slice.
- No color, behavior, API, schema, store, route, or layout geometry change at any of the 21 sites.

### How I verified
- `npm run test` (vue-tsc --noEmit): clean.
- `npx eslint` on all 11 changed files: same 7 pre-existing findings before/after (confirmed via `git stash`).
- `npx prettier --check` on the same files + `tailwind.css`: same 7-file pre-existing drift before/after (git-stash-confirmed) — one incidental reformat (add-checkpoint.vue's two `<select>` tags collapsed to one line once the class attribute shortened) applied via `prettier --write` to keep the file clean rather than leaving new drift.
- `npm run test:layout-contract`: holds, 0 new violations.
- `npm run test:lint-ratchet`: holds at 334/-58, no rule regression.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
Both DaisyUI form-control candidates named in slice 233's kaizen note are now closed. A fresh full-repo class-frequency survey (outside `kr-container`/`kr-icon-*`/`kr-img-cover`/`kr-input-*`/`kr-select-*`/`kr-checkbox-*`/`kr-textarea-*`) is needed to find the next slice's target.

### Notes for reviewer
Built on current `origin/main` (includes #2634).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYVHvQ974h6NQARFovH4Wt

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYVHvQ974h6NQARFovH4Wt)_