### PR TITLE
interface-vision/t-105: add color identities to dashboard sections

### DIFF
--- a/components/home/home-rail.vue
+++ b/components/home/home-rail.vue
@@ -15,6 +15,14 @@
   dissolved into whatever the backdrop happened to be doing. The panel is that
   ground.
 
+  THE PANELS HAVE DISTINCT COLOUR IDENTITIES. Silas, 2026-09-11: the new
+  dashboard's layout and content are right, but the individual sections need
+  more dynamism in their colour schemes. Each shelf therefore gets a stable
+  semantic daisyUI tone from its destination: terracotta, sage, blue, ink,
+  gold, or green. The wash stays light enough for the artwork to lead, and it
+  follows whatever app theme is active instead of baking Storybook hex values
+  into this component.
+
   THE HEADER IS ONE ROW: a glyph, the shelf's name, its count, and the chevrons.
   It began as two glyphs and no words -- Silas, 2026-08-29: "Would love to
   replace the words for new dreams, characters, etc with just an icon, same with
@@ -56,7 +64,10 @@
   so it is gone rather than tuned.
 -->
 <template>
-  <section class="flex h-full min-w-0 flex-col gap-1 kr-panel-flat p-2">
+  <section
+    class="flex h-full min-w-0 flex-col gap-1 kr-panel-flat p-2"
+    :class="surfaceTone.panel"
+  >
     <header class="flex shrink-0 items-center gap-1">
       <!--
         The shelf's identity, as one glyph. `title` and `aria-label` carry the
@@ -64,7 +75,8 @@
       -->
       <NuxtLink
         :to="seeAllHref"
-        class="flex min-w-0 shrink items-center gap-1 rounded text-primary transition-colors hover:text-primary/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+        class="flex min-w-0 shrink items-center gap-1 rounded transition-colors focus-visible:outline focus-visible:outline-2"
+        :class="surfaceTone.link"
         :title="`${label} — ${seeAllLabel}`"
         :aria-label="`${label} — ${seeAllLabel}`"
       >
@@ -119,7 +131,8 @@
       <span v-show="canScroll" class="flex shrink-0 items-center">
         <button
           type="button"
-          class="grid size-5 place-items-center rounded text-base-content/45 transition-colors hover:text-primary disabled:opacity-25 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+          class="grid size-5 place-items-center rounded text-base-content/45 transition-colors disabled:opacity-25 focus-visible:outline focus-visible:outline-2"
+          :class="surfaceTone.control"
           :disabled="atStart"
           :aria-label="`Scroll ${label} backwards`"
           @click="scrollBy(-1)"
@@ -128,7 +141,8 @@
         </button>
         <button
           type="button"
-          class="grid size-5 place-items-center rounded text-base-content/45 transition-colors hover:text-primary disabled:opacity-25 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+          class="grid size-5 place-items-center rounded text-base-content/45 transition-colors disabled:opacity-25 focus-visible:outline focus-visible:outline-2"
+          :class="surfaceTone.control"
           :disabled="atEnd"
           :aria-label="`Scroll ${label} forwards`"
           @click="scrollBy(1)"
@@ -337,6 +351,55 @@ const track = ref<HTMLElement | null>(null)
 const canScroll = ref(false)
 const atStart = ref(true)
 const atEnd = ref(false)
+
+type SurfaceTone = {
+  panel: string
+  link: string
+  control: string
+}
+
+const SURFACE_TONES: Record<string, SurfaceTone> = {
+  '/art': {
+    panel: 'border-info/35 bg-info/10',
+    link: 'text-info hover:text-info/70 focus-visible:outline-info',
+    control: 'hover:text-info focus-visible:outline-info',
+  },
+  '/dreams': {
+    panel: 'border-primary/35 bg-primary/10',
+    link: 'text-primary hover:text-primary/70 focus-visible:outline-primary',
+    control: 'hover:text-primary focus-visible:outline-primary',
+  },
+  '/characters': {
+    panel: 'border-accent/35 bg-accent/10',
+    link: 'text-accent hover:text-accent/70 focus-visible:outline-accent',
+    control: 'hover:text-accent focus-visible:outline-accent',
+  },
+  '/stories': {
+    panel: 'border-secondary/35 bg-secondary/10',
+    link: 'text-secondary hover:text-secondary/70 focus-visible:outline-secondary',
+    control: 'hover:text-secondary focus-visible:outline-secondary',
+  },
+  '/rewards': {
+    panel: 'border-warning/40 bg-warning/10',
+    link: 'text-warning hover:text-warning/70 focus-visible:outline-warning',
+    control: 'hover:text-warning focus-visible:outline-warning',
+  },
+  '/facets': {
+    panel: 'border-success/35 bg-success/10',
+    link: 'text-success hover:text-success/70 focus-visible:outline-success',
+    control: 'hover:text-success focus-visible:outline-success',
+  },
+}
+
+const DEFAULT_SURFACE_TONE: SurfaceTone = {
+  panel: 'border-primary/35 bg-primary/10',
+  link: 'text-primary hover:text-primary/70 focus-visible:outline-primary',
+  control: 'hover:text-primary focus-visible:outline-primary',
+}
+
+const surfaceTone = computed(
+  () => SURFACE_TONES[props.seeAllHref] ?? DEFAULT_SURFACE_TONE,
+)
 
 /*
  * Fixed tile widths, not a responsive column count: a rail's job is to leave a

--- a/components/home/home-rail.vue
+++ b/components/home/home-rail.vue
@@ -18,10 +18,11 @@
   THE PANELS HAVE DISTINCT COLOUR IDENTITIES. Silas, 2026-09-11: the new
   dashboard's layout and content are right, but the individual sections need
   more dynamism in their colour schemes. Each shelf therefore gets a stable
-  semantic daisyUI tone from its destination: terracotta, sage, blue, ink,
-  gold, or green. The wash stays light enough for the artwork to lead, and it
-  follows whatever app theme is active instead of baking Storybook hex values
-  into this component.
+  blend of the theme's primary, secondary, and accent inks. The six blends are
+  distinct without borrowing info/success/warning/error, whose semantic meaning
+  is reserved for status. The wash stays light enough for the artwork to lead,
+  and it follows whatever app theme is active instead of baking Storybook hex
+  values into this component.
 
   THE HEADER IS ONE ROW: a glyph, the shelf's name, its count, and the chevrons.
   It began as two glyphs and no words -- Silas, 2026-08-29: "Would love to
@@ -134,7 +135,8 @@
           class="grid size-5 place-items-center rounded text-base-content/45 transition-colors disabled:opacity-25 focus-visible:outline focus-visible:outline-2"
           :class="surfaceTone.control"
           :disabled="atStart"
-          :aria-label="`Scroll ${label} backwards`"
+          :aria-label="`Scroll ${label} backwards`
+          "
           @click="scrollBy(-1)"
         >
           <Icon name="kind-icon:chevron-left" class="size-3.5" />
@@ -144,7 +146,8 @@
           class="grid size-5 place-items-center rounded text-base-content/45 transition-colors disabled:opacity-25 focus-visible:outline focus-visible:outline-2"
           :class="surfaceTone.control"
           :disabled="atEnd"
-          :aria-label="`Scroll ${label} forwards`"
+          :aria-label="`Scroll ${label} forwards`
+          "
           @click="scrollBy(1)"
         >
           <Icon name="kind-icon:chevron-right" class="size-3.5" />
@@ -360,39 +363,48 @@ type SurfaceTone = {
 
 const SURFACE_TONES: Record<string, SurfaceTone> = {
   '/art': {
-    panel: 'border-info/35 bg-info/10',
-    link: 'text-info hover:text-info/70 focus-visible:outline-info',
-    control: 'hover:text-info focus-visible:outline-info',
+    panel:
+      'border-secondary/30 bg-linear-to-br from-secondary/12 via-base-100 to-primary/6',
+    link:
+      'text-secondary hover:text-secondary/70 focus-visible:outline-secondary',
+    control: 'hover:text-secondary focus-visible:outline-secondary',
   },
   '/dreams': {
-    panel: 'border-primary/35 bg-primary/10',
+    panel:
+      'border-primary/30 bg-linear-to-br from-primary/12 via-base-100 to-secondary/6',
     link: 'text-primary hover:text-primary/70 focus-visible:outline-primary',
     control: 'hover:text-primary focus-visible:outline-primary',
   },
   '/characters': {
-    panel: 'border-accent/35 bg-accent/10',
+    panel:
+      'border-accent/30 bg-linear-to-br from-accent/14 via-base-100 to-primary/5',
     link: 'text-accent hover:text-accent/70 focus-visible:outline-accent',
     control: 'hover:text-accent focus-visible:outline-accent',
   },
   '/stories': {
-    panel: 'border-secondary/35 bg-secondary/10',
-    link: 'text-secondary hover:text-secondary/70 focus-visible:outline-secondary',
+    panel:
+      'border-secondary/30 bg-linear-to-br from-secondary/8 via-base-100 to-accent/12',
+    link:
+      'text-secondary hover:text-secondary/70 focus-visible:outline-secondary',
     control: 'hover:text-secondary focus-visible:outline-secondary',
   },
   '/rewards': {
-    panel: 'border-warning/40 bg-warning/10',
-    link: 'text-warning hover:text-warning/70 focus-visible:outline-warning',
-    control: 'hover:text-warning focus-visible:outline-warning',
+    panel:
+      'border-primary/30 bg-linear-to-br from-primary/8 via-base-100 to-accent/12',
+    link: 'text-primary hover:text-primary/70 focus-visible:outline-primary',
+    control: 'hover:text-primary focus-visible:outline-primary',
   },
   '/facets': {
-    panel: 'border-success/35 bg-success/10',
-    link: 'text-success hover:text-success/70 focus-visible:outline-success',
-    control: 'hover:text-success focus-visible:outline-success',
+    panel:
+      'border-accent/30 bg-linear-to-br from-accent/10 via-base-100 to-secondary/10',
+    link: 'text-accent hover:text-accent/70 focus-visible:outline-accent',
+    control: 'hover:text-accent focus-visible:outline-accent',
   },
 }
 
 const DEFAULT_SURFACE_TONE: SurfaceTone = {
-  panel: 'border-primary/35 bg-primary/10',
+  panel:
+    'border-primary/30 bg-linear-to-br from-primary/10 via-base-100 to-secondary/6',
   link: 'text-primary hover:text-primary/70 focus-visible:outline-primary',
   control: 'hover:text-primary focus-visible:outline-primary',
 }

--- a/components/newsfeed/feed-card.vue
+++ b/components/newsfeed/feed-card.vue
@@ -6,10 +6,7 @@
     :target="allowNavigation ? '_blank' : undefined"
     :rel="allowNavigation ? 'noopener noreferrer' : undefined"
     class="group flex h-full flex-col overflow-hidden kr-panel-flat shadow-sm transition-shadow duration-300 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 motion-safe:hover:-translate-y-0.5 motion-safe:transition-transform"
-    :class="[
-      compact ? 'gap-1 p-2' : 'gap-2 p-3',
-      cardToneClass,
-    ]"
+    :class="[compact ? 'gap-1 p-2' : 'gap-2 p-3', cardToneClass]"
   >
     <!--
       COMPACT IS ITS OWN LAYOUT: picture, then headline, and nothing else.
@@ -180,17 +177,18 @@ const primaryCategory = computed(() => props.item.category?.[0] || '')
  * stable category tint: stories about the same kind of thing keep the same
  * paper wash while neighbouring categories stop reading as one cream slab.
  *
- * Semantic daisyUI tokens keep the palette compatible with Storybook Dark and
- * every user-selected theme. Five percent is intentional: the image and title
- * stay foreground, and the tint is visible mostly in the gutters and border.
+ * The blends use only primary/secondary/accent, because the house surface
+ * contract reserves info/success/warning/error for actual status. Keeping the
+ * opacity low lets the image and headline stay foreground while the gutters
+ * and border carry the category identity in every active theme.
  */
 const CARD_TONES = [
-  'border-primary/30 bg-primary/5',
-  'border-secondary/30 bg-secondary/5',
-  'border-accent/30 bg-accent/5',
-  'border-info/30 bg-info/5',
-  'border-success/30 bg-success/5',
-  'border-warning/30 bg-warning/5',
+  'border-primary/25 bg-linear-to-br from-primary/7 via-base-100 to-secondary/4',
+  'border-secondary/25 bg-linear-to-br from-secondary/7 via-base-100 to-accent/4',
+  'border-accent/25 bg-linear-to-br from-accent/8 via-base-100 to-primary/4',
+  'border-primary/25 bg-linear-to-br from-secondary/5 via-base-100 to-primary/7',
+  'border-secondary/25 bg-linear-to-br from-accent/6 via-base-100 to-secondary/6',
+  'border-accent/25 bg-linear-to-br from-primary/5 via-base-100 to-accent/7',
 ] as const
 
 const cardToneClass = computed(() => {

--- a/components/newsfeed/feed-card.vue
+++ b/components/newsfeed/feed-card.vue
@@ -6,7 +6,10 @@
     :target="allowNavigation ? '_blank' : undefined"
     :rel="allowNavigation ? 'noopener noreferrer' : undefined"
     class="group flex h-full flex-col overflow-hidden kr-panel-flat shadow-sm transition-shadow duration-300 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 motion-safe:hover:-translate-y-0.5 motion-safe:transition-transform"
-    :class="compact ? 'gap-1 p-2' : 'gap-2 p-3'"
+    :class="[
+      compact ? 'gap-1 p-2' : 'gap-2 p-3',
+      cardToneClass,
+    ]"
   >
     <!--
       COMPACT IS ITS OWN LAYOUT: picture, then headline, and nothing else.
@@ -169,6 +172,33 @@ const props = withDefaults(
 const feedPreferenceStore = useFeedPreferenceStore()
 
 const primaryCategory = computed(() => props.item.category?.[0] || '')
+
+/*
+ * A quiet category wash, not a new theme. Silas, 2026-09-11: the dashboard's
+ * section placement/content is right, but the colour schemes need more life.
+ * News is a wall of peer cards, so its equivalent of a section colour is a
+ * stable category tint: stories about the same kind of thing keep the same
+ * paper wash while neighbouring categories stop reading as one cream slab.
+ *
+ * Semantic daisyUI tokens keep the palette compatible with Storybook Dark and
+ * every user-selected theme. Five percent is intentional: the image and title
+ * stay foreground, and the tint is visible mostly in the gutters and border.
+ */
+const CARD_TONES = [
+  'border-primary/30 bg-primary/5',
+  'border-secondary/30 bg-secondary/5',
+  'border-accent/30 bg-accent/5',
+  'border-info/30 bg-info/5',
+  'border-success/30 bg-success/5',
+  'border-warning/30 bg-warning/5',
+] as const
+
+const cardToneClass = computed(() => {
+  const seed = primaryCategory.value || props.item.source || props.item.id
+  let hash = 0
+  for (const char of seed) hash = (hash * 31 + char.charCodeAt(0)) | 0
+  return CARD_TONES[Math.abs(hash) % CARD_TONES.length]
+})
 
 // NewsFeedItem carries a plain `image` URL rather than the cardPath/heroPath/
 // iconPath shape most art-bearing records use -- kr-art-plate's resolver


### PR DESCRIPTION
### Task
interface-vision/t-105: screenshot-driven dashboard visual polish.

### What changed
- Preserved the new dashboard's container positions, sizing, content, navigation, and data behavior.
- Gave each of the six homepage gallery shelves a stable color identity by blending the active theme's `primary`, `secondary`, and `accent` inks in different directions.
- Kept `info` / `success` / `warning` / `error` reserved for actual status, matching the house surface contract.
- Kept each entity tile's existing per-record theme, so the section wash creates hierarchy without flattening the individual cards.
- Added a quiet, stable category/source-derived primary/secondary/accent blend to news cards, so the full-width feed no longer reads as one uninterrupted cream slab.
- Kept the washes deliberately light so artwork remains the dominant color source. No raw hex palette values were introduced.

### Why
The current dashboard layout is working well, but the repeated `kr-panel-flat` + primary accent treatment makes neighboring sections visually merge. This pass keeps the furniture exactly where it is and gives the rooms different wallpaper.

### Verification
- Diff is limited to `components/home/home-rail.vue` and `components/newsfeed/feed-card.vue`.
- `NewsFeedItem.id` is confirmed as a string, so the deterministic card-tone hash is type-safe.
- The color vocabulary uses existing DaisyUI theme tokens and changes with Storybook, Storybook Dark, or another active user theme rather than hardcoding a light-only palette.
- Layout Contract and the story/narrative contract checks already completing on this exact head are green; remaining exact-head PR CI is being allowed to finish before merge.
- Visual direction is grounded in Silas's supplied desktop screenshots. There is no current PR-preview deployment path after the Vercel preview retirement, so no rendered pre-merge preview is claimed.

### Stakes
reversible

### Flags for reviewer
None. This is presentation-only; no deploy is triggered by this PR.