### PR TITLE
cthulhuquarium/t-077: compose rivalry penalties with production

### DIFF
--- a/server/utils/aquariumRivalryProduction.ts
+++ b/server/utils/aquariumRivalryProduction.ts
@@ -1,0 +1,30 @@
+import type { RivalryFish, RivalryResult } from './aquariumRivalry'
+import { evaluateRivalry } from './aquariumRivalry'
+
+export interface RivalryProductionFish extends RivalryFish {
+  production: number
+}
+
+export interface RivalryProductionResult {
+  rivalry: RivalryResult
+  productionByFishId: ReadonlyMap<number, number>
+  totalProduction: number
+}
+
+export function applyRivalryToProduction(
+  fish: readonly RivalryProductionFish[],
+  peaceWardActive = false,
+): RivalryProductionResult {
+  const rivalry = evaluateRivalry(fish, peaceWardActive)
+  const productionByFishId = new Map<number, number>()
+  let totalProduction = 0
+
+  for (const entry of fish) {
+    const multiplier = rivalry.multiplierByFishId.get(entry.id) ?? 1
+    const production = entry.production * multiplier
+    productionByFishId.set(entry.id, production)
+    totalProduction += production
+  }
+
+  return { rivalry, productionByFishId, totalProduction }
+}

--- a/utils/scripts/verifyAquariumRivalryProduction.test.ts
+++ b/utils/scripts/verifyAquariumRivalryProduction.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+
+import { applyRivalryToProduction } from '../../server/utils/aquariumRivalryProduction.js'
+
+const predatorPrey = applyRivalryToProduction([
+  { id: 1, slug: 'hunter', dietRole: 'predator', production: 10 },
+  { id: 2, slug: 'grazer', dietRole: 'prey', production: 20 },
+])
+
+assert.equal(predatorPrey.rivalry.active, true)
+assert.equal(predatorPrey.productionByFishId.get(1), 7)
+assert.equal(predatorPrey.productionByFishId.get(2), 14)
+assert.equal(predatorPrey.totalProduction, 21)
+
+const peaceful = applyRivalryToProduction([
+  { id: 1, slug: 'hunter', dietRole: 'predator', production: 10 },
+  { id: 2, slug: 'grazer', dietRole: 'prey', production: 20 },
+], true)
+
+assert.equal(peaceful.rivalry.active, false)
+assert.equal(peaceful.productionByFishId.get(1), 10)
+assert.equal(peaceful.productionByFishId.get(2), 20)
+assert.equal(peaceful.totalProduction, 30)
+
+const strongestRule = applyRivalryToProduction([
+  { id: 1, slug: 'same', dietRole: 'predator', rivals: ['same'], production: 100 },
+  { id: 2, slug: 'same', dietRole: 'prey', production: 100 },
+])
+
+assert.equal(strongestRule.rivalry.pairs[0]?.multiplierEach, 0.6)
+assert.equal(strongestRule.totalProduction, 120)
+
+console.log('✅ rivalry production composition applies strongest penalties and Peace Ward suppression')


### PR DESCRIPTION
## Summary
- add a pure production-composition layer over the existing rivalry evaluator
- apply each fish's strongest rivalry multiplier to its production contribution
- preserve Peace Ward suppression
- add focused node:test coverage for predator/prey, Peace Ward, and strongest-rule composition

## Scope
This is a narrow continuation slice of cthulhuquarium/t-077. It does not yet persist rivalry lifecycle state or wire the helper into the Prisma-backed tick path; those remain in t-077.

## Verification
CI requested on this PR. Conductor review transition is already verified for session `2026-09-11T201545Z-cthulhuquarium-t-077-q4n8`.
