### PR TITLE
scene-animator: drop the duplicate page title that was unreadable over the art

### DIFF
--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -1,30 +1,28 @@
 <template>
   <main class="kr-surface h-full min-h-0 overflow-hidden">
     <div class="kr-scroll kr-container-wide space-y-5 p-4 md:p-6">
-      <header class="kr-toolbar flex flex-wrap items-start justify-between gap-4">
-        <div class="max-w-3xl">
-          <p class="kr-text-eyebrow text-xs tracking-widest text-primary">
-            Admin production
-          </p>
-          <p class="mt-1 text-3xl font-black">Scene Animator</p>
-          <p class="mt-2 text-sm text-base-content/65">
-            Point Kind Robots at a folder of still scenes and let the existing Comfy video
-            queue bring each one to life. No shot-by-shot prompt writing required.
-          </p>
-        </div>
-        <div class="flex flex-wrap gap-2">
-          <span class="kr-badge-outline">Private output</span>
-          <span class="kr-badge-outline">ArtJob-backed resume</span>
-          <button
-            type="button"
-            class="kr-btn"
-            :disabled="store.loading || store.queueing || !userStore.isAdmin"
-            @click="store.load()"
-          >
-            <span v-if="store.loading" class="kr-spinner-xs" />
-            Refresh
-          </button>
-        </div>
+      <!-- Controls only. THE HEADER RULE (interface-vision t-004): the shell's
+           workspace-header already renders this page's title and subtitle from
+           content/channels/admin/scene-animator.md frontmatter, so a page
+           component never renders its own title block. This header previously
+           stacked an "Admin production" eyebrow, a text-3xl font-black
+           "Scene Animator", and a long description on top of the shell's own
+           header -- a triplicate of the frontmatter, laid over the page's
+           background art with no surface behind it, which is why it was close
+           to unreadable. It evaded the `one-header` lint because that rule
+           matches a literal <h1> and this was built from <p> tags. -->
+      <header class="kr-toolbar justify-end">
+        <span class="kr-badge-outline">Private output</span>
+        <span class="kr-badge-outline">ArtJob-backed resume</span>
+        <button
+          type="button"
+          class="kr-btn"
+          :disabled="store.loading || store.queueing || !userStore.isAdmin"
+          @click="store.load()"
+        >
+          <span v-if="store.loading" class="kr-spinner-xs" />
+          Refresh
+        </button>
       </header>
 
       <div v-if="!ready" class="grid min-h-60 place-items-center kr-panel">


### PR DESCRIPTION
### Task
Silas, seeing the Scene Animator surface for the first time now that the animate mount is live:

> *"lacking a background container, the title and description if almost impossible to read"*

### The readability problem is real — but a background container is the wrong fix
That text shouldn't be on the page at all.

**THE HEADER RULE** (interface-vision t-004), documented directly above `.kr-toolbar` in `tailwind.css`:

> *"workspace-header.vue already renders icon, hero image, room label, and title from content frontmatter on every page. A page component NEVER renders its own `<h1>` — that's a duplicate title, not a second heading. Need in-page controls? One `.kr-toolbar` row, never a stacked title block."*

`content/channels/admin/scene-animator.md` already supplies `title: Scene Animator`, `subtitle: Turn folders of still scenes into short living clips`, and a `description`. This page stacked an "Admin production" eyebrow, a `text-3xl font-black` "Scene Animator", and a two-line description **on top of** that — a triplicate of the frontmatter.

And it rendered them into a `.kr-toolbar`, which is `@apply relative z-20 flex shrink-0 flex-wrap items-center gap-2` — **a bare flex row with no surface of its own**, so the text sat directly over the page's background art. That's the whole readability failure.

Removed the title block. The toolbar keeps what it's for (the two badges and Refresh) and right-aligns now that it's no longer a two-column split.

### Why the lint missed it
`verifyLayoutContract.ts`'s `one-header` rule matches a literal `<h1>`. This block was built from `<p class="text-3xl font-black">` — so it did exactly what the rule forbids while passing it clean.

**Four other page components carry the same shape**: `users/[id].vue`, `email-confirmation.vue`, `play/challenges/leaderboard.vue`, `play/challenges/[slug].vue` — 5 of 15 page files total.

**Not touched here.** Each needs its own look to tell a genuine in-page heading from a duplicated shell title, and widening the rule to catch title-shaped `<p>` blocks is interface-vision's call, not a drive-by in an admin page fix. Worth filing as its own task — the rule is currently enforcing its letter rather than its intent.

### How I verified
- `vue-tsc --noEmit` — clean.
- `eslint` — clean.
- `npm run test:layout-contract` — holds, no new violations.

### Stakes
reversible — one page component's header markup. No store, API, route, or behaviour change.

### Notes for reviewer
Context: this surface only became viewable today. The animate tree was never mounted in the running container (the Unraid template predated the compose entry), so `/admin/scene-animator` had been returning a 503 rather than rendering — nobody had ever seen this header over real page art.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4LGW6k2vqnFtaDEMWp8GW

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4LGW6k2vqnFtaDEMWp8GW)_