### PR TITLE
interface-vision/t-105: make dashboard color variation visible

### DIFF
--- a/components/home/home-rail.vue
+++ b/components/home/home-rail.vue
@@ -17,12 +17,11 @@
 
   THE PANELS HAVE DISTINCT COLOUR IDENTITIES. Silas, 2026-09-11: the new
   dashboard's layout and content are right, but the individual sections need
-  more dynamism in their colour schemes. Each shelf therefore gets a stable
-  blend of the theme's primary, secondary, and accent inks. The six blends are
-  distinct without borrowing info/success/warning/error, whose semantic meaning
-  is reserved for status. The wash stays light enough for the artwork to lead,
-  and it follows whatever app theme is active instead of baking Storybook hex
-  values into this component.
+  more dynamism in their colour schemes. The first pass tried to get there with
+  tiny opacity shifts inside the house Storybook palette; on the real dashboard
+  those shifts were functionally invisible. Each shelf now wears one curated
+  built-in daisyUI theme instead, with a clearly visible primary/secondary wash.
+  The artwork and each entity tile's own theme still lead inside that frame.
 
   THE HEADER IS ONE ROW: a glyph, the shelf's name, its count, and the chevrons.
   It began as two glyphs and no words -- Silas, 2026-08-29: "Would love to
@@ -66,8 +65,8 @@
 -->
 <template>
   <section
-    class="flex h-full min-w-0 flex-col gap-1 kr-panel-flat p-2"
-    :class="surfaceTone.panel"
+    :data-theme="surfaceTone.theme"
+    class="flex h-full min-w-0 flex-col gap-1 kr-panel-flat border-2 border-primary/60 bg-linear-to-br from-primary/25 via-base-100 to-secondary/20 p-2 shadow-sm"
   >
     <header class="flex shrink-0 items-center gap-1">
       <!--
@@ -76,8 +75,7 @@
       -->
       <NuxtLink
         :to="seeAllHref"
-        class="flex min-w-0 shrink items-center gap-1 rounded transition-colors focus-visible:outline focus-visible:outline-2"
-        :class="surfaceTone.link"
+        class="flex min-w-0 shrink items-center gap-1 rounded text-primary transition-colors hover:text-primary/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
         :title="`${label} — ${seeAllLabel}`"
         :aria-label="`${label} — ${seeAllLabel}`"
       >
@@ -132,22 +130,18 @@
       <span v-show="canScroll" class="flex shrink-0 items-center">
         <button
           type="button"
-          class="grid size-5 place-items-center rounded text-base-content/45 transition-colors disabled:opacity-25 focus-visible:outline focus-visible:outline-2"
-          :class="surfaceTone.control"
+          class="grid size-5 place-items-center rounded text-base-content/45 transition-colors hover:text-primary disabled:opacity-25 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
           :disabled="atStart"
-          :aria-label="`Scroll ${label} backwards`
-          "
+          :aria-label="`Scroll ${label} backwards`"
           @click="scrollBy(-1)"
         >
           <Icon name="kind-icon:chevron-left" class="size-3.5" />
         </button>
         <button
           type="button"
-          class="grid size-5 place-items-center rounded text-base-content/45 transition-colors disabled:opacity-25 focus-visible:outline focus-visible:outline-2"
-          :class="surfaceTone.control"
+          class="grid size-5 place-items-center rounded text-base-content/45 transition-colors hover:text-primary disabled:opacity-25 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
           :disabled="atEnd"
-          :aria-label="`Scroll ${label} forwards`
-          "
+          :aria-label="`Scroll ${label} forwards`"
           @click="scrollBy(1)"
         >
           <Icon name="kind-icon:chevron-right" class="size-3.5" />
@@ -356,58 +350,19 @@ const atStart = ref(true)
 const atEnd = ref(false)
 
 type SurfaceTone = {
-  panel: string
-  link: string
-  control: string
+  theme: string
 }
 
 const SURFACE_TONES: Record<string, SurfaceTone> = {
-  '/art': {
-    panel:
-      'border-secondary/30 bg-linear-to-br from-secondary/12 via-base-100 to-primary/6',
-    link:
-      'text-secondary hover:text-secondary/70 focus-visible:outline-secondary',
-    control: 'hover:text-secondary focus-visible:outline-secondary',
-  },
-  '/dreams': {
-    panel:
-      'border-primary/30 bg-linear-to-br from-primary/12 via-base-100 to-secondary/6',
-    link: 'text-primary hover:text-primary/70 focus-visible:outline-primary',
-    control: 'hover:text-primary focus-visible:outline-primary',
-  },
-  '/characters': {
-    panel:
-      'border-accent/30 bg-linear-to-br from-accent/14 via-base-100 to-primary/5',
-    link: 'text-accent hover:text-accent/70 focus-visible:outline-accent',
-    control: 'hover:text-accent focus-visible:outline-accent',
-  },
-  '/stories': {
-    panel:
-      'border-secondary/30 bg-linear-to-br from-secondary/8 via-base-100 to-accent/12',
-    link:
-      'text-secondary hover:text-secondary/70 focus-visible:outline-secondary',
-    control: 'hover:text-secondary focus-visible:outline-secondary',
-  },
-  '/rewards': {
-    panel:
-      'border-primary/30 bg-linear-to-br from-primary/8 via-base-100 to-accent/12',
-    link: 'text-primary hover:text-primary/70 focus-visible:outline-primary',
-    control: 'hover:text-primary focus-visible:outline-primary',
-  },
-  '/facets': {
-    panel:
-      'border-accent/30 bg-linear-to-br from-accent/10 via-base-100 to-secondary/10',
-    link: 'text-accent hover:text-accent/70 focus-visible:outline-accent',
-    control: 'hover:text-accent focus-visible:outline-accent',
-  },
+  '/art': { theme: 'nord' },
+  '/dreams': { theme: 'cupcake' },
+  '/characters': { theme: 'garden' },
+  '/stories': { theme: 'retro' },
+  '/rewards': { theme: 'bumblebee' },
+  '/facets': { theme: 'aqua' },
 }
 
-const DEFAULT_SURFACE_TONE: SurfaceTone = {
-  panel:
-    'border-primary/30 bg-linear-to-br from-primary/10 via-base-100 to-secondary/6',
-  link: 'text-primary hover:text-primary/70 focus-visible:outline-primary',
-  control: 'hover:text-primary focus-visible:outline-primary',
-}
+const DEFAULT_SURFACE_TONE: SurfaceTone = { theme: 'pastel' }
 
 const surfaceTone = computed(
   () => SURFACE_TONES[props.seeAllHref] ?? DEFAULT_SURFACE_TONE,

--- a/components/newsfeed/feed-card.vue
+++ b/components/newsfeed/feed-card.vue
@@ -5,8 +5,9 @@
     :href="allowNavigation ? item.url : undefined"
     :target="allowNavigation ? '_blank' : undefined"
     :rel="allowNavigation ? 'noopener noreferrer' : undefined"
-    class="group flex h-full flex-col overflow-hidden kr-panel-flat shadow-sm transition-shadow duration-300 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 motion-safe:hover:-translate-y-0.5 motion-safe:transition-transform"
-    :class="[compact ? 'gap-1 p-2' : 'gap-2 p-3', cardToneClass]"
+    :data-theme="cardTheme"
+    class="group flex h-full flex-col overflow-hidden kr-panel-flat border-2 border-primary/45 bg-linear-to-br from-base-100 via-base-100 to-primary/20 shadow-sm transition-shadow duration-300 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 motion-safe:hover:-translate-y-0.5 motion-safe:transition-transform"
+    :class="compact ? 'gap-1 p-2' : 'gap-2 p-3'"
   >
     <!--
       COMPACT IS ITS OWN LAYOUT: picture, then headline, and nothing else.
@@ -171,31 +172,33 @@ const feedPreferenceStore = useFeedPreferenceStore()
 const primaryCategory = computed(() => props.item.category?.[0] || '')
 
 /*
- * A quiet category wash, not a new theme. Silas, 2026-09-11: the dashboard's
- * section placement/content is right, but the colour schemes need more life.
- * News is a wall of peer cards, so its equivalent of a section colour is a
- * stable category tint: stories about the same kind of thing keep the same
- * paper wash while neighbouring categories stop reading as one cream slab.
- *
- * The blends use only primary/secondary/accent, because the house surface
- * contract reserves info/success/warning/error for actual status. Keeping the
- * opacity low lets the image and headline stay foreground while the gutters
- * and border carry the category identity in every active theme.
+ * News needs visible variation, not a five-percent tint nobody can perceive.
+ * Use only stock daisyUI themes, the same palette source as entity cards. The
+ * category/source hash is stable, so neighboring topics vary without cards
+ * changing clothes on every render. This is deliberately a curated LIGHT set:
+ * enough hue range to break up the wall of paper, without dropping random dark
+ * themes into a reading-heavy feed.
  */
-const CARD_TONES = [
-  'border-primary/25 bg-linear-to-br from-primary/7 via-base-100 to-secondary/4',
-  'border-secondary/25 bg-linear-to-br from-secondary/7 via-base-100 to-accent/4',
-  'border-accent/25 bg-linear-to-br from-accent/8 via-base-100 to-primary/4',
-  'border-primary/25 bg-linear-to-br from-secondary/5 via-base-100 to-primary/7',
-  'border-secondary/25 bg-linear-to-br from-accent/6 via-base-100 to-secondary/6',
-  'border-accent/25 bg-linear-to-br from-primary/5 via-base-100 to-accent/7',
+const NEWS_CARD_THEMES = [
+  'cupcake',
+  'bumblebee',
+  'emerald',
+  'corporate',
+  'retro',
+  'valentine',
+  'garden',
+  'lemonade',
+  'winter',
+  'nord',
+  'caramellatte',
+  'silk',
 ] as const
 
-const cardToneClass = computed(() => {
+const cardTheme = computed(() => {
   const seed = primaryCategory.value || props.item.source || props.item.id
   let hash = 0
   for (const char of seed) hash = (hash * 31 + char.charCodeAt(0)) | 0
-  return CARD_TONES[Math.abs(hash) % CARD_TONES.length]
+  return NEWS_CARD_THEMES[Math.abs(hash) % NEWS_CARD_THEMES.length]
 })
 
 // NewsFeedItem carries a plain `image` URL rather than the cardPath/heroPath/


### PR DESCRIPTION
### Task
interface-vision/t-105, second screenshot-driven dashboard color pass.

### Root cause
The first color pass (#2636) changed the CSS but barely changed the picture. It used very low-opacity gradients inside Storybook's deliberately muted primary/secondary/accent palette, so the deployed page still read as one warm cream surface. Silas's follow-up screenshots made that failure obvious.

### What changed
- Kept dashboard geometry, content, navigation, scroll behavior, and data flow unchanged.
- Replaced the six gallery shelves' near-invisible tint variations with curated built-in daisyUI themes: nord, cupcake, garden, retro, bumblebee, and aqua.
- Added a visible theme-aware panel wash (`primary/25` to `secondary/20`) and stronger themed border to each shelf. Entity cards still keep their own record themes inside the shelf.
- Replaced the News cards' 4-8% tint math with a stable category/source-derived set of curated light daisyUI themes, plus a visible themed border/wash. The same category remains visually stable across renders.
- No raw palette hex values and no new custom themes.

### Verification
- Scope is two presentation components only: `components/home/home-rail.vue` and `components/newsfeed/feed-card.vue`.
- Branch is exactly two commits ahead of current main and zero behind.
- The change uses daisyUI themes already enabled by `themes: all` and the same stock-theme strategy already used by entity cards.
- The user's deployed screenshots are the visual regression evidence for why the previous subtle pass was insufficient.
- There is no current PR-preview deployment path, so rendered pre-merge verification is not claimed. CI must complete successfully before merge.

### Stakes
reversible

### Flags for reviewer
None. Presentation-only; merge does not deploy the self-hosted production site.