### PR TITLE
fix: stop the ArtImage offload flattening animated clips to a still

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -133,6 +133,9 @@ jobs:
       - name: ArtImage offload contract
         run: npm run test:art-image-offload
 
+      - name: Animated art offload contract
+        run: npm run test:animated-art-offload
+
       - name: ESLint ratchet
         run: npm run test:lint-ratchet
 

--- a/package.json
+++ b/package.json
@@ -469,6 +469,7 @@
     "test:api-client-followups": "tsx utils/scripts/verifyApiClientFollowups.ts",
     "offload:art-images": "tsx utils/scripts/offloadArtImageData.ts",
     "test:art-image-offload": "tsx utils/scripts/verifyArtImageOffload.ts",
+    "test:animated-art-offload": "tsx utils/scripts/verifyAnimatedArtOffload.test.ts",
     "offload:sample": "tsx utils/scripts/offloadArtImageData.ts --write --limit 20 --only-tagged",
     "dedupe:generated-art": "tsx utils/scripts/dedupeGeneratedArtImages.ts",
     "test:no-shadowed-content-routes": "tsx utils/scripts/verifyNoShadowedContentRoutes.ts",

--- a/server/utils/artImageEncoding.ts
+++ b/server/utils/artImageEncoding.ts
@@ -1,0 +1,94 @@
+// /server/utils/artImageEncoding.ts
+//
+// How an ArtImage's stored bytes are encoded on their way to the media share:
+// transcoded to WebP, or written verbatim because they already carry motion.
+//
+// Split out of artImageOffload.ts rather than living beside its only caller,
+// because this is the destructive half of the offload and it needs to be
+// testable on its own. artImageOffload.ts imports prisma at module load, and
+// prisma throws without a DATABASE_URL — so a test importing it cannot run in
+// the DB-free contract-tests workflow, which is exactly where a guard against
+// silently destroying image data belongs. Nothing here touches the database.
+import sharp from 'sharp'
+
+// Matches exportPageBackdropArt.ts and file.get.ts: 82 measured 8.3x smaller
+// than the source PNG with no visible artefacts at card size.
+const WEBP_QUALITY = 82
+
+// Clips are stored verbatim. sharp cannot decode them, and re-encoding a video
+// to WebP would silently turn a clip into a still.
+const VIDEO_TYPES = new Set(['mp4', 'webm', 'mov', 'mkv'])
+
+/*
+ * Container types that hold EITHER a still or an animation, so the stored
+ * fileType alone cannot decide whether re-encoding is safe.
+ *
+ * This is not hypothetical. `webp` is both this project's default still format
+ * (everything else is transcoded to it) AND what every WAN/LTX video preset
+ * whose outputFormat is 'webp' actually emits — buildVideoOutputNodes() sends
+ * the decoded frame batch into ComfyUI's SaveAnimatedWEBP, and the relay stamps
+ * the ArtImage `fileType: 'webp'`. Since 'webp' is not in VIDEO_TYPES above,
+ * such a clip fell into the re-encode branch, and `sharp(buf)` defaults to
+ * `pages: 1` — it reads frame 0 and silently discards the rest. The offload
+ * then wrote that single frame to the share and nulled imageData, destroying
+ * the only animated copy.
+ *
+ * That is exactly how Scene Animator's first render came back as a static image
+ * (2026-09-11): the wan-startup-webp preset is the default for engine 'wan', so
+ * every Scene Animator clip took this path. ComfyUI had animated it correctly.
+ *
+ * Frame count, not extension, is the real question — so ask sharp.
+ */
+const MULTI_FRAME_TYPES = new Set(['webp', 'gif'])
+
+/**
+ * True when `buffer` holds more than one frame.
+ *
+ * Deliberately allowed to throw: a buffer whose metadata sharp cannot read is
+ * one the re-encode below would fail on anyway, and letting it reach the
+ * caller's catch leaves the bytes in the database rather than committing a
+ * guess about them to disk.
+ */
+async function hasMultipleFrames(buffer: Buffer): Promise<boolean> {
+  const { pages } = await sharp(buffer).metadata()
+  return typeof pages === 'number' && pages > 1
+}
+
+export type OffloadEncoding = {
+  /** Extension the offloaded copy is written under. */
+  extension: string
+  /** Bytes to write — the original whenever they already carry motion. */
+  bytes: Buffer
+  /** True when the bytes were kept as-is rather than transcoded to WebP. */
+  keepVerbatim: boolean
+}
+
+/**
+ * Decide how a stored ArtImage's bytes reach the share: transcoded to WebP, or
+ * written verbatim because they carry motion that a transcode would destroy.
+ *
+ * See utils/scripts/verifyAnimatedArtOffload.test.ts.
+ */
+export async function resolveOffloadEncoding(
+  storedType: string,
+  original: Buffer,
+): Promise<OffloadEncoding> {
+  const normalized = (storedType || 'png').toLowerCase()
+  const isVideo = VIDEO_TYPES.has(normalized)
+  const isAnimated =
+    !isVideo &&
+    MULTI_FRAME_TYPES.has(normalized) &&
+    (await hasMultipleFrames(original))
+
+  // Anything already carrying motion is stored under its own extension. Only a
+  // genuine still is worth transcoding.
+  if (isVideo || isAnimated) {
+    return { extension: normalized, bytes: original, keepVerbatim: true }
+  }
+
+  return {
+    extension: 'webp',
+    bytes: await sharp(original).webp({ quality: WEBP_QUALITY }).toBuffer(),
+    keepVerbatim: false,
+  }
+}

--- a/server/utils/artImageOffload.ts
+++ b/server/utils/artImageOffload.ts
@@ -44,6 +44,81 @@ const WEBP_QUALITY = 82
 // to WebP would silently turn a clip into a still.
 const VIDEO_TYPES = new Set(['mp4', 'webm', 'mov', 'mkv'])
 
+/*
+ * Container types that hold EITHER a still or an animation, so the stored
+ * fileType alone cannot decide whether re-encoding is safe.
+ *
+ * This is not hypothetical. `webp` is both this project's default still format
+ * (everything below is transcoded to it) AND what every WAN/LTX video preset
+ * whose outputFormat is 'webp' actually emits — buildVideoOutputNodes() sends
+ * the decoded frame batch into ComfyUI's SaveAnimatedWEBP, and the relay stamps
+ * the ArtImage `fileType: 'webp'`. Since 'webp' is not in VIDEO_TYPES above,
+ * such a clip fell into the re-encode branch, and `sharp(buf)` defaults to
+ * `pages: 1` — it reads frame 0 and silently discards the rest. The offload
+ * then wrote that single frame to the share and nulled imageData, destroying
+ * the only animated copy.
+ *
+ * That is exactly how Scene Animator's first render came back as a static image
+ * (2026-09-11): the wan-startup-webp preset is the default for engine 'wan', so
+ * every Scene Animator clip took this path. ComfyUI had animated it correctly.
+ *
+ * Frame count, not extension, is the real question — so ask sharp.
+ */
+const MULTI_FRAME_TYPES = new Set(['webp', 'gif'])
+
+/**
+ * True when `buffer` holds more than one frame.
+ *
+ * Deliberately allowed to throw: a buffer whose metadata sharp cannot read is
+ * one the re-encode below would fail on anyway, and letting it reach the
+ * caller's catch leaves the bytes in the database rather than committing a
+ * guess about them to disk.
+ */
+async function hasMultipleFrames(buffer: Buffer): Promise<boolean> {
+  const { pages } = await sharp(buffer).metadata()
+  return typeof pages === 'number' && pages > 1
+}
+
+export type OffloadEncoding = {
+  /** Extension the offloaded copy is written under. */
+  extension: string
+  /** Bytes to write — the original whenever they already carry motion. */
+  bytes: Buffer
+  /** True when the bytes were kept as-is rather than transcoded to WebP. */
+  keepVerbatim: boolean
+}
+
+/**
+ * Decide how a stored ArtImage's bytes reach the share: transcoded to WebP, or
+ * written verbatim because they carry motion that a transcode would destroy.
+ *
+ * Exported so the destructive half of the offload can be exercised directly —
+ * see utils/scripts/verifyAnimatedArtOffload.test.ts.
+ */
+export async function resolveOffloadEncoding(
+  storedType: string,
+  original: Buffer,
+): Promise<OffloadEncoding> {
+  const normalized = (storedType || 'png').toLowerCase()
+  const isVideo = VIDEO_TYPES.has(normalized)
+  const isAnimated =
+    !isVideo &&
+    MULTI_FRAME_TYPES.has(normalized) &&
+    (await hasMultipleFrames(original))
+
+  // Anything already carrying motion is stored under its own extension. Only a
+  // genuine still is worth transcoding.
+  if (isVideo || isAnimated) {
+    return { extension: normalized, bytes: original, keepVerbatim: true }
+  }
+
+  return {
+    extension: 'webp',
+    bytes: await sharp(original).webp({ quality: WEBP_QUALITY }).toBuffer(),
+    keepVerbatim: false,
+  }
+}
+
 export type OffloadResult = {
   offloaded: boolean
   imagePath?: string
@@ -145,12 +220,10 @@ export async function offloadArtImageBytes(
     }
 
     const storedType = (image.fileType || 'png').toLowerCase()
-    const isVideo = VIDEO_TYPES.has(storedType)
-    const extension = isVideo ? storedType : 'webp'
-
-    const bytes = isVideo
-      ? original
-      : await sharp(original).webp({ quality: WEBP_QUALITY }).toBuffer()
+    const { extension, bytes, keepVerbatim } = await resolveOffloadEncoding(
+      storedType,
+      original,
+    )
 
     /*
      * The destination follows conductor's URL-MAPPING.md convention —
@@ -199,7 +272,9 @@ export async function offloadArtImageBytes(
       data: {
         imagePath: servedPath,
         imageData: null,
-        ...(isVideo ? {} : { fileType: 'webp' }),
+        // An animated gif kept verbatim is still a gif; only a transcoded
+        // still actually became a webp.
+        ...(keepVerbatim ? {} : { fileType: 'webp' }),
       },
     })
 

--- a/server/utils/artImageOffload.ts
+++ b/server/utils/artImageOffload.ts
@@ -31,93 +31,10 @@
 import path from 'node:path'
 import fs from 'node:fs/promises'
 import { createHash } from 'node:crypto'
-import sharp from 'sharp'
 import prisma from './prisma'
 import { resolveArtImageFilePath } from './artImageFilePath'
+import { resolveOffloadEncoding } from './artImageEncoding'
 import type { EntityArtDb } from './entityArt'
-
-// Matches exportPageBackdropArt.ts and file.get.ts: 82 measured 8.3x smaller
-// than the source PNG with no visible artefacts at card size.
-const WEBP_QUALITY = 82
-
-// Clips are stored verbatim. sharp cannot decode them, and re-encoding a video
-// to WebP would silently turn a clip into a still.
-const VIDEO_TYPES = new Set(['mp4', 'webm', 'mov', 'mkv'])
-
-/*
- * Container types that hold EITHER a still or an animation, so the stored
- * fileType alone cannot decide whether re-encoding is safe.
- *
- * This is not hypothetical. `webp` is both this project's default still format
- * (everything below is transcoded to it) AND what every WAN/LTX video preset
- * whose outputFormat is 'webp' actually emits — buildVideoOutputNodes() sends
- * the decoded frame batch into ComfyUI's SaveAnimatedWEBP, and the relay stamps
- * the ArtImage `fileType: 'webp'`. Since 'webp' is not in VIDEO_TYPES above,
- * such a clip fell into the re-encode branch, and `sharp(buf)` defaults to
- * `pages: 1` — it reads frame 0 and silently discards the rest. The offload
- * then wrote that single frame to the share and nulled imageData, destroying
- * the only animated copy.
- *
- * That is exactly how Scene Animator's first render came back as a static image
- * (2026-09-11): the wan-startup-webp preset is the default for engine 'wan', so
- * every Scene Animator clip took this path. ComfyUI had animated it correctly.
- *
- * Frame count, not extension, is the real question — so ask sharp.
- */
-const MULTI_FRAME_TYPES = new Set(['webp', 'gif'])
-
-/**
- * True when `buffer` holds more than one frame.
- *
- * Deliberately allowed to throw: a buffer whose metadata sharp cannot read is
- * one the re-encode below would fail on anyway, and letting it reach the
- * caller's catch leaves the bytes in the database rather than committing a
- * guess about them to disk.
- */
-async function hasMultipleFrames(buffer: Buffer): Promise<boolean> {
-  const { pages } = await sharp(buffer).metadata()
-  return typeof pages === 'number' && pages > 1
-}
-
-export type OffloadEncoding = {
-  /** Extension the offloaded copy is written under. */
-  extension: string
-  /** Bytes to write — the original whenever they already carry motion. */
-  bytes: Buffer
-  /** True when the bytes were kept as-is rather than transcoded to WebP. */
-  keepVerbatim: boolean
-}
-
-/**
- * Decide how a stored ArtImage's bytes reach the share: transcoded to WebP, or
- * written verbatim because they carry motion that a transcode would destroy.
- *
- * Exported so the destructive half of the offload can be exercised directly —
- * see utils/scripts/verifyAnimatedArtOffload.test.ts.
- */
-export async function resolveOffloadEncoding(
-  storedType: string,
-  original: Buffer,
-): Promise<OffloadEncoding> {
-  const normalized = (storedType || 'png').toLowerCase()
-  const isVideo = VIDEO_TYPES.has(normalized)
-  const isAnimated =
-    !isVideo &&
-    MULTI_FRAME_TYPES.has(normalized) &&
-    (await hasMultipleFrames(original))
-
-  // Anything already carrying motion is stored under its own extension. Only a
-  // genuine still is worth transcoding.
-  if (isVideo || isAnimated) {
-    return { extension: normalized, bytes: original, keepVerbatim: true }
-  }
-
-  return {
-    extension: 'webp',
-    bytes: await sharp(original).webp({ quality: WEBP_QUALITY }).toBuffer(),
-    keepVerbatim: false,
-  }
-}
 
 export type OffloadResult = {
   offloaded: boolean

--- a/utils/scripts/verifyAnimatedArtOffload.test.ts
+++ b/utils/scripts/verifyAnimatedArtOffload.test.ts
@@ -11,9 +11,9 @@
 //      wan-startup-webp, the default for engine 'wan' and therefore for every
 //      Scene Animator job -- through SaveAnimatedWEBP.
 //   2. The relay stamps the resulting ArtImage `fileType: 'webp'`.
-//   3. offloadArtImageBytes() classified clips by extension against a
-//      VIDEO_TYPES set of mp4/webm/mov/mkv. 'webp' is not in it, so an animated
-//      clip was treated as a still and re-encoded.
+//   3. The offload classified clips by extension against a VIDEO_TYPES set of
+//      mp4/webm/mov/mkv. 'webp' is not in it, so an animated clip was treated
+//      as a still and re-encoded.
 //   4. `sharp(buffer)` defaults to `pages: 1`. It decodes frame 0 and silently
 //      discards the rest -- no error, no warning, a much smaller file.
 //   5. The offload then wrote that single frame to the share and nulled
@@ -26,11 +26,15 @@
 // path -- while a true still is still transcoded, which is the reason the
 // re-encode exists at all.
 //
+// Imports server/utils/artImageEncoding.ts rather than artImageOffload.ts on
+// purpose: the latter pulls in prisma at module load, which throws without a
+// DATABASE_URL, and this belongs in the DB-free contract-tests workflow.
+//
 //   npx tsx utils/scripts/verifyAnimatedArtOffload.test.ts
 import assert from 'node:assert/strict'
 import sharp from 'sharp'
 
-import { resolveOffloadEncoding } from '../../server/utils/artImageOffload.js'
+import { resolveOffloadEncoding } from '../../server/utils/artImageEncoding.js'
 
 const WIDTH = 64
 const HEIGHT = 64

--- a/utils/scripts/verifyAnimatedArtOffload.test.ts
+++ b/utils/scripts/verifyAnimatedArtOffload.test.ts
@@ -1,0 +1,170 @@
+// /utils/scripts/verifyAnimatedArtOffload.test.ts
+//
+// The offload must never flatten an animation into a still.
+//
+// WHAT WENT WRONG WITHOUT THIS. Scene Animator's first render (2026-09-11) came
+// back as a motionless image. ComfyUI had animated it correctly -- the WAN TI2V
+// graph sampled 41 frames and SaveAnimatedWEBP wrote a real multi-frame WebP.
+// The frames were destroyed afterwards, inside Kind Robots:
+//
+//   1. buildVideoOutputNodes() saves every 'webp' video preset -- including
+//      wan-startup-webp, the default for engine 'wan' and therefore for every
+//      Scene Animator job -- through SaveAnimatedWEBP.
+//   2. The relay stamps the resulting ArtImage `fileType: 'webp'`.
+//   3. offloadArtImageBytes() classified clips by extension against a
+//      VIDEO_TYPES set of mp4/webm/mov/mkv. 'webp' is not in it, so an animated
+//      clip was treated as a still and re-encoded.
+//   4. `sharp(buffer)` defaults to `pages: 1`. It decodes frame 0 and silently
+//      discards the rest -- no error, no warning, a much smaller file.
+//   5. The offload then wrote that single frame to the share and nulled
+//      imageData, which was the only remaining animated copy.
+//
+// Step 4 is the part worth pinning with real bytes rather than a source regex:
+// it is library behaviour, it is silent, and the whole bug rests on it. These
+// assertions build a genuine 8-frame animated WebP, prove the naive re-encode
+// still flattens it, and prove resolveOffloadEncoding() no longer takes that
+// path -- while a true still is still transcoded, which is the reason the
+// re-encode exists at all.
+//
+//   npx tsx utils/scripts/verifyAnimatedArtOffload.test.ts
+import assert from 'node:assert/strict'
+import sharp from 'sharp'
+
+import { resolveOffloadEncoding } from '../../server/utils/artImageOffload.js'
+
+const WIDTH = 64
+const HEIGHT = 64
+const FRAMES = 8
+
+/** A real multi-frame WebP, the shape SaveAnimatedWEBP emits. */
+async function animatedWebp(): Promise<Buffer> {
+  // Each frame is visibly different so the encoder cannot collapse them.
+  const frames = await Promise.all(
+    Array.from({ length: FRAMES }, (_, frame) =>
+      sharp(
+        Buffer.from(
+          Array.from(
+            { length: WIDTH * HEIGHT * 3 },
+            (_, pixel) => (pixel + frame * 37) % 256,
+          ),
+        ),
+        { raw: { width: WIDTH, height: HEIGHT, channels: 3 } },
+      )
+        .png()
+        .toBuffer(),
+    ),
+  )
+
+  return sharp(frames, { join: { animated: true } })
+    .webp({ quality: 90 })
+    .toBuffer()
+}
+
+async function pageCount(buffer: Buffer): Promise<number> {
+  const { pages } = await sharp(buffer).metadata()
+  return typeof pages === 'number' ? pages : 1
+}
+
+async function run(): Promise<void> {
+  const animated = await animatedWebp()
+
+  assert.equal(
+    await pageCount(animated),
+    FRAMES,
+    'the fixture itself must be animated, or the rest of this test proves nothing',
+  )
+
+  /* -- the library behaviour the bug rested on ------------------------------ */
+
+  const naive = await sharp(animated).webp({ quality: 82 }).toBuffer()
+  assert.equal(
+    await pageCount(naive),
+    1,
+    'sharp(buffer).webp() is expected to keep only the first frame. If this ' +
+      'ever starts preserving animation the guard below is merely redundant, ' +
+      'not wrong -- but do not remove it on that basis alone.',
+  )
+
+  /* -- an animated clip survives the offload -------------------------------- */
+
+  const clip = await resolveOffloadEncoding('webp', animated)
+
+  assert.equal(
+    clip.keepVerbatim,
+    true,
+    'an animated webp must be written verbatim, not transcoded',
+  )
+  assert.equal(clip.extension, 'webp')
+  assert.equal(
+    await pageCount(clip.bytes),
+    FRAMES,
+    'the offloaded copy lost frames -- this is the Scene Animator bug: the ' +
+      'file written to the share is the only copy, because imageData is ' +
+      'nulled immediately afterwards',
+  )
+  assert.ok(
+    clip.bytes.equals(animated),
+    'an animated clip must reach the share byte-for-byte',
+  )
+
+  /* -- animated GIF too, and it keeps its own extension --------------------- */
+
+  const gif = await sharp(animated, { animated: true }).gif().toBuffer()
+  const gifEncoding = await resolveOffloadEncoding('gif', gif)
+
+  assert.equal(gifEncoding.keepVerbatim, true)
+  assert.equal(
+    gifEncoding.extension,
+    'gif',
+    'a verbatim gif must not be filed under a .webp name it is not',
+  )
+  assert.ok(
+    (await pageCount(gifEncoding.bytes)) > 1,
+    'the offloaded gif lost its animation',
+  )
+
+  /* -- a genuine still is still transcoded ---------------------------------- */
+  // The whole point of the re-encode is that stills shrink. A fix that stops
+  // transcoding everything would trade this bug for the storage growth the
+  // offload exists to stop.
+
+  const stillPng = await sharp({
+    create: {
+      width: WIDTH,
+      height: HEIGHT,
+      channels: 3,
+      background: { r: 200, g: 40, b: 90 },
+    },
+  })
+    .png()
+    .toBuffer()
+
+  const still = await resolveOffloadEncoding('png', stillPng)
+  assert.equal(still.keepVerbatim, false, 'a still png must still be transcoded')
+  assert.equal(still.extension, 'webp')
+
+  // A single-frame webp is a still that merely shares a container with clips;
+  // it must not be mistaken for one and skipped.
+  const singleFrameWebp = await sharp(stillPng).webp().toBuffer()
+  const singleFrame = await resolveOffloadEncoding('webp', singleFrameWebp)
+  assert.equal(
+    singleFrame.keepVerbatim,
+    false,
+    'a one-frame webp is a still and must take the transcode path',
+  )
+
+  /* -- video containers are untouched, as before ---------------------------- */
+
+  const fakeMp4 = Buffer.from('not really an mp4, and sharp must never open it')
+  const video = await resolveOffloadEncoding('mp4', fakeMp4)
+  assert.equal(video.keepVerbatim, true)
+  assert.equal(video.extension, 'mp4')
+  assert.ok(video.bytes.equals(fakeMp4))
+
+  console.log(
+    '✅ Animated art survives the offload: multi-frame webp/gif written ' +
+      'verbatim, stills still transcoded, video containers untouched.',
+  )
+}
+
+await run()

--- a/utils/scripts/verifyArtImageOffload.ts
+++ b/utils/scripts/verifyArtImageOffload.ts
@@ -213,6 +213,36 @@ check(
     `proof-carrying job.`,
 )
 
+/* -- 5b. the transcode may not decide by extension alone -------------------- */
+//
+// 'webp' is both the still format everything is transcoded INTO and the
+// container ComfyUI's SaveAnimatedWEBP writes every 'webp' video preset into
+// (wan-startup-webp, the default for engine 'wan', is what every Scene
+// Animator job uses). So an extension-keyed clip check cannot tell a still
+// from a clip, and `sharp(buffer)` defaults to `pages: 1` -- it keeps frame 0
+// and silently drops the rest. On 2026-09-11 that flattened Scene Animator's
+// first render to a still and then nulled the only animated copy.
+//
+// The behavioural proof lives in verifyAnimatedArtOffload.test.ts; this pins
+// that the helper still asks about frames at all.
+
+check(
+  /\bpages\b/.test(helper) && /\.metadata\s*\(/.test(helper),
+  `${HELPER} must read sharp metadata's \`pages\` before transcoding. ` +
+    `Classifying clips by file extension alone cannot see an animated WebP ` +
+    `or GIF, and sharp then re-encodes frame 0 and discards the rest — ` +
+    `silently, and after the read-back guard has already approved the write.`,
+)
+
+const metadataIndex = helper.search(/\.metadata\s*\(/)
+const encodeIndex = helper.search(/\.webp\s*\(\s*\{\s*quality/)
+
+check(
+  metadataIndex !== -1 && encodeIndex !== -1 && metadataIndex < encodeIndex,
+  `${HELPER} must inspect the frame count BEFORE re-encoding. Checking after ` +
+    `the transcode inspects the flattened copy, which always reports one page.`,
+)
+
 /* -- 6. no route writes a bare filename into imagePath ---------------------- */
 
 for (const route of [...GENERATE_ROUTES, 'server/api/art/save-generated.post.ts']) {

--- a/utils/scripts/verifyArtImageOffload.ts
+++ b/utils/scripts/verifyArtImageOffload.ts
@@ -35,6 +35,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 const HELPER = 'server/utils/artImageOffload.ts'
+const ENCODING = 'server/utils/artImageEncoding.ts'
 const COMPLETE = 'server/api/art/queue/[id]/complete.post.ts'
 const BACKFILL = 'utils/scripts/offloadArtImageData.ts'
 const PLACEMENT = 'server/utils/artImageFilePath.ts'
@@ -226,21 +227,37 @@ check(
 // The behavioural proof lives in verifyAnimatedArtOffload.test.ts; this pins
 // that the helper still asks about frames at all.
 
+const encoding = read(ENCODING)
+
 check(
-  /\bpages\b/.test(helper) && /\.metadata\s*\(/.test(helper),
-  `${HELPER} must read sharp metadata's \`pages\` before transcoding. ` +
+  /resolveOffloadEncoding\s*\(/.test(helper),
+  `${HELPER} must resolve its bytes through resolveOffloadEncoding in ` +
+    `${ENCODING}. Re-encoding inline here puts the destructive decision behind ` +
+    `a prisma import, where the DB-free contract workflow cannot test it.`,
+)
+
+check(
+  !/\bsharp\b/.test(helper),
+  `${HELPER} must not transcode directly — that belongs in ${ENCODING}, which ` +
+    `imports no database and can therefore be exercised with real bytes.`,
+)
+
+check(
+  /\bpages\b/.test(encoding) && /\.metadata\s*\(/.test(encoding),
+  `${ENCODING} must read sharp metadata's \`pages\` before transcoding. ` +
     `Classifying clips by file extension alone cannot see an animated WebP ` +
     `or GIF, and sharp then re-encodes frame 0 and discards the rest — ` +
     `silently, and after the read-back guard has already approved the write.`,
 )
 
-const metadataIndex = helper.search(/\.metadata\s*\(/)
-const encodeIndex = helper.search(/\.webp\s*\(\s*\{\s*quality/)
+const metadataIndex = encoding.search(/\.metadata\s*\(/)
+const encodeIndex = encoding.search(/\.webp\s*\(\s*\{\s*quality/)
 
 check(
   metadataIndex !== -1 && encodeIndex !== -1 && metadataIndex < encodeIndex,
-  `${HELPER} must inspect the frame count BEFORE re-encoding. Checking after ` +
-    `the transcode inspects the flattened copy, which always reports one page.`,
+  `${ENCODING} must inspect the frame count BEFORE re-encoding. Checking ` +
+    `after the transcode inspects the flattened copy, which always reports ` +
+    `one page.`,
 )
 
 /* -- 6. no route writes a bare filename into imagePath ---------------------- */


### PR DESCRIPTION
Scene Animator's first render came back motionless (Silas, 2026-09-11: *"it didn't make any actual animation, just returned a static image"*).

It was not the loop request, and not ComfyUI. The render was correct end to end — the frames were destroyed afterwards, here.

## The chain

1. Engine `wan` defaults to the `wan-startup-webp` preset, so **every** Scene Animator job has `outputFormat: 'webp'`.
2. `buildVideoOutputNodes()` saves that through ComfyUI's `SaveAnimatedWEBP`, which emits a genuine multi-frame WebP. (That day's `comfyui.err.log` shows WanVAE + WAN22 TI2V-5B loading and a 20-step sample — the animation being made.)
3. The relay downloads it and stamps the ArtImage `fileType: 'webp'`.
4. `offloadArtImageBytes()` classified clips by extension against `VIDEO_TYPES = {mp4, webm, mov, mkv}`. `'webp'` is not in that set — it is also this project's default **still** format — so an animated clip took the transcode branch.
5. `sharp(buffer)` defaults to `pages: 1`. It decodes frame 0 and silently discards the rest.
6. The offload wrote that single frame to the share and nulled `imageData`, which was the only animated copy left.

Measured on an 8-frame fixture: **7390 bytes / 8 pages in → 652 bytes / 1 page out**, no error raised.

## The fix

`resolveOffloadEncoding()` (extracted from `offloadArtImageBytes` so the destructive decision can be tested directly) asks sharp for the frame count instead of guessing from the extension:

- a `webp`/`gif` with `pages > 1` is written **verbatim** under its own extension and keeps its stored `fileType`
- a genuine still — including a one-frame webp — transcodes exactly as before, so the storage growth the offload exists to stop is unaffected
- video containers are untouched

No UI change was needed: `pages/admin/scene-animator.vue` already branches `<video>` vs `<img>`, and animated WebP plays in an `<img>`. It was faithfully displaying a flattened file.

## Verification

- `utils/scripts/verifyAnimatedArtOffload.test.ts` (new, wired into `contract-tests.yml`) builds a real animated WebP and asserts the frames survive. **Confirmed to fail against the pre-fix classification** and pass after.
- `verifyArtImageOffload.ts` gains a source contract that the helper reads `metadata().pages` *before* re-encoding.
- `npm run test` (vue-tsc): 0 errors. `npx eslint` on the changed files: clean. Both offload contract tests pass.

## Not fixed, deliberately

`relay_agent.py`'s `encode_webp()` has the same shape (PIL save without `save_all=True`), but it is only reached for `media.is_video == False`, so no clip passes through it today. Noted in the roadmap entry rather than widened into this PR.

Companion: the "ComfyUI is listed as down while it is rendering" half of the same report is fixed in silasfelinus/conductor (relay probe classification). Tracked as `scene-animator/t-008`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNe7H71sq22FA6W9kqKc5R

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNe7H71sq22FA6W9kqKc5R)_