### PR TITLE
interface-vision/t-104 slice 235: name kr-text-black-base, migrate 53 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -2205,6 +2205,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply font-black text-2xl;
   }
 
+  /* Sixth sibling in the `kr-text-black-*` family -- `font-black text-base`
+   * (interface-vision t-104 slice 235), the one Tailwind text size the
+   * family had not yet named (`-lg`/`-xl`/`-sm`/`-xs`/`-2xl` were all
+   * claimed; `text-base` is Tailwind's own name for its default size, so
+   * `-base` rather than inventing `-md`). A fresh full-repo class-frequency
+   * survey after slice 234 found this shape at 53 subset-match occurrences
+   * across 40 files -- mostly panel/card sub-headings (`<h2>`/`<h3>`, often
+   * paired with `truncate` on gallery card titles). Same
+   * subset-match/--exact-only codemod convention as every other
+   * `kr-text-black-*` sibling. */
+  .kr-text-black-base {
+    @apply font-black text-base;
+  }
+
   /* `font-black uppercase` eyebrow/label text (interface-vision t-104 slice
    * 167) -- a fresh full-repo class-frequency survey once both the
    * `kr-text-black-*` and `kr-text-dim-*` families closed out found this

--- a/components/academy/academy-remix.vue
+++ b/components/academy/academy-remix.vue
@@ -6,7 +6,7 @@
     >
       <div class="flex flex-col gap-1">
         <h2
-          class="flex items-center gap-2 text-base font-black text-base-content"
+          class="kr-text-black-base flex items-center gap-2 text-base-content"
         >
           <Icon name="kind-icon:magic" class="kr-icon-primary-5" />
           Remix Studio

--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -257,7 +257,7 @@
                 </div>
               </div>
               <div class="flex min-w-0 flex-col justify-center p-3">
-                <p class="text-base font-black leading-tight text-base-content">
+                <p class="kr-text-black-base leading-tight text-base-content">
                   {{ artist.name }}
                 </p>
                 <p class="mt-0.5 text-xs font-semibold text-primary/80">{{ artist.years }}</p>

--- a/components/academy/academy-styles-browser.vue
+++ b/components/academy/academy-styles-browser.vue
@@ -144,7 +144,7 @@
         </div>
 
         <div class="absolute inset-x-0 bottom-0 p-3 sm:p-4">
-          <p class="text-base font-black leading-tight text-white drop-shadow sm:text-lg">
+          <p class="kr-text-black-base leading-tight text-white drop-shadow sm:text-lg">
             {{ style.name }}
           </p>
           <p class="mt-1 truncate text-[0.68rem] font-semibold text-white/65">{{ style.region }}</p>

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -9,7 +9,7 @@
     >
       <div class="flex items-center gap-2">
         <Icon name="kind-icon:gallery" class="kr-icon-primary-5 shrink-0" />
-        <h2 class="min-w-0 truncate text-base font-black text-base-content">
+        <h2 class="kr-text-black-base min-w-0 truncate text-base-content">
           {{ activeGroup ? activeGroup.title : 'Gallery' }}
         </h2>
         <p

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -24,7 +24,7 @@
           <div class="flex w-full shrink-0 flex-col gap-2 lg:w-80">
             <button
               type="button"
-              class="btn btn-primary min-h-12 w-full rounded-2xl text-base font-black"
+              class="kr-text-black-base btn btn-primary min-h-12 w-full rounded-2xl"
               :class="canGenerate ? 'shadow-lg shadow-primary/25' : ''"
               :disabled="!canGenerate"
               @click="handleGenerate"

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -194,7 +194,7 @@
           <section class="kr-panel-muted-sm">
             <div class="mb-3 flex items-center justify-between gap-2">
               <div class="min-w-0">
-                <h2 class="truncate text-base font-black text-base-content">
+                <h2 class="kr-text-black-base truncate text-base-content">
                   Quick Edit
                 </h2>
                 <p class="kr-text-dim-xs-55 truncate">
@@ -343,7 +343,7 @@
             <div class="relative kr-panel-muted-sm">
               <div class="mb-2 flex items-center justify-between gap-2">
                 <div class="min-w-0">
-                  <h2 class="truncate text-base font-black text-base-content">
+                  <h2 class="kr-text-black-base truncate text-base-content">
                     Collections
                   </h2>
                   <p class="kr-text-dim-xs-55 truncate">
@@ -454,7 +454,7 @@
             <div class="rounded-2xl border border-primary/30 bg-primary/10 p-3">
               <div class="mb-2 flex items-center justify-between gap-2">
                 <div class="min-w-0">
-                  <h2 class="truncate text-base font-black text-primary">
+                  <h2 class="kr-text-black-base truncate text-primary">
                     Remix
                   </h2>
                   <p class="kr-text-dim-xs-60 truncate">

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -4,7 +4,7 @@
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-2">
         <Icon name="kind-icon:magic" class="kr-icon-primary-5" />
-        <h2 class="text-base font-black text-base-content">Style Transfer</h2>
+        <h2 class="kr-text-black-base text-base-content">Style Transfer</h2>
         <span class="kr-badge-primary-sm">Kontext</span>
       </div>
       <button

--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -120,7 +120,7 @@
       <div class="min-w-0">
         <div class="flex flex-wrap items-start justify-between gap-2">
           <div class="min-w-0 flex-1">
-            <h3 class="truncate text-base font-black" :title="jobTitle">
+            <h3 class="kr-text-black-base truncate" :title="jobTitle">
               {{ jobTitle }}
             </h3>
             <p

--- a/components/art/collection-card.vue
+++ b/components/art/collection-card.vue
@@ -124,7 +124,7 @@
     >
       <div class="min-w-0">
         <h2
-          class="font-black leading-tight text-base-content text-base"
+          class="kr-text-black-base leading-tight text-base-content"
           :title="collectionLabel"
         >
           {{ collectionLabel }}

--- a/components/art/stylist-calculator.vue
+++ b/components/art/stylist-calculator.vue
@@ -8,7 +8,7 @@
   <section class="flex flex-col gap-4 kr-panel-muted-md">
     <header class="flex items-center gap-2">
       <Icon name="kind-icon:sparkles" class="kr-icon-primary-5" />
-      <h2 class="text-base font-black text-base-content">New Appointment</h2>
+      <h2 class="kr-text-black-base text-base-content">New Appointment</h2>
     </header>
 
     <div class="grid gap-3 sm:grid-cols-2">

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -3,7 +3,7 @@
   <section class="stylist-clients kr-panel-muted flex flex-col gap-4 p-4">
     <header class="flex items-center gap-2">
       <Icon name="kind-icon:heart" class="kr-icon-primary-5" />
-      <h2 class="text-base font-black text-base-content">Clients</h2>
+      <h2 class="kr-text-black-base text-base-content">Clients</h2>
       <span class="kr-badge-ghost-sm">{{ superkate.sortedCustomers.length }}</span>
     </header>
 

--- a/components/art/stylist-history.vue
+++ b/components/art/stylist-history.vue
@@ -7,7 +7,7 @@
   <section class="flex flex-col gap-4 kr-panel-muted-md">
     <header class="flex items-center gap-2">
       <Icon name="kind-icon:book" class="kr-icon-primary-5" />
-      <h2 class="text-base font-black text-base-content">Appointments</h2>
+      <h2 class="kr-text-black-base text-base-content">Appointments</h2>
       <span class="kr-badge-ghost-sm">{{ results.length }}</span>
     </header>
 
@@ -52,7 +52,7 @@
               {{ formatCents(appointment.productCostCents) }}
             </span>
           </div>
-          <span class="text-base font-black text-primary">
+          <span class="kr-text-black-base text-primary">
             {{ formatCents(appointment.totalCents) }}
           </span>
           <button

--- a/components/art/stylist-restyle.vue
+++ b/components/art/stylist-restyle.vue
@@ -14,7 +14,7 @@
   <section class="flex flex-col gap-4 kr-panel-muted-md">
     <header class="flex items-center gap-2">
       <Icon name="kind-icon:magic" class="kr-icon-primary-5" />
-      <h2 class="text-base font-black text-base-content">Hair Studio</h2>
+      <h2 class="kr-text-black-base text-base-content">Hair Studio</h2>
       <span class="kr-badge-primary-sm">Kontext</span>
       <span class="kr-badge-ghost-sm">Private</span>
       <div class="flex-1" />

--- a/components/art/stylist-settings.vue
+++ b/components/art/stylist-settings.vue
@@ -8,7 +8,7 @@
   <section class="flex flex-col gap-4 kr-panel-muted-md">
     <header class="flex items-center gap-2">
       <Icon name="kind-icon:adjust" class="kr-icon-primary-5" />
-      <h2 class="text-base font-black text-base-content">Receipt Settings</h2>
+      <h2 class="kr-text-black-base text-base-content">Receipt Settings</h2>
     </header>
 
     <div class="grid gap-3 sm:grid-cols-2">

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -61,7 +61,7 @@
     >
       <div class="mb-3 flex items-center justify-between gap-3">
         <div class="min-w-0">
-          <h3 class="truncate text-base font-black text-primary">
+          <h3 class="kr-text-black-base truncate text-primary">
             {{ formTitle }}
           </h3>
 
@@ -245,7 +245,7 @@
               <div class="min-w-0">
                 <p class="kr-text-eyebrow-bold kr-text-dim-xs">Current Bot</p>
 
-                <h3 class="truncate text-base font-black text-base-content">
+                <h3 class="kr-text-black-base truncate text-base-content">
                   {{ selectedBotTitle }}
                 </h3>
 

--- a/components/characters/character-gallery.vue
+++ b/components/characters/character-gallery.vue
@@ -9,7 +9,7 @@
     >
       <div class="mb-3 flex items-center justify-between gap-3">
         <div class="min-w-0">
-          <h3 class="truncate text-base font-black text-primary">
+          <h3 class="kr-text-black-base truncate text-primary">
             {{ formTitle }}
           </h3>
 
@@ -153,7 +153,7 @@
                   Current Character
                 </p>
 
-                <h3 class="truncate text-base font-black text-base-content">
+                <h3 class="kr-text-black-base truncate text-base-content">
                   {{ selectedCharacterTitle }}
                 </h3>
 

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -7,7 +7,7 @@
       >
         <div class="flex flex-col gap-1">
           <h2
-            class="flex items-center gap-2 text-base font-black text-base-content"
+            class="kr-text-black-base flex items-center gap-2 text-base-content"
           >
             <Icon name="kind-icon:paintbrush" class="kr-icon-primary-5" />
             Coloring Book

--- a/components/conductor/newsfeed-page.vue
+++ b/components/conductor/newsfeed-page.vue
@@ -3,7 +3,7 @@
   <project-front-page class="kr-surface" slug="newsfeed" :fallback="config">
     <template #interactive>
       <section class="kr-panel-section">
-        <h2 class="mb-4 text-base font-black text-base-content">Live feed</h2>
+        <h2 class="kr-text-black-base mb-4 text-base-content">Live feed</h2>
         <NewsfeedFeed />
       </section>
     </template>

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -20,7 +20,7 @@
           <Icon name="kind-icon:box" class="size-5" />
         </span>
         <div>
-          <h3 class="text-base font-black text-base-content">Pack Generator</h3>
+          <h3 class="kr-text-black-base text-base-content">Pack Generator</h3>
           <p class="kr-text-dim-xs font-semibold">
             Admin only — items are created private until release is approved
           </p>

--- a/components/conductor/project-front-page.vue
+++ b/components/conductor/project-front-page.vue
@@ -142,7 +142,7 @@
             >
               <Icon :name="block.icon || 'kind-icon:sparkles'" class="size-5" />
             </span>
-            <h3 class="text-base font-black text-base-content">
+            <h3 class="kr-text-black-base text-base-content">
               {{ block.title }}
             </h3>
           </div>

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -327,7 +327,7 @@
                   Current Dream
                 </p>
 
-                <h3 class="truncate text-base font-black text-base-content">
+                <h3 class="kr-text-black-base truncate text-base-content">
                   {{ selectedDreamTitle }}
                 </h3>
 

--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -214,7 +214,7 @@
     <div v-else class="flex items-start justify-between gap-2">
       <div class="min-w-0">
         <h2
-          class="line-clamp-2 text-base font-black leading-tight text-base-content"
+          class="kr-text-black-base line-clamp-2 leading-tight text-base-content"
           :title="title"
         >
           {{ title }}

--- a/components/model-builder/model-builder-progress-matrix.vue
+++ b/components/model-builder/model-builder-progress-matrix.vue
@@ -3,7 +3,7 @@
   <div class="flex min-h-0 flex-1 flex-col gap-3">
     <div class="flex items-start justify-between gap-2">
       <div>
-        <h3 class="text-base font-black text-base-content">3. Build run</h3>
+        <h3 class="kr-text-black-base text-base-content">3. Build run</h3>
         <p class="kr-text-dim-xs-60 mt-1">
           <span class="font-bold text-base-content">{{
             run?.sourceLabel

--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -3,7 +3,7 @@
   <div class="flex min-h-0 flex-1 flex-col gap-3">
     <div class="flex items-start justify-between gap-2">
       <div>
-        <h3 class="text-base font-black text-base-content">
+        <h3 class="kr-text-black-base text-base-content">
           2. Choose a recipe &amp; outputs
         </h3>
         <p class="kr-text-dim-xs-60 mt-1">

--- a/components/model-builder/model-builder-run-history.vue
+++ b/components/model-builder/model-builder-run-history.vue
@@ -3,7 +3,7 @@
   <div class="flex min-h-0 flex-1 flex-col gap-3">
     <div class="flex items-start justify-between gap-2">
       <div>
-        <h3 class="text-base font-black text-base-content">Run history</h3>
+        <h3 class="kr-text-black-base text-base-content">Run history</h3>
         <p class="kr-text-dim-xs-60 mt-1">
           Your recent Model Builder runs. Reopen one to keep working, or cancel
           what you no longer need.

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -3,7 +3,7 @@
   <div class="flex min-h-0 flex-1 flex-col gap-3">
     <div class="flex items-start justify-between gap-2">
       <div>
-        <h3 class="text-base font-black text-base-content">1. Pick a source model</h3>
+        <h3 class="kr-text-black-base text-base-content">1. Pick a source model</h3>
         <p class="kr-text-dim-xs-60 mt-1">
           Choose the existing record to upgrade or expand from. Every run keeps a
           snapshot of this source.

--- a/components/navigation/navigation-trimmed.vue
+++ b/components/navigation/navigation-trimmed.vue
@@ -52,7 +52,7 @@
           <Icon :name="channel.icon" class="kr-icon-5" />
         </span>
         <div class="flex min-w-0 flex-col leading-tight">
-          <h3 class="truncate text-base font-black">{{ channel.label }}</h3>
+          <h3 class="kr-text-black-base truncate">{{ channel.label }}</h3>
           <p
             v-if="channel.summary || channel.description"
             class="kr-text-dim-xs-55 line-clamp-1"

--- a/components/navigation/tutorial-flyer.vue
+++ b/components/navigation/tutorial-flyer.vue
@@ -48,7 +48,7 @@
       <div class="flex min-w-0 flex-1 flex-col gap-1.5">
         <div class="flex flex-wrap items-center gap-2">
           <h3
-            class="text-base font-black leading-tight text-base-content md:text-lg"
+            class="kr-text-black-base leading-tight text-base-content md:text-lg"
           >
             {{ section.title }}
           </h3>
@@ -207,7 +207,7 @@
                 <div class="min-w-0 flex-1">
                   <div class="flex flex-wrap items-center gap-2">
                     <h3
-                      class="text-base font-black leading-tight text-base-content"
+                      class="kr-text-black-base leading-tight text-base-content"
                     >
                       {{ section.title }}
                     </h3>

--- a/components/navigation/workspace-narrator.vue
+++ b/components/navigation/workspace-narrator.vue
@@ -207,7 +207,7 @@
                     @click="closeChatFace"
                   >
                     <p
-                      class="truncate text-base font-black leading-tight text-base-content"
+                      class="kr-text-black-base truncate leading-tight text-base-content"
                     >
                       {{ narratorName }}
                     </p>

--- a/components/navigation/workspace-sheet.vue
+++ b/components/navigation/workspace-sheet.vue
@@ -310,7 +310,7 @@
           class="mx-auto h-12 w-12 text-base-content/25"
         />
 
-        <p class="mt-3 text-base font-black text-base-content/65">
+        <p class="kr-text-black-base mt-3 text-base-content/65">
           No completed cards yet.
         </p>
 

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -154,7 +154,7 @@
                     >
                       {{ gate.project.name }} · {{ gate.task.id }}
                     </button>
-                    <h3 class="mt-1 text-base font-black leading-snug">
+                    <h3 class="kr-text-black-base mt-1 leading-snug">
                       {{ gate.task.title }}
                     </h3>
                   </div>
@@ -347,7 +347,7 @@
                       {{ pitch.projectTarget || 'General' }}
                       <span v-if="pitch.date"> · {{ pitch.date }}</span>
                     </p>
-                    <h3 class="mt-1 text-base font-black leading-snug">
+                    <h3 class="kr-text-black-base mt-1 leading-snug">
                       {{ pitch.title }}
                     </h3>
                   </div>

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -514,7 +514,7 @@
                   >
                     Quest briefing
                   </p>
-                  <p class="text-base font-black">Check the map before departure</p>
+                  <p class="kr-text-black-base">Check the map before departure</p>
                 </div>
               </div>
               <dl class="mt-4 space-y-3 text-sm">

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -78,7 +78,7 @@
     >
       <div class="mb-3 flex items-center justify-between gap-3">
         <div class="min-w-0">
-          <h3 class="truncate text-base font-black text-primary">
+          <h3 class="kr-text-black-base truncate text-primary">
             {{ formTitle }}
           </h3>
 
@@ -214,7 +214,7 @@
                   Current Reward
                 </p>
 
-                <h3 class="truncate text-base font-black text-base-content">
+                <h3 class="kr-text-black-base truncate text-base-content">
                   {{ selectedRewardTitle }}
                 </h3>
 

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -7,7 +7,7 @@
     >
       <div class="flex items-center justify-between gap-3">
         <div class="min-w-0">
-          <h2 class="truncate text-base font-black text-base-content">
+          <h2 class="kr-text-black-base truncate text-base-content">
             {{ title }}
           </h2>
 
@@ -50,7 +50,7 @@
       class="min-h-0 shrink-0 overflow-y-auto rounded-2xl border border-primary/30 bg-base-100 p-3 shadow-md"
     >
       <div class="mb-3 flex items-center justify-between gap-3">
-        <h3 class="truncate text-base font-black text-primary">
+        <h3 class="kr-text-black-base truncate text-primary">
           {{ formMode === 'edit' ? 'Edit Scenario' : 'Add Scenario' }}
         </h3>
 
@@ -217,7 +217,7 @@
         <section v-if="showSelectedCharacterCards" class="kr-panel-flat p-3">
           <div class="mb-3 flex items-center justify-between gap-3">
             <div class="min-w-0">
-              <h3 class="truncate text-base font-black text-base-content">
+              <h3 class="kr-text-black-base truncate text-base-content">
                 {{ selectedScenarioTitle }} Cast
               </h3>
 
@@ -366,7 +366,7 @@
         <section v-if="showSelectedCharacterCards" class="kr-panel-flat p-3">
           <div class="mb-3 flex flex-wrap items-center justify-between gap-3">
             <div class="min-w-0">
-              <h3 class="truncate text-base font-black text-base-content">
+              <h3 class="kr-text-black-base truncate text-base-content">
                 {{ selectedScenarioTitle }} Cast
               </h3>
 

--- a/components/scenarios/scenario-relationship-gallery.vue
+++ b/components/scenarios/scenario-relationship-gallery.vue
@@ -63,7 +63,7 @@
       class="shrink-0 rounded-2xl border border-primary/30 bg-base-100 p-3 shadow-md"
     >
       <div class="mb-3 flex items-center justify-between gap-3">
-        <h3 class="truncate text-base font-black text-primary">
+        <h3 class="kr-text-black-base truncate text-primary">
           {{ formMode === 'edit' ? 'Edit Scenario' : 'Add Scenario' }}
         </h3>
 

--- a/components/storybook/storybook-life-run.vue
+++ b/components/storybook/storybook-life-run.vue
@@ -295,7 +295,7 @@
               v-else-if="currentChapter"
               class="flex flex-col gap-3 kr-panel-tint-md"
             >
-              <h4 v-if="currentChapter.title" class="text-base font-black">
+              <h4 v-if="currentChapter.title" class="kr-text-black-base">
                 {{ currentChapter.title }}
               </h4>
               <NarrativeArtStatus

--- a/components/taskmaster/taskmaster-sample-tasks.vue
+++ b/components/taskmaster/taskmaster-sample-tasks.vue
@@ -12,7 +12,7 @@
         >
           Serendipity's sparks
         </p>
-        <h3 id="taskmaster-samples-heading" class="mt-1 text-base font-black">
+        <h3 id="taskmaster-samples-heading" class="kr-text-black-base mt-1">
           Borrow a beginning
         </h3>
         <p class="kr-text-dim-xs-55 mt-1 leading-relaxed">

--- a/components/themes/theme-gallery.vue
+++ b/components/themes/theme-gallery.vue
@@ -315,7 +315,7 @@
                   class="h-10 w-10 text-secondary"
                 />
 
-                <p class="mt-2 text-base font-black">No shared themes found.</p>
+                <p class="kr-text-black-base mt-2">No shared themes found.</p>
 
                 <p class="mt-1 max-w-md text-sm">
                   Either the goblin published nothing, or your search is too

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -120,7 +120,7 @@
             <div class="min-w-0 flex-1">
               <div class="flex items-start justify-between gap-3">
                 <div class="min-w-0">
-                  <h3 class="truncate text-base font-black text-base-content">
+                  <h3 class="kr-text-black-base truncate text-base-content">
                     {{ thread.otherLabel }}
                   </h3>
                   <p
@@ -180,7 +180,7 @@
     <section v-else class="kr-stage kr-panel-flat">
       <div class="flex shrink-0 items-center gap-3 kr-panel-header-muted">
         <div
-          class="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-primary/15 text-base font-black text-primary"
+          class="kr-text-black-base flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-primary/15 text-primary"
         >
           <img
             v-if="activeThread.otherAvatar"
@@ -193,7 +193,7 @@
         </div>
 
         <div class="min-w-0">
-          <h3 class="truncate text-base font-black text-base-content">
+          <h3 class="kr-text-black-base truncate text-base-content">
             {{ activeThread.otherLabel }}
           </h3>
           <p class="kr-text-dim-xs truncate">

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -5,7 +5,7 @@
       <Icon name="kind-icon:sparkles" class="kr-icon-primary-5 shrink-0" />
 
       <div class="min-w-0 flex-1">
-        <p class="truncate text-base font-black text-base-content">
+        <p class="kr-text-black-base truncate text-base-content">
           {{ welcomeMessage }}
         </p>
         <p class="kr-text-dim-xs-55">

--- a/utils/scripts/codemods/kr_text_black_base_codemod.py
+++ b/utils/scripts/codemods/kr_text_black_base_codemod.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `font-black text-base` heading-emphasis text to
+`kr-text-black-base`.
+
+Sixth sibling of kr_text_black_{lg,xl,sm,xs,2xl}_codemod.py, naming the one
+Tailwind text size the `kr-text-black-*` family had not yet claimed
+(interface-vision t-104 slice 235): dry-run by default, --write to update
+matching Vue files in place. Only the exact `font-black text-base` shape is
+touched, and only in static `class="..."` attributes -- never
+`:class`/`v-bind:class` bindings, and regardless of the base tokens' order
+in the source. A source that already carries `kr-text-black-base`, or is
+missing either base token, is left untouched. Extra tokens beyond the base
+set (e.g. `truncate`, `text-base-content`) are preserved verbatim after the
+primitive class, matching the kr-text-black-{lg,xl,sm,xs,2xl} codemods'
+subset-match convention -- pass --exact-only to restrict a slice to sources
+with no extra tokens at all, the safest and most literal pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-text-black-base"
+BASE_TOKENS = {"font-black", "text-base"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-black-base {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: recurring kr-* front-end consistency sweep, slice 235 (kind: software)

### What changed / what I produced
- A fresh full-repo class-frequency survey (the kaizen note left by slice 234) found `font-black text-base` — the one Tailwind text size the existing `kr-text-black-*` family (`-lg`/`-xl`/`-sm`/`-xs`/`-2xl`) had not yet named — at 53 subset-match occurrences across 40 files, mostly panel/card sub-headings (`<h2>`/`<h3>`, often paired with `truncate` on gallery card titles).
- Added `.kr-text-black-base { @apply font-black text-base; }` to `assets/css/tailwind.css`'s existing family, named after Tailwind's own `text-base` token (matching the family's convention of naming after the Tailwind size, not inventing `-md`).
- New codemod `utils/scripts/codemods/kr_text_black_base_codemod.py`, modeled directly on `kr_text_black_sm_codemod.py`: subset-match, static `class="..."` attributes only (never `:class` bindings, via the shared `_class_attr.CLASS_ATTR` guard), preserves extra tokens (`truncate`, `text-base-content`, `text-primary`, `md:text-lg`, etc.) verbatim after the primitive.
- Ran `--write`: 53 occurrences migrated across 41 files (one file, `scenario-gallery.vue`, had 4 occurrences).

### How I verified
- `npm run test` (vue-tsc): 0 errors.
- `npx eslint` on all 41 changed `.vue` files: 10 pre-existing errors reported (dynamic-delete, unused-vars, unified-signatures, empty-block) in lines this diff never touches — confirmed identical via `git stash` against the pre-change tree, so nothing new.
- Manually reviewed every diff hunk: extra tokens (including responsive variants like `md:text-lg`) preserved verbatim, no color/behavior/geometry change — this is a pure class-name rename.
- Grepped for any remaining `font-black`/`text-base` combos to confirm no false positives or missed matches; the survey count (53/40 files) matched the codemod's dry-run output exactly.

### Stakes
reversible

### Kaizen suggestion
The `kr-text-black-*` family now covers `-xs`/`-sm`/`-base`/`-lg`/`-xl`/`-2xl` — every Tailwind text size from `xs` to `2xl`. Next slice: a fresh full-repo class-frequency survey outside all closed families (`kr-container`/`kr-icon-*`/`kr-img-cover`/`kr-input-*`/`kr-select-*`/`kr-checkbox-*`/`kr-textarea-*`/`kr-panel*`/`kr-text-black-*`/`kr-text-dim-*`/`kr-text-bold-*`/`kr-text-eyebrow*`/`kr-text-faded-*`/`kr-label-*`/`kr-btn-ghost-*`/`kr-note*`) to find the next target — a first pass on this run surfaced `btn`/`badge`/`input-bordered` combos (e.g. `btn btn-primary btn-sm rounded-2xl`, `badge badge-sm rounded-xl`) as promising candidates worth a closer look.

### Notes for reviewer
Roadmap task `interface-vision/t-104` closed via `close_task.py` in the companion conductor PR (this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ef7HZrgHMK75E7pfarRe9T

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ef7HZrgHMK75E7pfarRe9T)_