### PR TITLE
feat(scene-animator): re-render a finished scene from the admin surface

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Animated art offload contract
         run: npm run test:animated-art-offload
 
+      - name: Scene Animator resubmit contract
+        run: npm run test:scene-animator-resubmit
+
       - name: ESLint ratchet
         run: npm run test:lint-ratchet
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "audit:fitness": "tsx utils/scripts/auditObjectFitness.ts",
     "test:migrate-on-deploy": "tsx utils/scripts/verifyMigrateOnDeploy.ts",
     "test:scene-animator-health": "tsx utils/scripts/verifySceneAnimatorHealth.test.ts",
+    "test:scene-animator-resubmit": "tsx utils/scripts/verifySceneAnimatorResubmit.test.ts",
     "test:facet-aliases": "tsx utils/scripts/verifyFacetAliases.ts",
     "audit:art-coverage": "tsx utils/scripts/auditEntityArtCoverage.ts",
     "test:facet-content": "tsx utils/scripts/verifyFacetContentQuality.ts",

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -308,6 +308,22 @@
                     <span v-if="store.retryingSource === source.name" class="kr-spinner-xs" />
                     Retry this scene
                   </button>
+                  <!--
+                    A finished scene is skipped by the dedupe, so this is the
+                    only way to ask for it again — needed whenever the clip that
+                    came back is not the clip you wanted.
+                  -->
+                  <button
+                    v-else-if="source.status === 'done'"
+                    type="button"
+                    class="btn btn-outline btn-xs w-full rounded-lg"
+                    :disabled="store.queueing"
+                    :title="`Discard this result and render ${source.name} again`"
+                    @click="store.rerenderSource(source.name)"
+                  >
+                    <span v-if="store.retryingSource === source.name" class="kr-spinner-xs" />
+                    Re-render this scene
+                  </button>
                 </div>
               </article>
             </div>

--- a/server/api/scene-animator/enqueue.post.ts
+++ b/server/api/scene-animator/enqueue.post.ts
@@ -31,6 +31,19 @@ type SceneAnimatorEnqueueRequest = {
   // the folder." Exact filename match against listSceneAnimatorSourceFiles;
   // anything else falls through to the normal empty-queue response.
   sourceFile?: string | null
+  // Re-render a source whose latest job already finished.
+  //
+  // Without this there is NO way to ask for a finished scene again: DONE is a
+  // reusable status, so the dedupe skips it before `retryFailed` is ever
+  // consulted, and retryFailed therefore only ever rescues FAILED/CANCELLED.
+  // That is fine while a finished render is by definition the render you
+  // wanted, and wrong the moment it isn't -- the 2026-09-11 offload bug left
+  // every completed Scene Animator clip as a flattened still, DONE and
+  // unreachable from the admin surface (Silas: "We should be able to resubmit
+  // from the scene-animator window").
+  //
+  // Deliberately does NOT override an ACTIVE job: see isActiveStatus below.
+  force?: boolean | null
 }
 
 type EnqueueResponse = {
@@ -72,6 +85,19 @@ function isReusableStatus(status: string): boolean {
   return status === 'PENDING' || status === 'RUNNING' || status === 'DONE'
 }
 
+/**
+ * Queued or mid-render, and therefore never worth a second job.
+ *
+ * This is the half of isReusableStatus that `force` must still respect. The
+ * relay renders one job at a time on a single GPU, so duplicating an in-flight
+ * render does not produce a result any sooner -- it just puts a second job in
+ * front of everything else in the queue. "Re-render this" means the finished
+ * one, not the one already running.
+ */
+function isActiveStatus(status: string): boolean {
+  return status === 'PENDING' || status === 'RUNNING'
+}
+
 function contextFromPayload(payload: string): SceneAnimatorContext | null {
   try {
     const parsed = JSON.parse(payload) as Record<string, unknown>
@@ -88,6 +114,10 @@ export default defineEventHandler(async (event) => {
   const config = resolveConfig(body)
   const preset = getVideoPreset(config.presetId) ?? getDefaultVideoPreset(config.engine)
   const requestedSourceFile = String(body.sourceFile ?? '').trim()
+  // Scoped to one named source on purpose. A folder-wide force would re-render
+  // every finished scene in the batch off one click -- an unbounded GPU spend
+  // on a box that renders one clip at a time.
+  const force = Boolean(body.force) && Boolean(requestedSourceFile)
   const allSources = await listSceneAnimatorSourceFiles(folder)
   const sources = requestedSourceFile
     ? allSources.filter((source) => source.name === requestedSourceFile)
@@ -127,8 +157,10 @@ export default defineEventHandler(async (event) => {
     let existing = latestByKey.get(dedupeKey) ?? null
 
     // Recheck immediately before the expensive enqueue so two open admin tabs are
-    // unlikely to duplicate the same active/completed render.
-    if (!existing || (!isReusableStatus(existing.status) && body.retryFailed)) {
+    // unlikely to duplicate the same active/completed render. A forced re-render
+    // needs this most of all: it is the one path that enqueues over a job it
+    // already saw, so a stale read here is how two of them get queued at once.
+    if (!existing || force || (!isReusableStatus(existing.status) && body.retryFailed)) {
       const live = await prisma.artJob.findFirst({
         where: {
           projectSlug: SCENE_ANIMATOR_PROJECT_SLUG,
@@ -140,11 +172,16 @@ export default defineEventHandler(async (event) => {
       if (live) existing = live
     }
 
-    if (existing && isReusableStatus(existing.status)) {
+    // An active job is never duplicated, forced or not.
+    if (existing && isActiveStatus(existing.status)) {
       skipped.push({ sourceFile: source.name, jobId: existing.id, reason: existing.status })
       continue
     }
-    if (existing && !body.retryFailed) {
+    if (existing && isReusableStatus(existing.status) && !force) {
+      skipped.push({ sourceFile: source.name, jobId: existing.id, reason: existing.status })
+      continue
+    }
+    if (existing && !body.retryFailed && !force) {
       skipped.push({
         sourceFile: source.name,
         jobId: existing.id,

--- a/stores/sceneAnimatorStore.ts
+++ b/stores/sceneAnimatorStore.ts
@@ -326,7 +326,17 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
     }
   }
 
-  async function retrySource(sourceFile: string): Promise<boolean> {
+  /**
+   * Queue one source again.
+   *
+   * `force` is what makes a FINISHED scene re-renderable. Without it the
+   * server's dedupe treats DONE as a result worth keeping and skips the
+   * request, which is correct right up until the finished render is the thing
+   * that is wrong -- see the 2026-09-11 flattened-clip bug. It never overrides
+   * a queued or rendering job; that is the server's call, not this one's.
+   */
+  async function retrySource(sourceFile: string, force = false): Promise<boolean> {
+    const label = force ? 're-render this scene' : 'retry this scene'
     queueing.value = true
     retryingSource.value = sourceFile
     clearError()
@@ -342,6 +352,7 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
             durationSeconds: durationSeconds.value,
             isMature: isMature.value,
             retryFailed: true,
+            force,
             sourceFile,
           }),
         },
@@ -349,7 +360,7 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
         120_000,
       )
       if (!response.success || !response.data) {
-        throw new Error(response.message || 'Failed to retry this scene.')
+        throw new Error(response.message || `Failed to ${label}.`)
       }
       lastEnqueue.value = response.data
       if (response.data.errors.length) {
@@ -358,15 +369,34 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
           .join('\n')
         return false
       }
+      /*
+       * A force that queued nothing is a silent no-op otherwise: the card keeps
+       * its old Done badge and the click looks like it did nothing at all. The
+       * one way this happens is an active job the server declined to duplicate,
+       * so say that rather than leaving the operator clicking.
+       */
+      if (force && !response.data.queued.length) {
+        const [skip] = response.data.skipped
+        error.value = skip
+          ? `${sourceFile} was not re-queued: a job is already ${String(skip.reason).toLowerCase()}.`
+          : `${sourceFile} was not re-queued.`
+        await load()
+        return false
+      }
       await load()
       return true
     } catch (cause) {
-      error.value = errorMessage(cause, 'Failed to retry this scene.')
+      error.value = errorMessage(cause, `Failed to ${label}.`)
       return false
     } finally {
       queueing.value = false
       retryingSource.value = null
     }
+  }
+
+  /** Re-render a scene whose latest job already finished. */
+  async function rerenderSource(sourceFile: string): Promise<boolean> {
+    return retrySource(sourceFile, true)
   }
 
   async function selectFolder(folder: string) {
@@ -437,6 +467,7 @@ export const useSceneAnimatorStore = defineStore('sceneAnimatorStore', () => {
     load,
     enqueue,
     retrySource,
+    rerenderSource,
     selectFolder,
     setEngine,
     setPreset,

--- a/utils/scripts/verifySceneAnimatorResubmit.test.ts
+++ b/utils/scripts/verifySceneAnimatorResubmit.test.ts
@@ -1,0 +1,175 @@
+// /utils/scripts/verifySceneAnimatorResubmit.test.ts
+//
+// A finished Scene Animator scene can be asked for again — and an in-flight one
+// still cannot be duplicated.
+//
+// WHAT WENT WRONG WITHOUT THIS. The enqueue dedupe treats PENDING, RUNNING and
+// DONE alike as "reusable", and that check runs BEFORE `retryFailed` is
+// consulted. So `retryFailed` only ever rescued FAILED/CANCELLED, and a DONE
+// scene was unreachable from the admin surface by any request the UI could
+// send. That is correct exactly while a finished render is the render you
+// wanted — and wrong the moment it isn't. On 2026-09-11 the ArtImage offload
+// flattened every completed clip to a still; all of them sat DONE, visibly
+// wrong, with no way to re-queue them (Silas: "We should be able to resubmit
+// from the scene-animator window").
+//
+// The fix adds `force`, which is a narrow hole in a guard that exists for good
+// reasons, so the shape of the hole is what these assertions pin:
+//
+//   - force re-queues a DONE job (the whole point)
+//   - force NEVER re-queues PENDING or RUNNING: the relay renders one clip at a
+//     time, so a duplicate does not arrive sooner, it just jumps the queue
+//   - force is per-source only; a folder-wide force would re-render every
+//     finished scene in the batch off one click
+//   - without force, DONE is still skipped, exactly as before
+//
+// Mirrors verifySceneAnimatorHealth.test.ts: exercises the real decision rather
+// than describing it. The decision is pure, so it is re-derived here from the
+// route's source instead of booting h3 + prisma, and the source contract at the
+// bottom fails if the route stops matching it.
+//
+//   npx tsx utils/scripts/verifySceneAnimatorResubmit.test.ts
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const ROUTE = 'server/api/scene-animator/enqueue.post.ts'
+const STORE = 'stores/sceneAnimatorStore.ts'
+const PAGE = 'pages/admin/scene-animator.vue'
+
+const source = readFileSync(resolve(process.cwd(), ROUTE), 'utf8')
+
+type Decision = 'queue' | 'skip'
+
+/**
+ * The route's per-source branch, in the order the route applies it.
+ *
+ * Kept in step with the route by the source contract below — if the route's
+ * predicates change names or order, that contract fails and this model must be
+ * revisited rather than silently drifting into fiction.
+ */
+function decide(
+  status: string | null,
+  opts: { force?: boolean; retryFailed?: boolean } = {},
+): Decision {
+  const force = Boolean(opts.force)
+  if (!status) return 'queue'
+  if (status === 'PENDING' || status === 'RUNNING') return 'skip'
+  if ((status === 'DONE' || status === 'PENDING' || status === 'RUNNING') && !force) {
+    return 'skip'
+  }
+  if (!opts.retryFailed && !force) return 'skip'
+  return 'queue'
+}
+
+/* -- the bug: a finished scene was unreachable ------------------------------ */
+
+assert.equal(
+  decide('DONE', { retryFailed: true }),
+  'skip',
+  'retryFailed must NOT resurrect a DONE job — the dedupe skips it first. If ' +
+    'this ever starts queueing, the reusable-status guard has been weakened ' +
+    'and every batch re-run silently re-renders the whole folder.',
+)
+
+assert.equal(
+  decide('DONE', { force: true }),
+  'queue',
+  'force must re-queue a finished scene — this is the whole feature',
+)
+
+/* -- but an active job is still never duplicated ---------------------------- */
+
+for (const status of ['PENDING', 'RUNNING']) {
+  assert.equal(
+    decide(status, { force: true, retryFailed: true }),
+    'skip',
+    `force must not duplicate a ${status} job: the relay renders one clip at a ` +
+      `time, so a second job does not arrive sooner, it only jumps the queue`,
+  )
+}
+
+/* -- unchanged behaviour for everything else -------------------------------- */
+
+assert.equal(decide(null), 'queue', 'a source with no job at all must queue')
+assert.equal(decide('DONE'), 'skip', 'a plain batch run must still skip DONE')
+assert.equal(
+  decide('FAILED'),
+  'skip',
+  'a failed job still needs retryFailed — a bare batch run must not retry it',
+)
+assert.equal(decide('FAILED', { retryFailed: true }), 'queue')
+assert.equal(decide('CANCELLED', { retryFailed: true }), 'queue')
+assert.equal(
+  decide('FAILED', { force: true }),
+  'queue',
+  'force covers the failed case too, so one button can serve both',
+)
+
+/* -- source contract: the route must still match the model above ------------ */
+
+const check = (ok: boolean, message: string) => {
+  if (!ok) throw new Error(message)
+}
+
+check(
+  /function isActiveStatus\s*\(/.test(source),
+  `${ROUTE} must keep isActiveStatus() distinct from isReusableStatus(). ` +
+    `Collapsing them back into one predicate is what makes force able to ` +
+    `duplicate an in-flight render.`,
+)
+
+const activeIndex = source.search(/if \(existing && isActiveStatus\(/)
+const reusableIndex = source.search(/if \(existing && isReusableStatus\(/)
+
+check(
+  activeIndex !== -1 && reusableIndex !== -1 && activeIndex < reusableIndex,
+  `${ROUTE} must check isActiveStatus BEFORE the forceable reusable-status ` +
+    `branch. Reversed, a forced request reaches a PENDING/RUNNING job and ` +
+    `queues a duplicate against it.`,
+)
+
+// Same statement only — a multiline window here happily matches the unrelated
+// `const sources = requestedSourceFile ? …` two lines down and passes on a
+// route that no longer scopes force at all.
+check(
+  /const force = [^\n]*requestedSourceFile/.test(source),
+  `${ROUTE} must scope force to a named sourceFile. A folder-wide force ` +
+    `re-renders every finished scene in the batch from a single click.`,
+)
+
+check(
+  /if \(!existing \|\| force \|\|/.test(source),
+  `${ROUTE} must re-read the live job before a forced enqueue. force is the ` +
+    `one path that enqueues over a job it has already seen, so a stale read ` +
+    `here is how two renders get queued for the same scene.`,
+)
+
+/* -- the operator can actually reach it ------------------------------------- */
+
+const store = readFileSync(resolve(process.cwd(), STORE), 'utf8')
+const page = readFileSync(resolve(process.cwd(), PAGE), 'utf8')
+
+check(
+  /rerenderSource/.test(store) && /\bforce,/.test(store),
+  `${STORE} must expose rerenderSource and send force — a server-side flag no ` +
+    `client sets is not a feature.`,
+)
+
+check(
+  /rerenderSource\(source\.name\)/.test(page),
+  `${PAGE} must wire a control to rerenderSource. The whole request was to be ` +
+    `able to resubmit from this window.`,
+)
+
+check(
+  /source\.status === 'done'/.test(page),
+  `${PAGE} must offer the re-render control on DONE cards — those are the ` +
+    `ones with no other route back into the queue.`,
+)
+
+console.log(
+  '✅ Scene Animator resubmit: DONE is re-renderable with force, PENDING/' +
+    'RUNNING are never duplicated, force stays per-source, and the admin ' +
+    'surface is wired to it.',
+)


### PR DESCRIPTION
Silas, 2026-09-11: *"We should be able to resubmit from the scene-animator window."*

Correct — and there was genuinely no way to.

## Why `retryFailed` didn't cover this

The enqueue dedupe treats `PENDING`, `RUNNING` and `DONE` alike as reusable, and that check runs **before** `retryFailed` is consulted:

```ts
if (existing && isReusableStatus(existing.status)) { skip }   // DONE lands here
if (existing && !body.retryFailed) { skip }                   // never reached for DONE
```

So `retryFailed` only ever rescued `FAILED`/`CANCELLED`. A finished scene was unreachable from any request the UI could send — including the per-card "Retry this scene" button, which is why it only renders for failed/cancelled cards.

That behaviour is right while a finished render *is* the render you wanted. The offload bug fixed in #2641 made it wrong: every completed clip was a flattened still, all `DONE`, all visibly wrong, none re-queueable.

## The change

`force`, kept deliberately narrow because it's a hole in a guard that exists for good reasons:

| | behaviour |
|---|---|
| `DONE` + force | **re-queues** — the point of the feature |
| `FAILED`/`CANCELLED` + force | re-queues, so one control serves both cases |
| `PENDING`/`RUNNING` + force | **never duplicated.** `isActiveStatus` is split out of `isReusableStatus` and checked first — the relay renders one clip at a time, so a second job doesn't arrive sooner, it just jumps the queue |
| scope | one named `sourceFile` only. A folder-wide force would re-render every finished scene in a batch off a single click |
| staleness | forced requests re-read the live job first — it's the one path that enqueues over a job it already saw |

Since the listing already resolves the **newest** job per `dedupeKey` (`orderBy: createdAt desc`), a re-submitted job slots into the card with no listing changes.

UI: a "Re-render this scene" action on `DONE` cards, alongside the existing retry on failed ones. A forced request that queues nothing now says why, rather than leaving the card on its old Done badge looking like the click did nothing.

## Verification

`utils/scripts/verifySceneAnimatorResubmit.test.ts` (new, wired into `contract-tests.yml`) pins both the gate and the wiring. Verified to **fail** against four separate regressions, each re-run individually:

1. active-status guard removed → force could duplicate an in-flight render
2. `force` unscoped from `sourceFile` → folder-wide re-render
3. live re-read dropped → two renders queued for one scene
4. UI control unwired → server flag no client sets

`vue-tsc`: 0 errors. `eslint` on changed files: clean. Existing `test:scene-animator-health` still passes.

Note one contract check was initially too loose — a multiline regex matched an unrelated later `requestedSourceFile` and passed mutation 2. Tightened to the statement, then re-verified all four fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNe7H71sq22FA6W9kqKc5R

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNe7H71sq22FA6W9kqKc5R)_