### PR TITLE
interface-vision/t-104 slice 236: name kr-input-rounded-xl/-2xl, migrate 68 occurrences

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1639,6 +1639,29 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply select w-full bg-base-200;
   }
 
+  /* The `rounded-xl`-override sibling of .kr-input/.kr-input-sm/.kr-input-xs
+   * (interface-vision t-104 slice 236): those three primitives leave
+   * DaisyUI's own border radius untouched, but a separate pool of inputs
+   * across lora/server/user-directory/conductor/taskmaster surfaces
+   * explicitly overrides it -- previously hand-rolled as `input
+   * input-bordered rounded-xl`; `input-bordered` is the same dead legacy v4
+   * class .kr-input/.kr-input-sm already drop, leaving `input rounded-xl`
+   * as the real applied shape. 35 occurrences across 13 files. */
+  .kr-input-rounded-xl {
+    @apply input rounded-xl;
+  }
+
+  /* The `rounded-2xl` sibling of .kr-input-rounded-xl (same slice): the
+   * wider-corner-radius override on the same shape, previously hand-rolled
+   * as `input input-bordered rounded-2xl` across art-test/performer-
+   * creator/dream-maker/coloring-book surfaces -- `input-bordered` is the
+   * same dead legacy v4 class dropped the same way, leaving `input
+   * rounded-2xl` as the real applied shape. 33 occurrences across 16
+   * files. */
+  .kr-input-rounded-2xl {
+    @apply input rounded-2xl;
+  }
+
   /* The page-header icon badge: a tinted `h-12 w-12` square housing a
    * page-header `<Icon>`, sitting beside the page title (interface-vision
    * t-104 slice 149) -- previously hand-rolled identically across 8

--- a/components/art/add-collection.vue
+++ b/components/art/add-collection.vue
@@ -36,7 +36,7 @@
 
         <input
           v-model="label"
-          class="input input-bordered rounded-2xl bg-base-200"
+          class="kr-input-rounded-2xl bg-base-200"
           type="text"
           placeholder="Monster Drag Party favorites"
           :disabled="isSaving || disabled"

--- a/components/art/art-generator.vue
+++ b/components/art/art-generator.vue
@@ -313,7 +313,7 @@
                 </span>
                 <input
                   v-model.number="steps"
-                  class="input input-bordered rounded-2xl bg-base-100"
+                  class="kr-input-rounded-2xl bg-base-100"
                   type="number"
                   min="1"
                   max="150"
@@ -330,7 +330,7 @@
                 <input
                   v-if="activeProfile.supports.guidance"
                   v-model.number="guidance"
-                  class="input input-bordered rounded-2xl bg-base-100"
+                  class="kr-input-rounded-2xl bg-base-100"
                   type="number"
                   min="0"
                   max="30"
@@ -340,7 +340,7 @@
                 <input
                   v-else
                   v-model.number="cfg"
-                  class="input input-bordered rounded-2xl bg-base-100"
+                  class="kr-input-rounded-2xl bg-base-100"
                   type="number"
                   min="1"
                   max="30"
@@ -397,7 +397,7 @@
                   </span>
                   <input
                     v-model.number="width"
-                    class="input input-bordered rounded-2xl bg-base-100"
+                    class="kr-input-rounded-2xl bg-base-100"
                     type="number"
                     min="256"
                     max="2048"
@@ -411,7 +411,7 @@
                   </span>
                   <input
                     v-model.number="height"
-                    class="input input-bordered rounded-2xl bg-base-100"
+                    class="kr-input-rounded-2xl bg-base-100"
                     type="number"
                     min="256"
                     max="2048"
@@ -430,7 +430,7 @@
                 </span>
                 <input
                   v-model.number="seed"
-                  class="input input-bordered rounded-2xl bg-base-100"
+                  class="kr-input-rounded-2xl bg-base-100"
                   type="number"
                   placeholder="Random each run"
                   :disabled="artStore.isGenerating"

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -908,7 +908,7 @@ onMounted(async () => {
                   <input
                     v-model.number="width"
                     type="number"
-                    class="input input-bordered rounded-2xl bg-base-100"
+                    class="kr-input-rounded-2xl bg-base-100"
                   />
                 </label>
 
@@ -917,7 +917,7 @@ onMounted(async () => {
                   <input
                     v-model.number="height"
                     type="number"
-                    class="input input-bordered rounded-2xl bg-base-100"
+                    class="kr-input-rounded-2xl bg-base-100"
                   />
                 </label>
               </div>

--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -171,7 +171,7 @@
               <input
                 v-model="form.checkpoint"
                 list="artjob-checkpoint-presets"
-                class="input input-bordered rounded-2xl"
+                class="kr-input-rounded-2xl"
                 placeholder="Keep the current model or choose a preset"
               />
             </label>
@@ -180,7 +180,7 @@
               <span class="font-semibold">Style LoRA</span>
               <input
                 v-model="form.loraName"
-                class="input input-bordered rounded-2xl font-mono text-xs"
+                class="kr-input-rounded-2xl font-mono text-xs"
                 placeholder="e.g. Kontext/SFW/impressionist.safetensors"
               />
               <span class="text-[11px] text-base-content/50">

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -258,7 +258,7 @@
                   type="number"
                   min="1"
                   max="100"
-                  class="input input-bordered input-xs w-20 rounded-xl"
+                  class="kr-input-rounded-xl input-xs w-20"
                   @keyup.enter="applyPageSize"
                 />
               </label>
@@ -291,7 +291,7 @@
                   type="number"
                   min="1"
                   :max="artJobStore.jobPageCount"
-                  class="input input-bordered input-xs w-16 rounded-xl text-center"
+                  class="kr-input-rounded-xl input-xs w-16 text-center"
                   @keyup.enter="applyPage"
                 />
                 <span>of {{ artJobStore.jobPageCount }}</span>

--- a/components/art/artjob-slideshow.vue
+++ b/components/art/artjob-slideshow.vue
@@ -266,7 +266,7 @@
                   type="number"
                   min="1"
                   max="600"
-                  class="input input-bordered input-xs w-20 rounded-xl"
+                  class="kr-input-rounded-xl input-xs w-20"
                   @change="applyInterval"
                 />
               </div>

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -127,7 +127,7 @@
           <input
             v-model="actionNote"
             type="text"
-            class="input input-bordered rounded-2xl"
+            class="kr-input-rounded-2xl"
             placeholder="Optional cover decision or revision note"
           />
 
@@ -186,7 +186,7 @@
                 <input
                   v-model="legacyPath"
                   type="text"
-                  class="input input-bordered w-full rounded-2xl"
+                  class="kr-input-rounded-2xl w-full"
                   placeholder="approved/my-cover.webp"
                 />
                 <button

--- a/components/coloring/coloring-book-production-toolbar.vue
+++ b/components/coloring/coloring-book-production-toolbar.vue
@@ -119,7 +119,7 @@
       <input
         v-model="actionNote"
         type="text"
-        class="input input-bordered w-full rounded-2xl"
+        class="kr-input-rounded-2xl w-full"
         placeholder="Optional decision or revision note"
       />
 

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -455,7 +455,7 @@
           <input
             v-model="requestNote"
             type="text"
-            class="input input-bordered rounded-2xl"
+            class="kr-input-rounded-2xl"
             placeholder="Optional revision direction"
             :readonly="!userStore.isAdmin"
           />

--- a/components/dreams/daily-digest-object-dialog.vue
+++ b/components/dreams/daily-digest-object-dialog.vue
@@ -137,7 +137,7 @@
                   v-else
                   v-model="draft[field.key]"
                   type="text"
-                  class="input input-bordered rounded-2xl"
+                  class="kr-input-rounded-2xl"
                   :placeholder="field.placeholder"
                   :disabled="saving"
                 />

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -136,7 +136,7 @@
               >
               <input
                 v-model="seedTitle"
-                class="input input-bordered rounded-2xl bg-base-100 font-bold"
+                class="kr-input-rounded-2xl bg-base-100 font-bold"
                 type="text"
                 placeholder="The Drowned Archive"
                 @input="markHumanEdit"

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -81,7 +81,7 @@
                 </span>
                 <input
                   v-model="dreamStore.dreamForm.title"
-                  class="kr-text-bold-lg input input-bordered rounded-2xl bg-base-200"
+                  class="kr-input-rounded-2xl kr-text-bold-lg bg-base-200"
                   type="text"
                   placeholder="The Drowned Archive"
                 />
@@ -119,7 +119,7 @@
                 </span>
                 <input
                   v-model="dreamStore.dreamForm.slug"
-                  class="input input-bordered rounded-2xl bg-base-200"
+                  class="kr-input-rounded-2xl bg-base-200"
                   type="text"
                   placeholder="the-drowned-archive"
                 />
@@ -220,7 +220,7 @@
                 >
                 <input
                   v-model="dreamStore.dreamForm.icon"
-                  class="input input-bordered rounded-2xl bg-base-200"
+                  class="kr-input-rounded-2xl bg-base-200"
                   type="text"
                   placeholder="kind-icon:dream"
                 />
@@ -232,7 +232,7 @@
                 >
                 <input
                   v-model.number="dreamStore.dreamForm.artImageId"
-                  class="input input-bordered rounded-2xl bg-base-200"
+                  class="kr-input-rounded-2xl bg-base-200"
                   type="number"
                   min="1"
                   placeholder="Optional"
@@ -247,7 +247,7 @@
                 >
                 <input
                   v-model.number="dreamStore.dreamForm.artCollectionId"
-                  class="input input-bordered rounded-2xl bg-base-200"
+                  class="kr-input-rounded-2xl bg-base-200"
                   type="number"
                   min="1"
                   placeholder="Optional"
@@ -262,7 +262,7 @@
                 >
                 <input
                   v-model="dreamStore.dreamForm.designer"
-                  class="input input-bordered rounded-2xl bg-base-200"
+                  class="kr-input-rounded-2xl bg-base-200"
                   type="text"
                   placeholder="Kind Designer"
                 />

--- a/components/dreams/dream-relationship-gallery.vue
+++ b/components/dreams/dream-relationship-gallery.vue
@@ -33,7 +33,7 @@
           </select>
 
           <label
-            class="input input-bordered input-xs flex min-w-36 flex-1 items-center gap-2 rounded-2xl bg-base-200"
+            class="kr-input-rounded-2xl input-xs flex min-w-36 flex-1 items-center gap-2 bg-base-200"
           >
             <Icon name="kind-icon:search" class="kr-icon-4 opacity-50" />
             <input

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -42,7 +42,7 @@
 
         <input
           v-model="query"
-          class="input input-bordered rounded-xl"
+          class="kr-input-rounded-xl"
           :placeholder="
             source === 'civarchive'
               ? 'CivArchive model id or URL (recovers removed models)'

--- a/components/navigation/navigation-trimmed.vue
+++ b/components/navigation/navigation-trimmed.vue
@@ -27,7 +27,7 @@
             type="search"
             placeholder="Search destinations…"
             aria-label="Search destinations"
-            class="input input-bordered h-10 w-full rounded-xl pl-9 text-sm"
+            class="kr-input-rounded-xl h-10 w-full pl-9 text-sm"
           />
         </label>
       </div>

--- a/components/navigation/server-selector.vue
+++ b/components/navigation/server-selector.vue
@@ -147,7 +147,7 @@
 
                   <input
                     v-model.trim="openAiKey"
-                    class="input input-bordered min-w-0 rounded-xl"
+                    class="kr-input-rounded-xl min-w-0"
                     type="password"
                     name="openai-api-key"
                     autocomplete="new-password"
@@ -197,7 +197,7 @@
 
                   <input
                     v-model.trim="anthropicKey"
-                    class="input input-bordered min-w-0 rounded-xl"
+                    class="kr-input-rounded-xl min-w-0"
                     type="password"
                     name="anthropic-api-key"
                     autocomplete="new-password"
@@ -286,7 +286,7 @@
                 <span class="kr-label-bold">Label</span>
                 <input
                   v-model.trim="newLocal.label"
-                  class="input input-bordered w-full rounded-xl"
+                  class="kr-input-rounded-xl w-full"
                   type="text"
                   :placeholder="defaultLocalLabel(newLocal.serverType)"
                 />
@@ -296,7 +296,7 @@
                 <span class="kr-label-bold">Base URL</span>
                 <input
                   v-model.trim="newLocal.baseUrl"
-                  class="input input-bordered w-full rounded-xl"
+                  class="kr-input-rounded-xl w-full"
                   type="url"
                   placeholder="http://192.168.1.50:8188"
                 />
@@ -350,7 +350,7 @@
                 <span class="kr-label-bold">Label</span>
                 <input
                   v-model.trim="editForm.label"
-                  class="input input-bordered w-full rounded-xl"
+                  class="kr-input-rounded-xl w-full"
                   type="text"
                 />
               </label>
@@ -373,7 +373,7 @@
                 <span class="kr-label-bold">Base URL</span>
                 <input
                   v-model.trim="editForm.baseUrl"
-                  class="input input-bordered w-full rounded-xl"
+                  class="kr-input-rounded-xl w-full"
                   type="url"
                 />
               </label>
@@ -382,7 +382,7 @@
                 <span class="kr-label-bold">Endpoint Path</span>
                 <input
                   v-model.trim="editForm.endpointPath"
-                  class="input input-bordered w-full rounded-xl"
+                  class="kr-input-rounded-xl w-full"
                   type="text"
                 />
               </label>
@@ -391,7 +391,7 @@
                 <span class="kr-label-bold">Health Path</span>
                 <input
                   v-model.trim="editForm.healthPath"
-                  class="input input-bordered w-full rounded-xl"
+                  class="kr-input-rounded-xl w-full"
                   type="text"
                 />
               </label>
@@ -400,7 +400,7 @@
                 <span class="kr-label-bold">Model</span>
                 <input
                   v-model.trim="editForm.model"
-                  class="input input-bordered w-full rounded-xl"
+                  class="kr-input-rounded-xl w-full"
                   type="text"
                   placeholder="Optional"
                 />

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -273,7 +273,7 @@
                 v-model="newTodoTitle"
                 type="text"
                 placeholder="What needs doing?"
-                class="input input-bordered w-full rounded-xl"
+                class="kr-input-rounded-xl w-full"
                 :disabled="todoStore.loading"
               />
               <textarea
@@ -639,7 +639,7 @@
                   v-model="projectTaskTitle"
                   type="text"
                   placeholder="What needs doing?"
-                  class="input input-bordered w-full rounded-xl text-sm"
+                  class="kr-input-rounded-xl w-full text-sm"
                   :disabled="projectTaskSubmitting"
                 />
                 <textarea
@@ -726,7 +726,7 @@
                     >
                     <input
                       type="url"
-                      class="input input-bordered rounded-xl text-sm"
+                      class="kr-input-rounded-xl text-sm"
                       placeholder="https://..."
                       :value="linkedProject.liveUrl ?? ''"
                       :disabled="projectSaving"
@@ -739,7 +739,7 @@
                     >
                     <input
                       type="url"
-                      class="input input-bordered rounded-xl text-sm"
+                      class="kr-input-rounded-xl text-sm"
                       placeholder="https://github.com/..."
                       :value="linkedProject.repoUrl ?? ''"
                       :disabled="projectSaving"

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -332,7 +332,7 @@
                     v-model="vibeInput"
                     type="text"
                     placeholder="storm-lit, clockwork, defiant"
-                    class="input input-bordered w-full rounded-xl border-secondary/20 bg-base-100/90"
+                    class="kr-input-rounded-xl w-full border-secondary/20 bg-base-100/90"
                     :disabled="store.isWeaving"
                   />
                 </label>

--- a/components/resources/resource-gallery.vue
+++ b/components/resources/resource-gallery.vue
@@ -646,7 +646,7 @@ onMounted(async () => {
           <input
             v-model="query"
             type="search"
-            class="input input-bordered input-xs w-36 rounded-2xl sm:w-52"
+            class="kr-input-rounded-2xl input-xs w-36 sm:w-52"
             placeholder="Name, trigger, base model..."
             aria-label="Search Resources"
           />

--- a/components/scenarios/scenario-relationship-gallery.vue
+++ b/components/scenarios/scenario-relationship-gallery.vue
@@ -43,7 +43,7 @@
           </button>
 
           <label
-            class="input input-bordered input-xs flex min-w-36 flex-1 items-center gap-2 rounded-2xl bg-base-200"
+            class="kr-input-rounded-2xl input-xs flex min-w-36 flex-1 items-center gap-2 bg-base-200"
           >
             <Icon name="kind-icon:search" class="kr-icon-4 opacity-50" />
             <input

--- a/components/servers/add-server.vue
+++ b/components/servers/add-server.vue
@@ -33,7 +33,7 @@
           <span class="kr-label-bold">Title</span>
           <input
             v-model="form.title"
-            class="input input-bordered rounded-xl"
+            class="kr-input-rounded-xl"
             placeholder="Comfy"
             required
           />
@@ -43,7 +43,7 @@
           <span class="kr-label-bold">Label</span>
           <input
             v-model="form.label"
-            class="input input-bordered rounded-xl"
+            class="kr-input-rounded-xl"
             placeholder="Friendly display label"
           />
         </label>
@@ -82,7 +82,7 @@
           <span class="kr-label-bold">Base URL</span>
           <input
             v-model="form.baseUrl"
-            class="input input-bordered rounded-xl"
+            class="kr-input-rounded-xl"
             placeholder="https://ferngrotto.foxhound-chicken.ts.net"
             required
           />
@@ -92,7 +92,7 @@
           <span class="kr-label-bold">Endpoint Path</span>
           <input
             v-model="form.endpointPath"
-            class="input input-bordered rounded-xl"
+            class="kr-input-rounded-xl"
             placeholder="/prompt"
           />
         </label>
@@ -101,7 +101,7 @@
           <span class="kr-label-bold">Health Path</span>
           <input
             v-model="form.healthPath"
-            class="input input-bordered rounded-xl"
+            class="kr-input-rounded-xl"
             placeholder="/system_stats"
           />
         </label>
@@ -110,7 +110,7 @@
           <span class="kr-label-bold">Category</span>
           <input
             v-model="form.category"
-            class="input input-bordered rounded-xl"
+            class="kr-input-rounded-xl"
             placeholder="personal"
           />
         </label>
@@ -119,7 +119,7 @@
           <span class="kr-label-bold">Model</span>
           <input
             v-model="form.model"
-            class="input input-bordered rounded-xl"
+            class="kr-input-rounded-xl"
             placeholder="Optional model name"
           />
         </label>
@@ -147,7 +147,7 @@
             <span class="kr-label-bold">API Key Header Name</span>
             <input
               v-model="form.apiKeyName"
-              class="input input-bordered rounded-xl"
+              class="kr-input-rounded-xl"
               placeholder="X-API-Key"
             />
           </label>
@@ -157,7 +157,7 @@
             <input
               v-model="apiKey"
               :type="showApiKey ? 'text' : 'password'"
-              class="input input-bordered rounded-xl"
+              class="kr-input-rounded-xl"
               placeholder="Leave blank to keep existing key"
               autocomplete="off"
             />

--- a/components/servers/checkpoint-gallery.vue
+++ b/components/servers/checkpoint-gallery.vue
@@ -63,7 +63,7 @@
           <input
             v-if="showControls"
             v-model="searchQuery"
-            class="input input-bordered input-xs w-32 rounded-xl sm:w-44"
+            class="kr-input-rounded-xl input-xs w-32 sm:w-44"
             placeholder="Search checkpoints"
             aria-label="Search checkpoints"
           />

--- a/components/servers/server-gallery.vue
+++ b/components/servers/server-gallery.vue
@@ -54,7 +54,7 @@
         <div class="flex flex-wrap items-center gap-1.5">
           <input
             v-model="searchQuery"
-            class="input input-bordered input-xs w-32 rounded-xl sm:w-44"
+            class="kr-input-rounded-xl input-xs w-32 sm:w-44"
             placeholder="Filter servers"
             aria-label="Filter servers"
           />

--- a/components/stages/performer-creator.vue
+++ b/components/stages/performer-creator.vue
@@ -70,7 +70,7 @@
               <input
                 v-model="form.name"
                 type="text"
-                class="input input-bordered rounded-2xl bg-base-100 focus:border-primary"
+                class="kr-input-rounded-2xl bg-base-100 focus:border-primary"
                 placeholder="Captain Breadcrumbs, Lady Verdict..."
                 maxlength="100"
               />
@@ -84,7 +84,7 @@
               <input
                 v-model="form.comments"
                 type="text"
-                class="input input-bordered rounded-2xl bg-base-100 focus:border-primary"
+                class="kr-input-rounded-2xl bg-base-100 focus:border-primary"
                 placeholder="How they speak, what drives them..."
                 maxlength="300"
               />
@@ -215,7 +215,7 @@
                 <input
                   v-model="form.imagePath"
                   type="text"
-                  class="input input-bordered input-xs rounded-xl bg-base-100 focus:border-primary"
+                  class="kr-input-rounded-xl input-xs bg-base-100 focus:border-primary"
                   placeholder="Or paste image URL directly..."
                 />
               </div>

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -519,7 +519,7 @@
               <input
                 v-model="store.showTitle"
                 type="text"
-                class="input input-bordered rounded-2xl bg-base-100 focus:border-primary"
+                class="kr-input-rounded-2xl bg-base-100 focus:border-primary"
                 placeholder="Optional title"
                 @change="store.persist()"
               />
@@ -534,7 +534,7 @@
               <input
                 v-model="store.showTopic"
                 type="text"
-                class="input input-bordered rounded-2xl bg-base-100 focus:border-primary"
+                class="kr-input-rounded-2xl bg-base-100 focus:border-primary"
                 placeholder="What's the show about tonight?"
                 @change="store.persist()"
               />
@@ -549,7 +549,7 @@
               <input
                 v-model="store.customOpening"
                 type="text"
-                class="input input-bordered rounded-2xl bg-base-100 focus:border-primary"
+                class="kr-input-rounded-2xl bg-base-100 focus:border-primary"
                 :placeholder="
                   store.selectedStage?.openingCue || 'Opening cue...'
                 "
@@ -628,7 +628,7 @@
               <input
                 v-model="store.selectedModel"
                 type="text"
-                class="input input-bordered rounded-2xl bg-base-100 focus:border-primary"
+                class="kr-input-rounded-2xl bg-base-100 focus:border-primary"
                 placeholder="gpt-4o-mini, llama3.1..."
                 @change="store.persist()"
               />

--- a/components/user/chat-gallery.vue
+++ b/components/user/chat-gallery.vue
@@ -32,7 +32,7 @@
         class="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto] md:items-center"
       >
         <label
-          class="input input-bordered flex items-center gap-2 rounded-2xl bg-base-100"
+          class="kr-input-rounded-2xl flex items-center gap-2 bg-base-100"
         >
           <Icon name="kind-icon:search" class="kr-icon-4 opacity-60" />
           <input

--- a/components/user/messenger.vue
+++ b/components/user/messenger.vue
@@ -109,7 +109,7 @@
           <input
             v-model="draft"
             placeholder="Write a message…"
-            class="input input-bordered flex-1 rounded-xl bg-base-200"
+            class="kr-input-rounded-xl flex-1 bg-base-200"
           />
           <button
             type="submit"

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -171,19 +171,19 @@
           <input
             v-model="createForm.username"
             placeholder="username"
-            class="input input-bordered rounded-xl bg-base-200"
+            class="kr-input-rounded-xl bg-base-200"
           />
           <input
             v-model="createForm.email"
             type="email"
             placeholder="email (optional)"
-            class="input input-bordered rounded-xl bg-base-200"
+            class="kr-input-rounded-xl bg-base-200"
           />
           <input
             v-model="createForm.password"
             type="password"
             placeholder="password (optional, min 8)"
-            class="input input-bordered rounded-xl bg-base-200"
+            class="kr-input-rounded-xl bg-base-200"
           />
           <div class="flex items-center gap-3">
             <select

--- a/utils/scripts/codemods/kr_input_rounded_2xl_codemod.py
+++ b/utils/scripts/codemods/kr_input_rounded_2xl_codemod.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `input input-bordered rounded-2xl` shapes to
+`kr-input-rounded-2xl`.
+
+The `rounded-2xl` sibling of `.kr-input-rounded-xl` (interface-vision t-104
+slice 236, same slice): the wider-corner-radius override on the same
+`.kr-input`-family shape, previously hand-rolled across art-test/performer-
+creator/dream-maker/coloring-book surfaces. `input-bordered` is the same
+dead legacy v4 class every other `.kr-input*` primitive already drops (the
+base `input` class already carries a border in this repo's daisyUI v5),
+leaving `input rounded-2xl` as the real applied shape. 32 subset-match
+occurrences across 16 files.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+class strings containing all three base tokens (`input`, `input-bordered`,
+`rounded-2xl`) are touched, and only in static `class="..."` attributes --
+never `:class`/`v-bind:class` bindings (see _class_attr.py). A source that
+already carries `kr-input-rounded-2xl`, or is missing any one of the three
+base tokens, is left untouched. Extra tokens beyond the base set (w-full,
+bg-base-100, bg-base-200, focus:border-primary, input-xs, ...) are preserved
+verbatim after the primitive class, matching every other kr-*-codemod's
+subset-match convention -- pass --exact-only to restrict a slice to sources
+with no extra tokens at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-input-rounded-2xl"
+BASE_TOKENS = {"input", "input-bordered", "rounded-2xl"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim (no
+        # universal-newline translation) -- see kr_input_sm_codemod.py for
+        # why this matters (kind_robots add-bot.vue, slice 214).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"{PRIMITIVE} {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/scripts/codemods/kr_input_rounded_xl_codemod.py
+++ b/utils/scripts/codemods/kr_input_rounded_xl_codemod.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `input input-bordered rounded-xl` shapes to
+`kr-input-rounded-xl`.
+
+The `rounded-xl`-override sibling of `.kr-input`/`.kr-input-sm`/`.kr-input-xs`
+(interface-vision t-104 slice 236): those three primitives leave DaisyUI's
+own border radius untouched, but a separate pool of inputs across
+lora/server/user-directory/conductor/taskmaster surfaces explicitly overrides
+it with `rounded-xl`. `input-bordered` is the same dead legacy v4 class every
+other `.kr-input*` primitive already drops (the base `input` class already
+carries a border in this repo's daisyUI v5), leaving `input rounded-xl` as
+the real applied shape. 35 subset-match occurrences across 13 files.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+class strings containing all three base tokens (`input`, `input-bordered`,
+`rounded-xl`) are touched, and only in static `class="..."` attributes --
+never `:class`/`v-bind:class` bindings (see _class_attr.py). A source that
+already carries `kr-input-rounded-xl`, or is missing any one of the three
+base tokens, is left untouched. Extra tokens beyond the base set (w-full,
+bg-base-200, text-sm, min-w-0, input-xs, ...) are preserved verbatim after
+the primitive class, matching every other kr-*-codemod's subset-match
+convention -- pass --exact-only to restrict a slice to sources with no extra
+tokens at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-input-rounded-xl"
+BASE_TOKENS = {"input", "input-bordered", "rounded-xl"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim (no
+        # universal-newline translation) -- see kr_input_sm_codemod.py for
+        # why this matters (kind_robots add-bot.vue, slice 214).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"{PRIMITIVE} {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: slice 236 (kind: software, recurring kr-* consistency umbrella)

### What changed / what I produced
- A fresh full-repo class-frequency survey outside every closed kr-* family (per slice 235's kaizen note) surfaced two sizable pools on the `.kr-input` family that weren't yet named: `input input-bordered rounded-xl` and `input input-bordered rounded-2xl`. `.kr-input`/`.kr-input-sm`/`.kr-input-xs` all leave DaisyUI's default border radius untouched, but these two pools explicitly override it.
- Added `.kr-input-rounded-xl { @apply input rounded-xl; }` and `.kr-input-rounded-2xl { @apply input rounded-2xl; }` to `assets/css/tailwind.css`, dropping `input-bordered` — the same dead legacy v4 class every other `.kr-input*` primitive already drops (the base `input` class already carries a border in this daisyUI v5 setup).
- New codemods `utils/scripts/codemods/kr_input_rounded_xl_codemod.py` and `kr_input_rounded_2xl_codemod.py`, modeled directly on `kr_input_sm_codemod.py`'s subset-match convention (dry-run by default, `--write` to migrate, `--exact-only` to bound to the literal base set).
- Ran both with `--write`: 35 occurrences across 13 files (`-rounded-xl`) + 33 occurrences across 16 files (`-rounded-2xl`) = 68 occurrences across 25 files migrated. Extra tokens (`w-full`, `bg-base-100`/`bg-base-200`, `focus:border-primary`, `input-xs`, `text-sm`, `min-w-0`, ...) preserved verbatim after the primitive class, matching the established convention.
- No color/behavior/API/schema/route/geometry change — purely a class-name consolidation onto existing shared primitives.

### How I verified
- `npm run test` (vue-tsc --noEmit): 0 errors.
- `npx eslint` on all 28 changed `.vue` files: 5 pre-existing issues (3 errors, 2 warnings) in `daily-digest-object-dialog.vue`, `dream-maker.vue`, `performer-creator.vue`, `stage-manager.vue` — confirmed identical via `git stash` against the pre-change tree, none introduced by this diff.
- `npm run test:layout-contract`: holds, no new violations.
- Both codemods run in dry-run mode first to confirm counts before `--write`; diffs spot-checked (e.g. `components/servers/add-server.vue`) match the intended shape exactly.

### Stakes
reversible

### Flags for Reviewer
- None — straightforward class consolidation following the slice 235 kaizen note's own lead (btn/badge/input-bordered combos flagged as promising; this slice took the input-bordered branch).

### Kaizen suggestion
The `btn btn-primary btn-sm rounded-2xl` / `badge badge-sm rounded-xl` pools from the same original kaizen note remain unclaimed — next slice's natural target once this one lands.

### Notes for reviewer
Task closed to `status: review` in conductor with `implementation_pr` pointing here; will flip back to `ready` (recurring task) once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3ubmkkYpjQAYCt6mYdCUz

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3ubmkkYpjQAYCt6mYdCUz)_