### PR TITLE
docs(interface-vision): audit title-block false positives

### DIFF
--- a/docs/interface-vision-t-127-header-audit.md
+++ b/docs/interface-vision-t-127-header-audit.md
@@ -1,0 +1,39 @@
+# Interface Vision t-127: page-title audit
+
+This audit narrows the `one-header` layout-contract change before the verifier is widened. The trigger was `pages/admin/scene-animator.vue`: its duplicate shell title used a `<p class="text-3xl font-black">` inside the page's own top toolbar, so the existing literal-`<h1>` check missed it.
+
+## Known-page audit
+
+### `pages/admin/scene-animator.vue`
+
+**Duplicate shell title, already fixed in #2638.** This is the positive fixture for the widened rule. The removed block was page-level chrome: eyebrow + large `text-3xl font-black` title + description in the page's top toolbar. The shell already supplied the same title/subtitle from `content/channels/admin/scene-animator.md`.
+
+### `pages/users/[id].vue`
+
+**Legitimate in-page title. Do not flag.** `{{ displayName }}` is dynamic entity identity inside the public-profile `<article>`, below a Back to WonderLab navigation control and inside the profile card. The shell cannot supply a user's runtime display name. Its `text-3xl font-black` line is therefore content, not duplicate page chrome.
+
+### `pages/email-confirmation.vue`
+
+**Legitimate in-page result title. Do not flag.** `{{ result.title }}` is dynamic outcome copy inside a centered result `<section>` (`Email verified`, expired-link states, incomplete-link state). It is not a static page title and the shell cannot know the result before evaluating the query parameters.
+
+### `pages/play/challenges/leaderboard.vue`
+
+**Legitimate authored hero. Do not flag.** The page's top hero is a surfaced `<header>` after navigation, but its title uses the `kr-text-eyebrow` display primitive rather than the `text-2xl/text-3xl + font-black` duplicate-shell shape. The `text-3xl font-black` grep hit on this file is a rank medallion value inside leaderboard cards, not the page title.
+
+### `pages/play/challenges/[slug].vue`
+
+**Legitimate dynamic challenge hero. Do not flag.** The challenge title is runtime entity content inside a surfaced hero after navigation and uses `kr-text-eyebrow ... text-3xl`, not `font-black`. The grep's `font-black` large-type hits are matchup/rank display values such as `VS`, not duplicate shell chrome.
+
+## Contract boundary
+
+A broad `text-2xl|text-3xl` plus `font-black` sweep is unsafe. It would flag runtime entity names, result-state headings, scores, ranks, and other legitimate large values. A broad "first `<header>`" rule is also unsafe because challenge pages intentionally use surfaced dynamic heroes.
+
+The widened `one-header` detector should therefore stay structural and conservative:
+
+1. Keep literal page-component `<h1>` detection.
+2. Add a duplicate-title-block detector for a **shallow page-level header/toolbar block** whose heading line combines large display type (`text-2xl` or `text-3xl`, including responsive variants) with `font-black` and is accompanied by page-description/eyebrow copy.
+3. Do not descend into surfaced content containers such as `article`, `section`, `kr-panel*`, or card/grid descendants when looking for this non-`h1` shape.
+4. Treat dynamic entity/result heroes as content rather than shell-title duplication unless their structure is actually page chrome.
+5. Pin both sides with fixtures: the former Scene Animator toolbar must be detected; the public-profile and email-confirmation shapes must remain quiet.
+
+This gives the rule a useful signal without turning typography into a false-positive minefield.


### PR DESCRIPTION
### Task
interface-vision/t-127: widen the one-header rule to catch title blocks that avoid `<h1>` (kind: software)

### What changed / what I produced
- Audited the five known large/heavy title candidates before widening the verifier.
- Documented which title shapes are legitimate in-page content and which structural boundary the verifier should use.
- Preserves Scene Animator as the worked duplicate-shell-title example and avoids a broad typography rule that would create false positives.

### How I verified
- Inspected the five known page sources and the existing layout-contract intent.
- This slice is documentation-only; verifier implementation remains in t-127 after this audit lands.

### Stakes
reversible

### Kaizen suggestion
Add focused fixture tests around the eventual page-chrome title detector so dynamic profile/status titles cannot regress into the violation set.

### Notes for reviewer
Conductor already records t-127 at `status: review` for session `2026-09-11T231846Z-interface-vision-t-127-q7v2`.