### PR TITLE
interface-vision/t-104 slice 237: name kr-btn-primary-2xl, migrate badge-sm rounded-xl onto kr-badge-sm

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1126,6 +1126,18 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply btn btn-primary btn-sm rounded-xl;
   }
 
+  /* The `rounded-2xl` sibling of .kr-btn-primary (interface-vision t-104
+   * slice 237): same `sm` size, but with a wider `rounded-2xl` corner
+   * radius instead of `rounded-xl` — `btn btn-primary btn-sm rounded-2xl`,
+   * previously hand-rolled across dreams/stages/conductor/art/narrative
+   * surfaces (13 subset-match occurrences across 12 files). Named for the
+   * radius it overrides (not a size suffix) since the size matches the
+   * base .kr-btn-primary shape, mirroring .kr-btn-ghost-2xl's identical
+   * naming convention on the ghost family. */
+  .kr-btn-primary-2xl {
+    @apply btn btn-primary btn-sm rounded-2xl;
+  }
+
   /* Second-most-repeated filled-button shape (interface-vision t-104 slice 58):
    * DaisyUI's own default (unmodified) button size — no `btn-sm` utility at
    * all — with the same `rounded-xl` override as .kr-btn-primary, `btn

--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -333,7 +333,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-primary btn-sm rounded-2xl"
+            class="kr-btn-primary-2xl"
             :disabled="saving"
             @click="save"
           >

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -38,7 +38,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-primary btn-sm rounded-2xl"
+            class="kr-btn-primary-2xl"
             :disabled="isLoading"
             @click="refresh"
           >

--- a/components/builder/builder-card.vue
+++ b/components/builder/builder-card.vue
@@ -81,7 +81,7 @@
         </span>
 
         <span
-          class="badge badge-sm rounded-xl font-black"
+          class="kr-badge-sm rounded-xl font-black"
           :class="isCompleted ? 'badge-success' : 'badge-primary badge-outline'"
         >
           {{ isCompleted ? 'done' : 'open' }}

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -94,7 +94,7 @@
           selectedPack.price.hook
         }}</span>
         <span
-          class="badge badge-sm rounded-xl"
+          class="kr-badge-sm rounded-xl"
           :class="
             packStore.packBuildStatus(selectedPack.id) === 'ready'
               ? 'badge-success'

--- a/components/conductor/packmaker-pack-editor.vue
+++ b/components/conductor/packmaker-pack-editor.vue
@@ -201,7 +201,7 @@
 
     <!-- Save -->
     <div class="flex items-center gap-2">
-      <button class="btn btn-primary btn-sm rounded-2xl" @click="onSave">
+      <button class="kr-btn-primary-2xl" @click="onSave">
         {{ editingExisting ? 'Save changes' : 'Create pack' }}
       </button>
       <span

--- a/components/conductor/project-front-page.vue
+++ b/components/conductor/project-front-page.vue
@@ -35,13 +35,13 @@
           </span>
           <span
             v-if="statusLabel"
-            class="badge badge-sm rounded-xl font-semibold"
+            class="kr-badge-sm rounded-xl font-semibold"
             :class="statusBadgeClass"
             >{{ statusLabel }}</span
           >
           <span
             v-if="view.bridge"
-            class="badge badge-info badge-sm rounded-xl font-semibold gap-1"
+            class="kr-badge-sm badge-info rounded-xl font-semibold gap-1"
           >
             <Icon name="kind-icon:external-link" class="size-3" />External app
           </span>
@@ -65,7 +65,7 @@
             :href="launch.href"
             :target="launch.external ? '_blank' : undefined"
             :rel="launch.external ? 'noopener noreferrer' : undefined"
-            class="btn btn-primary btn-sm gap-1.5 rounded-2xl sm:btn-md"
+            class="kr-btn-primary-2xl gap-1.5 sm:btn-md"
           >
             <Icon :name="launch.icon || 'kind-icon:sparkles'" class="kr-icon-4" />
             {{ launch.label }}

--- a/components/content-visibility-controls.vue
+++ b/components/content-visibility-controls.vue
@@ -9,7 +9,7 @@
         </p>
       </div>
       <span
-        class="badge badge-sm rounded-xl"
+        class="kr-badge-sm rounded-xl"
         :class="isPublic ? 'badge-success badge-outline' : 'badge-neutral'"
       >
         {{ isPublic ? 'Public' : 'Private' }}

--- a/components/dreams/dream-brainstorm.vue
+++ b/components/dreams/dream-brainstorm.vue
@@ -20,7 +20,7 @@
         <div class="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap">
           <button
             type="button"
-            class="btn btn-primary btn-sm rounded-2xl text-white"
+            class="kr-btn-primary-2xl text-white"
             :disabled="dreamStore.loading || !canGenerate"
             @click="generateCandidates(false)"
           >

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -184,7 +184,7 @@
 
         <button
           v-if="allowAdd"
-          class="btn btn-primary btn-sm tooltip tooltip-bottom shrink-0 rounded-2xl text-white"
+          class="kr-btn-primary-2xl tooltip tooltip-bottom shrink-0 text-white"
           type="button"
           data-tip="New Dream"
           aria-label="New Dream"

--- a/components/dreams/dream-list.vue
+++ b/components/dreams/dream-list.vue
@@ -154,7 +154,7 @@
               <h4 class="line-clamp-1 font-black text-base-content">
                 {{ entry.title }}
               </h4>
-              <span v-if="entry.badge" class="badge badge-sm rounded-xl">
+              <span v-if="entry.badge" class="kr-badge-sm rounded-xl">
                 {{ entry.badge }}
               </span>
             </div>

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -44,7 +44,7 @@
           </button>
           <button
             type="button"
-            class="btn btn-primary btn-sm rounded-2xl text-white"
+            class="kr-btn-primary-2xl text-white"
             :disabled="dreamStore.isSaving || !canSave"
             @click="saveDream"
           >

--- a/components/gallery/kr-entity-card-body.vue
+++ b/components/gallery/kr-entity-card-body.vue
@@ -182,7 +182,7 @@
           <span
             v-for="badge in badges"
             :key="badge.title || badge.label"
-            class="badge badge-sm rounded-xl shadow"
+            class="kr-badge-sm rounded-xl shadow"
             :class="badge.class || 'badge-primary'"
             :title="badge.title || badge.label"
           >

--- a/components/giftshop/giftshop-interact.vue
+++ b/components/giftshop/giftshop-interact.vue
@@ -88,10 +88,7 @@
             </div>
           </div>
 
-          <NuxtLink
-            to="/giving"
-            class="btn btn-primary btn-sm shrink-0 rounded-2xl"
-          >
+          <NuxtLink to="/giving" class="kr-btn-primary-2xl shrink-0">
             <Icon name="kind-icon:gift" class="kr-icon-4" />
             Give directly
           </NuxtLink>

--- a/components/narrative/kr-narrator-stage.vue
+++ b/components/narrative/kr-narrator-stage.vue
@@ -88,7 +88,7 @@
         />
         <button
           type="button"
-          class="btn btn-primary btn-sm shrink-0 rounded-2xl text-white"
+          class="kr-btn-primary-2xl shrink-0 text-white"
           :disabled="!canSendNarrator"
           @click="sendNarratorMessage"
         >

--- a/components/narrative/narrative-ingredient-card.vue
+++ b/components/narrative/narrative-ingredient-card.vue
@@ -39,7 +39,7 @@
 
     <span
       v-if="item.badge"
-      class="badge badge-sm absolute left-2 top-2 z-10 max-w-[calc(100%_-_3.25rem)] truncate rounded-xl border-white/30 bg-black/55 text-[0.62rem] font-bold text-white shadow backdrop-blur"
+      class="kr-badge-sm absolute left-2 top-2 z-10 max-w-[calc(100%_-_3.25rem)] truncate rounded-xl border-white/30 bg-black/55 text-[0.62rem] font-bold text-white shadow backdrop-blur"
     >
       {{ item.badge }}
     </span>

--- a/components/navigation/workspace-narrator.vue
+++ b/components/navigation/workspace-narrator.vue
@@ -440,7 +440,7 @@
 
                   <button
                     type="button"
-                    class="btn btn-primary btn-sm rounded-2xl text-white"
+                    class="kr-btn-primary-2xl text-white"
                     :disabled="!canSendNarrator"
                     @click="sendNarratorMessage"
                   >

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -161,12 +161,12 @@
                   <div class="flex shrink-0 flex-wrap gap-1">
                     <span
                       v-if="isPausedGate(gate)"
-                      class="badge badge-neutral badge-sm rounded-xl"
+                      class="kr-badge-sm badge-neutral rounded-xl"
                     >
                       paused
                     </span>
                     <span
-                      class="badge badge-sm rounded-xl"
+                      class="kr-badge-sm rounded-xl"
                       :class="gate.task.softGate ? 'badge-info' : 'badge-error'"
                     >
                       {{ gate.task.softGate ? 'question' : 'approval' }}

--- a/components/pages/mermaids-page.vue
+++ b/components/pages/mermaids-page.vue
@@ -122,7 +122,7 @@
               href="https://www.amazon.com/Mermaids-Venice-Silas-Knight/dp/0615516742/"
               target="_blank"
               rel="noopener"
-              class="btn btn-primary btn-sm rounded-2xl"
+              class="kr-btn-primary-2xl"
             >
               <Icon name="kind-icon:external-link" class="kr-icon-4" />
               {{ draft.amazonLabel }}

--- a/components/pages/storybook-library-page.vue
+++ b/components/pages/storybook-library-page.vue
@@ -136,7 +136,7 @@
             <div class="flex items-start justify-between gap-2">
               <h3 class="truncate font-black">{{ story.bible.title }}</h3>
               <span
-                class="badge badge-sm rounded-xl"
+                class="kr-badge-sm rounded-xl"
                 :class="
                   story.status === 'complete'
                     ? 'badge-success'

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -719,7 +719,7 @@
                       </div>
                       <span
                         v-if="item.status === 'written'"
-                        class="badge badge-success badge-sm rounded-xl"
+                        class="kr-badge-sm badge-success rounded-xl"
                       >
                         written
                       </span>
@@ -837,7 +837,7 @@
                     <div class="flex items-start justify-between gap-2">
                       <p class="font-bold">{{ checkpoint.title }}</p>
                       <span
-                        class="badge badge-sm rounded-xl"
+                        class="kr-badge-sm rounded-xl"
                         :class="
                           checkpoint.status === 'completed'
                             ? 'badge-success'

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -726,7 +726,7 @@
             <template v-if="!store.isRunning">
               <button
                 type="button"
-                class="btn btn-primary btn-sm rounded-2xl gap-1.5"
+                class="kr-btn-primary-2xl gap-1.5"
                 :disabled="!store.castReady"
                 @click="store.start()"
               >
@@ -745,7 +745,7 @@
             <template v-else>
               <button
                 type="button"
-                class="btn btn-primary btn-sm rounded-2xl"
+                class="kr-btn-primary-2xl"
                 @click="store.resume()"
               >
                 <Icon name="mdi:play" class="kr-icon-4" /> Resume

--- a/utils/scripts/codemods/kr_badge_sm_rounded_xl_codemod.py
+++ b/utils/scripts/codemods/kr_badge_sm_rounded_xl_codemod.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `badge badge-sm rounded-xl` shapes onto the
+existing `kr-badge-sm` primitive.
+
+Unlike every other kr-*-codemod in this directory, this one does NOT define
+a new primitive. `.kr-badge-sm` (interface-vision t-104 slice 146) is
+already `badge badge-sm` with the corner radius deliberately left off --
+its own comment in tailwind.css explains that `rounded-2xl` rides alongside
+it as a separate utility at 15 of its 18 original call sites rather than
+being baked into the class, precisely so a different radius can ride
+alongside it too. This slice closes the remaining gap: `badge badge-sm
+rounded-xl` (the `rounded-xl` counterpart of that same shape) was still
+hand-rolled across dreams/gallery/conductor/builder/pages surfaces instead
+of using `.kr-badge-sm` -- 9 subset-match occurrences across 9 files.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+class strings containing all three base tokens (`badge`, `badge-sm`,
+`rounded-xl`) are touched, and only in static `class="..."` attributes --
+never `:class`/`v-bind:class` bindings (see _class_attr.py). A source that
+already carries `kr-badge-sm`, or is missing any one of the three base
+tokens, is left untouched. `rounded-xl` itself and any extra tokens beyond
+the base set (shadow, font-semibold, font-black, ...) are preserved
+verbatim after the primitive class -- only the literal `badge badge-sm`
+pair is replaced -- matching every other kr-*-codemod's subset-match
+convention. Pass --exact-only to restrict a slice to sources whose only
+extra token is `rounded-xl` itself (no further utility tokens preserved).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-badge-sm"
+REPLACED_TOKENS = {"badge", "badge-sm"}
+REQUIRED_TOKENS = REPLACED_TOKENS | {"rounded-xl"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not REQUIRED_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in REPLACED_TOKENS]
+    if exact_only and remaining != ["rounded-xl"]:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings whose only remaining token is "
+        "rounded-xl itself (no further utility tokens preserved). Bounds a "
+        "slice to the safest, most literal candidates; re-run without this "
+        "flag for the fuller subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim (no
+        # universal-newline translation) -- see kr_input_sm_codemod.py for
+        # why this matters (kind_robots add-bot.vue, slice 214).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"{PRIMITIVE} rounded-xl {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/scripts/codemods/kr_btn_primary_2xl_codemod.py
+++ b/utils/scripts/codemods/kr_btn_primary_2xl_codemod.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `btn btn-primary btn-sm rounded-2xl` shapes to
+`kr-btn-primary-2xl`.
+
+The `rounded-2xl` sibling of `.kr-btn-primary` (interface-vision t-104 slice
+237): `.kr-btn-primary` bakes in `rounded-xl`, but a separate pool of
+primary-filled buttons across dreams/stages/conductor/art surfaces
+explicitly overrides the corner radius with the wider `rounded-2xl` instead
+-- the same "radius, not size, is the suffix" naming convention already
+used for `.kr-btn-ghost-2xl` on the ghost-button family. 10 subset-match
+occurrences across 9 files.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+class strings containing all four base tokens (`btn`, `btn-primary`,
+`btn-sm`, `rounded-2xl`) are touched, and only in static `class="..."`
+attributes -- never `:class`/`v-bind:class` bindings (see _class_attr.py).
+A source that already carries `kr-btn-primary-2xl`, or is missing any one
+of the four base tokens, is left untouched. Extra tokens beyond the base
+set (text-white, gap-1.5, ...) are preserved verbatim after the primitive
+class, matching every other kr-*-codemod's subset-match convention -- pass
+--exact-only to restrict a slice to sources with no extra tokens at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-btn-primary-2xl"
+BASE_TOKENS = {"btn", "btn-primary", "btn-sm", "rounded-2xl"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim (no
+        # universal-newline translation) -- see kr_input_sm_codemod.py for
+        # why this matters (kind_robots add-bot.vue, slice 214).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"{PRIMITIVE} {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: recurring kr-* consistency umbrella (kind: software)

### What changed
- Named `.kr-btn-primary-2xl` (the `rounded-2xl` radius sibling of `.kr-btn-primary`, mirroring `.kr-btn-ghost-2xl`'s naming convention on the ghost family) and migrated 13 subset-match `btn btn-primary btn-sm rounded-2xl` occurrences across 12 files via a new `kr_btn_primary_2xl_codemod.py`.
- Migrated 13 subset-match `badge badge-sm rounded-xl` occurrences across 9 files onto the existing `.kr-badge-sm` primitive — no new CSS needed, since `.kr-badge-sm` is deliberately radius-less by design (its own comment: a different radius rides alongside it as a separate utility) — via a new `kr_badge_sm_rounded_xl_codemod.py`.
- No color/behavior/API/schema/route/geometry change: template `class` attributes only, plus one Prettier reflow (`giftshop-interact.vue`) where the shortened class string let its tag collapse onto one line.

This addresses the kaizen note left by slice 236: the btn/badge combos flagged by slice 235 (`btn btn-primary btn-sm rounded-2xl`, `badge badge-sm rounded-xl`) were still genuinely uncovered gaps (not already handled by the existing `.kr-btn-*`/`.kr-badge-*` families, confirmed by direct inspection before writing the codemods).

### How I verified
- `npm run test` (vue-tsc, full project) — 0 errors.
- `npx eslint` on all 22 changed `.vue`/`.css` files — 24 pre-existing errors confirmed identical via `git stash` against the pre-change tree; no new errors.
- `npm run test:layout-contract` — holds, zero new violations.
- `npx prettier --check` on all changed files — 15 files flag pre-existing drift confirmed via `git stash` to predate this change (one file, `giftshop-interact.vue`, needed a Prettier reflow after its class string shortened enough to collapse the tag onto one line — applied and re-verified clean).
- Manually inspected every codemod-generated diff for correctness (token order, preserved extras, color utilities riding alongside the now-colorless `kr-badge-sm` base).

### Stakes
reversible

### Kaizen suggestion for the next slice
No further exact-match `btn btn-primary btn-sm rounded-2xl` or `badge badge-sm rounded-xl` occurrences remain. The wider (still-hand-rolled) `badge badge-sm` pool has other radius/utility variants (`rounded-lg`, `shrink-0`, absolute positioning, etc. — see `components/conductor/coat-dance-page.vue`, `components/storybook/storybook-life-run.vue`, and others) that a future slice could survey individually, similar to how `.kr-badge-xs` treated its more varied pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4jEY99yWj7yN91qpZzW7S

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4jEY99yWj7yN91qpZzW7S)_