### PR TITLE
interface-vision/t-104 slice 238: extend kr-badge-sm bounded extras (shrink-0, rounded-lg[+font-black])

### DIFF
--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -157,7 +157,7 @@
                   {{ challenge.challengeType }}
                 </span>
                 <span
-                  class="badge badge-sm rounded-lg font-black"
+                  class="kr-badge-sm rounded-lg font-black"
                   :class="statusClass(challenge.status)"
                 >
                   {{ challenge.status }}

--- a/components/conductor/coat-dance-page.vue
+++ b/components/conductor/coat-dance-page.vue
@@ -26,7 +26,7 @@
             class="flex items-center gap-2 text-sm"
           >
             <span
-              class="badge badge-sm rounded-lg"
+              class="kr-badge-sm rounded-lg"
               :class="stage.status === 'done' ? 'badge-success' : 'badge-ghost'"
             >
               {{ stage.status === 'done' ? 'done' : 'planned' }}

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -364,7 +364,7 @@
               </p>
             </div>
             <span
-              class="badge badge-sm shrink-0"
+              class="kr-badge-sm shrink-0"
               :class="taskBadgeClass(task.status)"
             >
               {{ task.status }}
@@ -473,7 +473,7 @@
             </p>
           </div>
           <span
-            class="badge badge-sm shrink-0"
+            class="kr-badge-sm shrink-0"
             :class="milestoneBadgeClass(milestone.status)"
           >
             {{ milestone.status }}

--- a/components/conductor/voice-lab-page.vue
+++ b/components/conductor/voice-lab-page.vue
@@ -103,7 +103,7 @@
                 <td class="font-semibold">{{ adapter.domain }}</td>
                 <td>
                   <span
-                    class="badge badge-sm rounded-lg"
+                    class="kr-badge-sm rounded-lg"
                     :class="adapter.badgeClass"
                     >{{ adapter.status }}</span
                   >

--- a/components/model-builder/model-builder-recipe-selector.vue
+++ b/components/model-builder/model-builder-recipe-selector.vue
@@ -123,7 +123,7 @@
         </div>
 
         <span
-          class="badge badge-sm shrink-0"
+          class="kr-badge-sm shrink-0"
           :class="actionBadge(output.action)"
         >
           {{ output.action }}

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -868,7 +868,7 @@
                     </p>
                   </div>
                   <span
-                    class="badge badge-sm shrink-0"
+                    class="kr-badge-sm shrink-0"
                     :class="milestoneBadgeClass(milestone.status)"
                     >{{ milestone.status }}</span
                   >
@@ -975,7 +975,7 @@
                         </p>
                       </div>
                       <span
-                        class="badge badge-sm shrink-0"
+                        class="kr-badge-sm shrink-0"
                         :class="taskBadgeClass(task.status)"
                         >{{ task.status }}</span
                       >

--- a/components/storybook/storybook-life-run.vue
+++ b/components/storybook/storybook-life-run.vue
@@ -388,7 +388,7 @@
           class="flex flex-col items-center gap-3 rounded-2xl border border-primary/30 bg-primary/5 p-6 text-center"
         >
           <span
-            class="badge badge-sm rounded-lg font-black"
+            class="kr-badge-sm rounded-lg font-black"
             :class="victoryBadgeClass(endingData.victoryType)"
           >
             {{ endingData.victoryType }}

--- a/components/user/agent-credentials-panel.vue
+++ b/components/user/agent-credentials-panel.vue
@@ -76,7 +76,7 @@
             </p>
           </div>
           <span
-            class="badge badge-sm shrink-0"
+            class="kr-badge-sm shrink-0"
             :class="credential.revokedAt ? 'badge-error' : credentialExpired(credential) ? 'badge-warning' : 'badge-success'"
           >
             {{ credentialStatus(credential) }}

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -291,7 +291,7 @@
                         <template v-if="source.jobId"> · ArtJob #{{ source.jobId }}</template>
                       </p>
                     </div>
-                    <span class="badge badge-sm shrink-0" :class="statusClass(source.status)">
+                    <span class="kr-badge-sm shrink-0" :class="statusClass(source.status)">
                       {{ statusLabel(source.status) }}
                     </span>
                   </div>

--- a/utils/scripts/codemods/kr_badge_codemod.py
+++ b/utils/scripts/codemods/kr_badge_codemod.py
@@ -106,6 +106,34 @@ FAMILIES = [
 # its 15 call sites). Families not listed here keep the unrestricted
 # subset-match behavior they already had.
 #
+# Slice 237 (a separate one-off script, kr_badge_sm_rounded_xl_codemod.py)
+# migrated the `rounded-xl` extra-token pool directly rather than through
+# this shared module; that pool no longer appears in the source tree, so it
+# is not re-added here. Slice 238 audited the remaining hand-rolled
+# `badge badge-sm <extra>` call sites and adds two more clean, repeated
+# shapes to this bounded set --
+#   shrink-0             7 occurrences / 6 files (model-builder-recipe-
+#                         selector.vue, agent-credentials-panel.vue,
+#                         conductor/project-detail.vue x2, pages/conductor-
+#                         page.vue x2, pages/admin/scene-animator.vue --
+#                         the last of these also carries an unrelated
+#                         `:class="statusClass(...)"` binding, untouched)
+#   rounded-lg           2 occurrences / 2 files (conductor/coat-dance-
+#                         page.vue, conductor/voice-lab-page.vue)
+#   rounded-lg font-black 2 occurrences / 2 files (storybook/storybook-
+#                         life-run.vue, conductor/challenge-center-page.vue)
+# -- through this shared codemod instead of another one-off script, since
+# they are more of the same bounded-extras shape this module already
+# tracks. The remaining one-offs (kr-card-back.vue's `border-none bg-
+# black/60 text-white`, kr-entity-card-body.vue's `max-w-full truncate`,
+# entity-art-manager.vue's `border-0 bg-base-100/85 font-bold backdrop-
+# blur`, conductor-pitch-manager.vue's `shrink-0 rounded-2xl font-bold`,
+# conductor-page.vue's standalone `gap-1`, coloring-book-studio.vue's twin
+# `absolute bottom-2 left-2 rounded-2xl` positioned badges, and scene-
+# animator.vue's twin `absolute left-2 top-2 bg-base-100/90` positioned
+# badges) each carry a shape not shared widely enough to bound here and are
+# left hand-rolled for a future slice.
+#
 # kr-badge-ghost's {badge, badge-ghost} base is similarly small and appeared
 # (slice 181) inside a further ~13 hand-rolled combinations carrying varied
 # extra tokens. Slice 182 individually audited all of them: four clean,
@@ -124,7 +152,13 @@ FAMILIES = [
 # each carry a one-off extra-token combination not shared by any other call
 # site and are left hand-rolled rather than forced into a shared primitive.
 BOUNDED_EXTRAS: dict[str, set[frozenset[str]]] = {
-    "kr-badge-sm": {frozenset(), frozenset({"rounded-2xl"})},
+    "kr-badge-sm": {
+        frozenset(),
+        frozenset({"rounded-2xl"}),
+        frozenset({"shrink-0"}),
+        frozenset({"rounded-lg"}),
+        frozenset({"rounded-lg", "font-black"}),
+    },
     "kr-badge-ghost": {
         frozenset(),
         frozenset({"rounded-2xl"}),


### PR DESCRIPTION
### Task
interface-vision/t-104: recurring kr-* consistency umbrella (kind: software)

### What changed
- Audited the remaining hand-rolled `badge badge-sm <extra>` call sites left after slice 237's `rounded-xl` migration onto `.kr-badge-sm`. Found two more clean, repeated shapes:
  - `shrink-0`: 7 occurrences across 6 files (`model-builder-recipe-selector.vue`, `agent-credentials-panel.vue`, `conductor/project-detail.vue` ×2, `pages/conductor-page.vue` ×2, `pages/admin/scene-animator.vue`)
  - `rounded-lg` / `rounded-lg font-black`: 4 occurrences across 4 files (`conductor/coat-dance-page.vue`, `conductor/voice-lab-page.vue`, `storybook/storybook-life-run.vue`, `conductor/challenge-center-page.vue`)
- Extended `kr_badge_codemod.py`'s existing `BOUNDED_EXTRAS["kr-badge-sm"]` set (rather than writing another one-off script — this shared codemod already tracks bounded extras the same way for `kr-badge-ghost`/`kr-badge-outline`) and ran it with `--write`. Every migrated call site keeps its sibling `:class` color binding untouched.
- Left `components/ui/ui-gallery.vue`'s `kr-badge-outline`/`kr-badge-ghost` showcase-row matches alone — those are unrelated pre-existing codemod matches (confirmed via `git stash`) from the documented intentional raw-DaisyUI comparison row an earlier slice deliberately left untouched.
- No color/behavior/API/schema/route/geometry change: template `class` attributes and one Python codemod file only.

### How I verified
- `npm run test` (vue-tsc, full project) — 0 errors.
- `npx eslint` on all 9 changed `.vue` files — clean, no errors or warnings.
- `npm run test:layout-contract` — holds, zero new violations.
- `npx prettier --check` on all 9 changed files — 5 flag pre-existing drift confirmed via `git stash` against the pre-change tree; no new drift introduced.
- Manually reviewed every migrated diff for correctness (sibling `:class` bindings preserved verbatim, no reordering).
- Confirmed the pre-existing `ui-gallery.vue` showcase-row matches are unrelated to this change (present before this diff too, via `git stash`) and left that file untouched per established precedent.

### Stakes
reversible

### Kaizen suggestion for the next slice
Several remaining one-off `badge badge-sm <extra>` shapes are documented in the codemod's own comment block for future individual review: `kr-card-back.vue`'s `border-none bg-black/60 text-white`, `kr-entity-card-body.vue`'s `max-w-full truncate`, `entity-art-manager.vue`'s `border-0 bg-base-100/85 font-bold backdrop-blur`, `conductor-pitch-manager.vue`'s `shrink-0 rounded-2xl font-bold`, `conductor-page.vue`'s standalone `gap-1`, and two same-file-repeated positioned-badge pools (`coloring-book-studio.vue`'s `absolute bottom-2 left-2 rounded-2xl` ×2, `scene-animator.vue`'s `absolute left-2 top-2 bg-base-100/90` ×2) that could become their own bounded extras once individually audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BfTuCA8mBmv9itciTQ8Bz

---
_Generated by [Claude Code](https://claude.ai/code/session_016BfTuCA8mBmv9itciTQ8Bz)_