### PR TITLE
interface-vision/t-127: shallow duplicate-title detector, now with real tests

### DIFF
--- a/.github/workflows/layout-contract.yml
+++ b/.github/workflows/layout-contract.yml
@@ -41,3 +41,6 @@ jobs:
 
       - name: Verify mixed pane primitive fixture
         run: npx tsx utils/scripts/verifyMixedPanePrimitivesFixture.ts
+
+      - name: Layout header contract self-test
+        run: npm run test:layout-header-contract-selftest

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "test:facet-closure": "tsx utils/scripts/verifyFacetClosure.ts",
     "test:facet-gallery": "tsx utils/scripts/verifyFacetGallery.ts",
     "test:layout-contract": "tsx utils/scripts/verifyLayoutContract.ts",
+    "test:layout-header-contract-selftest": "tsx utils/scripts/layoutHeaderContract.test.ts",
     "test:art-slideshow-rotation": "tsx utils/scripts/verifyArtSlideshowRotation.test.ts",
     "audit:responsive": "node utils/scripts/auditResponsiveLayout.mjs",
     "test:daily-dream-facets": "prisma validate && tsx utils/scripts/verifyDailyDreamFacets.ts",

--- a/tests/python/README-layout-header-contract.md
+++ b/tests/python/README-layout-header-contract.md
@@ -1,0 +1,14 @@
+# Layout header contract fixtures
+
+`utils/scripts/layoutHeaderContract.ts` is the structural detector extracted for Interface Vision t-127 before wiring it into `verifyLayoutContract.ts`.
+
+The detector is deliberately conservative and encodes the audited boundary from `docs/interface-vision-t-127-header-audit.md`:
+
+- **positive:** a shallow page-chrome toolbar containing a direct `text-3xl font-black` title plus sibling eyebrow/description copy;
+- **positive:** the same shape with responsive `md:text-2xl` title sizing;
+- **negative:** a `text-3xl font-black` runtime profile name nested inside an `article`;
+- **negative:** a dynamic result title nested inside a `section`;
+- **negative:** a lone large `font-black` rank/score value with no sibling copy;
+- **negative:** a large title inside a `kr-panel*` or `card` surface.
+
+The next wiring step should call `hasShallowDuplicateTitleBlock(parseTemplate(template))` alongside the existing literal `<h1>` test. The helper accepts the verifier's existing parsed-node shape, so no second tokenizer is introduced.

--- a/utils/scripts/layoutHeaderContract.test.ts
+++ b/utils/scripts/layoutHeaderContract.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict'
+
+import {
+  hasShallowDuplicateTitleBlock,
+  type TemplateNode,
+} from './layoutHeaderContract.js'
+
+/*
+ * Pins the six fixture cases documented in
+ * tests/python/README-layout-header-contract.md against the audited
+ * false-positive boundary from docs/interface-vision-t-127-header-audit.md.
+ * The real verifier builds these nodes via verifyLayoutContract.ts's own
+ * parseTemplate(); these are hand-built to the same { tag, classTokens,
+ * children } shape so the detector can be pinned without a template string.
+ */
+function node(
+  tag: string,
+  classTokens: string[],
+  children: TemplateNode[] = [],
+): TemplateNode {
+  return { tag, classTokens, children }
+}
+
+function page(rootChildren: TemplateNode[]): TemplateNode[] {
+  return [node('div', ['kr-page'], rootChildren)]
+}
+
+// positive: a shallow page-chrome toolbar with a direct text-3xl font-black
+// title plus sibling eyebrow/description copy
+const shellToolbarTitle = page([
+  node('div', ['kr-toolbar'], [
+    node('p', ['text-xs', 'uppercase'], []),
+    node('p', ['text-3xl', 'font-black'], []),
+    node('p', ['text-sm'], []),
+  ]),
+])
+assert.equal(
+  hasShallowDuplicateTitleBlock(shellToolbarTitle),
+  true,
+  'shallow toolbar title + eyebrow/description should be flagged',
+)
+
+// positive: the same shape with responsive md:text-2xl title sizing
+const responsiveShellToolbarTitle = page([
+  node('div', ['kr-toolbar'], [
+    node('p', ['text-xs', 'uppercase'], []),
+    node('p', ['md:text-2xl', 'font-black'], []),
+  ]),
+])
+assert.equal(
+  hasShallowDuplicateTitleBlock(responsiveShellToolbarTitle),
+  true,
+  'responsive md:text-2xl title should still be flagged',
+)
+
+// negative: a text-3xl font-black runtime profile name nested inside an article
+const runtimeProfileNameInArticle = page([
+  node('article', [], [
+    node('h2', ['text-3xl', 'font-black'], []),
+    node('p', [], []),
+  ]),
+])
+assert.equal(
+  hasShallowDuplicateTitleBlock(runtimeProfileNameInArticle),
+  false,
+  'a content-surface <article> title must not be flagged',
+)
+
+// negative: a dynamic result title nested inside a section
+const dynamicResultTitleInSection = page([
+  node('section', [], [
+    node('p', ['text-3xl', 'font-black'], []),
+    node('p', [], []),
+  ]),
+])
+assert.equal(
+  hasShallowDuplicateTitleBlock(dynamicResultTitleInSection),
+  false,
+  'a content-surface <section> title must not be flagged',
+)
+
+// negative: a lone large font-black rank/score value with no sibling copy
+const loneRankValue = page([
+  node('div', ['kr-rank-tile'], [node('span', ['text-3xl', 'font-black'], [])]),
+])
+assert.equal(
+  hasShallowDuplicateTitleBlock(loneRankValue),
+  false,
+  'a lone large value with no sibling copy must not be flagged',
+)
+
+// negative: a large title inside a kr-panel*/card surface
+const titleInsidePanelSurface = page([
+  node('div', ['kr-panel-header'], [
+    node('p', ['text-3xl', 'font-black'], []),
+    node('p', [], []),
+  ]),
+])
+assert.equal(
+  hasShallowDuplicateTitleBlock(titleInsidePanelSurface),
+  false,
+  'a title inside a kr-panel*/card surface must not be flagged',
+)
+
+console.log('layoutHeaderContract.test.ts: all assertions passed')

--- a/utils/scripts/layoutHeaderContract.ts
+++ b/utils/scripts/layoutHeaderContract.ts
@@ -1,0 +1,51 @@
+type TemplateNode = {
+  tag: string
+  classTokens: string[]
+  children: TemplateNode[]
+}
+
+const SURFACED_TAGS = new Set(['article', 'section'])
+const SURFACED_CLASSES = /^(?:kr-panel|card)(?:-|$)/
+const LARGE_TITLE = /^(?:(?:sm|md|lg|xl|2xl):)?text-(?:2xl|3xl)$/
+
+function isSurface(node: TemplateNode): boolean {
+  return (
+    SURFACED_TAGS.has(node.tag.toLowerCase()) ||
+    node.classTokens.some((token) => SURFACED_CLASSES.test(token))
+  )
+}
+
+function isLargeBlackTitle(node: TemplateNode): boolean {
+  return (
+    node.classTokens.includes('font-black') &&
+    node.classTokens.some((token) => LARGE_TITLE.test(token))
+  )
+}
+
+function shallowTitleStack(node: TemplateNode): boolean {
+  if (isSurface(node)) return false
+
+  const directTitle = node.children.some(isLargeBlackTitle)
+  if (!directTitle) return false
+
+  // A duplicate shell-title block is a stack, not a lone display value. Requiring
+  // sibling copy keeps ranks/scores and other large values out of the signal.
+  return node.children.length >= 2
+}
+
+/**
+ * Conservative non-h1 half of Interface Vision's one-header contract.
+ *
+ * Only inspect the page root and its immediate children. Do not descend through
+ * article/section/panel/card content surfaces: runtime entity names, result-state
+ * headings and authored heroes belong there and are not shell-title duplication.
+ */
+export function hasShallowDuplicateTitleBlock(nodes: TemplateNode[]): boolean {
+  const root = nodes[0]
+  if (!root) return false
+
+  if (shallowTitleStack(root)) return true
+  return root.children.some(shallowTitleStack)
+}
+
+export type { TemplateNode }


### PR DESCRIPTION
### Task
interface-vision/t-127: Widen the one-header rule to catch title blocks that avoid `<h1>` (kind: software)

### What changed / what I produced
- `utils/scripts/layoutHeaderContract.ts` (prior commit on this branch): `hasShallowDuplicateTitleBlock()`, the conservative non-`<h1>` half of the widened one-header contract, extracted per the audited boundary in `docs/interface-vision-t-127-header-audit.md`.
- `tests/python/README-layout-header-contract.md` (prior commit): prose description of six fixture cases the detector should handle.
- **This commit**: the prior README documented the six cases but no executable test actually exercised them — added `utils/scripts/layoutHeaderContract.test.ts`, asserting all six (2 positive: shallow toolbar title + eyebrow/description, same shape with responsive `md:text-2xl`; 4 negative: title nested in `<article>`, in `<section>`, a lone value with no sibling copy, and a title inside a `kr-panel*`/`card` surface) against the real implementation. Wired it into CI (`layout-contract.yml`) and added the `test:layout-header-contract-selftest` npm script, matching this repo's existing `*.test.ts` self-test convention.

### How I verified
- `npx tsx utils/scripts/layoutHeaderContract.test.ts` — all six assertions pass.
- Manually traced `hasShallowDuplicateTitleBlock()`'s logic against each fixture by hand before writing assertions, to confirm the test isn't just restating the implementation.
- `node -e "JSON.parse(...)"` on `package.json` after editing, to confirm it's still valid JSON.
- Did not run a full `npm ci` / `vue-tsc` in this sandbox (no local `node_modules`); `tsx` is already a declared devDependency (`package.json`), so `npm run test:layout-header-contract-selftest` will resolve correctly under CI's `npm ci`.

### Stakes
reversible — additive-only: one new test file, one new npm script, one new CI step. No behavior change; `hasShallowDuplicateTitleBlock()` still isn't wired into `verifyLayoutContract.ts`'s `one-header` rule.

### Flags for Reviewer
- Wiring `hasShallowDuplicateTitleBlock()` into `verifyLayoutContract.ts`'s `one-header` check (calling it alongside the existing literal `<h1>` test, per the README's own next-step note) remains open follow-on work for this task — t-127 should stay at `status: review`/`ready` for that slice rather than closing to `done` from this PR alone.
- I did not run the full CI-equivalent locally (sandbox has no `node_modules`); the new CI step (`Layout header contract self-test`) will get its first real run on this PR's own CI.

### Kaizen suggestion
A repo lint/CI check that a `test(...)`-prefixed commit's diff actually touches a file matching `*.test.*` (or otherwise contains an assertion) would have caught this gap — a "test:" commit that only adds prose — before it reached `status: review`.

### Notes for reviewer
This PR only adds the missing test coverage for work already on this branch; it does not change `hasShallowDuplicateTitleBlock()` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CVwTqHY8TjrZiT4iRXCos

---
_Generated by [Claude Code](https://claude.ai/code/session_012CVwTqHY8TjrZiT4iRXCos)_