### PR TITLE
interface-vision/t-127: wire shallow duplicate-title detector into one-header rule

### DIFF
--- a/docs/interface-vision-t-127-header-audit.md
+++ b/docs/interface-vision-t-127-header-audit.md
@@ -24,6 +24,10 @@ This audit narrows the `one-header` layout-contract change before the verifier i
 
 **Legitimate dynamic challenge hero. Do not flag.** The challenge title is runtime entity content inside a surfaced hero after navigation and uses `kr-text-eyebrow ... text-3xl`, not `font-black`. The grep's `font-black` large-type hits are matchup/rank display values such as `VS`, not duplicate shell chrome.
 
+### `components/pages/giving-page.vue` (found by the wired verifier, not the original grep)
+
+**Hero/CTA block, not duplicate shell chrome. Refined the detector rather than the page.** The shell already supplies `title: 'Giving & Support'` / `subtitle: 'Direct aid and monthly support'` from `content/giving.md`'s frontmatter (mounted via `:giving-page`). The page's own top block renders a large `text-3xl font-black` line reading "Give Directly. We Never Touch It." — different copy from the shell's title, alongside a donate icon and a `btn btn-primary` CTA link. This is exactly the case the design brief calls out: *"a page whose heading says something the shell does not is not a violation."* Rather than editing the page, `hasShallowDuplicateTitleBlock()` was narrowed so a shallow title stack that also carries a link/button (real `<a>`/`<button>`, or any `btn`/`kr-btn`-classed element) or standalone media (`<img>`/`<svg>`/`<Icon>`) is treated as a hero/CTA section, not shell-title duplication — Scene Animator's actual violation was bare eyebrow+title+description copy with nothing interactive or illustrative alongside it.
+
 ## Contract boundary
 
 A broad `text-2xl|text-3xl` plus `font-black` sweep is unsafe. It would flag runtime entity names, result-state headings, scores, ranks, and other legitimate large values. A broad "first `<header>`" rule is also unsafe because challenge pages intentionally use surfaced dynamic heroes.
@@ -35,5 +39,6 @@ The widened `one-header` detector should therefore stay structural and conservat
 3. Do not descend into surfaced content containers such as `article`, `section`, `kr-panel*`, or card/grid descendants when looking for this non-`h1` shape.
 4. Treat dynamic entity/result heroes as content rather than shell-title duplication unless their structure is actually page chrome.
 5. Pin both sides with fixtures: the former Scene Animator toolbar must be detected; the public-profile and email-confirmation shapes must remain quiet.
+6. Treat a shallow title stack that also carries its own link/button or standalone media (icon/image) as a hero/CTA section, not shell-title duplication — see `components/pages/giving-page.vue` below.
 
 This gives the rule a useful signal without turning typography into a false-positive minefield.

--- a/utils/scripts/layoutHeaderContract.test.ts
+++ b/utils/scripts/layoutHeaderContract.test.ts
@@ -102,4 +102,22 @@ assert.equal(
   'a title inside a kr-panel*/card surface must not be flagged',
 )
 
+// negative: a hero/CTA block -- large title, description, an icon, and a
+// donate button -- says something the shell's own title does not and is not
+// a bare eyebrow+title+description toolbar (kind_robots
+// components/pages/giving-page.vue, conductor interface-vision/t-127)
+const heroWithIconAndCta = page([
+  node('div', ['rounded-2xl', 'border', 'bg-primary/10', 'p-6'], [
+    node('icon', [], []),
+    node('p', ['text-3xl', 'font-black'], []),
+    node('p', [], []),
+    node('a', ['btn', 'btn-primary', 'btn-lg'], []),
+  ]),
+])
+assert.equal(
+  hasShallowDuplicateTitleBlock(heroWithIconAndCta),
+  false,
+  'a title block that also carries its own icon and CTA button must not be flagged',
+)
+
 console.log('layoutHeaderContract.test.ts: all assertions passed')

--- a/utils/scripts/layoutHeaderContract.ts
+++ b/utils/scripts/layoutHeaderContract.ts
@@ -7,6 +7,9 @@ type TemplateNode = {
 const SURFACED_TAGS = new Set(['article', 'section'])
 const SURFACED_CLASSES = /^(?:kr-panel|card)(?:-|$)/
 const LARGE_TITLE = /^(?:(?:sm|md|lg|xl|2xl):)?text-(?:2xl|3xl)$/
+const ACTION_TAGS = new Set(['a', 'button'])
+const MEDIA_TAGS = new Set(['img', 'svg', 'icon'])
+const ACTION_CLASS = /^(?:btn|kr-btn)(?:-|$)/
 
 function isSurface(node: TemplateNode): boolean {
   return (
@@ -22,11 +25,36 @@ function isLargeBlackTitle(node: TemplateNode): boolean {
   )
 }
 
+/*
+ * A link/button (real <a>/<button>, or anything carrying a btn/kr-btn class)
+ * or standalone media (<img>/<svg>/<Icon>) sibling means this block is a
+ * distinct hero/CTA section, not a repeat of the shell's title -- a genuine
+ * duplicate shell-title block is pure copy (an eyebrow, the title, a
+ * description line), nothing interactive or illustrative alongside it.
+ */
+function isActionOrMedia(node: TemplateNode): boolean {
+  const tag = node.tag.toLowerCase()
+  return (
+    ACTION_TAGS.has(tag) ||
+    MEDIA_TAGS.has(tag) ||
+    node.classTokens.some((token) => ACTION_CLASS.test(token))
+  )
+}
+
 function shallowTitleStack(node: TemplateNode): boolean {
   if (isSurface(node)) return false
 
   const directTitle = node.children.some(isLargeBlackTitle)
   if (!directTitle) return false
+
+  // kind_robots components/pages/giving-page.vue (conductor
+  // interface-vision/t-127): its "Give Directly. We Never Touch It." headline
+  // says something the shell's "Giving & Support" title does not, and sits
+  // beside a donate button and an icon -- structurally a hero/CTA section,
+  // not Scene Animator's bare eyebrow+title+description toolbar. A block
+  // this shallow that also carries its own action or media is content, not
+  // shell-chrome duplication.
+  if (node.children.some(isActionOrMedia)) return false
 
   // A duplicate shell-title block is a stack, not a lone display value. Requiring
   // sibling copy keeps ranks/scores and other large values out of the signal.

--- a/utils/scripts/verifyLayoutContract.ts
+++ b/utils/scripts/verifyLayoutContract.ts
@@ -46,6 +46,7 @@ import {
   ratchetRecordedAt,
   writeRatchetBaseline,
 } from './ratchetBaseline'
+import { hasShallowDuplicateTitleBlock } from './layoutHeaderContract'
 
 const ROOT = process.cwd()
 const BASELINE_PATH = join(ROOT, 'utils/scripts/layout-contract-baseline.json')
@@ -72,7 +73,8 @@ type Baseline = {
 }
 
 const RULE_TITLES: Record<RuleId, string> = {
-  'one-header': 'page components rendering their own <h1>',
+  'one-header':
+    'page components rendering their own <h1> (or an equivalent shell-title block)',
   'one-scroll': 'components declaring more than one scroll region',
   'no-viewport': 'viewport-height units inside the h-dvh shell',
   'one-mdc': 'content pages mounting more than one component',
@@ -383,6 +385,19 @@ function combineScrollCounts(siblings: TemplateNode[]): number {
 /* Count actual scroll-owner elements, not raw utility-string occurrences. */
 function scrollRegionCount(template: string): number {
   return combineScrollCounts(parseTemplate(template))
+}
+
+/*
+ * parseTemplate() walks the whole `<template>...</template>` markup, so its
+ * own top-level result is a single node for the `<template>` tag itself
+ * (matching every other rule above, e.g. the scroll-region fixtures). The
+ * page's real root element -- what hasShallowDuplicateTitleBlock() expects as
+ * nodes[0] -- is one level down, inside that wrapper's children. Same
+ * single-root assumption rootClassList() already makes by reading the
+ * `<template>` block's first opening tag directly.
+ */
+function templateRootNodes(template: string): TemplateNode[] {
+  return parseTemplate(template)[0]?.children ?? []
 }
 
 /*
@@ -765,6 +780,75 @@ function verifyViewportGridBreakpointFixture(): void {
   }
 }
 
+/*
+ * End-to-end pin for the widened one-header rule (conductor interface-vision
+ * t-127): hasShallowDuplicateTitleBlock() is unit-pinned in isolation by
+ * layoutHeaderContract.test.ts against hand-built nodes; this fixture pins
+ * the actual integration path -- real template markup through parseTemplate()
+ * and templateRootNodes() -- so an unwrap mistake here (e.g. forgetting the
+ * <template> wrapper is its own node) fails loudly instead of quietly
+ * returning false on every real page.
+ */
+function verifyShallowDuplicateTitleFixture(): void {
+  const shellToolbarTitle = templateOf(`
+    <template>
+      <div class="kr-toolbar">
+        <p class="text-xs uppercase"></p>
+        <p class="text-3xl font-black"></p>
+        <p class="text-sm"></p>
+      </div>
+    </template>
+  `)
+  if (!hasShallowDuplicateTitleBlock(templateRootNodes(shellToolbarTitle))) {
+    throw new Error(
+      'Shallow-duplicate-title fixture (shell toolbar) was not classified correctly.',
+    )
+  }
+
+  const profileNameInArticle = templateOf(`
+    <template>
+      <article>
+        <h2 class="text-3xl font-black"></h2>
+        <p></p>
+      </article>
+    </template>
+  `)
+  if (hasShallowDuplicateTitleBlock(templateRootNodes(profileNameInArticle))) {
+    throw new Error(
+      'Shallow-duplicate-title fixture (content-surface article) produced a false positive.',
+    )
+  }
+
+  const loneRankValue = templateOf(`
+    <template>
+      <div class="kr-rank-tile">
+        <span class="text-3xl font-black"></span>
+      </div>
+    </template>
+  `)
+  if (hasShallowDuplicateTitleBlock(templateRootNodes(loneRankValue))) {
+    throw new Error(
+      'Shallow-duplicate-title fixture (lone rank value) produced a false positive.',
+    )
+  }
+
+  const heroWithIconAndCta = templateOf(`
+    <template>
+      <div class="rounded-2xl border bg-primary/10 p-6">
+        <Icon name="kind-icon:hand-heart" />
+        <p class="mt-4 text-3xl font-black">Give Directly. We Never Touch It.</p>
+        <p class="mt-3">Donate straight to AMF.</p>
+        <a href="#" class="btn btn-primary btn-lg mt-6">Donate</a>
+      </div>
+    </template>
+  `)
+  if (hasShallowDuplicateTitleBlock(templateRootNodes(heroWithIconAndCta))) {
+    throw new Error(
+      'Shallow-duplicate-title fixture (hero with icon + CTA) produced a false positive.',
+    )
+  }
+}
+
 function verifyAnchorScrollFixture(): void {
   const withAnchorPanes = templateOf(`
     <template>
@@ -865,7 +949,11 @@ function collect(): Record<RuleId, string[]> {
     const r = rel(file)
     const pageComponent = isPageComponent(file)
 
-    if (pageComponent && /<h1[\s>]/.test(templateMarkupOf(source))) {
+    if (
+      pageComponent &&
+      (/<h1[\s>]/.test(templateMarkupOf(source)) ||
+        hasShallowDuplicateTitleBlock(templateRootNodes(template)))
+    ) {
       violations['one-header'].push(r)
     }
 
@@ -989,6 +1077,7 @@ function main(): void {
   verifyFixedOverlayFixture()
   verifyPaneScrollFixture()
   verifyPaneDisplayFixture()
+  verifyShallowDuplicateTitleFixture()
   verifyAnchorScrollFixture()
   verifyViewportGridBreakpointFixture()
   const current = collect()


### PR DESCRIPTION
### Task
interface-vision/t-127: Widen the one-header rule to catch title blocks that avoid `<h1>`, then work the five pages (kind: software)

### What changed / what I produced
- Wired `hasShallowDuplicateTitleBlock()` (added in #2648) into `verifyLayoutContract.ts`'s `one-header` rule, so the widened non-`<h1>` half of the contract actually gates CI instead of sitting unit-tested but unused.
- Added `templateRootNodes()` to unwrap `parseTemplate()`'s `<template>` wrapper node into the node array the detector expects (its own top-level result is the `<template>` tag itself, one level above the page's real root).
- Added `verifyShallowDuplicateTitleFixture()` — an end-to-end fixture pinning the real `parseTemplate()` + detector integration path (not just hand-built nodes, which `layoutHeaderContract.test.ts` already covers in isolation).
- Ran the widened rule against the whole repo. The four pages the prior audit (`docs/interface-vision-t-127-header-audit.md`) called legitimate stayed correctly quiet: `pages/users/[id].vue`, `pages/email-confirmation.vue`, `pages/play/challenges/leaderboard.vue`, `pages/play/challenges/[slug].vue`.
- One real, previously-unaudited hit turned up: `components/pages/giving-page.vue`. Its hero block ("Give Directly. We Never Touch It.") is different copy from the shell's own title ("Giving & Support", from `content/giving.md` frontmatter) and sits beside a donate icon and a `btn btn-primary` CTA link — a hero/CTA section, not Scene Animator's original bare eyebrow+title+description toolbar.
- Per the design brief's own rule ("a page whose heading says something the shell does not is not a violation"), refined the detector rather than the page: `layoutHeaderContract.ts`'s `shallowTitleStack()` now excludes a shallow title block that also carries a link/button (`<a>`/`<button>`, or anything `btn`/`kr-btn`-classed) or standalone media (`<img>`/`<svg>`/`<Icon>`). Added matching positive/negative fixtures to `layoutHeaderContract.test.ts` and the new integration fixture, and recorded the finding + refined contract rule in `docs/interface-vision-t-127-header-audit.md`.
- `one-header`'s baseline count stays at 0 — no `layout-contract-baseline.json` change needed.

### How I verified
- `npx tsx utils/scripts/layoutHeaderContract.test.ts` — all assertions pass (including the two new giving-page-shaped fixtures).
- `npm run test:layout-contract` — report mode and gated mode, exit 0, `one-header` unchanged at 0, all other rule counts unchanged.
- `npx vue-tsc --noEmit` — clean.
- `npx eslint` on the four touched files — clean.

### Stakes
reversible

### Flags for Reviewer
- `components/pages/giving-page.vue` itself is untouched — the fix is entirely in the detector, per the design brief's explicit guidance not to flag copy that differs from the shell's title. Worth a second look if you read it differently.
- This closes out interface-vision/t-127's remaining scope (the docs audit already established the four known pages need no edits; this PR is the actual CI wiring plus the one new false positive it surfaced).

### Kaizen suggestion
`viewport-grid` currently sits at 205 unfixed occurrences in the baseline — the single largest bucket by far. A future slice could pick off the highest-traffic offenders (e.g. `components/art/*`) the same way the `kr-input`/`kr-btn`/`kr-badge` consistency slices have been working through other buckets.

### Notes for reviewer
Conductor task: interface-vision/t-127 (status: review at the time of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TU8avhpfPYmZkN89TrB9kY

---
_Generated by [Claude Code](https://claude.ai/code/session_01TU8avhpfPYmZkN89TrB9kY)_