### PR TITLE
interface-vision/t-104 slice 239: finish migrating size-4 icon shorthand to kr-icon-4

### DIFF
--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -93,7 +93,7 @@
               <Icon
                 v-else
                 :name="facet.icon || 'kind-icon:tag'"
-                class="size-4"
+                class="kr-icon-4"
               />
             </span>
             <button

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -151,7 +151,7 @@
           @pointerdown.stop
           @click="stepCarousel(-1)"
         >
-          <Icon name="kind-icon:chevron-left" class="size-4" />
+          <Icon name="kind-icon:chevron-left" class="kr-icon-4" />
         </button>
         <button
           type="button"
@@ -160,7 +160,7 @@
           @pointerdown.stop
           @click="stepCarousel(1)"
         >
-          <Icon name="kind-icon:chevron-right" class="size-4" />
+          <Icon name="kind-icon:chevron-right" class="kr-icon-4" />
         </button>
       </template>
     </div>
@@ -196,7 +196,7 @@
             v-else
             class="flex size-full items-center justify-center text-base-content/30"
           >
-            <Icon name="kind-icon:image" class="size-4" />
+            <Icon name="kind-icon:image" class="kr-icon-4" />
           </span>
           <span
             v-if="slide.kind === 'slot'"
@@ -380,7 +380,7 @@
           :disabled="prompt.trim().length < 3 || submitting || (generationMode === 'img2img' && !currentSrc)"
         >
           <span v-if="submitting" class="kr-spinner-xs" />
-          <Icon v-else name="kind-icon:sparkles" class="size-4" />
+          <Icon v-else name="kind-icon:sparkles" class="kr-icon-4" />
           {{ submitting ? 'Queuing…' : `Queue ${selectedSlot.label}` }}
         </button>
       </div>
@@ -479,7 +479,7 @@
           :disabled="!uploadFile || submitting"
         >
           <span v-if="submitting" class="kr-spinner-xs" />
-          <Icon v-else name="kind-icon:upload" class="size-4" />
+          <Icon v-else name="kind-icon:upload" class="kr-icon-4" />
           {{ submitting ? 'Uploading…' : 'Upload & replace' }}
         </button>
       </div>

--- a/components/art/stylist-client-gallery.vue
+++ b/components/art/stylist-client-gallery.vue
@@ -60,7 +60,7 @@
         :class="{ 'btn-disabled': uploading }"
       >
         <span v-if="uploading" class="kr-spinner-xs" />
-        <Icon v-else name="kind-icon:upload" class="size-4" />
+        <Icon v-else name="kind-icon:upload" class="kr-icon-4" />
         Add photos
         <input
           type="file"
@@ -75,7 +75,7 @@
         class="kr-btn-ghost-plain"
         :class="{ 'btn-disabled': uploading }"
       >
-        <Icon name="kind-icon:camera" class="size-4" />
+        <Icon name="kind-icon:camera" class="kr-icon-4" />
         Take photo
         <input
           type="file"

--- a/components/bots/bot-manager.vue
+++ b/components/bots/bot-manager.vue
@@ -17,7 +17,7 @@
             title="Brainstorm variations grounded in this Bot"
             @click="startBrainstormWithBot"
           >
-            <Icon name="kind-icon:brain" class="size-4" />
+            <Icon name="kind-icon:brain" class="kr-icon-4" />
             <span class="hidden sm:inline">Brainstorm variations</span>
           </button>
         </div>

--- a/components/characters/character-manager.vue
+++ b/components/characters/character-manager.vue
@@ -19,7 +19,7 @@
             title="Start a Storybook story seeded with this Character"
             @click="startStoryWithCharacter"
           >
-            <Icon name="kind-icon:book-open" class="size-4" />
+            <Icon name="kind-icon:book-open" class="kr-icon-4" />
             <span class="hidden sm:inline">Start a story with this</span>
           </button>
           <button
@@ -28,7 +28,7 @@
             title="Brainstorm variations grounded in this Character"
             @click="startBrainstormWithCharacter"
           >
-            <Icon name="kind-icon:brain" class="size-4" />
+            <Icon name="kind-icon:brain" class="kr-icon-4" />
             <span class="hidden sm:inline">Brainstorm variations</span>
           </button>
         </div>

--- a/components/coloring/coloring-book-production-history.vue
+++ b/components/coloring/coloring-book-production-history.vue
@@ -122,7 +122,7 @@
             rel="noopener noreferrer"
             class="btn btn-outline btn-sm mt-auto rounded-2xl"
           >
-            <icon name="kind-icon:external-link" class="size-4" />
+            <icon name="kind-icon:external-link" class="kr-icon-4" />
             Open archived image
           </a>
         </div>

--- a/components/coloring/coloring-book-readiness.vue
+++ b/components/coloring/coloring-book-readiness.vue
@@ -72,7 +72,7 @@
         </div>
 
         <div class="mt-3 flex items-center gap-2 text-xs font-semibold text-warning">
-          <icon name="kind-icon:book" class="size-4" />
+          <icon name="kind-icon:book" class="kr-icon-4" />
           Cover workflow not managed yet
         </div>
       </button>

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -127,7 +127,7 @@
           :class="activeMode === mode.key ? 'tab-active' : ''"
           @click="activeMode = mode.key"
         >
-          <icon :name="mode.icon" class="size-4" />
+          <icon :name="mode.icon" class="kr-icon-4" />
           {{ mode.label }}
         </button>
       </div>

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -43,7 +43,7 @@
       >
         <Icon
           name="kind-icon:sparkles"
-          class="mt-0.5 size-4 shrink-0 opacity-60"
+          class="kr-icon-4 mt-0.5 shrink-0 opacity-60"
         />
         <div class="min-w-0 flex-1">
           <p class="italic opacity-80">{{ tankStore.lastRareEvent.tone }}</p>
@@ -60,7 +60,7 @@
           aria-label="Dismiss"
           @click="tankStore.dismissRareEvent()"
         >
-          <Icon name="kind-icon:close" class="size-4" />
+          <Icon name="kind-icon:close" class="kr-icon-4" />
         </button>
       </div>
 
@@ -88,7 +88,7 @@
           aria-label="Dismiss"
           @click="tankStore.dismissMilestoneToast()"
         >
-          <Icon name="kind-icon:close" class="size-4" />
+          <Icon name="kind-icon:close" class="kr-icon-4" />
         </button>
       </div>
 
@@ -99,7 +99,7 @@
             {{ tankStore.coins }}
           </span>
           <span class="flex items-center gap-1 opacity-70">
-            <Icon name="kind-icon:fish" class="size-4" />
+            <Icon name="kind-icon:fish" class="kr-icon-4" />
             {{ tankStore.stock.length }}
           </span>
           <span class="flex items-center gap-1 text-xs opacity-60">
@@ -124,7 +124,7 @@
            deliberately co-viable routes (the debris set and The Sexton are
            the other two, both still unbuilt); this is only the first. -->
       <div class="flex items-center gap-2">
-        <Icon name="kind-icon:sparkles" class="size-4 shrink-0 opacity-60" />
+        <Icon name="kind-icon:sparkles" class="kr-icon-4 shrink-0 opacity-60" />
         <div
           class="h-1.5 flex-1 overflow-hidden rounded-full bg-base-300"
           role="meter"
@@ -434,7 +434,7 @@
             :name="
               showBestiary ? 'kind-icon:chevron-up' : 'kind-icon:chevron-down'
             "
-            class="size-4 shrink-0 opacity-60"
+            class="kr-icon-4 shrink-0 opacity-60"
           />
         </button>
 
@@ -529,7 +529,7 @@
           </span>
           <Icon
             :name="showSets ? 'kind-icon:chevron-up' : 'kind-icon:chevron-down'"
-            class="size-4 shrink-0 opacity-60"
+            class="kr-icon-4 shrink-0 opacity-60"
           />
         </button>
 
@@ -608,7 +608,7 @@
             :name="
               showDecor ? 'kind-icon:chevron-up' : 'kind-icon:chevron-down'
             "
-            class="size-4 shrink-0 opacity-60"
+            class="kr-icon-4 shrink-0 opacity-60"
           />
         </button>
 
@@ -679,7 +679,7 @@
           </span>
           <Icon
             :name="showEggs ? 'kind-icon:chevron-up' : 'kind-icon:chevron-down'"
-            class="size-4 shrink-0 opacity-60"
+            class="kr-icon-4 shrink-0 opacity-60"
           />
         </button>
 

--- a/components/curation/coloring-book-curation.vue
+++ b/components/curation/coloring-book-curation.vue
@@ -276,7 +276,7 @@
           </div>
 
           <div v-else class="kr-text-dim-xs-45 flex items-center gap-2">
-            <Icon name="kind-icon:lock" class="size-4" />
+            <Icon name="kind-icon:lock" class="kr-icon-4" />
             Production edits are admin-only.
           </div>
         </div>

--- a/components/dreams/daily-digest-browser.vue
+++ b/components/dreams/daily-digest-browser.vue
@@ -176,7 +176,7 @@
             aria-label="Show the previous daily digest"
             @click="showOlder"
           >
-            <Icon name="kind-icon:chevron-left" class="size-4" />
+            <Icon name="kind-icon:chevron-left" class="kr-icon-4" />
             Previous
           </button>
           <button
@@ -187,7 +187,7 @@
             @click="showNewer"
           >
             Next
-            <Icon name="kind-icon:chevron-right" class="size-4" />
+            <Icon name="kind-icon:chevron-right" class="kr-icon-4" />
           </button>
         </div>
 
@@ -208,7 +208,7 @@
           :disabled="loading"
           @click="loadDigests"
         >
-          <Icon name="kind-icon:refresh-cw" class="size-4" />
+          <Icon name="kind-icon:refresh-cw" class="kr-icon-4" />
           Refresh archive
         </button>
       </div>

--- a/components/dreams/daily-digest-object-dialog.vue
+++ b/components/dreams/daily-digest-object-dialog.vue
@@ -29,7 +29,7 @@
             aria-label="Close object details"
             @click="emit('close')"
           >
-            <Icon name="kind-icon:x" class="size-4" />
+            <Icon name="kind-icon:x" class="kr-icon-4" />
           </button>
         </header>
 
@@ -42,7 +42,7 @@
             :class="activeTab === tab.key ? 'btn-primary' : 'btn-ghost'"
             @click="activeTab = tab.key"
           >
-            <Icon :name="tab.icon" class="size-4" />
+            <Icon :name="tab.icon" class="kr-icon-4" />
             {{ tab.label }}
           </button>
         </nav>
@@ -165,7 +165,7 @@
                   :disabled="saving || !hasChanges || missingRequiredField"
                 >
                   <span v-if="saving" class="kr-spinner-xs" />
-                  <Icon v-else name="kind-icon:save" class="size-4" />
+                  <Icon v-else name="kind-icon:save" class="kr-icon-4" />
                   {{ saving ? 'Saving…' : 'Save changes' }}
                 </button>
               </div>

--- a/components/dreams/daily-dream-generator.vue
+++ b/components/dreams/daily-dream-generator.vue
@@ -20,7 +20,7 @@
       <span class="badge badge-secondary rounded-xl">{{ dateKey }}</span>
       <Icon
         name="kind-icon:chevron-down"
-        class="size-4 transition-transform group-open:rotate-180"
+        class="kr-icon-4 transition-transform group-open:rotate-180"
       />
     </summary>
 
@@ -63,7 +63,7 @@
           @click="createDailyDream"
         >
           <span v-if="loading" class="kr-spinner-xs" />
-          <Icon v-else name="kind-icon:dream" class="size-4" />
+          <Icon v-else name="kind-icon:dream" class="kr-icon-4" />
           Build today’s Dream
         </button>
       </div>

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -167,7 +167,7 @@
             @click="queueArt"
           >
             <span v-if="submitting" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:sparkles" class="size-4" />
+            <Icon v-else name="kind-icon:sparkles" class="kr-icon-4" />
             {{ submitting ? 'Queuing…' : `Queue ${selectedSlot.label}` }}
           </button>
         </div>

--- a/components/facets/facet-profile.vue
+++ b/components/facets/facet-profile.vue
@@ -17,7 +17,7 @@
         class="kr-btn-ghost"
         @click="closeFacet"
       >
-        <Icon name="kind-icon:chevron-left" class="size-4" /> All Facets
+        <Icon name="kind-icon:chevron-left" class="kr-icon-4" /> All Facets
       </button>
 
       <div class="min-w-0 flex-1">

--- a/components/home/home-dream-hero.vue
+++ b/components/home/home-dream-hero.vue
@@ -415,7 +415,7 @@
         aria-label="Scroll the cast backwards"
         @click="scrollCast(-1)"
       >
-        <Icon name="kind-icon:chevron-left" class="size-4" />
+        <Icon name="kind-icon:chevron-left" class="kr-icon-4" />
       </button>
       <button
         v-show="castCanScroll"
@@ -425,7 +425,7 @@
         aria-label="Scroll the cast forwards"
         @click="scrollCast(1)"
       >
-        <Icon name="kind-icon:chevron-right" class="size-4" />
+        <Icon name="kind-icon:chevron-right" class="kr-icon-4" />
       </button>
     </div>
   </section>

--- a/components/home/home-object-sheet.vue
+++ b/components/home/home-object-sheet.vue
@@ -65,7 +65,7 @@
             aria-label="Close"
             @click="emit('close')"
           >
-            <Icon name="kind-icon:x" class="size-4" />
+            <Icon name="kind-icon:x" class="kr-icon-4" />
           </button>
         </header>
 
@@ -254,7 +254,7 @@
               :aria-expanded="redoOpen"
               @click="toggleRedo"
             >
-              <Icon name="kind-icon:palette-color" class="size-4" />
+              <Icon name="kind-icon:palette-color" class="kr-icon-4" />
               Redo art
             </button>
 
@@ -263,7 +263,7 @@
               class="btn btn-primary btn-sm gap-1.5 rounded-xl"
             >
               Open {{ kindLabel.toLowerCase() }}
-              <Icon name="kind-icon:chevron-right" class="size-4" />
+              <Icon name="kind-icon:chevron-right" class="kr-icon-4" />
             </NuxtLink>
           </div>
         </footer>

--- a/components/home/home-rail.vue
+++ b/components/home/home-rail.vue
@@ -79,7 +79,7 @@
         :title="`${label} — ${seeAllLabel}`"
         :aria-label="`${label} — ${seeAllLabel}`"
       >
-        <Icon :name="icon || placeholderIcon" class="size-4 shrink-0" />
+        <Icon :name="icon || placeholderIcon" class="kr-icon-4 shrink-0" />
         <!--
           THE WORDS COME BACK WHERE THERE IS ROOM. Silas, 2026-09-01: "objects
           section should be labeled if the screen supports it."

--- a/components/narrative/narrative-ingredient-card.vue
+++ b/components/narrative/narrative-ingredient-card.vue
@@ -49,7 +49,7 @@
       class="absolute right-2 top-2 z-10 flex size-8 items-center justify-center rounded-full bg-secondary text-secondary-content shadow-lg"
       aria-hidden="true"
     >
-      <Icon name="kind-icon:check" class="size-4" />
+      <Icon name="kind-icon:check" class="kr-icon-4" />
     </span>
 
     <span class="relative z-10 mt-auto flex min-w-0 flex-col gap-1.5 p-3 text-white">

--- a/components/narrative/narrative-ingredient-multi-picker.vue
+++ b/components/narrative/narrative-ingredient-multi-picker.vue
@@ -65,7 +65,7 @@
     >
       <Icon
         name="kind-icon:alert"
-        class="mt-0.5 size-4 shrink-0"
+        class="kr-icon-4 mt-0.5 shrink-0"
         aria-hidden="true"
       />
       <span>{{ error }}</span>
@@ -126,7 +126,7 @@
       >
         <Icon
           :name="expanded ? 'kind-icon:chevron-up' : 'kind-icon:chevron-down'"
-          class="size-4"
+          class="kr-icon-4"
           aria-hidden="true"
         />
         {{ expanded ? 'Show fewer' : `Show all ${filteredItems.length}` }}

--- a/components/narrative/narrative-ingredient-picker.vue
+++ b/components/narrative/narrative-ingredient-picker.vue
@@ -125,7 +125,7 @@
           class="absolute right-2 top-2 flex size-8 items-center justify-center rounded-full bg-secondary text-secondary-content shadow"
           aria-hidden="true"
         >
-          <Icon name="kind-icon:check" class="size-4" />
+          <Icon name="kind-icon:check" class="kr-icon-4" />
         </span>
         <span class="absolute inset-x-0 bottom-0 p-3 text-white">
           <span class="kr-text-black-sm block sm:text-base">
@@ -160,7 +160,7 @@
       >
         <Icon
           :name="expanded ? 'kind-icon:chevron-up' : 'kind-icon:chevron-down'"
-          class="size-4"
+          class="kr-icon-4"
           aria-hidden="true"
         />
         {{ expanded ? 'Show fewer' : `Show all ${filteredItems.length}` }}

--- a/components/narrative/narrative-response-composer.vue
+++ b/components/narrative/narrative-response-composer.vue
@@ -47,7 +47,7 @@
           class="loading loading-spinner loading-sm motion-reduce:hidden"
           aria-hidden="true"
         />
-        <Icon v-else :name="icon" class="size-4" aria-hidden="true" />
+        <Icon v-else :name="icon" class="kr-icon-4" aria-hidden="true" />
         <span class="hidden sm:inline">{{ buttonLabel }}</span>
       </button>
     </div>

--- a/components/narrative/narrative-role-assigner.vue
+++ b/components/narrative/narrative-role-assigner.vue
@@ -54,7 +54,7 @@
           @dragleave="dragOverRole = null"
           @drop.prevent="dropRole(option.key)"
         >
-          <Icon :name="option.icon" class="size-4 shrink-0" aria-hidden="true" />
+          <Icon :name="option.icon" class="kr-icon-4 shrink-0" aria-hidden="true" />
           <span>{{ option.label }}</span>
         </div>
       </div>

--- a/components/newsfeed/newsfeed-feed.vue
+++ b/components/newsfeed/newsfeed-feed.vue
@@ -127,7 +127,7 @@
         >
           <Icon
             :name="startsHere ? 'kind-icon:star' : 'kind-icon:stars'"
-            class="size-4"
+            class="kr-icon-4"
           />
           <span v-if="!compact" class="hidden 2xl:inline">{{ pinLabel }}</span>
         </button>
@@ -139,7 +139,7 @@
           aria-controls="newsfeed-manage-feeds-panel"
           @click="showManageFeeds = !showManageFeeds"
         >
-          <Icon name="kind-icon:sliders" class="size-4" />
+          <Icon name="kind-icon:sliders" class="kr-icon-4" />
           <span v-if="!compact" class="hidden 2xl:inline">Manage feeds</span>
           <Icon
             :name="
@@ -159,7 +159,7 @@
           @click="loadFeed()"
         >
           <span v-if="isLoading" class="kr-spinner-xs" />
-          <Icon v-else name="kind-icon:refresh" class="size-4" />
+          <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
           <span v-if="!compact" class="hidden 2xl:inline">Refresh</span>
         </button>
 

--- a/components/newsfeed/newsfeed-filters.vue
+++ b/components/newsfeed/newsfeed-filters.vue
@@ -45,7 +45,7 @@
             :disabled="!includeDraft.trim()"
             @click="submitInclude()"
           >
-            <Icon name="kind-icon:plus" class="size-4" />
+            <Icon name="kind-icon:plus" class="kr-icon-4" />
           </button>
         </div>
         <div class="flex flex-wrap gap-1.5">
@@ -85,7 +85,7 @@
             :disabled="!excludeDraft.trim()"
             @click="submitExclude()"
           >
-            <Icon name="kind-icon:plus" class="size-4" />
+            <Icon name="kind-icon:plus" class="kr-icon-4" />
           </button>
         </div>
         <div class="flex flex-wrap gap-1.5">

--- a/components/newsfeed/newsfeed-preferences.vue
+++ b/components/newsfeed/newsfeed-preferences.vue
@@ -47,7 +47,7 @@
             :aria-label="`Move ${feed.title} up`"
             @click="moveFeed(feed.slug, -1)"
           >
-            <Icon name="kind-icon:chevron-up" class="size-4" />
+            <Icon name="kind-icon:chevron-up" class="kr-icon-4" />
           </button>
           <button
             type="button"
@@ -56,7 +56,7 @@
             :aria-label="`Move ${feed.title} down`"
             @click="moveFeed(feed.slug, 1)"
           >
-            <Icon name="kind-icon:chevron-down" class="size-4" />
+            <Icon name="kind-icon:chevron-down" class="kr-icon-4" />
           </button>
           <input
             type="checkbox"
@@ -74,7 +74,7 @@
         class="flex items-center justify-between gap-3 py-2.5 opacity-70"
       >
         <div class="flex min-w-0 items-center gap-2">
-          <Icon :name="feed.icon" class="size-4 shrink-0" />
+          <Icon :name="feed.icon" class="kr-icon-4 shrink-0" />
           <div class="min-w-0">
             <span class="block truncate font-semibold">{{ feed.title }}</span>
             <span class="kr-text-dim-xs-55 block truncate">

--- a/components/rewards/reward-manager.vue
+++ b/components/rewards/reward-manager.vue
@@ -20,7 +20,7 @@
             title="Brainstorm variations grounded in this Reward"
             @click="startBrainstormWithReward"
           >
-            <Icon name="kind-icon:brain" class="size-4" />
+            <Icon name="kind-icon:brain" class="kr-icon-4" />
             <span class="hidden sm:inline">Brainstorm variations</span>
           </button>
         </div>

--- a/components/scenarios/scenario-manager.vue
+++ b/components/scenarios/scenario-manager.vue
@@ -22,7 +22,7 @@
             title="Start a Storybook story seeded with this Scenario"
             @click="startStoryWithScenario"
           >
-            <Icon name="kind-icon:book-open" class="size-4" />
+            <Icon name="kind-icon:book-open" class="kr-icon-4" />
             <span class="hidden sm:inline">Start a story with this</span>
           </button>
           <button
@@ -31,7 +31,7 @@
             title="Brainstorm variations grounded in this Scenario"
             @click="startBrainstormWithScenario"
           >
-            <Icon name="kind-icon:brain" class="size-4" />
+            <Icon name="kind-icon:brain" class="kr-icon-4" />
             <span class="hidden sm:inline">Brainstorm variations</span>
           </button>
         </div>

--- a/components/storybook/storybook-life-run.vue
+++ b/components/storybook/storybook-life-run.vue
@@ -127,7 +127,7 @@
             @click="startLife"
           >
             <span v-if="submitting" class="kr-spinner-sm" />
-            <Icon v-else name="kind-icon:sparkles" class="size-4" />
+            <Icon v-else name="kind-icon:sparkles" class="kr-icon-4" />
             Begin this life
           </button>
         </div>
@@ -278,7 +278,7 @@
                   :disabled="narrating"
                   @click="narrateChapter()"
                 >
-                  <Icon name="kind-icon:refresh" class="size-4" />
+                  <Icon name="kind-icon:refresh" class="kr-icon-4" />
                   Try again
                 </button>
                 <button
@@ -375,7 +375,7 @@
                 @click="resolveLife"
               >
                 <span v-if="submitting" class="kr-spinner-sm" />
-                <Icon v-else name="kind-icon:trophy" class="size-4" />
+                <Icon v-else name="kind-icon:trophy" class="kr-icon-4" />
                 See your ending
               </button>
             </div>
@@ -412,7 +412,7 @@
             class="btn btn-outline btn-sm gap-1.5 rounded-xl"
             @click="playAgain"
           >
-            <Icon name="kind-icon:refresh" class="size-4" />
+            <Icon name="kind-icon:refresh" class="kr-icon-4" />
             Live another life
           </button>
         </div>

--- a/components/storybook/storybook-visual-setup.vue
+++ b/components/storybook/storybook-visual-setup.vue
@@ -277,7 +277,7 @@
             @click="beginStory"
           >
             <span v-if="store.isWeaving" class="kr-spinner-sm" />
-            <Icon v-else name="kind-icon:book-open" class="size-4" />
+            <Icon v-else name="kind-icon:book-open" class="kr-icon-4" />
             {{ store.isWeaving ? 'Opening…' : 'Open this story' }}
           </button>
         </div>

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -461,7 +461,7 @@
             class="btn btn-ghost btn-sm rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
             @click="selectedId = null"
           >
-            <Icon name="kind-icon:close" class="size-4" />
+            <Icon name="kind-icon:close" class="kr-icon-4" />
           </button>
         </template>
       </watchlist-entry-detail>

--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -19,7 +19,7 @@
         >
           <Icon
             name="kind-icon:star"
-            class="size-4"
+            class="kr-icon-4"
             :class="entry.starred ? 'text-warning' : 'text-base-content/25'"
           />
         </button>

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -24,7 +24,7 @@
             @click="refresh"
           >
             <span v-if="loading" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:refresh" class="size-4" />
+            <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
             Refresh
           </button>
           <button
@@ -36,7 +36,7 @@
             @click="triageStore.saveChanges()"
           >
             <span v-if="triageStore.isSaving" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:save" class="size-4" />
+            <Icon v-else name="kind-icon:save" class="kr-icon-4" />
             Save {{ triageStore.pendingChanges.length }} change{{
               triageStore.pendingChanges.length === 1 ? '' : 's'
             }}

--- a/pages/play/aquarium/browse/[username]/[slug].vue
+++ b/pages/play/aquarium/browse/[username]/[slug].vue
@@ -15,7 +15,7 @@
           to="/play/aquarium/browse"
           class="kr-btn-ghost"
         >
-          <Icon name="kind-icon:arrow-left" class="size-4" />
+          <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
           Public tanks
         </NuxtLink>
       </nav>

--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -11,7 +11,7 @@
     >
       <nav class="flex items-center justify-between gap-3">
         <NuxtLink to="/play/aquarium" class="kr-btn-ghost">
-          <Icon name="kind-icon:arrow-left" class="size-4" />
+          <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
           Your tank
         </NuxtLink>
       </nav>
@@ -108,7 +108,7 @@
             :disabled="loading || skip <= 0"
             @click="prevPage"
           >
-            <Icon name="kind-icon:arrow-left" class="size-4" />
+            <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
             Newer
           </button>
           <p class="kr-text-dim-xs font-bold">
@@ -121,7 +121,7 @@
             @click="nextPage"
           >
             Older
-            <Icon name="kind-icon:arrow-right" class="size-4" />
+            <Icon name="kind-icon:arrow-right" class="kr-icon-4" />
           </button>
         </div>
       </template>

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -12,7 +12,7 @@
     >
       <nav class="flex items-center justify-between gap-3">
         <NuxtLink to="/play/aquarium" class="kr-btn-ghost">
-          <Icon name="kind-icon:arrow-left" class="size-4" />
+          <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
           Your tank
         </NuxtLink>
       </nav>
@@ -105,7 +105,7 @@
             :disabled="loading || skip <= 0"
             @click="prevPage"
           >
-            <Icon name="kind-icon:arrow-left" class="size-4" />
+            <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
             Higher ranks
           </button>
           <p class="kr-text-dim-xs font-bold">
@@ -118,7 +118,7 @@
             @click="nextPage"
           >
             Lower ranks
-            <Icon name="kind-icon:arrow-right" class="size-4" />
+            <Icon name="kind-icon:arrow-right" class="kr-icon-4" />
           </button>
         </div>
       </template>

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -5,14 +5,14 @@
     >
       <nav class="flex flex-wrap items-center justify-between gap-3">
         <NuxtLink to="/play/challenges" class="kr-btn-ghost">
-          <Icon name="kind-icon:arrow-left" class="size-4" />
+          <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
           Fight card
         </NuxtLink>
         <NuxtLink
           to="/play/challenges/leaderboard"
           class="kr-btn btn-outline"
         >
-          <Icon name="kind-icon:trophy" class="size-4" />
+          <Icon name="kind-icon:trophy" class="kr-icon-4" />
           Rankings
         </NuxtLink>
       </nav>

--- a/pages/play/challenges/leaderboard.vue
+++ b/pages/play/challenges/leaderboard.vue
@@ -5,7 +5,7 @@
     >
       <nav class="flex flex-wrap items-center justify-between gap-3">
         <NuxtLink to="/play/challenges" class="kr-btn-ghost">
-          <Icon name="kind-icon:arrow-left" class="size-4" />
+          <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
           Fight card
         </NuxtLink>
         <button
@@ -15,7 +15,7 @@
           @click="loadLeaderboard"
         >
           <span v-if="loading" class="kr-spinner-xs" />
-          <Icon v-else name="kind-icon:refresh" class="size-4" />
+          <Icon v-else name="kind-icon:refresh" class="kr-icon-4" />
           Refresh
         </button>
       </nav>

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -46,7 +46,7 @@
             :aria-selected="workspaceView === view.value"
             @click="workspaceView = view.value"
           >
-            <Icon :name="view.icon" class="size-4" />
+            <Icon :name="view.icon" class="kr-icon-4" />
             {{ view.label }}
           </button>
         </div>
@@ -332,13 +332,13 @@
 
                 <div class="flex items-center justify-between gap-2 kr-panel-divider">
                   <button type="button" class="kr-btn-ghost-plain" :disabled="focusNavigationLocked" @click="store.previousCard()">
-                    <Icon name="kind-icon:back" class="size-4" />
+                    <Icon name="kind-icon:back" class="kr-icon-4" />
                     Previous
                   </button>
                   <span class="kr-text-faded-xs-55">{{ currentPositionLabel }}</span>
                   <button type="button" class="kr-btn-ghost-plain" :disabled="focusNavigationLocked" @click="store.nextCard()">
                     Next
-                    <Icon name="kind-icon:forward" class="size-4" />
+                    <Icon name="kind-icon:forward" class="kr-icon-4" />
                   </button>
                 </div>
               </div>

--- a/pages/users/[id].vue
+++ b/pages/users/[id].vue
@@ -6,7 +6,7 @@
         to="/plan/wonderlab"
         class="btn btn-ghost btn-sm mb-4 rounded-xl"
       >
-        <Icon name="kind-icon:arrow-left" class="size-4" />
+        <Icon name="kind-icon:arrow-left" class="kr-icon-4" />
         Back to WonderLab
       </NuxtLink>
 


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules — slice 239 (kind: software, recurring)

### What changed / what I produced
- `size-4` is Tailwind's shorthand for `h-4 w-4`, CSS-identical to the bare icon-glyph shape `kr-icon-4` already covers (`h-4 w-4` fully migrated repo-wide in slice 223).
- kind_robots#2608 migrated the first 42 plain (uncolored) `size-4` occurrences (`components/conductor`, `components/pages`) via `kr_icon_4_size_shorthand_codemod.py`. This slice runs the same existing codemod across the rest of the repo, migrating the remaining **82 occurrences across 28 files** — `components/dreams`, `components/narrative`, `components/newsfeed`, `components/watchlist`, `components/home`, `components/rewards`, `components/scenarios`, `components/storybook`, `components/facets`, `pages/admin`, `pages/play`, `pages/users`.
- Colored `size-4` icons (`text-primary`, etc.) remain out of scope, same as #2608 — the codemod already excludes any class string carrying a `text-*`/`stroke-*`/`fill-*` token.
- A dry run of the codemod now reports 0 remaining `size-4` shorthand candidates repo-wide.
- No color/behavior/API/schema/route/geometry change — `.kr-icon-4` applies the same `h-4 w-4`.

### How I verified
- `npx vue-tsc --noEmit` — clean.
- `npx eslint` on all 40 touched files — 6 pre-existing errors in 4 files (`vue/no-mutating-props`, `no-empty`, `@typescript-eslint/no-dynamic-delete`), confirmed identical before/after via `git stash` — none touch the migrated class attributes.
- `npx prettier --check` on all touched files — 19 pre-existing warnings, confirmed identical before/after via the same stash comparison (no new wrap-width regression like the one caught in a prior slice's TALKBACK).
- `npm run test:layout-contract` — exit 0, all nine rule counts unchanged. This slice touches three of the four pages `interface-vision/t-127` just audited for the widened `one-header` rule (`pages/users/[id].vue`, `pages/play/challenges/leaderboard.vue`, `pages/play/challenges/[slug].vue`) — confirmed no interaction (the class-attribute change is unrelated to title-block structure).

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
`size-3`, `size-3.5`, and `size-5` (Tailwind's shorthand siblings of `size-4`) don't have their own shorthand codemods yet, only the two-token `h-N w-N` spellings do (`kr_icon_3_codemod.py`, `kr_icon_3_5_codemod.py`, `kr_icon_5_codemod.py`). A future slice could survey the repo for bare `size-3`/`size-3.5`/`size-5` occurrences and add matching shorthand codemods, mirroring this one.

### Notes for reviewer
Conductor task: interface-vision/t-104 (status: review at the time of this PR, recurring — will re-arm to `ready` after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TU8avhpfPYmZkN89TrB9kY

---
_Generated by [Claude Code](https://claude.ai/code/session_01TU8avhpfPYmZkN89TrB9kY)_