### PR TITLE
ci(interface): warn on assertionless test commits

### DIFF
--- a/.github/workflows/layout-contract.yml
+++ b/.github/workflows/layout-contract.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -44,3 +46,7 @@ jobs:
 
       - name: Layout header contract self-test
         run: npm run test:layout-header-contract-selftest
+
+      - name: Audit test-prefixed commits for executable assertions
+        if: github.event_name == 'pull_request'
+        run: bash scripts/check-test-commit-assertions.sh "${{ github.event.pull_request.base.sha }}"

--- a/scripts/check-test-commit-assertions.sh
+++ b/scripts/check-test-commit-assertions.sh
@@ -7,11 +7,13 @@ if [[ -z "$base_ref" ]]; then
   exit 2
 fi
 
+test_prefix_re='^test(\([^)]*\))?:[[:space:]]'
+
 warned=0
 while IFS= read -r commit; do
   [[ -z "$commit" ]] && continue
   subject="$(git log -1 --format=%s "$commit")"
-  if [[ ! "$subject" =~ ^test(\([^)]*\))?:[[:space:]] ]]; then
+  if [[ ! "$subject" =~ $test_prefix_re ]]; then
     continue
   fi
 

--- a/scripts/check-test-commit-assertions.sh
+++ b/scripts/check-test-commit-assertions.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${1:-}"
+if [[ -z "$base_ref" ]]; then
+  echo "usage: $0 <base-ref>" >&2
+  exit 2
+fi
+
+warned=0
+while IFS= read -r commit; do
+  [[ -z "$commit" ]] && continue
+  subject="$(git log -1 --format=%s "$commit")"
+  if [[ ! "$subject" =~ ^test(\([^)]*\))?:[[:space:]] ]]; then
+    continue
+  fi
+
+  if git diff-tree --no-commit-id --name-only -r "$commit" | grep -Eq '(^|/)[^/]+\.(test|spec)\.[^.]+$'; then
+    continue
+  fi
+
+  if git show --format= --unified=0 "$commit" | grep -Eq '^\+[^+].*\b(assert|expect)[[:space:]]*\('; then
+    continue
+  fi
+
+  echo "::warning title=Test commit without assertion::${commit:0:12} '${subject}' touches no *.test.*/*.spec.* file and adds no assert(...)/expect(...) call. Confirm this commit contains executable test coverage rather than fixtures, prose, or test infrastructure only."
+  warned=1
+done < <(git rev-list --reverse "${base_ref}..HEAD")
+
+if [[ "$warned" -eq 1 ]]; then
+  echo "Test-commit assertion audit completed with warnings."
+else
+  echo "Test-commit assertion audit clean."
+fi


### PR DESCRIPTION
## Summary
- add a warning-only audit for commits whose subject starts with `test:` or `test(scope):`
- treat touching `*.test.*` / `*.spec.*` or adding `assert(...)` / `expect(...)` as executable-test evidence
- emit a GitHub Actions warning when neither signal exists, without blocking legitimate test-infrastructure-only commits
- fetch full PR history in Layout Contract CI so the audit can inspect the base-to-head commit range

## Verification
- Conductor `interface-vision/t-128` was claimed and moved to `review` by session `2026-09-12T051543Z-interface-vision-t-128-k7p4` before this PR opened
- complete branch diff against main is 2 files, +40/-0
- CI is the authoritative execution environment for this git-history check; merge only after the actual PR checks complete successfully

## Safety
Reversible CI-only change. Warning-only by design; no runtime, schema, deployment, billing, secret, or production-data changes.