### PR TITLE
style(art,academy): migrate viewport-grid card lists to container-width fluid grids

### DIFF
--- a/components/academy/academy-style-detail.vue
+++ b/components/academy/academy-style-detail.vue
@@ -197,7 +197,7 @@
             How to spot it
           </p>
           <h4 class="kr-text-black-xl mt-2 text-base-content">Train your eye</h4>
-          <div class="mt-4 grid gap-3 sm:grid-cols-2">
+          <div class="mt-4 grid grid-cols-[repeat(auto-fit,minmax(min(100%,16rem),1fr))] gap-3">
             <div
               v-for="(cue, index) in lesson.recognitionCues"
               :key="cue"
@@ -227,7 +227,7 @@
             </span>
           </div>
 
-          <div class="mt-4 grid gap-3 sm:grid-cols-2">
+          <div class="mt-4 grid grid-cols-[repeat(auto-fit,minmax(min(100%,20rem),1fr))] gap-3">
             <div
               v-for="artist in lesson.artists"
               :key="artist.name"

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -63,7 +63,7 @@
         {{ formatAge(stats.oldestPending.ageSeconds) }}.
       </div>
 
-      <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,10rem),1fr))] gap-3">
         <div
           v-for="status in summaryStatuses"
           :key="status"
@@ -96,7 +96,7 @@
               {{ artJobStore.queuePaused ? 'Resume queue' : 'Pause queue' }}
             </button>
           </div>
-          <div class="grid gap-2 sm:grid-cols-2">
+          <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,14rem),1fr))] gap-2">
             <div
               v-for="server in privateArtServers"
               :key="server.id"
@@ -318,7 +318,7 @@
           <p class="kr-text-dim-sm-70">{{ queueLoadMessage }}</p>
         </div>
 
-        <div v-else class="mt-3 grid gap-3 xl:grid-cols-2">
+        <div v-else class="mt-3 grid grid-cols-[repeat(auto-fit,minmax(min(100%,18rem),1fr))] gap-3">
           <artjob-queue-card
             v-for="job in artJobStore.jobs"
             :key="job.id"

--- a/components/art/collection-picker.vue
+++ b/components/art/collection-picker.vue
@@ -38,7 +38,7 @@
     <Transition name="picker-panel">
       <div
         v-if="expanded"
-        class="grid max-h-72 gap-2 overflow-y-auto rounded-2xl border border-base-content/10 bg-base-200/80 p-2 sm:grid-cols-2 lg:grid-cols-3"
+        class="grid max-h-72 grid-cols-[repeat(auto-fit,minmax(min(100%,12rem),1fr))] gap-2 overflow-y-auto rounded-2xl border border-base-content/10 bg-base-200/80 p-2"
       >
         <button
           type="button"

--- a/utils/scripts/layout-contract-baseline.json
+++ b/utils/scripts/layout-contract-baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Layout-contract allow-list. RATCHET: this file may only ever shrink. --update refuses to record a larger count. See utils/scripts/verifyLayoutContract.ts.",
-  "recorded": "2026-09-10",
+  "recorded": "2026-09-12",
   "violations": {
     "one-header": [],
     "one-scroll": [],
@@ -13,7 +13,6 @@
     "viewport-grid": [
       "components/academy/academy-manager.vue → xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]",
       "components/academy/academy-remix.vue → xl:grid-cols-[minmax(0,1.2fr)_minmax(300px,0.8fr)]",
-      "components/academy/academy-style-detail.vue → sm:grid-cols-2",
       "components/achievements/achievement-gallery.vue → lg:grid-cols-3",
       "components/animation/animation-manager.vue → sm:grid-cols-2",
       "components/animation/animation-manager.vue → xl:grid-cols-3",
@@ -39,13 +38,9 @@
       "components/art/artjob-editor.vue → lg:grid-cols-[minmax(0,1.25fr)_minmax(280px,0.75fr)]",
       "components/art/artjob-editor.vue → sm:grid-cols-2",
       "components/art/artjob-editor.vue → sm:grid-cols-3",
-      "components/art/artjob-queue-browser.vue → sm:grid-cols-2",
       "components/art/artjob-queue-browser.vue → xl:grid-cols-2",
-      "components/art/artjob-queue-browser.vue → xl:grid-cols-4",
       "components/art/artjob-trainer-redo-controls.vue → sm:grid-cols-2",
       "components/art/build-bench.vue → md:grid-cols-2",
-      "components/art/collection-picker.vue → lg:grid-cols-3",
-      "components/art/collection-picker.vue → sm:grid-cols-2",
       "components/art/entity-art-manager.vue → lg:grid-cols-4",
       "components/art/entity-art-manager.vue → sm:grid-cols-2",
       "components/art/entity-art-manager.vue → sm:grid-cols-[minmax(0,1fr)_auto]",


### PR DESCRIPTION
### Task
interface-vision/t-129 (slice 1): Survey and migrate the highest-traffic viewport-grid offenders onto container-width grids (kind: software)

### What changed / what I produced
- Migrated 5 unique viewport-breakpoint `grid-cols` tokens across 3 files onto `grid-cols-[repeat(auto-fit,minmax(min(100%,Nrem),1fr))]` fluid grids, following the established pattern already used elsewhere in the repo (`newsfeed-feed.vue`, `narrative-ingredient-picker.vue`, `cthulhuquarium-game.vue`) and interface-vision t-112/t-113's documented rationale:
  - `components/art/collection-picker.vue`: `sm:grid-cols-2 lg:grid-cols-3` → `minmax(min(100%,12rem),1fr)`
  - `components/academy/academy-style-detail.vue`: two card-list grids (recognition cues, artist cards) → `minmax(min(100%,16rem)/20rem,1fr)`
  - `components/art/artjob-queue-browser.vue`: three card-list grids (status summary tiles, private-server list, artjob-queue-card list) → `minmax(min(100%,10rem)/14rem/18rem,1fr)`
- Deliberately left `artjob-queue-browser.vue`'s `xl:grid-cols-2` (line 81 — a two-panel side-by-side layout, not a repeating card list) untouched; scoped this slice to genuinely repeating card/tile lists only.
- Ratcheted the `viewport-grid` layout-contract baseline 205 → 200 via `--update`.

### How I verified
- `npx tsx utils/scripts/verifyLayoutContract.ts` — baseline holds, ratcheted down, no new violations
- `npx tsx utils/scripts/verifyMixedPanePrimitivesFixture.ts` — passes
- `npx tsx utils/scripts/layoutHeaderContract.test.ts` — all assertions pass
- Reviewed the full diff by hand — no color/behavior/API/schema/route change, only the grid-cols mechanism (viewport breakpoint → container-width auto-fit)
- Did not visually verify pre-merge (no PR-preview infra for kind_robots per repo convention); rem sizes were chosen to roughly preserve current column counts at common widths, matching sibling migrated examples

### Stakes
reversible

### Flags for Reviewer
- rem sizes (10/12/14/16/18/20rem) are a best-effort match to each card's approximate natural width; no visual/screenshot verification was possible pre-merge in this sandbox — flag if any look off after a Force Update + `responsive-layout-audit.yml` run

### Kaizen suggestion
~200 viewport-grid occurrences remain (was 205). Filed as interface-vision/t-131: continue this survey-and-migrate pattern in further bounded slices.

### Notes for reviewer
Second, independent task worked in this same session after interface-vision/t-128 (kind_robots#2651, ci fix); one claim at a time, this is the only one in flight now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QNdSc2vAec5G148K3UC3L

---
_Generated by [Claude Code](https://claude.ai/code/session_015QNdSc2vAec5G148K3UC3L)_