### PR TITLE
interface-vision/t-104 slice 240: migrate size-3/size-3.5/size-5 icon shorthand to kr-icon-*

### DIFF
--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -31,7 +31,7 @@
       >
         <span
           v-if="facetArtwork(facet)"
-          class="size-5 overflow-hidden rounded-lg bg-base-200"
+          class="kr-icon-5 overflow-hidden rounded-lg bg-base-200"
         >
           <img
             :src="facetArtwork(facet) || ''"
@@ -69,7 +69,7 @@
           <div
             class="kr-text-eyebrow sticky top-0 z-10 flex items-center gap-2 bg-base-100/95 px-2 py-1 text-[10px] tracking-wide text-base-content/45 backdrop-blur"
           >
-            <Icon name="kind-icon:tag" class="size-3" />
+            <Icon name="kind-icon:tag" class="kr-icon-3" />
             {{ group.label }}
             <span class="font-semibold text-base-content/25">{{
               group.facets.length
@@ -124,7 +124,7 @@
                 v-if="artRequests.requesting[facet.id]"
                 class="kr-spinner-xs"
               />
-              <Icon v-else name="kind-icon:image" class="size-3.5" />
+              <Icon v-else name="kind-icon:image" class="kr-icon-3-5" />
               {{ artRequests.requested[facet.id] ? 'Requested' : 'Art' }}
             </button>
             <button
@@ -134,7 +134,7 @@
               aria-label="Add Facet"
               @click="addFacet(facet.id)"
             >
-              <Icon name="kind-icon:plus" class="size-3.5" />
+              <Icon name="kind-icon:plus" class="kr-icon-3-5" />
             </button>
           </div>
         </template>

--- a/components/art/art-lora-picker.vue
+++ b/components/art/art-lora-picker.vue
@@ -81,7 +81,7 @@
                 :aria-label="`Move ${loraLabel(entry.resource)} earlier`"
                 @click="move(index, -1)"
               >
-                <Icon name="kind-icon:chevron-up" class="size-3.5" />
+                <Icon name="kind-icon:chevron-up" class="kr-icon-3-5" />
               </button>
               <button
                 type="button"
@@ -90,7 +90,7 @@
                 :aria-label="`Move ${loraLabel(entry.resource)} later`"
                 @click="move(index, 1)"
               >
-                <Icon name="kind-icon:chevron-down" class="size-3.5" />
+                <Icon name="kind-icon:chevron-down" class="kr-icon-3-5" />
               </button>
               <button
                 type="button"
@@ -98,7 +98,7 @@
                 :aria-label="`Remove ${loraLabel(entry.resource)}`"
                 @click="remove(entry.resourceId)"
               >
-                <Icon name="kind-icon:close" class="size-3.5" />
+                <Icon name="kind-icon:close" class="kr-icon-3-5" />
               </button>
             </span>
           </div>
@@ -195,7 +195,7 @@
                 <Icon
                   v-else
                   name="kind-icon:sparkles"
-                  class="size-5 opacity-30"
+                  class="kr-icon-5 opacity-30"
                 />
               </span>
 

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -19,7 +19,7 @@
           class="btn btn-secondary btn-xs gap-1 rounded-lg"
           @click="openGenerate"
         >
-          <Icon name="kind-icon:sparkles" class="size-3" />
+          <Icon name="kind-icon:sparkles" class="kr-icon-3" />
           Generate replacement
         </button>
         <button
@@ -27,7 +27,7 @@
           class="btn btn-primary btn-xs gap-1 rounded-lg"
           @click="openUpload"
         >
-          <Icon name="kind-icon:upload" class="size-3" />
+          <Icon name="kind-icon:upload" class="kr-icon-3" />
           Upload image
         </button>
       </div>
@@ -119,7 +119,7 @@
             @click="promoteActiveSlide"
           >
             <span v-if="promoting" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:star" class="size-3" />
+            <Icon v-else name="kind-icon:star" class="kr-icon-3" />
             Set as {{ primarySlot.label.toLowerCase() }}
           </button>
           <template v-else>
@@ -128,7 +128,7 @@
               class="btn btn-secondary btn-xs gap-1 rounded-lg"
               @click="openGenerate"
             >
-              <Icon name="kind-icon:sparkles" class="size-3" />
+              <Icon name="kind-icon:sparkles" class="kr-icon-3" />
               Generate
             </button>
             <button
@@ -136,7 +136,7 @@
               class="btn btn-xs gap-1 rounded-lg border-0 bg-base-100/85 backdrop-blur"
               @click="openUpload"
             >
-              <Icon name="kind-icon:upload" class="size-3" />
+              <Icon name="kind-icon:upload" class="kr-icon-3" />
               Upload
             </button>
           </template>
@@ -214,7 +214,7 @@
           @click="removeHistory(slide.artImageId)"
         >
           <span v-if="removingHistoryId === slide.artImageId" class="kr-spinner-xs" />
-          <Icon v-else name="kind-icon:trash" class="size-3" />
+          <Icon v-else name="kind-icon:trash" class="kr-icon-3" />
         </button>
       </div>
     </div>
@@ -237,7 +237,7 @@
           :disabled="submitting"
           @click="closeForms"
         >
-          <Icon name="kind-icon:x" class="size-3" />
+          <Icon name="kind-icon:x" class="kr-icon-3" />
         </button>
       </div>
 
@@ -404,7 +404,7 @@
           :disabled="submitting"
           @click="closeForms"
         >
-          <Icon name="kind-icon:x" class="size-3" />
+          <Icon name="kind-icon:x" class="kr-icon-3" />
         </button>
       </div>
 

--- a/components/art/stylist-client-gallery.vue
+++ b/components/art/stylist-client-gallery.vue
@@ -20,7 +20,7 @@
         :aria-expanded="uploadOpen"
         @click="uploadOpen = !uploadOpen"
       >
-        <Icon name="kind-icon:upload" class="size-3.5" />
+        <Icon name="kind-icon:upload" class="kr-icon-3-5" />
         <span class="hidden sm:inline">Upload</span>
       </button>
     </header>

--- a/components/art/stylist-clients.vue
+++ b/components/art/stylist-clients.vue
@@ -58,7 +58,7 @@
 
           <div class="flex flex-wrap items-center gap-1">
             <button type="button" class="btn btn-primary btn-xs" @click="toggleGallery(customer.id)">
-              <Icon name="kind-icon:image" class="size-3.5" />
+              <Icon name="kind-icon:image" class="kr-icon-3-5" />
               {{ openGalleryId === customer.id ? 'Close gallery' : 'Open gallery' }}
             </button>
             <button type="button" class="kr-btn-ghost-xs-plain" @click="edit(customer)">Edit</button>

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -82,7 +82,7 @@
               {{ facet.aliases.join(' · ') }}
             </span>
           </span>
-          <Icon name="kind-icon:plus" class="size-3.5 shrink-0" />
+          <Icon name="kind-icon:plus" class="kr-icon-3-5 shrink-0" />
         </button>
         <p
           v-if="!searchResults.length"

--- a/components/coloring/coloring-book-cover-studio.vue
+++ b/components/coloring/coloring-book-cover-studio.vue
@@ -105,7 +105,7 @@
           @click="savePrompt"
         >
           <span v-if="studio.savingCoverPrompt" class="kr-spinner-sm" />
-          <icon v-else name="kind-icon:save" class="size-5" />
+          <icon v-else name="kind-icon:save" class="kr-icon-5" />
           Save canonical cover prompt
         </button>
 
@@ -139,7 +139,7 @@
               @click="requestCover(false)"
             >
               <span v-if="studio.requestingAction" class="kr-spinner-sm" />
-              <icon v-else name="kind-icon:sparkles" class="size-5" />
+              <icon v-else name="kind-icon:sparkles" class="kr-icon-5" />
               Generate cover candidate
             </button>
 
@@ -150,7 +150,7 @@
               :disabled="studio.requestingAction || promptDirty"
               @click="requestCover(true)"
             >
-              <icon name="kind-icon:refresh" class="size-5" />
+              <icon name="kind-icon:refresh" class="kr-icon-5" />
               Archive and regenerate
             </button>
 
@@ -195,7 +195,7 @@
                   :disabled="!validLegacyPath || studio.requestingAction"
                   @click="adoptExisting"
                 >
-                  <icon name="kind-icon:gallery" class="size-5" />
+                  <icon name="kind-icon:gallery" class="kr-icon-5" />
                   Adopt exact file
                 </button>
               </div>

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -138,7 +138,7 @@
             </div>
           </div>
           <div v-else class="alert alert-success mt-3 rounded-2xl">
-            <icon name="kind-icon:check" class="size-5" />
+            <icon name="kind-icon:check" class="kr-icon-5" />
             <span>All canonical source assets are complete and verified.</span>
           </div>
         </article>
@@ -201,7 +201,7 @@
       </div>
 
       <div class="alert alert-info rounded-2xl">
-        <icon name="kind-icon:info" class="size-5" />
+        <icon name="kind-icon:info" class="kr-icon-5" />
         <span>
           Canonical source art is {{ packageData.requirements.sourcePixelSize }} at
           {{ packageData.requirements.sourceAspectRatio }}. It will not be cropped into a

--- a/components/coloring/coloring-book-production-toolbar.vue
+++ b/components/coloring/coloring-book-production-toolbar.vue
@@ -67,7 +67,7 @@
       v-if="colorUsesLegacyAsset || bwUsesLegacyAsset"
       class="alert alert-info rounded-2xl"
     >
-      <icon name="kind-icon:gallery" class="size-5" />
+      <icon name="kind-icon:gallery" class="kr-icon-5" />
       <span>
         The displayed {{ legacyAssetLabel }} predates the current ArtJob queue. Adopting it
         keeps the existing Conductor file and does not fabricate missing generation metadata.
@@ -142,7 +142,7 @@
           @click="requestBw(false)"
         >
           <span v-if="studio.requestingAction" class="kr-spinner-sm" />
-          <icon v-else name="kind-icon:pencil" class="size-5" />
+          <icon v-else name="kind-icon:pencil" class="kr-icon-5" />
           Generate B&amp;W counterpart
         </button>
 
@@ -174,7 +174,7 @@
         :disabled="studio.requestingAction"
         @click="requestBw(true)"
       >
-        <icon name="kind-icon:refresh" class="size-5" />
+        <icon name="kind-icon:refresh" class="kr-icon-5" />
         Archive and regenerate B&amp;W
       </button>
 
@@ -184,7 +184,7 @@
     </div>
 
     <div v-else class="alert rounded-2xl">
-      <icon name="kind-icon:lock" class="size-5" />
+      <icon name="kind-icon:lock" class="kr-icon-5" />
       <span>Production decisions are visible to everyone and writable by admins.</span>
     </div>
   </section>

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -21,13 +21,13 @@
         @click="studio.fetchStudio()"
       >
         <span v-if="studio.loading" class="kr-spinner-sm" />
-        <icon v-else name="kind-icon:refresh" class="size-5" />
+        <icon v-else name="kind-icon:refresh" class="kr-icon-5" />
         Refresh Conductor
       </button>
     </header>
 
     <div v-if="studio.error" class="alert alert-error rounded-2xl" role="alert">
-      <icon name="kind-icon:alert" class="size-5" />
+      <icon name="kind-icon:alert" class="kr-icon-5" />
       <span>{{ studio.error }}</span>
       <button
         type="button"
@@ -43,7 +43,7 @@
       class="alert alert-success rounded-2xl"
       role="status"
     >
-      <icon name="kind-icon:check" class="size-5" />
+      <icon name="kind-icon:check" class="kr-icon-5" />
       <span>{{ studio.message }}</span>
       <button
         type="button"
@@ -178,7 +178,7 @@
             class="btn btn-primary mt-auto rounded-2xl"
             @click="openBook(book.slug)"
           >
-            <icon name="kind-icon:gallery" class="size-5" />
+            <icon name="kind-icon:gallery" class="kr-icon-5" />
             Open page ledger
           </button>
         </article>
@@ -446,7 +446,7 @@
               v-if="studio.savingPrompt"
               class="kr-spinner-sm"
             />
-            <icon v-else name="kind-icon:save" class="size-5" />
+            <icon v-else name="kind-icon:save" class="kr-icon-5" />
             Save canonical prompt
           </button>
 
@@ -472,7 +472,7 @@
               v-if="studio.requestingRender"
               class="kr-spinner-sm"
             />
-            <icon v-else name="kind-icon:sparkles" class="size-5" />
+            <icon v-else name="kind-icon:sparkles" class="kr-icon-5" />
             {{
               requestNeedsForce
                 ? 'Archive current and request revision'
@@ -484,7 +484,7 @@
             v-if="!userStore.isAdmin"
             class="alert rounded-2xl bg-base-200 text-sm"
           >
-            <icon name="kind-icon:lock" class="size-5" />
+            <icon name="kind-icon:lock" class="kr-icon-5" />
             <span>Production edits and render requests are admin-only.</span>
           </div>
 

--- a/components/coloring/production-action-button.vue
+++ b/components/coloring/production-action-button.vue
@@ -7,7 +7,7 @@
     @click="emit('click')"
   >
     <span v-if="busy" class="kr-spinner-sm" />
-    <icon v-else :name="iconName" class="size-5" />
+    <icon v-else :name="iconName" class="kr-icon-5" />
     {{ armed ? confirmLabel : label }}
   </button>
 </template>

--- a/components/coloring/production-stage-card.vue
+++ b/components/coloring/production-stage-card.vue
@@ -3,7 +3,7 @@
     <div class="flex items-center justify-between gap-2">
       <icon
         :name="iconName"
-        class="size-5"
+        class="kr-icon-5"
         :class="done ? 'text-success' : 'text-base-content/40'"
       />
       <span

--- a/components/conductor/challenge-center-page.vue
+++ b/components/conductor/challenge-center-page.vue
@@ -118,7 +118,7 @@
             role="alert"
             class="alert alert-warning rounded-2xl text-sm"
           >
-            <Icon name="kind-icon:warning" class="size-5" />
+            <Icon name="kind-icon:warning" class="kr-icon-5" />
             <span>{{ errorMessage }}</span>
           </div>
 

--- a/components/conductor/packmaker-admin-panel.vue
+++ b/components/conductor/packmaker-admin-panel.vue
@@ -17,7 +17,7 @@
         <span
           class="flex size-9 items-center justify-center rounded-xl bg-warning/15 text-warning"
         >
-          <Icon name="kind-icon:box" class="size-5" />
+          <Icon name="kind-icon:box" class="kr-icon-5" />
         </span>
         <div>
           <h3 class="kr-text-black-base text-base-content">Pack Generator</h3>
@@ -28,7 +28,7 @@
       </div>
       <div class="flex items-center gap-1.5">
         <button class="kr-btn-xs btn-primary" @click="openNewPack">
-          <Icon name="kind-icon:plus" class="size-3.5" />
+          <Icon name="kind-icon:plus" class="kr-icon-3-5" />
           New pack
         </button>
         <button class="kr-btn-ghost-xs" @click="showImport = !showImport">
@@ -107,7 +107,7 @@
           title="Rename the pack or edit its manifest entries"
           @click="editorMode = 'edit'"
         >
-          <Icon name="kind-icon:pencil" class="size-3.5" />
+          <Icon name="kind-icon:pencil" class="kr-icon-3-5" />
           Edit / rename
         </button>
         <p class="kr-text-dim-sm-70 w-full leading-relaxed">
@@ -187,7 +187,7 @@
               title="Forget the local link and start this item over as a fresh row"
               @click="packStore.resetItem(selectedPack.id, item.id)"
             >
-              <Icon name="kind-icon:refresh" class="size-3.5" />
+              <Icon name="kind-icon:refresh" class="kr-icon-3-5" />
             </button>
           </div>
         </article>

--- a/components/conductor/packmaker-pack-editor.vue
+++ b/components/conductor/packmaker-pack-editor.vue
@@ -104,7 +104,7 @@
           >Items ({{ draft.items.length }})</span
         >
         <button class="kr-btn-ghost-xs" @click="addItem">
-          <Icon name="kind-icon:plus" class="size-3.5" />
+          <Icon name="kind-icon:plus" class="kr-icon-3-5" />
           Add item
         </button>
       </div>

--- a/components/conductor/project-deliverables-panel.vue
+++ b/components/conductor/project-deliverables-panel.vue
@@ -19,7 +19,7 @@
       >
         <Icon
           :name="editing ? 'kind-icon:x' : 'kind-icon:edit'"
-          class="size-3.5"
+          class="kr-icon-3-5"
         />
         {{ editing ? 'Close' : 'Edit' }}
       </button>

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -8,7 +8,7 @@
         class="btn btn-ghost btn-xs gap-0.5 rounded-lg px-1.5"
         @click="goBack"
       >
-        <Icon name="kind-icon:chevron-left" class="size-3" />
+        <Icon name="kind-icon:chevron-left" class="kr-icon-3" />
         Back
       </button>
       <Icon name="kind-icon:folder" class="size-3.5 shrink-0 text-primary/70" />
@@ -37,7 +37,7 @@
             :name="
               linkedProject.isPublic ? 'kind-icon:eye' : 'kind-icon:eye-off'
             "
-            class="size-3.5"
+            class="kr-icon-3-5"
           />
         </button>
         <button
@@ -53,7 +53,7 @@
           :disabled="projectSaving"
           @click="patchProject({ isMature: !linkedProject.isMature })"
         >
-          <Icon name="kind-icon:warning" class="size-3.5" />
+          <Icon name="kind-icon:warning" class="kr-icon-3-5" />
         </button>
         <button
           type="button"
@@ -68,7 +68,7 @@
           :disabled="projectSaving"
           @click="patchProject({ allowReviews: !linkedProject.allowReviews })"
         >
-          <Icon name="kind-icon:comment" class="size-3.5" />
+          <Icon name="kind-icon:comment" class="kr-icon-3-5" />
         </button>
       </template>
 
@@ -117,7 +117,7 @@
         aria-label="Brainstorm variations grounded in this Project"
         @click="startBrainstormWithProject"
       >
-        <Icon name="kind-icon:brain" class="size-3.5" />
+        <Icon name="kind-icon:brain" class="kr-icon-3-5" />
       </button>
       <button
         type="button"
@@ -127,7 +127,7 @@
         @click="refreshProject"
       >
         <span v-if="refreshing" class="kr-spinner-xs" />
-        <Icon v-else name="kind-icon:refresh" class="size-3.5" />
+        <Icon v-else name="kind-icon:refresh" class="kr-icon-3-5" />
       </button>
     </div>
 
@@ -310,7 +310,7 @@
       >
         <Icon
           name="kind-icon:chevron-right"
-          class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
+          class="kr-icon-3-5 shrink-0 transition-transform group-open:rotate-90"
         />
         <span class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide">
           Roadmap
@@ -330,7 +330,7 @@
               class="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full border"
               :class="taskIconClass(task.status)"
             >
-              <Icon :name="taskIcon(task.status)" class="size-3" />
+              <Icon :name="taskIcon(task.status)" class="kr-icon-3" />
             </div>
             <div class="min-w-0 flex-1">
               <p class="break-words text-sm font-semibold leading-snug">
@@ -387,7 +387,7 @@
           >
             <Icon
               name="kind-icon:chevron-right"
-              class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
+              class="kr-icon-3-5 shrink-0 transition-transform group-open:rotate-90"
             />
             Completed
             <span class="kr-badge-success-xs ml-auto">{{ doneTaskCount }}</span>
@@ -437,7 +437,7 @@
       >
         <Icon
           name="kind-icon:chevron-right"
-          class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
+          class="kr-icon-3-5 shrink-0 transition-transform group-open:rotate-90"
         />
         <span class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide">
           Milestones
@@ -456,7 +456,7 @@
             class="flex size-6 shrink-0 items-center justify-center rounded-full border"
             :class="milestoneIconClass(milestone.status)"
           >
-            <Icon :name="milestoneIcon(milestone.status)" class="size-3" />
+            <Icon :name="milestoneIcon(milestone.status)" class="kr-icon-3" />
           </div>
           <div class="min-w-0 flex-1">
             <p class="break-words text-sm font-semibold leading-snug">
@@ -492,7 +492,7 @@
       >
         <Icon
           name="kind-icon:chevron-right"
-          class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
+          class="kr-icon-3-5 shrink-0 transition-transform group-open:rotate-90"
         />
         <Icon name="kind-icon:document" class="size-4 text-info" />
         <span class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide">

--- a/components/conductor/project-front-page.vue
+++ b/components/conductor/project-front-page.vue
@@ -43,7 +43,7 @@
             v-if="view.bridge"
             class="kr-badge-sm badge-info rounded-xl font-semibold gap-1"
           >
-            <Icon name="kind-icon:external-link" class="size-3" />External app
+            <Icon name="kind-icon:external-link" class="kr-icon-3" />External app
           </span>
         </div>
 
@@ -140,7 +140,7 @@
             <span
               class="flex size-9 items-center justify-center rounded-xl bg-primary/12 text-primary"
             >
-              <Icon :name="block.icon || 'kind-icon:sparkles'" class="size-5" />
+              <Icon :name="block.icon || 'kind-icon:sparkles'" class="kr-icon-5" />
             </span>
             <h3 class="kr-text-black-base text-base-content">
               {{ block.title }}

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -111,7 +111,7 @@
               <Icon
                 v-if="index < setupStep"
                 name="kind-icon:check"
-                class="size-3.5"
+                class="kr-icon-3-5"
               />
               <span v-else>{{ index + 1 }}</span>
             </span>

--- a/components/conductor/task-responder.vue
+++ b/components/conductor/task-responder.vue
@@ -7,7 +7,7 @@
       :aria-expanded="open"
       @click="toggle"
     >
-      <Icon name="kind-icon:comment" class="size-3" />
+      <Icon name="kind-icon:comment" class="kr-icon-3" />
       {{ isGated ? 'Answer this gate' : 'Respond' }}
     </button>
 
@@ -41,7 +41,7 @@
             @click="runTaskAction('answer')"
           >
             <span v-if="busy" class="kr-spinner-xs" />
-            <Icon v-else name="kind-icon:send" class="size-3" />
+            <Icon v-else name="kind-icon:send" class="kr-icon-3" />
             Send to agent
           </button>
           <button
@@ -80,7 +80,7 @@
           @click="sendTaskNote"
         >
           <span v-if="busy" class="kr-spinner-xs" />
-          <Icon v-else name="kind-icon:send" class="size-3" />
+          <Icon v-else name="kind-icon:send" class="kr-icon-3" />
           Send to worker
         </button>
       </div>

--- a/components/dreams/daily-digest-browser.vue
+++ b/components/dreams/daily-digest-browser.vue
@@ -40,7 +40,7 @@
             class="absolute inset-x-0 top-0 flex flex-wrap items-center gap-2 p-4 sm:p-5"
           >
             <span class="badge badge-primary gap-1 rounded-xl shadow-sm">
-              <Icon name="kind-icon:moon" class="size-3.5" />
+              <Icon name="kind-icon:moon" class="kr-icon-3-5" />
               Daily digest
             </span>
             <span
@@ -103,28 +103,28 @@
                 v-if="relatedDreamCount"
                 class="badge badge-outline gap-1 rounded-xl"
               >
-                <Icon name="kind-icon:map" class="size-3.5" />
+                <Icon name="kind-icon:map" class="kr-icon-3-5" />
                 {{ relatedDreamCount }} place{{ relatedDreamCount === 1 ? '' : 's' }}
               </span>
               <span
                 v-if="activeDream.Characters.length"
                 class="badge badge-outline gap-1 rounded-xl"
               >
-                <Icon name="kind-icon:users" class="size-3.5" />
+                <Icon name="kind-icon:users" class="kr-icon-3-5" />
                 {{ activeDream.Characters.length }} cast
               </span>
               <span
                 v-if="activeDream.Rewards.length"
                 class="badge badge-outline gap-1 rounded-xl"
               >
-                <Icon name="kind-icon:gift" class="size-3.5" />
+                <Icon name="kind-icon:gift" class="kr-icon-3-5" />
                 {{ activeDream.Rewards.length }} discoveries
               </span>
               <span
                 v-if="activeDream.Scenarios.length"
                 class="badge badge-outline gap-1 rounded-xl"
               >
-                <Icon name="kind-icon:story" class="size-3.5" />
+                <Icon name="kind-icon:story" class="kr-icon-3-5" />
                 {{ activeDream.Scenarios.length }} scenario{{
                   activeDream.Scenarios.length === 1 ? '' : 's'
                 }}
@@ -133,7 +133,7 @@
                 v-if="activeDream.Bots.length"
                 class="badge badge-outline gap-1 rounded-xl"
               >
-                <Icon name="kind-icon:robot" class="size-3.5" />
+                <Icon name="kind-icon:robot" class="kr-icon-3-5" />
                 {{ activeDream.Bots.length }} narrator{{
                   activeDream.Bots.length === 1 ? '' : 's'
                 }}

--- a/components/dreams/daily-digest-object-gallery.vue
+++ b/components/dreams/daily-digest-object-gallery.vue
@@ -89,7 +89,7 @@
 
             <span class="mt-auto inline-flex items-center gap-1 pt-1.5 text-[0.65rem] font-black text-primary">
               Open details
-              <Icon name="kind-icon:chevron-right" class="size-3" />
+              <Icon name="kind-icon:chevron-right" class="kr-icon-3" />
             </span>
           </div>
         </button>

--- a/components/dreams/daily-dream-generator.vue
+++ b/components/dreams/daily-dream-generator.vue
@@ -9,7 +9,7 @@
       <span
         class="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-secondary text-secondary-content"
       >
-        <Icon name="kind-icon:sparkles" class="size-5" />
+        <Icon name="kind-icon:sparkles" class="kr-icon-5" />
       </span>
       <span class="min-w-0 flex-1">
         <span class="block font-black">Today’s Facet Dream</span>

--- a/components/facets/facet-interact.vue
+++ b/components/facets/facet-interact.vue
@@ -14,7 +14,7 @@
   <div v-if="!selectedFacet" class="flex h-full min-h-0 flex-col gap-2">
     <div class="flex shrink-0 justify-end">
       <button type="button" class="kr-btn-secondary" @click="goToCreateFacet">
-        <Icon name="kind-icon:plus" class="size-3.5" />
+        <Icon name="kind-icon:plus" class="kr-icon-3-5" />
         New Facet
       </button>
     </div>

--- a/components/facets/facet-manager.vue
+++ b/components/facets/facet-manager.vue
@@ -68,7 +68,7 @@
               v-if="facetStore.saving"
               class="kr-spinner-xs"
             />
-            <Icon v-else name="kind-icon:plus" class="size-3.5" />
+            <Icon v-else name="kind-icon:plus" class="kr-icon-3-5" />
             Create canonical Facet
           </button>
         </div>

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -89,7 +89,7 @@
               {{ facet.aliases.join(' · ') }}
             </span>
           </span>
-          <Icon name="kind-icon:plus" class="size-3.5 shrink-0" />
+          <Icon name="kind-icon:plus" class="kr-icon-3-5 shrink-0" />
         </button>
 
         <p
@@ -142,7 +142,7 @@
             v-if="facetStore.saving"
             class="kr-spinner-xs"
           />
-          <Icon v-else name="kind-icon:plus" class="size-3.5" />
+          <Icon v-else name="kind-icon:plus" class="kr-icon-3-5" />
           Create and attach
         </button>
       </div>

--- a/components/facets/facet-profile.vue
+++ b/components/facets/facet-profile.vue
@@ -49,7 +49,7 @@
         :aria-expanded="reviewsOpen"
         @click="reviewsOpen = !reviewsOpen"
       >
-        <Icon name="kind-icon:comment" class="size-3.5" />
+        <Icon name="kind-icon:comment" class="kr-icon-3-5" />
         <span class="hidden sm:inline">Reviews</span>
       </button>
 
@@ -59,7 +59,7 @@
         title="Start a Storybook story seeded with this Facet"
         @click="startStoryWithFacet"
       >
-        <Icon name="kind-icon:book-open" class="size-3.5" />
+        <Icon name="kind-icon:book-open" class="kr-icon-3-5" />
         <span class="hidden sm:inline">Start a story with this</span>
       </button>
     </header>

--- a/components/home/home-art-shelf.vue
+++ b/components/home/home-art-shelf.vue
@@ -51,7 +51,7 @@
           v-for="option in MODES"
           :key="option.key"
           type="button"
-          class="grid size-5 place-items-center transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+          class="kr-icon-5 grid place-items-center transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
           :class="
             mode === option.key
               ? 'bg-primary text-primary-content'
@@ -62,7 +62,7 @@
           :aria-label="option.label"
           @click="setMode(option.key)"
         >
-          <Icon :name="option.icon" class="size-3" />
+          <Icon :name="option.icon" class="kr-icon-3" />
         </button>
       </span>
 

--- a/components/home/home-attention.vue
+++ b/components/home/home-attention.vue
@@ -182,7 +182,7 @@
               @click="act(gate, 'answer')"
             >
               <span v-if="isUpdating(gate)" class="kr-spinner-xs" />
-              <Icon v-else name="kind-icon:send" class="size-3" />
+              <Icon v-else name="kind-icon:send" class="kr-icon-3" />
               Send to agent
             </button>
 

--- a/components/home/home-dream-hero.vue
+++ b/components/home/home-dream-hero.vue
@@ -149,7 +149,7 @@
           Open the dream
           <Icon
             name="kind-icon:chevron-right"
-            class="size-3 motion-safe:transition-transform motion-safe:group-hover:translate-x-1"
+            class="kr-icon-3 motion-safe:transition-transform motion-safe:group-hover:translate-x-1"
           />
         </span>
       </div>

--- a/components/home/home-object-sheet.vue
+++ b/components/home/home-object-sheet.vue
@@ -217,7 +217,7 @@
               @click="submitRedo"
             >
               <span v-if="redoBusy" class="kr-spinner-xs" />
-              <Icon v-else name="kind-icon:refresh" class="size-3.5" />
+              <Icon v-else name="kind-icon:refresh" class="kr-icon-3-5" />
               Queue new art
             </button>
 

--- a/components/home/home-rail.vue
+++ b/components/home/home-rail.vue
@@ -135,7 +135,7 @@
           :aria-label="`Scroll ${label} backwards`"
           @click="scrollBy(-1)"
         >
-          <Icon name="kind-icon:chevron-left" class="size-3.5" />
+          <Icon name="kind-icon:chevron-left" class="kr-icon-3-5" />
         </button>
         <button
           type="button"
@@ -144,7 +144,7 @@
           :aria-label="`Scroll ${label} forwards`"
           @click="scrollBy(1)"
         >
-          <Icon name="kind-icon:chevron-right" class="size-3.5" />
+          <Icon name="kind-icon:chevron-right" class="kr-icon-3-5" />
         </button>
       </span>
     </header>

--- a/components/narrative/narrative-cast-card.vue
+++ b/components/narrative/narrative-cast-card.vue
@@ -55,7 +55,7 @@
         <Icon
           v-if="roleIcon"
           :name="roleIcon"
-          class="size-3"
+          class="kr-icon-3"
           aria-hidden="true"
         />
         {{ roleLabel }}

--- a/components/newsfeed/newsfeed-feed.vue
+++ b/components/newsfeed/newsfeed-feed.vue
@@ -99,7 +99,7 @@
           :aria-pressed="activeSlug === group.slug"
           @click="activeSlug = group.slug"
         >
-          <Icon :name="group.icon" class="size-3.5" />
+          <Icon :name="group.icon" class="kr-icon-3-5" />
           {{ group.title }}
         </button>
       </div>
@@ -147,7 +147,7 @@
                 ? 'kind-icon:chevron-up'
                 : 'kind-icon:chevron-down'
             "
-            class="size-3.5"
+            class="kr-icon-3-5"
           />
         </button>
 

--- a/components/newsfeed/newsfeed-filters.vue
+++ b/components/newsfeed/newsfeed-filters.vue
@@ -60,7 +60,7 @@
               aria-label="Remove include keyword"
               @click="feedPreferenceStore.removeIncludeKeyword(word)"
             >
-              <Icon name="kind-icon:close" class="size-3" />
+              <Icon name="kind-icon:close" class="kr-icon-3" />
             </button>
           </span>
         </div>
@@ -100,7 +100,7 @@
               aria-label="Remove exclude keyword"
               @click="feedPreferenceStore.removeExcludeKeyword(word)"
             >
-              <Icon name="kind-icon:close" class="size-3" />
+              <Icon name="kind-icon:close" class="kr-icon-3" />
             </button>
           </span>
         </div>
@@ -122,7 +122,7 @@
           "
           @click="feedPreferenceStore.toggleCategory(category)"
         >
-          <Icon name="kind-icon:tag" class="size-3" />
+          <Icon name="kind-icon:tag" class="kr-icon-3" />
           {{ category }}
         </button>
       </div>

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -15,7 +15,7 @@
           class="btn btn-ghost btn-xs gap-0.5 rounded-lg px-1.5"
           @click="goToOverview"
         >
-          <Icon name="kind-icon:chevron-left" class="size-3" />
+          <Icon name="kind-icon:chevron-left" class="kr-icon-3" />
           Back
         </button>
         <span v-else class="flex items-center gap-1.5">
@@ -80,7 +80,7 @@
               :name="
                 linkedProject.isPublic ? 'kind-icon:eye' : 'kind-icon:eye-off'
               "
-              class="size-3.5"
+              class="kr-icon-3-5"
             />
           </button>
           <button
@@ -98,7 +98,7 @@
             :disabled="projectSaving"
             @click="patchProject({ isMature: !linkedProject.isMature })"
           >
-            <Icon name="kind-icon:warning" class="size-3.5" />
+            <Icon name="kind-icon:warning" class="kr-icon-3-5" />
           </button>
           <button
             type="button"
@@ -117,7 +117,7 @@
             :disabled="projectSaving"
             @click="patchProject({ allowReviews: !linkedProject.allowReviews })"
           >
-            <Icon name="kind-icon:comment" class="size-3.5" />
+            <Icon name="kind-icon:comment" class="kr-icon-3-5" />
           </button>
           <span
             v-if="projectSaving"
@@ -149,7 +149,7 @@
 
       <!-- Error indicator -->
       <span v-if="error" class="kr-text-error-xs flex items-center gap-1">
-        <Icon name="kind-icon:warning" class="size-3" />
+        <Icon name="kind-icon:warning" class="kr-icon-3" />
         <span class="hidden max-w-32 truncate sm:inline">{{
           error.message
         }}</span>
@@ -174,7 +174,7 @@
           @click="syncMissingProjects"
         >
           <span v-if="syncingMissing" class="kr-spinner-xs" />
-          <Icon v-else name="kind-icon:warning" class="size-3" />
+          <Icon v-else name="kind-icon:warning" class="kr-icon-3" />
           Sync {{ missingProjectSlugs.length }}
         </button>
         <span
@@ -199,7 +199,7 @@
           @click="refreshWorkspace"
         >
           <span v-if="pending" class="kr-spinner-xs" />
-          <Icon v-else name="kind-icon:refresh" class="size-3.5" />
+          <Icon v-else name="kind-icon:refresh" class="kr-icon-3-5" />
         </button>
       </template>
     </div>
@@ -435,7 +435,7 @@
                             ? 'kind-icon:check-circle'
                             : 'kind-icon:circle'
                         "
-                        class="size-5"
+                        class="kr-icon-5"
                       />
                     </button>
                     <span
@@ -470,7 +470,7 @@
                         title="Archive"
                         @click="todoStore.archiveTodo(todo.id)"
                       >
-                        <Icon name="kind-icon:archive" class="size-3" />
+                        <Icon name="kind-icon:archive" class="kr-icon-3" />
                       </button>
                       <button
                         type="button"
@@ -478,7 +478,7 @@
                         title="Delete"
                         @click="todoStore.deleteTodo(todo.id)"
                       >
-                        <Icon name="kind-icon:x" class="size-3" />
+                        <Icon name="kind-icon:x" class="kr-icon-3" />
                       </button>
                     </div>
                   </div>
@@ -619,7 +619,7 @@
                 class="badge badge-sm gap-1"
                 :class="taskBadgeClass(status)"
               >
-                <Icon :name="taskIcon(status)" class="size-3" />{{ count }}
+                <Icon :name="taskIcon(status)" class="kr-icon-3" />{{ count }}
                 {{ status }}
               </span>
             </div>
@@ -755,7 +755,7 @@
                     rel="noopener noreferrer"
                     class="btn btn-xs btn-outline gap-1"
                   >
-                    <Icon name="kind-icon:external-link" class="size-3" /> Live
+                    <Icon name="kind-icon:external-link" class="kr-icon-3" /> Live
                     Site
                   </a>
                   <a
@@ -765,7 +765,7 @@
                     rel="noopener noreferrer"
                     class="btn btn-xs btn-outline gap-1"
                   >
-                    <Icon name="kind-icon:code" class="size-3" /> Repo
+                    <Icon name="kind-icon:code" class="kr-icon-3" /> Repo
                   </a>
                 </div>
               </div>
@@ -775,7 +775,7 @@
               >
                 <Icon
                   name="kind-icon:dream"
-                  class="mx-auto mb-1 size-5 opacity-40"
+                  class="kr-icon-5 mx-auto mb-1 opacity-40"
                 />
                 No Project record linked for
                 <strong>{{ selectedProject.slug }}</strong>
@@ -798,7 +798,7 @@
               >
                 <Icon
                   name="kind-icon:chevron-right"
-                  class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
+                  class="kr-icon-3-5 shrink-0 transition-transform group-open:rotate-90"
                 />
                 <Icon name="kind-icon:document" class="size-4 text-info" />
                 <span
@@ -827,7 +827,7 @@
               >
                 <Icon
                   name="kind-icon:chevron-right"
-                  class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
+                  class="kr-icon-3-5 shrink-0 transition-transform group-open:rotate-90"
                 />
                 <span
                   class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide"
@@ -849,7 +849,7 @@
                   >
                     <Icon
                       :name="milestoneIcon(milestone.status)"
-                      class="size-3.5"
+                      class="kr-icon-3-5"
                     />
                   </div>
                   <div class="min-w-0 flex-1">
@@ -885,7 +885,7 @@
               >
                 <Icon
                   name="kind-icon:chevron-right"
-                  class="size-3.5 shrink-0 transition-transform group-open:rotate-90"
+                  class="kr-icon-3-5 shrink-0 transition-transform group-open:rotate-90"
                 />
                 <span
                   class="kr-text-eyebrow-bold kr-text-dim-xs-60 tracking-wide"
@@ -907,7 +907,7 @@
                         class="kr-icon-6 mt-0.5 flex shrink-0 items-center justify-center rounded-full border"
                         :class="taskIconClass(task.status)"
                       >
-                        <Icon :name="taskIcon(task.status)" class="size-3" />
+                        <Icon :name="taskIcon(task.status)" class="kr-icon-3" />
                       </div>
                       <div class="min-w-0 flex-1">
                         <p
@@ -1001,7 +1001,7 @@
                     >
                       <Icon
                         name="kind-icon:chevron-right"
-                        class="mt-0.5 size-3.5 shrink-0 transition-transform group-open:rotate-90"
+                        class="kr-icon-3-5 mt-0.5 shrink-0 transition-transform group-open:rotate-90"
                       />
                       <span class="min-w-0 flex-1 break-words">{{
                         group.title

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -16,7 +16,7 @@
         <div class="min-w-0 flex-1">
           <div class="flex flex-wrap items-center gap-2">
             <span class="flex size-10 items-center justify-center rounded-2xl bg-secondary/15 text-secondary">
-              <Icon name="kind-icon:sparkles" class="size-5" />
+              <Icon name="kind-icon:sparkles" class="kr-icon-5" />
             </span>
             <div>
               <h2 class="kr-text-black-xl tracking-tight sm:text-2xl">
@@ -90,7 +90,7 @@
           v-if="activeTab === 'review' && likelyOverlapCount"
           class="badge badge-warning h-8 gap-1 rounded-2xl px-3"
         >
-          <Icon name="kind-icon:warning" class="size-3.5" />
+          <Icon name="kind-icon:warning" class="kr-icon-3-5" />
           {{ likelyOverlapCount }} overlap signal{{ likelyOverlapCount === 1 ? '' : 's' }}
         </span>
       </div>
@@ -137,7 +137,7 @@
                 class="flex size-10 shrink-0 items-center justify-center rounded-2xl"
                 :class="statusIconClass(pitch)"
               >
-                <Icon :name="statusIcon(pitch)" class="size-5" />
+                <Icon :name="statusIcon(pitch)" class="kr-icon-5" />
               </span>
 
               <div class="min-w-0 flex-1">
@@ -154,7 +154,7 @@
                 </div>
                 <div class="kr-text-dim-xs-45 mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
                   <span v-if="pitch.projectTarget" class="flex items-center gap-1">
-                    <Icon name="kind-icon:folder" class="size-3" />
+                    <Icon name="kind-icon:folder" class="kr-icon-3" />
                     {{ pitch.projectTarget }}
                   </span>
                   <span v-if="pitch.date">{{ pitch.date }}</span>
@@ -218,7 +218,7 @@
                   @click="setStatus(pitch, 'approved')"
                 >
                   <span v-if="isUpdating(pitch.slug)" class="kr-spinner-xs" />
-                  <Icon v-else name="kind-icon:check" class="size-3.5" />
+                  <Icon v-else name="kind-icon:check" class="kr-icon-3-5" />
                   Approve
                 </button>
                 <button
@@ -227,7 +227,7 @@
                   :disabled="isUpdating(pitch.slug)"
                   @click="setStatus(pitch, 'rejected')"
                 >
-                  <Icon name="kind-icon:x" class="size-3.5" />
+                  <Icon name="kind-icon:x" class="kr-icon-3-5" />
                   Reject
                 </button>
                 <button
@@ -236,7 +236,7 @@
                   :disabled="isUpdating(pitch.slug)"
                   @click="setStatus(pitch, 'duplicate')"
                 >
-                  <Icon name="kind-icon:layers" class="size-3.5" />
+                  <Icon name="kind-icon:layers" class="kr-icon-3-5" />
                   Duplicate
                 </button>
                 <button
@@ -245,7 +245,7 @@
                   :disabled="isUpdating(pitch.slug)"
                   @click="setStatus(pitch, 'archived')"
                 >
-                  <Icon name="kind-icon:archive" class="size-3.5" />
+                  <Icon name="kind-icon:archive" class="kr-icon-3-5" />
                   Archive
                 </button>
               </div>
@@ -257,7 +257,7 @@
                   :disabled="isUpdating(pitch.slug)"
                   @click="setStatus(pitch, 'awaiting-silas')"
                 >
-                  <Icon name="kind-icon:undo" class="size-3.5" />
+                  <Icon name="kind-icon:undo" class="kr-icon-3-5" />
                   Return to review
                 </button>
                 <button
@@ -267,7 +267,7 @@
                   :disabled="isUpdating(pitch.slug)"
                   @click="setStatus(pitch, 'archived')"
                 >
-                  <Icon name="kind-icon:archive" class="size-3.5" />
+                  <Icon name="kind-icon:archive" class="kr-icon-3-5" />
                   Archive
                 </button>
               </div>

--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -71,7 +71,7 @@
           @click="createProject"
         >
           <span v-if="projects.saving" class="kr-spinner-xs" />
-          <Icon v-else name="kind-icon:plus" class="size-3.5" />
+          <Icon v-else name="kind-icon:plus" class="kr-icon-3-5" />
           Create Project
         </button>
         <p v-if="createError" class="kr-text-error-xs">{{ createError }}</p>
@@ -162,7 +162,7 @@
               :aria-pressed="filter === option.value"
               @click="filter = option.value"
             >
-              <Icon :name="option.icon" class="size-3" />
+              <Icon :name="option.icon" class="kr-icon-3" />
               <span class="hidden sm:inline">{{ option.label }}</span>
               <span class="kr-badge-xs">{{ filterCount(option.value) }}</span>
             </button>
@@ -174,7 +174,7 @@
               :aria-pressed="showSync"
               @click="showSync = !showSync"
             >
-              <Icon name="kind-icon:warning" class="size-3" />
+              <Icon name="kind-icon:warning" class="kr-icon-3" />
               <span class="hidden sm:inline">Sync</span>
               <span class="kr-badge-xs">{{ syncIssueCount }}</span>
             </button>
@@ -186,7 +186,7 @@
               :aria-pressed="showBlocked"
               @click="showBlocked = !showBlocked"
             >
-              <Icon name="kind-icon:pause" class="size-3" />
+              <Icon name="kind-icon:pause" class="kr-icon-3" />
               <span class="hidden sm:inline">Blocked</span>
               <span class="kr-badge-xs">{{ blockedTasks.length }}</span>
             </button>
@@ -197,7 +197,7 @@
               :aria-expanded="createOpen"
               @click="createOpen = !createOpen"
             >
-              <Icon name="kind-icon:plus" class="size-3.5" />
+              <Icon name="kind-icon:plus" class="kr-icon-3-5" />
               <span class="hidden sm:inline">Create</span>
             </button>
 
@@ -207,7 +207,7 @@
               @click="refresh"
             >
               <span v-if="loading" class="kr-spinner-xs" />
-              <Icon v-else name="kind-icon:refresh" class="size-3.5" />
+              <Icon v-else name="kind-icon:refresh" class="kr-icon-3-5" />
               <span class="hidden sm:inline">Refresh</span>
             </button>
           </div>

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -26,7 +26,7 @@
         >
           <div class="min-w-0">
             <div class="flex items-center gap-2 text-accent">
-              <Icon name="kind-icon:sparkles" class="size-5" />
+              <Icon name="kind-icon:sparkles" class="kr-icon-5" />
               <p class="kr-text-eyebrow text-xs tracking-[0.18em]">For You</p>
             </div>
             <h2 class="kr-text-black-xl mt-1 sm:text-2xl">
@@ -43,7 +43,7 @@
               v-if="userStore.isAdmin"
               class="badge badge-warning h-auto gap-1 rounded-xl px-3 py-2"
             >
-              <Icon name="kind-icon:lock" class="size-3.5" />
+              <Icon name="kind-icon:lock" class="kr-icon-3-5" />
               {{ conductorStore.humanGates.length }} active gate{{
                 conductorStore.humanGates.length === 1 ? '' : 's'
               }}
@@ -52,13 +52,13 @@
               v-if="userStore.isAdmin"
               class="badge badge-secondary h-auto gap-1 rounded-xl px-3 py-2"
             >
-              <Icon name="kind-icon:lightbulb" class="size-3.5" />
+              <Icon name="kind-icon:lightbulb" class="kr-icon-3-5" />
               {{ conductorStore.pendingPitches.length }} pitch{{
                 conductorStore.pendingPitches.length === 1 ? '' : 'es'
               }}
             </span>
             <span class="badge badge-accent h-auto gap-1 rounded-xl px-3 py-2">
-              <Icon name="kind-icon:check-square" class="size-3.5" />
+              <Icon name="kind-icon:check-square" class="kr-icon-3-5" />
               {{ todoStore.honeyDoTodos.length }} follow-up{{
                 todoStore.honeyDoTodos.length === 1 ? '' : 's'
               }}

--- a/components/pages/taskmaster-page.vue
+++ b/components/pages/taskmaster-page.vue
@@ -76,7 +76,7 @@
               <span
                 class="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-secondary text-secondary-content shadow-md"
               >
-                <Icon name="kind-icon:magic" class="size-5" />
+                <Icon name="kind-icon:magic" class="kr-icon-5" />
               </span>
               <div class="min-w-0">
                 <p
@@ -109,7 +109,7 @@
               <span
                 class="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-info text-info-content shadow-md"
               >
-                <Icon name="kind-icon:target" class="size-5" />
+                <Icon name="kind-icon:target" class="kr-icon-5" />
               </span>
               <div class="min-w-0 flex-1">
                 <p
@@ -181,7 +181,7 @@
               <span
                 class="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-secondary text-secondary-content shadow-md"
               >
-                <Icon name="kind-icon:flask" class="size-5" />
+                <Icon name="kind-icon:flask" class="kr-icon-5" />
               </span>
               <div class="min-w-0 flex-1">
                 <p
@@ -240,7 +240,7 @@
                     <span
                       class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-secondary/10 text-secondary"
                     >
-                      <Icon name="kind-icon:dream" class="size-5" />
+                      <Icon name="kind-icon:dream" class="kr-icon-5" />
                     </span>
                     <span class="min-w-0 flex-1">
                       <span
@@ -284,7 +284,7 @@
                     <span
                       class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent/10 text-accent"
                     >
-                      <Icon name="kind-icon:story" class="size-5" />
+                      <Icon name="kind-icon:story" class="kr-icon-5" />
                     </span>
                     <span class="min-w-0 flex-1">
                       <span
@@ -506,7 +506,7 @@
                 <span
                   class="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-info text-info-content"
                 >
-                  <Icon name="kind-icon:map" class="size-5" />
+                  <Icon name="kind-icon:map" class="kr-icon-5" />
                 </span>
                 <div>
                   <p
@@ -566,7 +566,7 @@
                 <span
                   class="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-secondary text-secondary-content"
                 >
-                  <Icon name="kind-icon:magic" class="size-5" />
+                  <Icon name="kind-icon:magic" class="kr-icon-5" />
                 </span>
                 <div>
                   <p
@@ -606,7 +606,7 @@
           <span
             class="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-info text-info-content"
           >
-            <Icon name="kind-icon:target" class="size-5" />
+            <Icon name="kind-icon:target" class="kr-icon-5" />
           </span>
           <div class="min-w-0 flex-1">
             <p

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -82,7 +82,7 @@
               {{ facet.aliases.join(' · ') }}
             </span>
           </span>
-          <Icon name="kind-icon:plus" class="size-3.5 shrink-0" />
+          <Icon name="kind-icon:plus" class="kr-icon-3-5 shrink-0" />
         </button>
         <p
           v-if="!searchResults.length"

--- a/components/storybook/storybook-life-run.vue
+++ b/components/storybook/storybook-life-run.vue
@@ -33,7 +33,7 @@
           class="btn btn-ghost btn-xs gap-1 rounded-lg text-base-content/50 normal-case"
           @click="leaveLife"
         >
-          <Icon name="kind-icon:arrow-left" class="size-3.5" />
+          <Icon name="kind-icon:arrow-left" class="kr-icon-3-5" />
           Back to the table
         </button>
       </div>
@@ -43,7 +43,7 @@
         role="alert"
         class="alert alert-warning rounded-2xl text-sm"
       >
-        <Icon name="kind-icon:warning" class="size-5" />
+        <Icon name="kind-icon:warning" class="kr-icon-5" />
         <span>{{ errorMessage }}</span>
       </div>
 
@@ -156,7 +156,7 @@
               :disabled="submitting"
               @click="abandonRun"
             >
-              <Icon name="kind-icon:close" class="size-3.5" />
+              <Icon name="kind-icon:close" class="kr-icon-3-5" />
               Abandon this life
             </button>
           </div>

--- a/components/storybook/storybook-visual-setup.vue
+++ b/components/storybook/storybook-visual-setup.vue
@@ -38,7 +38,7 @@
           <div
             class="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary"
           >
-            <Icon name="kind-icon:sparkles" class="size-5" />
+            <Icon name="kind-icon:sparkles" class="kr-icon-5" />
           </div>
           <div class="min-w-0">
             <h2 class="kr-text-black-lg">The spark</h2>
@@ -105,7 +105,7 @@
             <span
               class="flex size-9 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary"
             >
-              <Icon :name="option.icon" class="size-5" />
+              <Icon :name="option.icon" class="kr-icon-5" />
             </span>
             <span class="min-w-0 flex-1">
               <span class="kr-text-black-sm block">{{ option.label }}</span>
@@ -146,7 +146,7 @@
             <span
               class="flex size-9 shrink-0 items-center justify-center rounded-xl bg-secondary/10 text-secondary"
             >
-              <Icon :name="option.icon" class="size-5" />
+              <Icon :name="option.icon" class="kr-icon-5" />
             </span>
             <span class="min-w-0 flex-1">
               <span class="kr-text-black-sm block">{{ option.label }}</span>

--- a/components/taskmaster/taskmaster-quest-stepper.vue
+++ b/components/taskmaster/taskmaster-quest-stepper.vue
@@ -23,7 +23,7 @@
         <Icon
           v-if="index < activeIndex"
           name="kind-icon:check"
-          class="size-3.5"
+          class="kr-icon-3-5"
         />
         <template v-else>{{ index + 1 }}</template>
       </span>

--- a/components/taskmaster/taskmaster-sample-tasks.vue
+++ b/components/taskmaster/taskmaster-sample-tasks.vue
@@ -56,7 +56,7 @@
                 v-if="startingId === sample.id"
                 class="kr-spinner-sm"
               />
-              <Icon v-else :name="sample.icon" class="size-5" />
+              <Icon v-else :name="sample.icon" class="kr-icon-5" />
             </span>
             <Icon
               name="kind-icon:chevron-right"

--- a/components/tasks/honeydo-card.vue
+++ b/components/tasks/honeydo-card.vue
@@ -27,7 +27,7 @@
       >
         <Icon
           :name="isDone ? 'kind-icon:check-circle' : 'kind-icon:circle'"
-          class="size-5"
+          class="kr-icon-5"
         />
       </button>
       <span
@@ -66,7 +66,7 @@
           title="Archive"
           @click="emit('archive')"
         >
-          <Icon name="kind-icon:archive" class="size-3" />
+          <Icon name="kind-icon:archive" class="kr-icon-3" />
         </button>
         <button
           v-if="showDeleteAction"
@@ -75,7 +75,7 @@
           title="Delete"
           @click="emit('delete')"
         >
-          <Icon name="kind-icon:x" class="size-3" />
+          <Icon name="kind-icon:x" class="kr-icon-3" />
         </button>
       </div>
     </div>

--- a/components/ui/allow-reviews-toggle.vue
+++ b/components/ui/allow-reviews-toggle.vue
@@ -8,7 +8,7 @@
     :disabled="saving"
     @click="$emit('toggle')"
   >
-    <Icon name="kind-icon:chat" class="size-3.5" />{{
+    <Icon name="kind-icon:chat" class="kr-icon-3-5" />{{
       allowReviews ? 'Reviews On' : 'Reviews Off'
     }}
   </button>

--- a/components/user/user-manager.vue
+++ b/components/user/user-manager.vue
@@ -46,7 +46,7 @@
         </p>
       </div>
       <NuxtLink to="/login" class="btn btn-primary rounded-xl px-8">
-        <Icon name="kind-icon:login" class="size-5" />
+        <Icon name="kind-icon:login" class="kr-icon-5" />
         Log In
       </NuxtLink>
     </section>

--- a/components/watchlist/watchlist-browse.vue
+++ b/components/watchlist/watchlist-browse.vue
@@ -345,7 +345,7 @@
           :aria-pressed="starredOnly"
           @click="starredOnly = !starredOnly"
         >
-          <Icon name="kind-icon:star" class="size-3.5" />
+          <Icon name="kind-icon:star" class="kr-icon-3-5" />
           Starred
         </button>
 
@@ -361,7 +361,7 @@
             "
             :aria-pressed="activeMonths.size > 0"
           >
-            <Icon name="kind-icon:clock" class="size-3.5" />
+            <Icon name="kind-icon:clock" class="kr-icon-3-5" />
             {{ activeMonths.size ? `Month (${activeMonths.size})` : 'Month' }}
           </button>
           <div
@@ -415,7 +415,7 @@
           class="btn btn-ghost btn-sm ml-auto gap-1.5 rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
           @click="exportCsv"
         >
-          <Icon name="kind-icon:download" class="size-3.5" />
+          <Icon name="kind-icon:download" class="kr-icon-3-5" />
           Export CSV
         </button>
       </div>
@@ -494,14 +494,14 @@
                 v-if="entry.rating"
                 class="kr-badge-warning-sm gap-0.5 rounded-lg"
               >
-                <Icon name="kind-icon:star" class="size-3" />{{ entry.rating }}
+                <Icon name="kind-icon:star" class="kr-icon-3" />{{ entry.rating }}
               </span>
               <span
                 v-if="entry.rewatch && entry.rewatch >= 2"
                 class="kr-badge-ghost-sm gap-0.5 rounded-lg"
                 :title="`Watched ${entry.rewatch}x`"
               >
-                <Icon name="kind-icon:history" class="size-3" />{{
+                <Icon name="kind-icon:history" class="kr-icon-3" />{{
                   entry.rewatch
                 }}x
               </span>

--- a/components/watchlist/watchlist-entry-detail.vue
+++ b/components/watchlist/watchlist-entry-detail.vue
@@ -56,7 +56,7 @@
             aria-label="Lower rating"
             @click="stepRating(-1)"
           >
-            <Icon name="kind-icon:minus" class="size-3" />
+            <Icon name="kind-icon:minus" class="kr-icon-3" />
           </button>
           <span
             class="min-w-[3.5rem] text-center text-sm font-semibold text-base-content"
@@ -70,7 +70,7 @@
             aria-label="Raise rating"
             @click="stepRating(1)"
           >
-            <Icon name="kind-icon:plus" class="size-3" />
+            <Icon name="kind-icon:plus" class="kr-icon-3" />
           </button>
           <button
             v-if="entry.rating"
@@ -80,7 +80,7 @@
             aria-label="Clear rating"
             @click="clearRating"
           >
-            <Icon name="kind-icon:close" class="size-3" />
+            <Icon name="kind-icon:close" class="kr-icon-3" />
           </button>
         </dd>
       </div>
@@ -94,7 +94,7 @@
           v-if="entry.reviewPublic"
           class="badge badge-success badge-sm gap-1 rounded-lg"
         >
-          <Icon name="kind-icon:check" class="size-3" />
+          <Icon name="kind-icon:check" class="kr-icon-3" />
           Published
         </span>
         <span v-else-if="saveState !== 'idle'" class="kr-text-dim-xs-45">

--- a/pages/play/challenges/[slug].vue
+++ b/pages/play/challenges/[slug].vue
@@ -135,7 +135,7 @@
           v-if="!isLoggedIn"
           class="alert rounded-2xl border border-warning/30 bg-warning/10"
         >
-          <Icon name="kind-icon:warning" class="size-5" />
+          <Icon name="kind-icon:warning" class="kr-icon-5" />
           <span>
             Browse freely, but sign in before voting. Each account gets exactly
             one current vote per submission.
@@ -151,7 +151,7 @@
             :name="
               voteStatus === 'error' ? 'kind-icon:warning' : 'kind-icon:check'
             "
-            class="size-5"
+            class="kr-icon-5"
           />
           <span>{{ voteMessage }}</span>
         </div>

--- a/pages/play/challenges/leaderboard.vue
+++ b/pages/play/challenges/leaderboard.vue
@@ -122,7 +122,7 @@
       </section>
 
       <div v-if="errorMessage" class="alert alert-error rounded-2xl">
-        <Icon name="kind-icon:warning" class="size-5" />
+        <Icon name="kind-icon:warning" class="kr-icon-5" />
         <span>{{ errorMessage }}</span>
       </div>
 

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -221,7 +221,7 @@
                   :title="prompt.title"
                   @click="studyPromptMode = prompt.value"
                 >
-                  <Icon :name="prompt.icon" class="size-3.5" />
+                  <Icon :name="prompt.icon" class="kr-icon-3-5" />
                   <span class="hidden sm:inline">{{ prompt.label }}</span>
                 </button>
               </div>
@@ -301,7 +301,7 @@
                         :disabled="artBusy"
                         @click="queueCurrentIllustration"
                       >
-                        <Icon name="kind-icon:image" class="size-3.5" />
+                        <Icon name="kind-icon:image" class="kr-icon-3-5" />
                         {{ artBusy ? 'Submitting…' : 'Request art' }}
                       </button>
                       <button

--- a/utils/scripts/codemods/kr_icon_3_5_size_shorthand_codemod.py
+++ b/utils/scripts/codemods/kr_icon_3_5_size_shorthand_codemod.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Find or migrate the `size-3.5` Tailwind shorthand to `kr-icon-3-5`.
+
+`size-3.5` is a plain alias for `h-3.5 w-3.5` (Tailwind's `size-*` utility
+sets both axes at once) -- CSS-identical to the bare icon-glyph shape
+`kr_icon_3_5_codemod.py` already migrated repo-wide onto `.kr-icon-3-5`
+(dash-substituted spelling decided by interface-vision t-104 slice 203,
+since a literal `.` is not a valid bare character in a CSS class selector
+without an escape). `size-3.5` is a separate source spelling of the exact
+same primitive, not a new shape: `.kr-icon-3-5 { @apply h-3.5 w-3.5; }` in
+tailwind.css covers both verbatim. Same convention as
+`kr_icon_4_size_shorthand_codemod.py` (interface-vision t-104 slice 223),
+just for the `size-3.5` sibling flagged as still-open by that slice's own
+kaizen note.
+
+Excludes any class string carrying a `text-*`/`stroke-*`/`fill-*` token --
+that is the `kr-icon-primary-3-5` (or another future colored sibling)
+shape, not this one -- same convention as
+`kr_icon_4_size_shorthand_codemod.py`.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+static `class="..."` attributes are touched, never `:class`/`v-bind:class`
+bindings (see _class_attr.py). Pass --exact-only to restrict a slice to
+sources with no extra tokens beyond `size-3.5` itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-3-5"
+BASE_TOKEN = "size-3.5"
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or BASE_TOKEN not in tokens:
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token != BASE_TOKEN]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly `size-3.5` (no "
+        "extra utility tokens preserved).",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-3-5 (size-3.5 shorthand) {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/scripts/codemods/kr_icon_3_size_shorthand_codemod.py
+++ b/utils/scripts/codemods/kr_icon_3_size_shorthand_codemod.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Find or migrate the `size-3` Tailwind shorthand to `kr-icon-3`.
+
+`size-3` is a plain alias for `h-3 w-3` (Tailwind's `size-*` utility sets
+both axes at once) -- CSS-identical to the bare icon-glyph shape
+`kr_icon_3_codemod.py` already migrated repo-wide. `size-3` is a separate
+source spelling of the exact same primitive, not a new shape:
+`.kr-icon-3 { @apply h-3 w-3; }` in tailwind.css covers both verbatim.
+Same convention as `kr_icon_4_size_shorthand_codemod.py` (interface-vision
+t-104 slice 223), just for the `size-3` sibling flagged as still-open by
+that slice's own kaizen note.
+
+Excludes any class string carrying a `text-*`/`stroke-*`/`fill-*` token --
+that is the `kr-icon-primary-3` (or another future colored sibling) shape,
+not this one -- same convention as `kr_icon_4_size_shorthand_codemod.py`.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+static `class="..."` attributes are touched, never `:class`/`v-bind:class`
+bindings (see _class_attr.py). Pass --exact-only to restrict a slice to
+sources with no extra tokens beyond `size-3` itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-3"
+BASE_TOKEN = "size-3"
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or BASE_TOKEN not in tokens:
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token != BASE_TOKEN]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly `size-3` (no "
+        "extra utility tokens preserved).",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-3 (size-3 shorthand) {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/scripts/codemods/kr_icon_5_size_shorthand_codemod.py
+++ b/utils/scripts/codemods/kr_icon_5_size_shorthand_codemod.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Find or migrate the `size-5` Tailwind shorthand to `kr-icon-5`.
+
+`size-5` is a plain alias for `h-5 w-5` (Tailwind's `size-*` utility sets
+both axes at once) -- CSS-identical to the bare icon-glyph shape
+`kr_icon_5_codemod.py` already migrated repo-wide. `size-5` is a separate
+source spelling of the exact same primitive, not a new shape:
+`.kr-icon-5 { @apply h-5 w-5; }` in tailwind.css covers both verbatim.
+Same convention as `kr_icon_4_size_shorthand_codemod.py` (interface-vision
+t-104 slice 223), just for the `size-5` sibling flagged as still-open by
+that slice's own kaizen note.
+
+Excludes any class string carrying a `text-*`/`stroke-*`/`fill-*` token --
+that is the `kr-icon-primary-5` (or another future colored sibling) shape,
+not this one -- same convention as `kr_icon_4_size_shorthand_codemod.py`.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+static `class="..."` attributes are touched, never `:class`/`v-bind:class`
+bindings (see _class_attr.py). Pass --exact-only to restrict a slice to
+sources with no extra tokens beyond `size-5` itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-5"
+BASE_TOKEN = "size-5"
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or BASE_TOKEN not in tokens:
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token != BASE_TOKEN]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly `size-5` (no "
+        "extra utility tokens preserved).",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-5 (size-5 shorthand) {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104 slice 240: recurring kr-* consistency umbrella (kind: software)

### What changed / what I produced
- Three new sibling codemods to `kr_icon_4_size_shorthand_codemod.py`: `kr_icon_3_size_shorthand_codemod.py`, `kr_icon_3_5_size_shorthand_codemod.py`, `kr_icon_5_size_shorthand_codemod.py`.
- Migrated the Tailwind `size-3`, `size-3.5`, and `size-5` shorthand utilities onto their existing `.kr-icon-3`/`.kr-icon-3-5`/`.kr-icon-5` primitives (already defined in `tailwind.css` from earlier slices covering the `h-N w-N` spelling of the same shapes):
  - `size-3` → `kr-icon-3`: 45 occurrences across 24 files
  - `size-3.5` → `kr-icon-3-5`: 72 occurrences across 32 files
  - `size-5` → `kr-icon-5`: 49 occurrences across 27 files
- Each shorthand is CSS-identical to its already-migrated `h-N w-N` sibling — this covers a separate source spelling of the same primitive, not a new shape. Excludes any class string carrying a `text-*`/`stroke-*`/`fill-*` token (the colored `kr-icon-primary-*` shape, untouched). Only static `class="..."` attributes are touched, never `:class`/`v-bind:class` bindings (via the shared `_class_attr.py` guard).
- Purely mechanical 1:1 token substitution — no line-structure or unrelated formatting changes (166 insertions / 166 deletions across the 53 touched `.vue` files, plus the 3 new codemod scripts).

### How I verified
- `npx vue-tsc --noEmit` (full project) — clean.
- `npx eslint` on all 53 changed `.vue` files — 8 pre-existing errors across 5 files, confirmed byte-identical via `git stash` against baseline `main` (unrelated `vue/no-mutating-props`, `no-empty`, `@typescript-eslint/no-dynamic-delete`, `@typescript-eslint/no-unused-vars` findings, none touching the migrated class strings).
- `npm run test:layout-contract` — holds at the same baseline counts (unchanged).
- `npm run test:lint-ratchet` — holds at 334/-58 (unchanged).
- Re-ran all three codemods in dry-run mode after `--write` — 0 remaining candidates for each.
- All 55 CI checks green on the current head.

### Stakes
reversible

### Flags for Reviewer
- **Self-caught and fixed mid-PR**: an earlier revision of this commit ran a blanket `prettier --write` across every touched file to tidy up a couple of multi-line attributes my codemod's shorter class string had made short enough to re-collapse onto one line. That blanket write also reformatted unrelated pre-existing 80-col drift throughout each file (drift that already existed on `main` and was never CI-enforced), which incidentally broke two hardcoded literal-string contract checks — `verifyTaskmasterCheckpointEngine.mjs` and `verifyDailyDreamArchiveWorkbench.ts` — by reflowing text/calls those checks depend on staying contiguous. CI caught both. Root-caused and fixed by reverting to a clean, purely mechanical diff (no `prettier --write` at all, since this repo has no CI-enforced prettier check) instead of chasing each incidental reflow one at a time. Force-pushed the corrected commit; all 55 checks are now green.

### Kaizen suggestion
Slice 239's kaizen note (bare `size-3`/`size-3.5`/`size-5` shorthand codemods) is now fully closed. The `kr-icon-4` shorthand family is also fully migrated (slice 239). Two threads for a future slice: (1) the still-open one-off `badge badge-sm <extra>` shapes documented in `kr_badge_codemod.py`'s own comment block (slice 238's kaizen note) and the wider `size-6`/`size-7`/`size-8` shorthand siblings (mirroring the `kr-icon-6`/`-7`/`-8` primitives that already exist); (2) a repo-wide `prettier --write` is currently unsafe to run blind because a handful of scripts (`verifyTaskmasterCheckpointEngine.mjs`, `verifyDailyDreamArchiveWorkbench.ts`, and possibly others among the 524 `verify*` scripts) hardcode literal multi-line-sensitive substrings against files that aren't themselves prettier-clean on `main` — worth either bringing those files to prettier-clean once so future incidental reformatting can't touch them, or auditing `verify*` scripts for substring checks that assume specific line-wrapping.

### Notes for reviewer
Filed and implemented from a scheduled `silasfelinus/conductor` agent run picking up `interface-vision/t-104`'s recurring umbrella task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012juV5C1PmKTLs3kFTQP27Y

---
_Generated by [Claude Code](https://claude.ai/code/session_012juV5C1PmKTLs3kFTQP27Y)_