### PR TITLE
ci: syntax-check changed shell scripts

### DIFF
--- a/.github/workflows/layout-contract.yml
+++ b/.github/workflows/layout-contract.yml
@@ -47,6 +47,16 @@ jobs:
       - name: Layout header contract self-test
         run: npm run test:layout-header-contract-selftest
 
+      - name: Syntax-check changed shell scripts
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          mapfile -d '' shell_files < <(git diff --name-only --diff-filter=ACMR -z "${{ github.event.pull_request.base.sha }}...HEAD" -- '*.sh')
+          for file in "${shell_files[@]}"; do
+            echo "bash -n $file"
+            bash -n "$file"
+          done
+
       - name: Audit test-prefixed commits for executable assertions
         if: github.event_name == 'pull_request'
         run: bash scripts/check-test-commit-assertions.sh "${{ github.event.pull_request.base.sha }}"


### PR DESCRIPTION
## Summary
- add a blocking `bash -n` check for every added/modified/renamed `*.sh` file in PRs
- use NUL-delimited `git diff` output so filenames are handled safely
- run before the existing test-commit assertion audit

## Verification
- CI-only change; Layout Contract workflow will exercise the step on this PR
- full-history checkout already exists, so the PR base SHA is available

## Conductor
interface-vision/t-130
session: `2026-09-12T061811Z-interface-vision-t-130-x9c4`

## Flags for Reviewer
No deploy/schema/runtime changes. The check intentionally covers PR diffs only, matching the task scope; push-to-main runs skip it because the changed-file comparison is a PR concept.