### PR TITLE
interface-vision/t-104 slice 241: migrate size-6/size-7/size-8 icon shorthand to kr-icon-*

### DIFF
--- a/components/art/stylist-client-gallery.vue
+++ b/components/art/stylist-client-gallery.vue
@@ -120,7 +120,7 @@
                 v-else
                 class="flex h-full w-full items-center justify-center text-base-content/30"
               >
-                <Icon name="kind-icon:image" class="size-8" />
+                <Icon name="kind-icon:image" class="kr-icon-8" />
               </div>
               <span
                 v-if="photoById.get(Number(item.id))!.isPrimary"

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -25,7 +25,7 @@
       >
         <span
           v-if="artwork(facet)"
-          class="size-6 shrink-0 overflow-hidden rounded-lg bg-base-200"
+          class="kr-icon-6 shrink-0 overflow-hidden rounded-lg bg-base-200"
         >
           <img
             :src="artwork(facet) || ''"

--- a/components/coloring/coloring-book-package-readiness.vue
+++ b/components/coloring/coloring-book-package-readiness.vue
@@ -100,7 +100,7 @@
           class="kr-panel-tint-md"
         >
           <div class="flex items-center justify-between gap-2">
-            <icon :name="stage.icon" class="size-6" :class="stage.ready ? 'text-success' : 'text-warning'" />
+            <icon :name="stage.icon" class="kr-icon-6" :class="stage.ready ? 'text-success' : 'text-warning'" />
             <span class="kr-badge-sm rounded-2xl" :class="stage.ready ? 'badge-success' : 'badge-warning'">
               {{ stage.ready ? 'Ready' : 'Pending' }}
             </span>

--- a/components/conductor/project-detail.vue
+++ b/components/conductor/project-detail.vue
@@ -327,7 +327,7 @@
         >
           <div class="flex items-start gap-2.5">
             <div
-              class="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full border"
+              class="kr-icon-6 mt-0.5 flex shrink-0 items-center justify-center rounded-full border"
               :class="taskIconClass(task.status)"
             >
               <Icon :name="taskIcon(task.status)" class="kr-icon-3" />
@@ -453,7 +453,7 @@
           class="flex items-center gap-3 kr-panel-muted-compact-row"
         >
           <div
-            class="flex size-6 shrink-0 items-center justify-center rounded-full border"
+            class="kr-icon-6 flex shrink-0 items-center justify-center rounded-full border"
             :class="milestoneIconClass(milestone.status)"
           >
             <Icon :name="milestoneIcon(milestone.status)" class="kr-icon-3" />

--- a/components/conductor/project-front-page.vue
+++ b/components/conductor/project-front-page.vue
@@ -31,7 +31,7 @@
             v-if="view.icon"
             class="flex size-11 shrink-0 items-center justify-center rounded-2xl border border-white/20 bg-base-100/70 text-primary shadow-lg backdrop-blur"
           >
-            <Icon :name="view.icon" class="size-6" />
+            <Icon :name="view.icon" class="kr-icon-6" />
           </span>
           <span
             v-if="statusLabel"

--- a/components/conductor/storybook-page.vue
+++ b/components/conductor/storybook-page.vue
@@ -12,7 +12,7 @@
       <div
         class="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-primary/30 bg-primary/10 text-primary"
       >
-        <Icon name="kind-icon:book" class="size-6" />
+        <Icon name="kind-icon:book" class="kr-icon-6" />
       </div>
       <div class="min-w-0 flex-1 basis-full sm:basis-auto">
         <p class="kr-text-black-2xl leading-tight">
@@ -106,7 +106,7 @@
             @click="setupStep = index"
           >
             <span
-              class="flex size-6 shrink-0 items-center justify-center rounded-full border border-current/25"
+              class="kr-icon-6 flex shrink-0 items-center justify-center rounded-full border border-current/25"
             >
               <Icon
                 v-if="index < setupStep"
@@ -402,7 +402,7 @@
                     :key="member.slug"
                     class="flex items-center gap-2 rounded-xl border border-base-300 bg-base-100 py-1 pl-1 pr-2.5"
                   >
-                    <div class="size-8 shrink-0 overflow-hidden rounded-lg">
+                    <div class="kr-icon-8 shrink-0 overflow-hidden rounded-lg">
                       <KrArtPlate
                         :source="member"
                         variant="icon"
@@ -427,7 +427,7 @@
                     :key="facet.slug"
                     class="flex items-center gap-2 rounded-xl border border-base-300 bg-base-100 py-1 pl-1 pr-2.5"
                   >
-                    <div class="size-8 shrink-0 overflow-hidden rounded-lg">
+                    <div class="kr-icon-8 shrink-0 overflow-hidden rounded-lg">
                       <KrArtPlate
                         :source="facet"
                         variant="icon"
@@ -452,7 +452,7 @@
                     :key="reward.slug"
                     class="flex items-center gap-2 rounded-xl border border-base-300 bg-base-100 py-1 pl-1 pr-2.5"
                   >
-                    <div class="size-8 shrink-0 overflow-hidden rounded-lg">
+                    <div class="kr-icon-8 shrink-0 overflow-hidden rounded-lg">
                       <KrArtPlate
                         :source="reward"
                         variant="icon"

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -29,7 +29,7 @@
       >
         <span
           v-if="facetArtwork(facet)"
-          class="size-6 shrink-0 overflow-hidden rounded-lg bg-base-200"
+          class="kr-icon-6 shrink-0 overflow-hidden rounded-lg bg-base-200"
         >
           <img
             :src="facetArtwork(facet) || ''"

--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -153,7 +153,7 @@
               >
                 <Icon
                   :name="item.placeholderIcon || 'kind-icon:image'"
-                  class="size-7"
+                  class="kr-icon-7"
                 />
                 <span
                   v-if="item.placeholderLabel"
@@ -232,7 +232,7 @@
               >
                 <Icon
                   :name="item.placeholderIcon || 'kind-icon:image'"
-                  class="size-8"
+                  class="kr-icon-8"
                 />
                 <span
                   v-if="item.placeholderLabel"

--- a/components/mandarin/mandarin-card-art.vue
+++ b/components/mandarin/mandarin-card-art.vue
@@ -12,7 +12,7 @@
       {{ simplified }}
     </span>
     <span v-else class="mandarin-art__waiting">
-      <Icon name="kind-icon:image" class="size-8 opacity-80" />
+      <Icon name="kind-icon:image" class="kr-icon-8 opacity-80" />
       <span class="text-xs opacity-80">Picture not ready yet</span>
     </span>
     <slot />

--- a/components/narrative/kr-art-plate.vue
+++ b/components/narrative/kr-art-plate.vue
@@ -38,7 +38,7 @@
       v-else
       class="flex h-full w-full items-center justify-center text-base-content/40"
     >
-      <Icon :name="placeholderIcon" class="size-8" aria-hidden="true" />
+      <Icon :name="placeholderIcon" class="kr-icon-8" aria-hidden="true" />
     </div>
 
     <!-- Scrim only when there is a caption to keep legible. An unconditional

--- a/components/narrative/kr-chat-window.vue
+++ b/components/narrative/kr-chat-window.vue
@@ -76,7 +76,7 @@
           v-if="turn.portrait && turn.from !== 'user'"
           :src="turn.portrait"
           :alt="turn.speaker || 'Narrator'"
-          class="size-8 shrink-0 rounded-full border border-base-300 bg-base-300 object-cover"
+          class="kr-icon-8 shrink-0 rounded-full border border-base-300 bg-base-300 object-cover"
           loading="lazy"
         />
 

--- a/components/pages/conductor-page.vue
+++ b/components/pages/conductor-page.vue
@@ -551,7 +551,7 @@
                     >
                       <Icon
                         :name="kindIcon(selectedProject.kind)"
-                        class="size-7"
+                        class="kr-icon-7"
                       />
                     </div>
                   </div>

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -59,7 +59,7 @@
           @click="activeTab = tab.key"
         >
           <span
-            class="flex size-8 shrink-0 items-center justify-center rounded-xl"
+            class="kr-icon-8 flex shrink-0 items-center justify-center rounded-xl"
             :class="tab.iconClass"
           >
             <Icon :name="tab.icon" class="kr-icon-4" />
@@ -280,7 +280,7 @@
           class="flex min-h-72 flex-col items-center justify-center kr-panel-flat border-dashed rounded-3xl bg-base-100/70 p-8 text-center"
         >
           <span class="flex size-16 items-center justify-center rounded-3xl bg-success/10 text-success">
-            <Icon :name="emptyIcon" class="size-8" />
+            <Icon :name="emptyIcon" class="kr-icon-8" />
           </span>
           <h3 class="kr-text-black-xl mt-4">{{ emptyTitle }}</h3>
           <p class="kr-text-dim-sm-50 mt-1 max-w-lg">

--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -6,7 +6,7 @@
       <div
         class="flex size-12 shrink-0 items-center justify-center rounded-2xl bg-primary/15 text-primary"
       >
-        <Icon name="kind-icon:gallery" class="size-6" />
+        <Icon name="kind-icon:gallery" class="kr-icon-6" />
       </div>
       <div class="min-w-0 flex-1">
         <h2 class="kr-text-black-2xl tracking-tight">Projects</h2>

--- a/components/pages/portos-page.vue
+++ b/components/pages/portos-page.vue
@@ -3,7 +3,7 @@
     <div class="kr-scroll flex flex-col gap-4">
       <header class="flex items-start gap-3">
         <div class="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-accent/30 bg-accent/10 text-accent">
-          <Icon name="kind-icon:server" class="size-6" />
+          <Icon name="kind-icon:server" class="kr-icon-6" />
         </div>
         <div class="min-w-0 flex-1">
           <p class="kr-text-eyebrow-bold text-xs tracking-wide text-accent/70">Portos</p>

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -25,7 +25,7 @@
       >
         <span
           v-if="artwork(facet)"
-          class="size-6 shrink-0 overflow-hidden rounded-lg bg-base-200"
+          class="kr-icon-6 shrink-0 overflow-hidden rounded-lg bg-base-200"
         >
           <img
             :src="artwork(facet) || ''"

--- a/components/ruler-hooked/ruler-hooked-cosmetics-picker.vue
+++ b/components/ruler-hooked/ruler-hooked-cosmetics-picker.vue
@@ -63,7 +63,7 @@
           v-if="customPreviewUrl"
           :src="customPreviewUrl"
           alt="Custom portrait preview"
-          class="size-8 rounded object-cover"
+          class="kr-icon-8 rounded object-cover"
         />
         {{ customFile.name }}
         <button type="button" class="kr-btn-ghost-xs-plain" @click="clearCustom">

--- a/components/taskmaster/taskmaster-quest-stepper.vue
+++ b/components/taskmaster/taskmaster-quest-stepper.vue
@@ -11,7 +11,7 @@
       :aria-current="step.key === active ? 'step' : undefined"
     >
       <span
-        class="kr-text-black-xs flex size-7 shrink-0 items-center justify-center rounded-full border shadow-sm"
+        class="kr-icon-7 kr-text-black-xs flex shrink-0 items-center justify-center rounded-full border shadow-sm"
         :class="
           step.key === active
             ? 'border-secondary bg-secondary text-secondary-content'

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -194,7 +194,7 @@
               />
 
               <label
-                class="absolute left-2 top-2 grid size-8 cursor-pointer place-items-center rounded-lg bg-base-100/90 shadow"
+                class="kr-icon-8 absolute left-2 top-2 grid cursor-pointer place-items-center rounded-lg bg-base-100/90 shadow"
               >
                 <input
                   type="checkbox"

--- a/pages/coloring-page.vue
+++ b/pages/coloring-page.vue
@@ -13,7 +13,7 @@
         <div
           class="flex size-12 shrink-0 items-center justify-center rounded-2xl bg-primary/15 text-primary"
         >
-          <Icon name="kind-icon:magic" class="size-6" />
+          <Icon name="kind-icon:magic" class="kr-icon-6" />
         </div>
         <div class="min-w-0 flex-1">
           <div class="flex flex-wrap items-center gap-2">

--- a/pages/music-mentor.vue
+++ b/pages/music-mentor.vue
@@ -5,7 +5,7 @@
         <div
           class="flex size-12 shrink-0 items-center justify-center rounded-2xl bg-primary/15 text-primary"
         >
-          <Icon name="kind-icon:microphone" class="size-6" />
+          <Icon name="kind-icon:microphone" class="kr-icon-6" />
         </div>
         <div class="min-w-0 flex-1 space-y-1">
           <p class="kr-text-black-2xl tracking-tight">Music Mentor</p>

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -70,7 +70,7 @@
             class="flex items-center gap-3 kr-panel-flat p-3 shadow-sm"
           >
             <span
-              class="kr-text-black-xs grid size-8 shrink-0 place-items-center rounded-full bg-base-200"
+              class="kr-icon-8 kr-text-black-xs grid shrink-0 place-items-center rounded-full bg-base-200"
             >
               {{ entry.rank }}
             </span>

--- a/utils/scripts/codemods/kr_icon_6_size_shorthand_codemod.py
+++ b/utils/scripts/codemods/kr_icon_6_size_shorthand_codemod.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Find or migrate the `size-6` Tailwind shorthand to `kr-icon-6`.
+
+`size-6` is a plain alias for `h-6 w-6` (Tailwind's `size-*` utility sets
+both axes at once) -- CSS-identical to the bare icon-glyph shape
+`.kr-icon-6 { @apply h-6 w-6; }` already covers in tailwind.css. `size-6`
+is a separate source spelling of the exact same primitive, not a new
+shape. Same convention as `kr_icon_5_size_shorthand_codemod.py`
+(interface-vision t-104 slice 241), just for the `size-6` sibling flagged
+as still-open by slice 240's kaizen note.
+
+Excludes any class string carrying a `text-*`/`stroke-*`/`fill-*` token --
+that is the `kr-icon-primary-6` (or another future colored sibling) shape,
+not this one -- same convention as `kr_icon_5_size_shorthand_codemod.py`.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+static `class="..."` attributes are touched, never `:class`/`v-bind:class`
+bindings (see _class_attr.py). Pass --exact-only to restrict a slice to
+sources with no extra tokens beyond `size-6` itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-6"
+BASE_TOKEN = "size-6"
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or BASE_TOKEN not in tokens:
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token != BASE_TOKEN]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly `size-6` (no "
+        "extra utility tokens preserved).",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-6 (size-6 shorthand) {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/scripts/codemods/kr_icon_7_size_shorthand_codemod.py
+++ b/utils/scripts/codemods/kr_icon_7_size_shorthand_codemod.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Find or migrate the `size-7` Tailwind shorthand to `kr-icon-7`.
+
+`size-7` is a plain alias for `h-7 w-7` (Tailwind's `size-*` utility sets
+both axes at once) -- CSS-identical to the bare icon-glyph shape
+`.kr-icon-7 { @apply h-7 w-7; }` already covers in tailwind.css. `size-7`
+is a separate source spelling of the exact same primitive, not a new
+shape. Same convention as `kr_icon_5_size_shorthand_codemod.py`
+(interface-vision t-104 slice 241), just for the `size-7` sibling flagged
+as still-open by slice 240's kaizen note.
+
+Excludes any class string carrying a `text-*`/`stroke-*`/`fill-*` token --
+that is the `kr-icon-primary-7` (or another future colored sibling) shape,
+not this one -- same convention as `kr_icon_5_size_shorthand_codemod.py`.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+static `class="..."` attributes are touched, never `:class`/`v-bind:class`
+bindings (see _class_attr.py). Pass --exact-only to restrict a slice to
+sources with no extra tokens beyond `size-7` itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-7"
+BASE_TOKEN = "size-7"
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or BASE_TOKEN not in tokens:
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token != BASE_TOKEN]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly `size-7` (no "
+        "extra utility tokens preserved).",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-7 (size-7 shorthand) {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/scripts/codemods/kr_icon_8_size_shorthand_codemod.py
+++ b/utils/scripts/codemods/kr_icon_8_size_shorthand_codemod.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Find or migrate the `size-8` Tailwind shorthand to `kr-icon-8`.
+
+`size-8` is a plain alias for `h-8 w-8` (Tailwind's `size-*` utility sets
+both axes at once) -- CSS-identical to the bare icon-glyph shape
+`.kr-icon-8 { @apply h-8 w-8; }` already covers in tailwind.css. `size-8`
+is a separate source spelling of the exact same primitive, not a new
+shape. Same convention as `kr_icon_5_size_shorthand_codemod.py`
+(interface-vision t-104 slice 241), just for the `size-8` sibling flagged
+as still-open by slice 240's kaizen note.
+
+Excludes any class string carrying a `text-*`/`stroke-*`/`fill-*` token --
+that is the `kr-icon-primary-8` (or another future colored sibling) shape,
+not this one -- same convention as `kr_icon_5_size_shorthand_codemod.py`.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+static `class="..."` attributes are touched, never `:class`/`v-bind:class`
+bindings (see _class_attr.py). Pass --exact-only to restrict a slice to
+sources with no extra tokens beyond `size-8` itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-8"
+BASE_TOKEN = "size-8"
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or BASE_TOKEN not in tokens:
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token != BASE_TOKEN]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly `size-8` (no "
+        "extra utility tokens preserved).",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-8 (size-8 shorthand) {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: recurring kr-* consistency umbrella, slice 241 (kind: software)

### What changed / what I produced
- Three new codemods mirroring the existing `kr_icon_{3,3.5,4,5}_size_shorthand_codemod.py` pattern: `kr_icon_6_size_shorthand_codemod.py`, `kr_icon_7_size_shorthand_codemod.py`, `kr_icon_8_size_shorthand_codemod.py`.
- `.kr-icon-6`/`.kr-icon-7`/`.kr-icon-8` already exist in `tailwind.css` (`@apply h-N w-N`) — this is a pure source-spelling migration onto an established primitive, not a new shape.
- Migrated 13 `size-6`, 3 `size-7`, and 13 `size-8` occurrences across 22 files (29 total, 22 files changed). Excludes any class string carrying a `text-*`/`stroke-*`/`fill-*` token (the colored `kr-icon-primary-N` sibling shape). Only static `class="..."` attributes touched, never `:class`/`v-bind:class` bindings.
- No color/behavior/API/schema/route/geometry change.

### How I verified
- Re-ran all three codemods after `--write`: 0 remaining candidates each.
- `npm run test` (vue-tsc typecheck): clean, exit 0.
- `npm run test:layout-contract`: clean, no new violations.
- `npm run test:lint-ratchet`: holds (334 problems across 25 rules, **-58** vs. baseline).
- `npx eslint` on the changed file list surfaced 2 pre-existing errors (`stylist-client-gallery.vue`'s `no-dynamic-delete`, `conductor-pitch-manager.vue`'s `no-unused-vars`) — confirmed via `git stash` to be byte-identical on `origin/main`, unrelated to this diff.
- Spot-checked several diffs by hand (`storybook-page.vue`, `kr-gallery.vue`, `conductor-pitch-manager.vue`) to confirm mechanical 1:1 substitution and that a static `class="flex size-8 ..."` alongside a separate `:class="tab.iconClass"` binding only touched the static attribute.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
The remaining kaizen items from slice 240's note: (1) the still-open one-off `badge badge-sm <extra>` shapes from slice 238's kaizen note (several documented in `kr_badge_codemod.py`'s own comment block: `kr-card-back.vue`'s `border-none bg-black/60 text-white`, `kr-entity-card-body.vue`'s `max-w-full`, etc.) — each is a single-instance shape needing individual review rather than a mechanical codemod; (2) a repo-wide `prettier --write` is still unsafe to run blind because several `verify*.{ts,mjs}` scripts hardcode literal multi-line-sensitive substrings against files that are not themselves prettier-clean on `main` — worth bringing those specific files to prettier-clean once.

### Notes for reviewer
Roadmap task flipped to `status: review` via `close_task.py` (companion conductor PR incoming) ahead of this PR per AGENTS.md step 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vz9cAHp7k8Y8KwBTb3mxmq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vz9cAHp7k8Y8KwBTb3mxmq)_