### PR TITLE
feat(scene-animator): tune the motion prompt, and stop cropping the previews

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -139,6 +139,9 @@ jobs:
       - name: Scene Animator resubmit contract
         run: npm run test:scene-animator-resubmit
 
+      - name: Scene Animator prompt contract
+        run: npm run test:scene-animator-prompt
+
       - name: ESLint ratchet
         run: npm run test:lint-ratchet
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "test:migrate-on-deploy": "tsx utils/scripts/verifyMigrateOnDeploy.ts",
     "test:scene-animator-health": "tsx utils/scripts/verifySceneAnimatorHealth.test.ts",
     "test:scene-animator-resubmit": "tsx utils/scripts/verifySceneAnimatorResubmit.test.ts",
+    "test:scene-animator-prompt": "tsx utils/scripts/verifySceneAnimatorPrompt.test.ts",
     "test:facet-aliases": "tsx utils/scripts/verifyFacetAliases.ts",
     "audit:art-coverage": "tsx utils/scripts/auditEntityArtCoverage.ts",
     "test:facet-content": "tsx utils/scripts/verifyFacetContentQuality.ts",

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -134,10 +134,10 @@
             <details class="kr-panel-compact text-sm">
               <summary class="cursor-pointer font-black">Automatic motion direction</summary>
               <p class="mt-2 leading-relaxed text-base-content/60">
-                Bring this still scene naturally to life with subtle coherent motion. Preserve the
-                subjects, composition, identity, lighting, and visual style. Add only plausible
-                ambient movement, gentle secondary motion, and stable cinematic camera behavior.
-                Do not introduce new characters, objects, text, or scene changes.
+                {{ SCENE_ANIMATOR_PROMPT }}
+              </p>
+              <p class="kr-text-dim-xs mt-2 leading-relaxed">
+                <span class="font-bold">Avoiding:</span> {{ SCENE_ANIMATOR_NEGATIVE_PROMPT }}
               </p>
             </details>
 
@@ -245,7 +245,7 @@
                       v-if="store.sourcePreviewUrls[source.name]"
                       :src="store.sourcePreviewUrls[source.name]"
                       :alt="`Source ${source.name}`"
-                      class="size-full object-cover"
+                      class="size-full object-contain"
                     />
                     <div v-else class="grid size-full place-items-center text-xs text-base-content/35">
                       Source
@@ -258,7 +258,7 @@
                       <video
                         v-if="isVideoResult(source)"
                         :src="store.resultUrl(source) || undefined"
-                        class="size-full object-cover"
+                        class="size-full object-contain"
                         controls
                         muted
                         loop
@@ -268,7 +268,7 @@
                         v-else
                         :src="store.resultUrl(source) || undefined"
                         :alt="`Animated result for ${source.name}`"
-                        class="size-full object-cover"
+                        class="size-full object-contain"
                       />
                     </template>
                     <div v-else class="kr-text-dim-xs-40 grid size-full place-items-center p-3 text-center">
@@ -339,6 +339,10 @@ import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useSceneAnimatorStore, type SceneAnimatorSource } from '@/stores/sceneAnimatorStore'
 import { useUserStore } from '@/stores/userStore'
 import type { VideoEngine, VideoPresetId } from '@/utils/videoPresets'
+import {
+  SCENE_ANIMATOR_NEGATIVE_PROMPT,
+  SCENE_ANIMATOR_PROMPT,
+} from '@/utils/sceneAnimatorPrompt'
 
 type StatusFilter = 'all' | 'missing' | 'active' | 'done' | 'failed'
 

--- a/server/api/scene-animator/enqueue.post.ts
+++ b/server/api/scene-animator/enqueue.post.ts
@@ -3,6 +3,7 @@ import prisma from '@/server/utils/prisma'
 import { requireAdminApiUser } from '@/server/utils/authGuard'
 import {
   SCENE_ANIMATOR_PROJECT_SLUG,
+  SCENE_ANIMATOR_NEGATIVE_PROMPT,
   SCENE_ANIMATOR_PROMPT,
   listSceneAnimatorSourceFiles,
   parseSceneAnimatorContext,
@@ -207,7 +208,7 @@ export default defineEventHandler(async (event) => {
           engine: config.engine,
           presetId: config.presetId,
           promptString: SCENE_ANIMATOR_PROMPT,
-          negativePrompt: '',
+          negativePrompt: SCENE_ANIMATOR_NEGATIVE_PROMPT,
           firstImageBase64,
           durationSeconds: config.durationSeconds,
           fps: config.fps,

--- a/server/utils/sceneAnimator.ts
+++ b/server/utils/sceneAnimator.ts
@@ -11,8 +11,13 @@ import type {
 
 export const SCENE_ANIMATOR_PROJECT_SLUG = 'scene-animator'
 
-export const SCENE_ANIMATOR_PROMPT =
-  'Bring this still scene naturally to life with subtle coherent motion. Preserve the subjects, composition, identity, lighting, and visual style. Add only plausible ambient movement, gentle secondary motion, and stable cinematic camera behavior. Do not introduce new characters, objects, text, or scene changes.'
+// Re-exported so existing server-side importers keep working; the strings
+// themselves live in utils/ so the admin surface renders the same text it
+// sends rather than a hand-copied paraphrase. See that file for tuning notes.
+export {
+  SCENE_ANIMATOR_PROMPT,
+  SCENE_ANIMATOR_NEGATIVE_PROMPT,
+} from '@/utils/sceneAnimatorPrompt'
 
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif'])
 

--- a/utils/sceneAnimatorPrompt.ts
+++ b/utils/sceneAnimatorPrompt.ts
@@ -1,0 +1,51 @@
+// /utils/sceneAnimatorPrompt.ts
+//
+// The motion direction every Scene Animator clip is rendered with.
+//
+// Lives in utils/ rather than server/utils/ so the admin surface can render the
+// exact string that will be sent. It previously lived server-side only, and
+// pages/admin/scene-animator.vue reproduced it as literal HTML in its
+// "Automatic motion direction" panel -- two copies, no link between them, so
+// editing the prompt would have left the operator reading the old one with no
+// indication anything had changed.
+//
+// TUNING HISTORY. The first version asked for "subtle coherent motion ...
+// only plausible ambient movement, gentle secondary motion, and stable
+// cinematic camera behavior", and got exactly what it asked for: Silas,
+// 2026-09-11, on the first real batch -- "the animations are pretty lackluster
+// ... the others have minimal movement". Every hedge in that sentence (subtle,
+// only, gentle, stable) was a vote against motion, and WAN obliged.
+//
+// The one clip he rated highly moved a robot deliberately and gave it an
+// interaction, which is the bar. So the direction now asks for motion plainly
+// and, where there is a figure, names the performance wanted: "if there is a
+// figure, they should be animated, wink, smile, laugh".
+//
+// What must NOT loosen is subject integrity. The same batch produced a
+// miniature figure riding a Segway across the Humboldt Scoop Solutions dog
+// logo -- invented from nothing. The final clause is the guard against that,
+// and the negative prompt below reinforces it; keep both when retuning.
+export const SCENE_ANIMATOR_PROMPT =
+  'Animate this scene with clear, deliberate motion. Any person, animal, ' +
+  'robot, or character in the frame must visibly perform: blink, shift ' +
+  'expression with a smile, a wink or a laugh, turn or tilt the head, and ' +
+  'move hands, arms or body with intent. Give the rest of the scene life as ' +
+  'well -- hair and cloth sway, foliage and water move, light and shadow ' +
+  'shift, background elements drift. Camera movement stays slow and ' +
+  'purposeful. Preserve every subject exactly as drawn: identity, faces, ' +
+  'design, colors, composition, and art style are unchanged, and no ' +
+  'character, creature, vehicle, object, logo, or text is added, removed, or ' +
+  'replaced.'
+
+// Sent as the negative prompt on every Scene Animator job.
+//
+// Two jobs, matching the two ways the first batch went wrong. The stillness
+// terms push against the near-frozen results; the addition terms push against
+// inventions like the Segway rider. A negative prompt is the right lever for
+// both -- it constrains without spending positive-prompt attention, which is
+// where the performance direction above needs to land.
+export const SCENE_ANIMATOR_NEGATIVE_PROMPT =
+  'static image, still frame, frozen, motionless, no movement, slideshow, ' +
+  'duplicate frames, additional characters, extra people, extra limbs, new ' +
+  'objects appearing, vehicles, added text, watermark, signature, logo ' +
+  'changes, identity change, face morphing, distortion, warping, flicker'

--- a/utils/scripts/verifySceneAnimatorPrompt.test.ts
+++ b/utils/scripts/verifySceneAnimatorPrompt.test.ts
@@ -1,0 +1,163 @@
+// /utils/scripts/verifySceneAnimatorPrompt.test.ts
+//
+// The motion direction is tuned for motion, reaches the renderer, and is shown
+// to the operator from one source of truth.
+//
+// WHAT WENT WRONG WITHOUT THIS.
+//
+// 1. The first prompt asked for "subtle coherent motion ... only plausible
+//    ambient movement, gentle secondary motion, and stable cinematic camera
+//    behavior" and got precisely that (Silas, 2026-09-11, on the first real
+//    batch: "the animations are pretty lackluster ... minimal movement").
+//    Every hedge was a vote against motion. A prompt that reacquires them is
+//    the same bug, so the hedges are named here rather than left to review.
+//
+// 2. The same batch invented a miniature figure on a Segway riding across the
+//    Humboldt Scoop Solutions dog logo. Subject integrity is what stops that,
+//    and it is exactly what a "make it more dynamic" retune is tempted to
+//    drop -- so both halves are pinned together, deliberately.
+//
+// 3. pages/admin/scene-animator.vue reproduced the whole prompt as literal HTML
+//    in its "Automatic motion direction" panel. Nothing connected the two
+//    copies, so editing the prompt would have left the operator reading the old
+//    text while a different one was sent. That is the failure this file is most
+//    useful against, because it is invisible: both halves keep working, they
+//    just stop agreeing.
+//
+//   npx tsx utils/scripts/verifySceneAnimatorPrompt.test.ts
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import {
+  SCENE_ANIMATOR_NEGATIVE_PROMPT,
+  SCENE_ANIMATOR_PROMPT,
+} from '../../utils/sceneAnimatorPrompt.js'
+
+const PAGE = 'pages/admin/scene-animator.vue'
+const ENQUEUE = 'server/api/scene-animator/enqueue.post.ts'
+
+const read = (file: string) => readFileSync(resolve(process.cwd(), file), 'utf8')
+
+/* -- 1. the prompt asks for motion, not for restraint ----------------------- */
+
+const prompt = SCENE_ANIMATOR_PROMPT.toLowerCase()
+
+// The exact hedges that produced the lackluster batch. Each one told WAN to do
+// less; together they told it to do almost nothing.
+for (const hedge of [
+  'subtle',
+  'gentle',
+  'only plausible',
+  'ambient movement',
+  'stable cinematic camera',
+]) {
+  assert.ok(
+    !prompt.includes(hedge),
+    `SCENE_ANIMATOR_PROMPT must not reacquire the hedge "${hedge}" — that ` +
+      `phrasing is what produced near-frozen clips on the first batch`,
+  )
+}
+
+// Silas: "if there is a figure, they should be animated, wink, smile, laugh".
+for (const performance of ['blink', 'smile', 'wink', 'laugh']) {
+  assert.ok(
+    prompt.includes(performance),
+    `SCENE_ANIMATOR_PROMPT must name "${performance}" — naming the expression ` +
+      `is what gets a figure to act rather than sit still`,
+  )
+}
+
+assert.ok(
+  /\bdeliberate\b|\bclear\b/.test(prompt),
+  'SCENE_ANIMATOR_PROMPT must ask for motion in plain terms',
+)
+
+/* -- 2. ...without loosening subject integrity ------------------------------ */
+
+assert.ok(
+  /\bpreserve\b|\bunchanged\b/.test(prompt),
+  'SCENE_ANIMATOR_PROMPT must still require subjects be preserved',
+)
+
+assert.ok(
+  /\badded\b|\bdo not add\b|\bno character\b/.test(prompt),
+  'SCENE_ANIMATOR_PROMPT must still forbid inventing new subjects. Dropping ' +
+    'this while chasing dynamism is how the Segway rider got onto the HSS logo.',
+)
+
+/* -- 3. the negative prompt covers both failure modes ----------------------- */
+
+const negative = SCENE_ANIMATOR_NEGATIVE_PROMPT.toLowerCase()
+
+assert.ok(
+  /static|still frame|frozen|motionless/.test(negative),
+  'the negative prompt must push against stillness',
+)
+assert.ok(
+  /additional characters|extra people|new objects/.test(negative),
+  'the negative prompt must push against invented subjects',
+)
+
+/* -- 4. it actually reaches the renderer ------------------------------------ */
+
+const enqueue = read(ENQUEUE)
+
+assert.ok(
+  /negativePrompt:\s*SCENE_ANIMATOR_NEGATIVE_PROMPT/.test(enqueue),
+  `${ENQUEUE} must send SCENE_ANIMATOR_NEGATIVE_PROMPT. It shipped as ` +
+    `negativePrompt: '' — a tuned negative prompt no job carries is inert.`,
+)
+
+assert.ok(
+  /promptString:\s*SCENE_ANIMATOR_PROMPT/.test(enqueue),
+  `${ENQUEUE} must send the shared prompt constant, not an inline string`,
+)
+
+/* -- 5. the operator is shown the real thing, not a stale copy -------------- */
+
+const page = read(PAGE)
+
+assert.ok(
+  /\{\{\s*SCENE_ANIMATOR_PROMPT\s*\}\}/.test(page),
+  `${PAGE} must render SCENE_ANIMATOR_PROMPT by reference. It previously ` +
+    `inlined the full text as HTML, which silently goes stale the first time ` +
+    `the prompt is tuned — the operator reads one direction while another is ` +
+    `sent.`,
+)
+
+// The specific stale copy that was there, and any re-paste of the live one.
+assert.ok(
+  !page.includes('Bring this still scene naturally to life'),
+  `${PAGE} still contains the retired prompt text verbatim`,
+)
+assert.ok(
+  !page.includes(SCENE_ANIMATOR_PROMPT.slice(0, 60)),
+  `${PAGE} inlines the current prompt text. Interpolate the constant instead, ` +
+    `or this drifts again on the next tune.`,
+)
+
+/* -- 6. the still/motion pair is shown whole, not cropped ------------------- */
+//
+// Silas, 2026-09-11: "I can't see the entire image on the display." The cards
+// pair a square source against a square clip inside an aspect-video box, so
+// object-cover ate the top and bottom of both.
+
+assert.ok(
+  !/aspect-video[^"]*"[\s\S]{0,400}?object-cover/.test(page),
+  `${PAGE} must not use object-cover inside the aspect-video preview boxes — ` +
+    `it crops square sources, which is most of the animate folder. Use ` +
+    `object-contain so the whole frame is visible.`,
+)
+
+assert.equal(
+  (page.match(/size-full object-contain/g) || []).length,
+  3,
+  `${PAGE} must fit all three previews (source still, video result, image ` +
+    `result) — cropping any one of them breaks the comparison the card exists for`,
+)
+
+console.log(
+  '✅ Scene Animator prompt: motion-forward without losing subject integrity, ' +
+    'negative prompt wired, admin surface reads the live constant, previews uncropped.',
+)


### PR DESCRIPTION
Three things from the first real batch (Silas, 2026-09-11).

## 1. The prompt asked for restraint, and got it

> *"the animations are pretty lackluster ... the others have minimal movement"*

The old direction was:

> Bring this still scene naturally to life with **subtle** coherent motion. ... Add **only plausible ambient movement**, **gentle** secondary motion, and **stable** cinematic camera behavior.

Five hedges in one sentence, every one a vote against movement. WAN obliged.

It now asks for deliberate motion and, where there's a figure, **names the performance** — *"if there is a figure, they should be animated, wink, smile, laugh"*:

> Animate this scene with clear, deliberate motion. Any person, animal, robot, or character in the frame must visibly perform: blink, shift expression with a smile, a wink or a laugh, turn or tilt the head, and move hands, arms or body with intent. Give the rest of the scene life as well — hair and cloth sway, foliage and water move, light and shadow shift, background elements drift. Camera movement stays slow and purposeful. Preserve every subject exactly as drawn: identity, faces, design, colors, composition, and art style are unchanged, and no character, creature, vehicle, object, logo, or text is added, removed, or replaced.

**Subject integrity is deliberately untouched.** The same batch invented a miniature figure on a Segway riding across the HSS dog logo, and that clause is the obvious casualty of a "make it more dynamic" retune. The test pins both halves together for that reason.

## 2. `negativePrompt` was empty

It shipped as `negativePrompt: ''`. It now carries terms for both observed failure modes — stillness (`static image, still frame, frozen, motionless…`) and invented subjects (`additional characters, extra people, new objects appearing, vehicles…`). A negative prompt is the cheaper lever for constraints than spending positive-prompt attention on them.

## 3. The previews were cropped

> *"I can't see the entire image on the display"*

The cards pair a square source against a square clip inside an `aspect-video` box using `object-cover` — so both got their top and bottom eaten. Now `object-contain`, which letterboxes and shows the whole frame. That's what a still/motion comparison is for.

## A trap found on the way

`pages/admin/scene-animator.vue` had the **entire prompt re-typed as literal HTML** in its "Automatic motion direction" panel. Nothing connected the two copies, so tuning the prompt would have left the operator reading the old direction while a different one was sent — both halves keep working and quietly stop agreeing.

The constants move to `utils/sceneAnimatorPrompt.ts` (re-exported from the server util for existing importers), the page interpolates them, and the test refuses any inlined copy — including a re-paste of the *current* text.

## Verification

`utils/scripts/verifySceneAnimatorPrompt.test.ts`, wired into `contract-tests.yml`. Verified to fail against four regressions, each run individually:

1. previews reverted to `object-cover`
2. prompt re-inlined into the page
3. prompt reacquires a hedge (`subtle`)
4. no-new-subjects clause dropped

One of those (#3) initially reported a false pass because my mutation's anchor didn't match the file — re-run with the correct anchor before trusting it.

`vue-tsc`: 0 errors. `eslint` on changed files: clean. Existing `test:scene-animator-health` and `test:scene-animator-resubmit` still pass.

## Note

This changes the prompt but **not** the dedupe key, so it does not orphan existing jobs or re-queue anything on its own. Picking up the new direction means re-rendering — which is what silasfelinus/kind_robots#2643 added the button for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNe7H71sq22FA6W9kqKc5R

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNe7H71sq22FA6W9kqKc5R)_