### PR TITLE
fix(art-queue): release RUNNING rows a single-slot relay abandoned when it polls again

### DIFF
--- a/.github/workflows/entity-art-manager-contract.yml
+++ b/.github/workflows/entity-art-manager-contract.yml
@@ -25,6 +25,9 @@ on:
       - 'server/api/art/entities/**'
       - 'server/utils/entityArt.ts'
       - 'utils/scripts/verifyArtQueueClaimFastPath.ts'
+      - 'utils/scripts/verifyArtQueueRelaySlotRelease.ts'
+      - 'server/utils/artJobRelaySlot.ts'
+      - 'components/art/artjob-queue-card.vue'
       - 'utils/scripts/verifyEntityArtManager.ts'
       - 'utils/entityArtPromptFraming.ts'
       - 'stores/dailyDreamArchiveStore.ts'
@@ -49,6 +52,7 @@ jobs:
       - run: npm ci
       - run: npx prisma generate
       - run: npx tsx utils/scripts/verifyArtQueueClaimFastPath.ts
+      - run: npx tsx utils/scripts/verifyArtQueueRelaySlotRelease.ts
       - run: npx tsx utils/scripts/verifyEntityArtManager.ts
       - run: npx tsx utils/scripts/verifyEntityArtPromptFraming.ts
       - run: npx tsx utils/scripts/verifyDailyDreamArchiveWorkbench.ts

--- a/components/art/artjob-queue-card.vue
+++ b/components/art/artjob-queue-card.vue
@@ -206,6 +206,9 @@
         v-if="job.error"
         class="kr-text-error-xs rounded-2xl border border-error/30 bg-error/10 p-2"
       >
+        <span v-if="errorIsFromEarlierAttempt" class="font-semibold">
+          Earlier attempt ·
+        </span>
         {{ job.error }}
       </div>
 
@@ -418,6 +421,10 @@ const jobRequestId = computed<string>(() => artJobRequestId(props.job))
 const jobImagePath = computed<string>(() => artJobImagePath(props.job))
 
 const jobSettings = computed<string[]>(() => artJobSettings(props.job))
+
+const errorIsFromEarlierAttempt = computed<boolean>(
+  () => props.job.status === 'RUNNING' || props.job.status === 'PENDING',
+)
 
 const imageVersion = computed<string>(() => artJobImageVersion(props.job))
 

--- a/package.json
+++ b/package.json
@@ -296,6 +296,7 @@
     "test:model-builder-async-poll-failure-guard": "tsx utils/scripts/verifyModelBuilderAsyncPollFailureGuard.ts",
     "test:art-queue-poll-failure-guard-selftest": "tsx utils/scripts/verifyArtQueuePollFailureGuard.test.ts",
     "test:art-queue-poll-failure-guard": "tsx utils/scripts/verifyArtQueuePollFailureGuard.ts",
+    "test:art-queue-relay-slot-release": "tsx utils/scripts/verifyArtQueueRelaySlotRelease.ts",
     "test:video-job-poll-failure-guard-selftest": "tsx utils/scripts/verifyVideoJobPollFailureGuard.test.ts",
     "test:video-job-poll-failure-guard": "tsx utils/scripts/verifyVideoJobPollFailureGuard.ts",
     "test:build-bench-poll-failure-guard-selftest": "tsx utils/scripts/verifyBuildBenchPollFailureGuard.test.ts",

--- a/server/api/art/queue/claim.post.ts
+++ b/server/api/art/queue/claim.post.ts
@@ -14,6 +14,18 @@
 // strict FIFO.
 // The claim itself is an updateMany guarded on the expected status, so two
 // relays can never win the same job — the loser retries another candidate.
+//
+// A relay is one slot: it claims, renders, reports, and only then polls again.
+// So a poll from an agent that still holds a RUNNING row is proof that row was
+// abandoned — the outcome report never landed (relay restart between claim and
+// complete, a lost /complete POST, a crash inside process()). Before handing
+// out new work, this releases every RUNNING row the polling agent still holds:
+// back to PENDING with its attempt count intact, or FAILED once the budget is
+// spent. Without that, the abandoned row stayed RUNNING beside the fresh claim
+// until the queue happened to re-offer it after STALE_CLAIM_MINUTES, and a
+// low-priority one could sit behind priority-100 work for hours (2026-09-12:
+// #21788, attempt 2, RUNNING for 63 minutes next to the live #21803). A relay
+// that genuinely renders several jobs at once opts out with singleSlot=false.
 import { createError, defineEventHandler, readBody } from 'h3'
 import prisma from '../../../utils/prisma'
 import { errorHandler } from '../../../utils/error'
@@ -40,6 +52,7 @@ import {
 } from '../../../utils/artJobSamplerRepair'
 import { recordRelayClaimAttempt } from '../../../utils/relayAgentRegistry'
 import { isQueuePaused } from '../../../utils/queueControl'
+import { releaseAbandonedRelayClaims } from '../../../utils/artJobRelaySlot'
 
 const STALE_CLAIM_MINUTES = 15
 const MAX_ATTEMPTS = 3
@@ -54,6 +67,7 @@ type ClaimRequestBody = {
   supportsCompletionProof?: boolean | null
   agentVersion?: string | null
   smartQueue?: boolean | null
+  singleSlot?: boolean | null
 }
 
 export default defineEventHandler(async (event) => {
@@ -75,13 +89,13 @@ export default defineEventHandler(async (event) => {
     const engines = (body?.engines || ['A1111', 'COMFY'])
       .map((engine) => String(engine).toUpperCase())
       .filter((engine) => engine === 'A1111' || engine === 'COMFY') as (
-      | 'A1111'
-      | 'COMFY'
+      'A1111' | 'COMFY'
     )[]
 
     const supportsInputImages = body?.supportsInputImages === true
     const supportsCompletionProof = body?.supportsCompletionProof === true
     const smartQueue = body?.smartQueue !== false
+    const singleSlot = body?.singleSlot !== false
 
     recordRelayClaimAttempt({
       agentId: claimedBy,
@@ -94,6 +108,14 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, message: 'No valid engines given.' })
     }
 
+    // Runs before the paused check and the idle fast path on purpose: a relay
+    // polling while paused has still abandoned whatever it holds, and a
+    // released row is new PENDING work (or a fresh FAILED) that the probe
+    // below must see either way.
+    const released = singleSlot
+      ? await releaseAbandonedRelayClaims(claimedBy, MAX_ATTEMPTS)
+      : []
+
     // Queue paused (admin toggle): hand out no work so the queue is preserved
     // but not drained. Graceful — defaults to not-paused if the control table
     // is not migrated yet, so this can never wedge the pipeline.
@@ -103,6 +125,7 @@ export default defineEventHandler(async (event) => {
         message: 'Queue processing is paused.',
         data: {
           job: null,
+          released,
           paused: true,
           scheduling: { mode: smartQueue ? 'SMART' : 'FIFO' },
         },
@@ -132,6 +155,7 @@ export default defineEventHandler(async (event) => {
         message: 'No runnable jobs.',
         data: {
           job: null,
+          released,
           scheduling: {
             mode: smartQueue ? 'SMART' : 'FIFO',
             preferredAffinity: null,
@@ -208,6 +232,7 @@ export default defineEventHandler(async (event) => {
           message: 'No runnable jobs.',
           data: {
             job: null,
+            released,
             scheduling: {
               mode: smartQueue ? 'SMART' : 'FIFO',
               preferredAffinity,
@@ -352,6 +377,7 @@ export default defineEventHandler(async (event) => {
             : 'Job claimed.',
           data: {
             job: job ? decodeArtJobPayload(job) : null,
+            released,
             relayContract: {
               supportsCompletionProof,
               completionProofRequired:

--- a/server/utils/artJobRelaySlot.ts
+++ b/server/utils/artJobRelaySlot.ts
@@ -1,0 +1,72 @@
+// /server/utils/artJobRelaySlot.ts
+//
+// The home relay (conductor ops/home-server/relay_agent.py) is one slot: it
+// claims a job, renders it, reports the outcome, and only then polls
+// /api/art/queue/claim again. So a claim poll from an agent that still holds a
+// RUNNING row is proof that row was abandoned — the relay restarted between
+// claim and complete, the /complete POST was lost, or process() crashed and the
+// failure report never landed. Left alone, that row stayed RUNNING beside the
+// fresh claim until the queue happened to re-offer it after the stale window,
+// and a low-priority one could sit behind priority-100 work for hours
+// (2026-09-12: #21788, attempt 2, RUNNING for 63 minutes next to the live
+// #21803, both shown as running on the dashboard).
+//
+// Releasing mirrors the relay's own shutdown handler (requeue with
+// resetAttempts=false): the attempt was counted at claim time, and keeping the
+// count means a job that wedges the relay on every try still reaches the
+// attempt budget and stops instead of looping forever.
+import prisma from './prisma'
+
+export const RELAY_CLAIM_RELEASE_REASON =
+  'Released by the queue: the relay polled for new work while this job was still marked RUNNING, so its outcome report never arrived.'
+
+export type ReleasedRelayClaim = {
+  id: number
+  attempts: number
+  status: 'PENDING' | 'FAILED'
+}
+
+export function relayClaimReleaseError(priorError: string | null | undefined) {
+  const prior = priorError?.trim()
+  return (
+    prior
+      ? `${RELAY_CLAIM_RELEASE_REASON} Previous error: ${prior}`
+      : RELAY_CLAIM_RELEASE_REASON
+  ).slice(0, 4000)
+}
+
+export async function releaseAbandonedRelayClaims(
+  claimedBy: string,
+  maxAttempts: number,
+): Promise<ReleasedRelayClaim[]> {
+  const held = await prisma.artJob.findMany({
+    where: { status: 'RUNNING', claimedBy },
+    select: { id: true, attempts: true, claimedAt: true, error: true },
+  })
+
+  const released: ReleasedRelayClaim[] = []
+
+  for (const job of held) {
+    const status = job.attempts >= maxAttempts ? 'FAILED' : 'PENDING'
+
+    // Guarded on the claim we read so a completion that lands in between wins.
+    const result = await prisma.artJob.updateMany({
+      where: { id: job.id, status: 'RUNNING', claimedAt: job.claimedAt },
+      data: {
+        status,
+        error: relayClaimReleaseError(job.error),
+        claimedAt: null,
+        claimedBy: null,
+      },
+    })
+
+    if (result.count !== 1) continue
+
+    released.push({ id: job.id, attempts: job.attempts, status })
+    console.warn(
+      `⚠️ ArtJob ${job.id} was still RUNNING (attempt ${job.attempts}) when relay ${claimedBy} polled for new work — released to ${status}.`,
+    )
+  }
+
+  return released
+}

--- a/utils/scripts/verifyArtQueueRelaySlotRelease.ts
+++ b/utils/scripts/verifyArtQueueRelaySlotRelease.ts
@@ -1,0 +1,103 @@
+// /utils/scripts/verifyArtQueueRelaySlotRelease.ts
+//
+// Regression guard for the "two jobs shown as running" dashboard symptom
+// (2026-09-12: ArtJob #21788, attempt 2, sat RUNNING for 63 minutes next to
+// the live #21803 — its earlier "timed out" error still on the card).
+//
+// The home relay is one slot: claim → render → report → poll again. A claim
+// poll from an agent that still holds a RUNNING row therefore proves the row
+// was abandoned (relay restart, lost /complete POST, crash in process()), and
+// claim.post.ts must release it — PENDING with attempts intact, FAILED once
+// the budget is spent — BEFORE the paused check and the idle fast path, so
+// the released row is visible to both. Source-text assertions, matching
+// verifyArtQueueClaimFastPath.ts, plus a pure check of the error message the
+// release stamps so a prior attempt's error is kept rather than overwritten.
+import { readFileSync } from 'node:fs'
+import {
+  RELAY_CLAIM_RELEASE_REASON,
+  relayClaimReleaseError,
+} from '../../server/utils/artJobRelaySlot'
+
+const route = readFileSync('server/api/art/queue/claim.post.ts', 'utf8')
+const util = readFileSync('server/utils/artJobRelaySlot.ts', 'utf8')
+const card = readFileSync('components/art/artjob-queue-card.vue', 'utf8')
+
+function assertIncludes(source: string, name: string, required: string) {
+  if (!source.includes(required)) {
+    throw new Error(`${name} is missing: ${required}`)
+  }
+}
+
+for (const required of [
+  "import { releaseAbandonedRelayClaims } from '../../../utils/artJobRelaySlot'",
+  'singleSlot?: boolean | null',
+  'const singleSlot = body?.singleSlot !== false',
+  'await releaseAbandonedRelayClaims(claimedBy, MAX_ATTEMPTS)',
+]) {
+  assertIncludes(route, 'Art queue claim relay-slot release', required)
+}
+
+const releaseAt = route.indexOf('await releaseAbandonedRelayClaims(')
+const pausedAt = route.indexOf('if (await isQueuePaused())')
+const fastPathAt = route.indexOf(
+  'const queueSignal = await prisma.artJob.findFirst',
+)
+if (releaseAt < 0 || pausedAt < 0 || fastPathAt < 0) {
+  throw new Error(
+    'Art queue claim route lost a landmark the release ordering depends on.',
+  )
+}
+if (!(releaseAt < pausedAt && releaseAt < fastPathAt)) {
+  throw new Error(
+    'releaseAbandonedRelayClaims must run before the paused check and the idle fast path.',
+  )
+}
+
+for (const required of [
+  "where: { status: 'RUNNING', claimedBy }",
+  "where: { id: job.id, status: 'RUNNING', claimedAt: job.claimedAt }",
+  "const status = job.attempts >= maxAttempts ? 'FAILED' : 'PENDING'",
+  'claimedAt: null,',
+  'claimedBy: null,',
+]) {
+  assertIncludes(util, 'artJobRelaySlot release', required)
+}
+
+if (util.includes('attempts: 0') || util.includes('attempts: { set: 0 }')) {
+  throw new Error(
+    'Releasing an abandoned claim must keep the attempt count (mirrors requeue resetAttempts=false).',
+  )
+}
+
+if (relayClaimReleaseError(null) !== RELAY_CLAIM_RELEASE_REASON) {
+  throw new Error(
+    'Release error without a prior error should be the bare reason.',
+  )
+}
+const kept = relayClaimReleaseError(
+  '  ComfyUI image job timed out after 600s  ',
+)
+if (
+  !kept.startsWith(RELAY_CLAIM_RELEASE_REASON) ||
+  !kept.endsWith('Previous error: ComfyUI image job timed out after 600s')
+) {
+  throw new Error(
+    `Release error must keep the prior attempt's error, got: ${kept}`,
+  )
+}
+if (relayClaimReleaseError('x'.repeat(5000)).length !== 4000) {
+  throw new Error('Release error must be capped at the 4000-char error column.')
+}
+
+for (const required of [
+  'v-if="errorIsFromEarlierAttempt"',
+  "props.job.status === 'RUNNING' || props.job.status === 'PENDING'",
+]) {
+  assertIncludes(
+    card,
+    'ArtJob queue card earlier-attempt error label',
+    required,
+  )
+}
+
+console.log('Art queue relay-slot release verified.')


### PR DESCRIPTION
## Symptom

The ArtJob dashboard showed two COMFY jobs RUNNING on a one-slot render box (2026-09-12): #21803 (attempt 1, priority 100, claimed 02:44) next to #21788 (attempt 2, priority 0, claimed 01:41, still carrying its attempt-1 "timed out" error). #21788 had sat RUNNING for 63 minutes.

## Cause

The relay (`conductor ops/home-server/relay_agent.py`) is a single slot: claim → render → report → poll `claim` again. When its outcome report for a job never lands (relay restart between claim and complete, a lost `/complete` POST, a crash in `process()` whose failure report also failed), the row stays RUNNING. `claim.post.ts` only flips a stale RUNNING row to FAILED once `attempts >= 3`; below that it is merely re-claimable after 15 minutes, and because candidates are ordered by priority a low-priority abandoned row waits behind every priority-100 job — RUNNING the whole time, beside whatever the relay is actually rendering.

## Fix

- `server/utils/artJobRelaySlot.ts`: `releaseAbandonedRelayClaims(claimedBy, maxAttempts)` — a claim poll from an agent that still holds RUNNING rows is proof those rows were abandoned. Release them the way the relay's own shutdown handler would (`requeue` with `resetAttempts: false`): PENDING with the attempt count intact, or FAILED once the budget is spent; the prior attempt's error text is kept behind the release reason. Each update is guarded on the claim that was read so a completion landing in between wins.
- `claim.post.ts`: runs the release before the paused check and the idle fast path, so a released row is visible to both. New body field `singleSlot` (default true) lets a relay that genuinely renders several jobs at once opt out. Every success response now carries `data.released`.
- `artjob-queue-card.vue`: an error on a RUNNING/PENDING card is labelled "Earlier attempt ·" so a live job no longer reads as currently failing.
- `utils/scripts/verifyArtQueueRelaySlotRelease.ts` (+ `npm run test:art-queue-relay-slot-release`), wired into `entity-art-manager-contract.yml`: asserts the release ordering, the attempts-preserving guard, the error-keeping message helper, and the card label.

## Verification

- `npx tsx utils/scripts/verifyArtQueueRelaySlotRelease.ts` and `verifyArtQueueClaimFastPath.ts` pass
- `eslint` + `prettier` clean on the changed files
- `npm test` (full `vue-tsc --noEmit`) exit 0

No relay change is required; the existing relay gets the behaviour on its next poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeAA1xmrGik25bmZw2TkLZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeAA1xmrGik25bmZw2TkLZ)_