### PR TITLE
storybook: one direct-prose narration contract for every shape and deck

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -305,6 +305,12 @@ jobs:
       - name: Da Vinci narration bounds contract
         run: npm run test:davinci-narration
 
+      - name: Ending deck math contract
+        run: npm run test:ending-deck-math
+
+      - name: Storybook narration bounds contract
+        run: npm run test:storybook-narration
+
       - name: Da Vinci dimension-tone guard self-test
         run: npm run test:davinci-dimension-tone-guard-selftest
 

--- a/package.json
+++ b/package.json
@@ -126,6 +126,8 @@
     "seed:bestiary:verify": "tsx utils/scripts/verifyBestiarySeedMapping.ts",
     "seed:davinci:playloop-verify": "tsx utils/scripts/verifyDaVinciPlayLoop.ts",
     "test:davinci-narration": "tsx utils/scripts/verifyDaVinciNarration.ts",
+    "test:ending-deck-math": "tsx utils/scripts/verifyEndingDeckMath.ts",
+    "test:storybook-narration": "tsx utils/scripts/verifyStorybookNarration.ts",
     "test:davinci-dimension-tone-guard-selftest": "tsx utils/scripts/verifyDaVinciDimensionToneGuard.test.ts",
     "test:davinci-dimension-tone-guard": "tsx utils/scripts/verifyDaVinciDimensionToneGuard.ts",
     "test:davinci-narration-error-tone-guard-selftest": "tsx utils/scripts/verifyDaVinciNarrationErrorToneGuard.test.ts",

--- a/server/utils/davinciDimensions.ts
+++ b/server/utils/davinciDimensions.ts
@@ -8,9 +8,17 @@
 // job. davinci.ts re-exports everything here, so existing importers are
 // unaffected.
 //
+// The Life deck's axes are now also declared, with labels, as LIFE_DECK in
+// ./endingDeckMath.ts, which owns the deck-generic version of this same math
+// for every Storybook shape. This module stays the Life-specific vocabulary
+// (and its resolveOutcomeKey delegates there) so every existing importer and
+// the DaVinciDimension type keep working unchanged.
+//
 // Bit order matches conductor's projects/davinci/data/ending-dimensions.yaml
 // and scripts/generate_davinci_endings.py: outcomeKey[i] is DIMENSIONS[i],
 // '1' = pass. Do not reorder without migrating the seeded endings.
+
+import { LIFE_DECK, resolveDeckOutcomeKey } from './endingDeckMath'
 
 export const DAVINCI_DIMENSIONS = [
   'legacy',
@@ -35,7 +43,5 @@ export function resolveOutcomeKey(
   stats: Partial<Record<string, number>>,
   passValue: number = DAVINCI_PASS_VALUE,
 ): string {
-  return DAVINCI_DIMENSIONS.map((key) =>
-    (stats[key] ?? 0) >= passValue ? '1' : '0',
-  ).join('')
+  return resolveDeckOutcomeKey({ ...LIFE_DECK, passValue }, stats)
 }

--- a/server/utils/davinciNarration.ts
+++ b/server/utils/davinciNarration.ts
@@ -1,45 +1,61 @@
 // /server/utils/davinciNarration.ts
 //
-// Da Vinci AI-narration layer. Implements conductor's
-// projects/davinci/docs/narration-layer-spec.md (davinci/t-015).
+// Da Vinci AI-narration layer, now an ADAPTER over ./storybookNarration.ts.
 //
-// BOUNDARY: this module is a *caller* of the play-loop, never a second owner
-// of durable state. It reads a run, asks a narrator for the next chapter's
-// prose + choice options + proposed stat deltas, and validates that response
-// against app-owned bounds. It writes nothing. The client still calls
-// POST /api/davinci/runs/:id/choices and .../resolve separately, so
-// LifeChoice/LifeStat/LifeEnding writes and all outcome math stay exactly
-// where they are in server/utils/davinci.ts.
+// The life shape is one of Storybook's four shapes (merged 2026-09-09,
+// kind_robots #2549) and one of its ending decks (`life`, ten axes, 1,024
+// endings), so the narration contract it pioneered was generalized rather than
+// duplicated -- storybook/t-025 and t-031. Everything this module exported
+// still exists and still behaves identically, because POST
+// /api/davinci/runs/:id/narrate and utils/scripts/verifyDaVinciNarration.ts
+// both depend on the exact names, bounds, error strings, and response-document
+// shape below.
 //
-// The narrator proposes; the app disposes. A narration response that invents
-// an eleventh dimension, swings a stat by 40, or returns one choice is a
-// schema violation — not a new rule.
+// What is deliberately preserved rather than modernized here:
+//   - the response document keeps `milestoneCandidate` (the shared layer calls
+//     it `endingHint`) and omits `moveEffects`/`stateDelta`, because the narrate
+//     endpoint has no move to score and writes no inventory;
+//   - the effects map stays UNCAPPED (`maxEffectAxes: null`) while new shapes
+//     cap a move at three axes -- narrowing a live game's tuning is a design
+//     change, not a refactor.
+//
+// BOUNDARY, unchanged: a caller of the play loop, never a second owner of
+// durable state. LifeChoice/LifeStat/LifeEnding writes and all outcome math
+// stay in server/utils/davinci.ts. The narrator proposes; the app disposes.
 
 import { DAVINCI_DIMENSIONS, type DaVinciDimension } from './davinciDimensions'
+import { LIFE_DECK } from './endingDeckMath'
+import {
+  buildStorybookSystemPrompt,
+  buildStorybookUserPrompt,
+  generateStorybookTurn,
+  storybookResponseSchema,
+  validateStorybookNarration,
+  PROSE_BOUNDS_BY_SHAPE,
+  type StorybookNarrationRequest,
+  type StoryNarrator,
+} from './storybookNarration'
 
-// Narration is synchronous from the player's point of view — they are staring
-// at a spinner waiting for the next chapter — so this budget is deliberately
-// tighter than the async WonderLab review generator's 30s.
-const NARRATION_TIMEOUT_MS = 20_000
-const NARRATION_MODEL = 'gpt-4o-mini'
+// The four bound constants are NOT re-exported from here on purpose. Nitro
+// auto-imports every symbol under server/utils, so exporting the same name from
+// two modules makes the auto-import ambiguous and warns on every build. They
+// have one home now -- ./storybookNarration -- and both narration guards import
+// them from there.
 
-// Per-choice swing bounds. A dimension passes at DAVINCI_PASS_VALUE (1), so an
-// unclamped narrator could resolve a whole run in one chapter. Design default
-// from the spec's open question — revisit after real playtesting.
-export const NARRATION_EFFECT_MIN = -2
-export const NARRATION_EFFECT_MAX = 2
-export const NARRATION_MIN_CHOICES = 2
-export const NARRATION_MAX_CHOICES = 4
-const NARRATIVE_MIN_WORDS = 20
-const NARRATIVE_MAX_WORDS = 400
 const RECENT_CHOICE_WINDOW = 3
 
-export interface DaVinciNarrator {
-  name: string
-  personality: string | null
-  narrativeVoice: string | null
-  prompt: string | null
-}
+/** The life shape's slice of the shared response document. */
+const LIFE_NARRATION_OPTIONS = {
+  includeMoveEffects: false,
+  includeStateDelta: false,
+  hintKey: 'milestoneCandidate',
+  hintDescription:
+    'Optional short phrase naming the ending this life seems headed toward, or null. Display-only flavor; awards nothing.',
+  maxEffectAxes: null,
+} as const
+
+/** Narrator identity. Alias of the shared type; both spellings are in use. */
+export type DaVinciNarrator = StoryNarrator
 
 export interface DaVinciRecentChoice {
   chapter: number
@@ -68,108 +84,62 @@ export interface DaVinciNarrationResult {
   narrativeText: string
   choices: DaVinciChoiceOption[]
   artPrompt: string | null
-  // The narrator's guess at a resonant ending theme. Display-only flavor —
+  // The narrator's guess at a resonant ending theme. Display-only flavor --
   // resolveLifeRunEnding never reads it, and nothing is ever awarded from it.
   // Outcome math stays 100% derived from stored LifeStat rows.
   milestoneCandidate: string | null
-}
-
-const CHOICE_IDS = ['a', 'b', 'c', 'd'] as const
-
-// OpenAI structured-output strict mode requires every property to appear in
-// `required` and forbids additionalProperties, so the effects map lists all ten
-// dimensions as nullable integers rather than as optional keys. Null means "this
-// choice does not move that dimension" and is dropped during validation, which
-// preserves the spec's "an option can be flavor with zero mechanical effect"
-// rule without needing optional properties strict mode won't accept.
-//
-// Range and item-count bounds are deliberately NOT expressed as
-// minimum/maximum/minItems/maxItems: support for those keywords under strict
-// mode is uneven, and the app re-validates every bound server-side anyway.
-// They live in the descriptions so the model still sees them.
-function effectsSchema() {
-  return {
-    type: 'object',
-    description:
-      `Proposed stat deltas for this choice. Each value is an integer from ` +
-      `${NARRATION_EFFECT_MIN} to ${NARRATION_EFFECT_MAX}, or null when the ` +
-      `choice does not move that dimension. Most choices should move two or ` +
-      `three dimensions, not all ten.`,
-    properties: Object.fromEntries(
-      DAVINCI_DIMENSIONS.map((dimension) => [
-        dimension,
-        {
-          type: ['integer', 'null'],
-          description: `Change to the ${dimension} dimension, or null.`,
-        },
-      ]),
-    ),
-    required: [...DAVINCI_DIMENSIONS],
-    additionalProperties: false,
-  }
-}
-
-export function narrationResponseSchema(): Record<string, unknown> {
-  return {
-    type: 'object',
-    properties: {
-      narrativeText: {
-        type: 'string',
-        description:
-          `This chapter's prose, in second person, ${NARRATIVE_MIN_WORDS}-` +
-          `${NARRATIVE_MAX_WORDS} words. End on the brink of a decision — do ` +
-          `not state the options themselves.`,
-      },
-      choices: {
-        type: 'array',
-        description:
-          `Between ${NARRATION_MIN_CHOICES} and ${NARRATION_MAX_CHOICES} ` +
-          `distinct options the protagonist could take.`,
-        items: {
-          type: 'object',
-          properties: {
-            id: {
-              type: 'string',
-              enum: [...CHOICE_IDS],
-              description: 'Stable id within this chapter, in order.',
-            },
-            choiceText: {
-              type: 'string',
-              description:
-                'One sentence, phrased as an action the player takes.',
-            },
-            effects: effectsSchema(),
-          },
-          required: ['id', 'choiceText', 'effects'],
-          additionalProperties: false,
-        },
-      },
-      artPrompt: {
-        type: ['string', 'null'],
-        description:
-          'Optional image prompt for this scene, or null. Visual detail only.',
-      },
-      milestoneCandidate: {
-        type: ['string', 'null'],
-        description:
-          'Optional short phrase naming the ending this life seems headed ' +
-          'toward, or null. Display-only flavor; awards nothing.',
-      },
-    },
-    required: ['narrativeText', 'choices', 'artPrompt', 'milestoneCandidate'],
-    additionalProperties: false,
-  }
 }
 
 function isDimension(key: string): key is DaVinciDimension {
   return (DAVINCI_DIMENSIONS as readonly string[]).includes(key)
 }
 
-function clampEffect(value: number): number {
-  return Math.max(
-    NARRATION_EFFECT_MIN,
-    Math.min(NARRATION_EFFECT_MAX, Math.trunc(value)),
-  )
+/**
+ * Map a life narration request onto the shared one.
+ *
+ * The life run's seed columns become a minimal story bible: the protagonist is
+ * the cast, the genre is the single creative Facet. There is no turn budget --
+ * a life resolves on its own clock once MIN_CHAPTERS_BEFORE_ENDING is met -- so
+ * the prompt says "Turn 4", not "Turn 4 of N".
+ */
+function toStorybookRequest(
+  request: DaVinciNarrationRequest,
+): StorybookNarrationRequest {
+  return {
+    shape: 'life',
+    deck: LIFE_DECK,
+    narratorStyle: null,
+    narrator: request.narrator,
+    seed: request.seed,
+    turnIndex: request.chapter,
+    turnBudget: null,
+    isFinalTurn: false,
+    bible: {
+      title: request.protagonistName || 'An unwritten life',
+      premise: null,
+      cast: request.protagonistName
+        ? [{ name: request.protagonistName, role: 'protagonist' }]
+        : [],
+      location: null,
+      facets: request.genre
+        ? [{ title: request.genre }]
+        : [{ title: 'unspecified — pick a tone and hold it' }],
+      scenario: null,
+      treasures: [],
+    },
+    statsSoFar: request.statsSoFar,
+    inventory: [],
+    recentTurns: request.recentChoices.map((choice) => ({
+      turnIndex: choice.chapter,
+      narrativeText: choice.resultText || 'That scene is not recorded.',
+      move: { source: 'option' as const, text: choice.choiceText },
+    })),
+    move: null,
+  }
+}
+
+export function narrationResponseSchema(): Record<string, unknown> {
+  return storybookResponseSchema(LIFE_DECK, LIFE_NARRATION_OPTIONS)
 }
 
 // App-owned enforcement. Runs on every narration response even though the
@@ -177,243 +147,41 @@ function clampEffect(value: number): number {
 export function validateNarrationPayload(
   value: unknown,
 ): DaVinciNarrationResult {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error('The narrator returned a non-object response.')
+  const result = validateStorybookNarration(value, LIFE_DECK, {
+    ...LIFE_NARRATION_OPTIONS,
+    bounds: PROSE_BOUNDS_BY_SHAPE.life,
+  })
+  return {
+    narrativeText: result.narrativeText,
+    choices: result.choices.map((choice) => ({
+      id: choice.id,
+      choiceText: choice.choiceText,
+      effects: choice.effects as Partial<Record<DaVinciDimension, number>>,
+    })),
+    artPrompt: result.artPrompt,
+    milestoneCandidate: result.endingHint,
   }
-  const payload = value as Record<string, unknown>
-
-  const narrativeText =
-    typeof payload.narrativeText === 'string'
-      ? payload.narrativeText.trim()
-      : ''
-  const wordCount = narrativeText.split(/\s+/).filter(Boolean).length
-  if (wordCount < NARRATIVE_MIN_WORDS || wordCount > NARRATIVE_MAX_WORDS) {
-    throw new Error(
-      `Chapter prose must be ${NARRATIVE_MIN_WORDS}-${NARRATIVE_MAX_WORDS} words (got ${wordCount}).`,
-    )
-  }
-
-  if (!Array.isArray(payload.choices)) {
-    throw new Error('The narrator returned no choice list.')
-  }
-
-  const choices: DaVinciChoiceOption[] = []
-  const seenIds = new Set<string>()
-
-  for (const raw of payload.choices) {
-    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-      throw new Error('Each choice must be an object.')
-    }
-    const option = raw as Record<string, unknown>
-
-    const choiceText =
-      typeof option.choiceText === 'string' ? option.choiceText.trim() : ''
-    if (!choiceText) throw new Error('Each choice needs non-empty choiceText.')
-
-    const id =
-      typeof option.id === 'string' && option.id.trim()
-        ? option.id.trim().toLowerCase()
-        : CHOICE_IDS[choices.length] || String(choices.length)
-    if (seenIds.has(id)) {
-      throw new Error(`Duplicate choice id "${id}" in one chapter.`)
-    }
-    seenIds.add(id)
-
-    const effects: Partial<Record<DaVinciDimension, number>> = {}
-    const rawEffects = option.effects
-    if (
-      rawEffects &&
-      typeof rawEffects === 'object' &&
-      !Array.isArray(rawEffects)
-    ) {
-      for (const [key, delta] of Object.entries(
-        rawEffects as Record<string, unknown>,
-      )) {
-        // A response that invents an eleventh stat name is a schema violation,
-        // not a new stat — reject rather than silently pass it through to
-        // recordLifeChoice, which accepts arbitrary keys by design.
-        if (!isDimension(key)) {
-          throw new Error(
-            `Choice "${id}" proposed unknown dimension "${key}". Allowed: ${DAVINCI_DIMENSIONS.join(', ')}.`,
-          )
-        }
-        if (delta === null || delta === undefined) continue
-        if (typeof delta !== 'number' || !Number.isFinite(delta)) {
-          throw new Error(
-            `Choice "${id}" proposed a non-numeric delta for "${key}".`,
-          )
-        }
-        const clamped = clampEffect(delta)
-        if (clamped !== 0) effects[key] = clamped
-      }
-    }
-
-    choices.push({ id, choiceText, effects })
-  }
-
-  if (
-    choices.length < NARRATION_MIN_CHOICES ||
-    choices.length > NARRATION_MAX_CHOICES
-  ) {
-    throw new Error(
-      `A chapter must offer ${NARRATION_MIN_CHOICES}-${NARRATION_MAX_CHOICES} choices (got ${choices.length}).`,
-    )
-  }
-
-  const artPrompt =
-    typeof payload.artPrompt === 'string' && payload.artPrompt.trim()
-      ? payload.artPrompt.trim()
-      : null
-  const milestoneCandidate =
-    typeof payload.milestoneCandidate === 'string' &&
-    payload.milestoneCandidate.trim()
-      ? payload.milestoneCandidate.trim()
-      : null
-
-  return { narrativeText, choices, artPrompt, milestoneCandidate }
 }
 
 export function buildNarrationSystemPrompt(narrator: DaVinciNarrator): string {
-  return [
-    `You are ${narrator.name}, narrating a single human life in Kind Robots' Da Vinci life simulator.`,
-    narrator.prompt || '',
-    narrator.personality ? `Personality: ${narrator.personality}` : '',
-    narrator.narrativeVoice
-      ? `Narrative voice: ${narrator.narrativeVoice}`
-      : '',
-    '',
-    'Write one chapter at a time, in second person, present tense. Each chapter is a',
-    'concrete scene with a real decision at the end of it — not a summary of years.',
-    'Let the accumulated stats colour what happens: a life already rich in wealth but',
-    'poor in love should meet situations that reflect both.',
-    '',
-    `The ten dimensions are: ${DAVINCI_DIMENSIONS.join(', ')}.`,
-    `Every choice proposes integer deltas from ${NARRATION_EFFECT_MIN} to ${NARRATION_EFFECT_MAX}`,
-    'on a few of those dimensions and null on the rest. Real trade-offs beat pure',
-    'upgrades: a choice that raises wealth should usually cost something else.',
-    'Never state or imply that the player has won, lost, or unlocked anything — the',
-    'app alone decides how a life resolves.',
-  ]
-    .filter((line) => line !== '')
-    .join('\n')
+  return buildStorybookSystemPrompt(
+    toStorybookRequest({
+      runId: 0,
+      chapter: 1,
+      protagonistName: null,
+      genre: null,
+      seed: '',
+      narrator,
+      statsSoFar: {},
+      recentChoices: [],
+    }),
+  )
 }
 
 export function buildNarrationUserPrompt(
   request: DaVinciNarrationRequest,
 ): string {
-  const stats = DAVINCI_DIMENSIONS.map(
-    (dimension) => `${dimension}=${request.statsSoFar[dimension] ?? 0}`,
-  ).join(', ')
-
-  const history = request.recentChoices.length
-    ? request.recentChoices
-        .map(
-          (choice) =>
-            `- Chapter ${choice.chapter}: ${choice.choiceText}${
-              choice.resultText ? ` → ${choice.resultText}` : ''
-            }`,
-        )
-        .join('\n')
-    : '- (none yet — this is the opening chapter)'
-
-  return [
-    `Protagonist: ${request.protagonistName || 'an unnamed life'}`,
-    `Genre: ${request.genre || 'unspecified — pick a tone and hold it'}`,
-    `Seed: ${request.seed}`,
-    `Chapter to write: ${request.chapter}`,
-    '',
-    `Stats so far: ${stats}`,
-    '',
-    'Recent choices:',
-    history,
-    '',
-    `Write chapter ${request.chapter} and offer ${NARRATION_MIN_CHOICES}-${NARRATION_MAX_CHOICES} choices.`,
-  ].join('\n')
-}
-
-async function callNarrator(
-  request: DaVinciNarrationRequest,
-): Promise<DaVinciNarrationResult> {
-  const config = useRuntimeConfig()
-  const apiKey = String(
-    config.openaiApiKey || process.env.OPENAI_API_KEY || '',
-  ).trim()
-  if (!apiKey) {
-    throw new Error('No OpenAI API key is configured for Da Vinci narration.')
-  }
-
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), NARRATION_TIMEOUT_MS)
-  try {
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      signal: controller.signal,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: apiKey.startsWith('Bearer ')
-          ? apiKey
-          : `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: NARRATION_MODEL,
-        messages: [
-          {
-            role: 'system',
-            content: buildNarrationSystemPrompt(request.narrator),
-          },
-          { role: 'user', content: buildNarrationUserPrompt(request) },
-        ],
-        temperature: 0.9,
-        max_tokens: 900,
-        response_format: {
-          type: 'json_schema',
-          json_schema: {
-            name: 'davinci_chapter',
-            strict: true,
-            schema: narrationResponseSchema(),
-          },
-        },
-      }),
-    })
-
-    const body = (await response.json().catch(() => null)) as {
-      choices?: Array<{ message?: { content?: string | null } }>
-      error?: { message?: string }
-    } | null
-    if (!response.ok) {
-      throw new Error(
-        body?.error?.message ||
-          `Da Vinci narration failed (${response.status}).`,
-      )
-    }
-
-    const content = body?.choices?.[0]?.message?.content?.trim()
-    if (!content) throw new Error('The narrator returned an empty chapter.')
-
-    try {
-      return validateNarrationPayload(JSON.parse(content))
-    } catch (error) {
-      if (error instanceof SyntaxError) {
-        throw new Error(
-          'The narrator returned invalid JSON for this chapter.',
-          {
-            cause: error,
-          },
-        )
-      }
-      throw error
-    }
-  } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      throw new Error(
-        'The narrator timed out before the serverless deadline.',
-        { cause: error },
-      )
-    }
-    throw error
-  } finally {
-    clearTimeout(timeout)
-  }
+  return buildStorybookUserPrompt(toStorybookRequest(request))
 }
 
 export function buildNarrationRequest(
@@ -459,23 +227,25 @@ export function buildNarrationRequest(
   }
 }
 
-// Top-level entry point used by POST /api/davinci/runs/:id/narrate.
-// Retries once on a validation/parse failure — models occasionally emit a
-// truncated document even under strict mode — then surfaces the error rather
-// than substituting a synthetic chapter. A visible retry prompt beats a
-// silently fabricated one.
+// Top-level entry point used by POST /api/davinci/runs/:id/narrate. Retry and
+// timeout behaviour live in generateStorybookTurn and are unchanged: one retry
+// on a validation/parse failure, none on a timeout, and never a synthetic
+// chapter substituted for a failed one.
 export async function generateDaVinciChapter(
   request: DaVinciNarrationRequest,
 ): Promise<DaVinciNarrationResult> {
-  try {
-    return await callNarrator(request)
-  } catch (firstError) {
-    if (firstError instanceof Error && firstError.name === 'AbortError')
-      throw firstError
-    try {
-      return await callNarrator(request)
-    } catch {
-      throw firstError
-    }
+  const result = await generateStorybookTurn(
+    toStorybookRequest(request),
+    LIFE_NARRATION_OPTIONS,
+  )
+  return {
+    narrativeText: result.narrativeText,
+    choices: result.choices.map((choice) => ({
+      id: choice.id,
+      choiceText: choice.choiceText,
+      effects: choice.effects as Partial<Record<DaVinciDimension, number>>,
+    })),
+    artPrompt: result.artPrompt,
+    milestoneCandidate: result.endingHint,
   }
 }

--- a/server/utils/endingDeckMath.ts
+++ b/server/utils/endingDeckMath.ts
@@ -1,0 +1,244 @@
+// /server/utils/endingDeckMath.ts
+//
+// Deck-generic outcome math for Storybook's endings.
+//
+// Every Storybook shape resolves the same way: a run accumulates stats on the
+// axes its ENDING DECK declares, and at the end those axes are read as bits in
+// declaration order to produce an `outcomeKey`, which names exactly one ending
+// in that deck. The Life deck (formerly Da Vinci) is one such deck with ten
+// axes and 1,024 endings; a genre deck is the same idea with three or four axes
+// and eight or sixteen. The engine does not know the difference.
+//
+// DB-FREE ON PURPOSE, exactly like davinciDimensions.ts, which now delegates
+// here: importing ./prisma throws at module load when DATABASE_URL is unset, as
+// it is in the contract-tests job, so the pure math has to stay importable
+// without it.
+//
+// Bit order is a data contract. `outcomeKey[i]` is `axes[i]`, '1' means the
+// stat met the deck's pass value. Reordering a deck's axes renames every one of
+// its endings, so a deck's axes may not be reordered after its endings are
+// seeded -- see conductor projects/storybook/data/ending-decks/README.md.
+
+export interface DeckAxis {
+  /** snake_case stat key, matching LifeStat.key. */
+  key: string
+  /** Short human label, e.g. "Truth". */
+  label: string
+  /** One line telling the narrator what moves this axis. */
+  description?: string | null
+  /** What passing this axis reads as in an ending, e.g. "the case is solved". */
+  passLabel?: string | null
+  /** What failing it reads as. */
+  failLabel?: string | null
+}
+
+export interface DeckDefinition {
+  key: string
+  title?: string
+  axes: DeckAxis[]
+  /** A stat passes its axis at or above this value. Missing stats fail. */
+  passValue: number
+}
+
+export const MIN_DECK_AXES = 1
+export const MAX_DECK_AXES = 12
+export const DEFAULT_DECK_PASS_VALUE = 1
+
+const AXIS_KEY_PATTERN = /^[a-z][a-z0-9_]*$/
+
+/**
+ * The deterministic bit string for a run's stats against its deck.
+ *
+ * Identical in behaviour to davinciDimensions.resolveOutcomeKey for the Life
+ * deck; that function is now a one-line delegate, so the 1,024 seeded endings
+ * keep resolving to exactly the keys they were generated for.
+ */
+export function resolveDeckOutcomeKey(
+  deck: DeckDefinition,
+  stats: Partial<Record<string, number>>,
+): string {
+  const passValue = Number.isFinite(deck.passValue)
+    ? deck.passValue
+    : DEFAULT_DECK_PASS_VALUE
+  return deck.axes
+    .map((axis) => ((stats[axis.key] ?? 0) >= passValue ? '1' : '0'))
+    .join('')
+}
+
+/** Every outcomeKey a deck can produce, in ascending binary order. */
+export function deckOutcomeKeys(deck: DeckDefinition): string[] {
+  const total = 2 ** deck.axes.length
+  const keys: string[] = []
+  for (let index = 0; index < total; index += 1) {
+    keys.push(index.toString(2).padStart(deck.axes.length, '0'))
+  }
+  return keys
+}
+
+/** How many endings a deck with these axes must have to be complete. */
+export function deckEndingCount(deck: DeckDefinition): number {
+  return 2 ** deck.axes.length
+}
+
+/**
+ * Parse and validate an EndingDeck.axes JSON column.
+ *
+ * Throws rather than returning a partial list: an axis set that silently loses
+ * an entry would renumber every bit after it, which is the one failure mode
+ * that corrupts already-seeded endings instead of merely erroring.
+ */
+export function parseDeckAxes(value: string | null | undefined): DeckAxis[] {
+  if (!value || !value.trim()) throw new Error('A deck must declare its axes.')
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch (error) {
+    throw new Error("A deck's axes column is not valid JSON.", { cause: error })
+  }
+  if (!Array.isArray(parsed)) throw new Error("A deck's axes must be an array.")
+  if (parsed.length < MIN_DECK_AXES || parsed.length > MAX_DECK_AXES) {
+    throw new Error(
+      `A deck must declare ${MIN_DECK_AXES}-${MAX_DECK_AXES} axes (got ${parsed.length}).`,
+    )
+  }
+
+  const axes: DeckAxis[] = []
+  const seen = new Set<string>()
+  for (const raw of parsed) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new Error('Each deck axis must be an object.')
+    }
+    const entry = raw as Record<string, unknown>
+    const key = typeof entry.key === 'string' ? entry.key.trim() : ''
+    if (!AXIS_KEY_PATTERN.test(key)) {
+      throw new Error(
+        `Deck axis key "${key}" must be snake_case starting with a letter.`,
+      )
+    }
+    if (seen.has(key)) throw new Error(`Duplicate deck axis key "${key}".`)
+    seen.add(key)
+
+    axes.push({
+      key,
+      label:
+        typeof entry.label === 'string' && entry.label.trim()
+          ? entry.label.trim()
+          : key,
+      description:
+        typeof entry.description === 'string' && entry.description.trim()
+          ? entry.description.trim()
+          : null,
+      passLabel:
+        typeof entry.passLabel === 'string' && entry.passLabel.trim()
+          ? entry.passLabel.trim()
+          : null,
+      failLabel:
+        typeof entry.failLabel === 'string' && entry.failLabel.trim()
+          ? entry.failLabel.trim()
+          : null,
+    })
+  }
+  return axes
+}
+
+/** Serialize axes back to the shape parseDeckAxes accepts. */
+export function serializeDeckAxes(axes: DeckAxis[]): string {
+  return JSON.stringify(
+    axes.map((axis) => ({
+      key: axis.key,
+      label: axis.label,
+      description: axis.description ?? null,
+      passLabel: axis.passLabel ?? null,
+      failLabel: axis.failLabel ?? null,
+    })),
+  )
+}
+
+// The Life deck, in the bit order fixed by conductor
+// projects/davinci/data/ending-dimensions.yaml and reproduced by
+// scripts/generate_davinci_endings.py. Labels and descriptions come from that
+// file's pass_label/pass_summary; the keys and their order must not change
+// while 1,024 seeded LifeEnding rows depend on them.
+export const LIFE_DECK_KEY = 'life'
+
+export const LIFE_DECK: DeckDefinition = {
+  key: LIFE_DECK_KEY,
+  title: 'A whole life',
+  passValue: DEFAULT_DECK_PASS_VALUE,
+  axes: [
+    {
+      key: 'legacy',
+      label: 'Legacy',
+      description: 'What the life leaves behind once it is over.',
+      passLabel: 'remembered',
+      failLabel: 'forgotten',
+    },
+    {
+      key: 'wealth',
+      label: 'Wealth',
+      description:
+        'Whether material needs are met and resources can be directed.',
+      passLabel: 'prosperous',
+      failLabel: 'wanting',
+    },
+    {
+      key: 'love',
+      label: 'Love',
+      description: 'Bonds of affection, trust, and chosen family.',
+      passLabel: 'beloved',
+      failLabel: 'alone',
+    },
+    {
+      key: 'wisdom',
+      label: 'Wisdom',
+      description:
+        'Whether experience turns into discernment rather than certainty.',
+      passLabel: 'wise',
+      failLabel: 'foolish',
+    },
+    {
+      key: 'health',
+      label: 'Health',
+      description: 'What the body and mind can still carry.',
+      passLabel: 'vital',
+      failLabel: 'diminished',
+    },
+    {
+      key: 'freedom',
+      label: 'Freedom',
+      description: 'How much of the path the protagonist still chooses.',
+      passLabel: 'free',
+      failLabel: 'bound',
+    },
+    {
+      key: 'fame',
+      label: 'Fame',
+      description: 'How widely the name, work, or myth is known.',
+      passLabel: 'renowned',
+      failLabel: 'obscure',
+    },
+    {
+      key: 'creation',
+      label: 'Creation',
+      description: 'What the protagonist actually made and finished.',
+      passLabel: 'creator',
+      failLabel: 'barren',
+    },
+    {
+      key: 'community',
+      label: 'Community',
+      description:
+        'Belonging to a shared place, practice, movement, or network.',
+      passLabel: 'rooted',
+      failLabel: 'exiled',
+    },
+    {
+      key: 'mystery',
+      label: 'Mystery',
+      description: 'Contact with the strange, sacred, uncanny, or unknowable.',
+      passLabel: 'awakened',
+      failLabel: 'mundane',
+    },
+  ],
+}

--- a/server/utils/storybookNarration.ts
+++ b/server/utils/storybookNarration.ts
@@ -1,0 +1,817 @@
+// /server/utils/storybookNarration.ts
+//
+// ONE narration layer for every Storybook shape.
+//
+// Before this, the same idea -- (narrator config + seed objects + state
+// snapshot + recent history) -> a structured response -- was built twice:
+// client-side in stores/storybookStore.ts for the beat shapes, and server-side
+// in server/utils/davinciNarration.ts for the life shape (storybook/t-025 filed
+// exactly that duplication). It runs on the server for all four shapes now,
+// because only the server can hold the offered choices between turns, and a
+// client that authors its own stat deltas is a client that can author its own
+// ending.
+//
+// BOUNDARY, inherited from davinciNarration.ts and still true: this module is a
+// CALLER of the play loop, never a second owner of durable state. It reads a
+// request, asks a narrator for the next scene, and validates the response
+// against app-owned bounds. It writes nothing. The narrator proposes; the app
+// disposes. A response that invents an axis the deck does not have, swings a
+// stat by 40, or returns one choice is a schema violation, not a new rule.
+//
+// DB-FREE ON PURPOSE so the contract-tests job (no DATABASE_URL) can exercise
+// every bound directly. Nothing here may import ./prisma.
+
+import { DEFAULT_DECK_PASS_VALUE, type DeckDefinition } from './endingDeckMath'
+import { completeStructured } from './structuredCompletion'
+
+export type StorybookShape = 'short-story' | 'chaptered' | 'episodic' | 'life'
+
+export type StorybookNarratorStyle =
+  'cinematic' | 'playful' | 'storybook' | 'mysterious' | 'intimate'
+
+/** How the reader made this turn's move. */
+export type StorybookMoveSource = 'option' | 'custom' | 'sheet'
+
+export interface StorybookMove {
+  source: StorybookMoveSource
+  text: string
+  /** Set when source is 'option': which of the offered choices was taken. */
+  optionId?: string | null
+  /** Set when source is 'sheet': the Reward slug played from the sheet. */
+  rewardSlug?: string | null
+}
+
+/** Narrator identity, from a Bot or a Character. Shape unchanged from Da Vinci. */
+export interface StoryNarrator {
+  name: string
+  personality: string | null
+  narrativeVoice: string | null
+  prompt: string | null
+}
+
+export interface StoryTreasure {
+  slug: string
+  name: string
+  rewardType: string
+  rarity: string
+  effect?: string | null
+  flavorText?: string | null
+}
+
+export interface StoryCastMember {
+  name: string
+  role?: string | null
+  description?: string | null
+}
+
+/** The board the reader assembled, snapshotted when the run was created. */
+export interface StoryBible {
+  title: string
+  premise?: string | null
+  cast: StoryCastMember[]
+  location?: { title: string; description?: string | null } | null
+  facets: { title: string; description?: string | null }[]
+  scenario?: { title: string; description?: string | null } | null
+  treasures: StoryTreasure[]
+  notes?: string | null
+}
+
+export interface StoryRecentTurn {
+  turnIndex: number
+  narrativeText: string
+  move?: StorybookMove | null
+}
+
+export interface StorybookNarrationRequest {
+  shape: StorybookShape
+  deck: DeckDefinition
+  narratorStyle?: StorybookNarratorStyle | null
+  narrator: StoryNarrator
+  seed: string
+  turnIndex: number
+  /** null when the shape has no fixed budget (the life shape resolves on its own clock). */
+  turnBudget: number | null
+  isFinalTurn: boolean
+  bible: StoryBible
+  statsSoFar: Record<string, number>
+  inventory: StoryTreasure[]
+  recentTurns: StoryRecentTurn[]
+  /** null asks for the opening scene, or a re-narration of the current turn. */
+  move?: StorybookMove | null
+  /** Resolved Reward when move.source is 'sheet'. */
+  playedReward?: StoryTreasure | null
+}
+
+export interface StorybookChoiceOption {
+  id: string
+  choiceText: string
+  effects: Record<string, number>
+}
+
+export interface StorybookStateDelta {
+  consequences: string[]
+  relationshipShifts: string[]
+  inventoryAdd: string[]
+  inventoryRemove: string[]
+}
+
+export interface StorybookNarrationResult {
+  narrativeText: string
+  /** What the reader's own move cost or gained. Empty when there was no move. */
+  moveEffects: Record<string, number>
+  choices: StorybookChoiceOption[]
+  stateDelta: StorybookStateDelta
+  artPrompt: string | null
+  /** Display-only flavor. Nothing is ever awarded from it. */
+  endingHint: string | null
+}
+
+// Per-move swing bounds. An axis passes at DEFAULT_DECK_PASS_VALUE (1), so an
+// unclamped narrator could resolve a whole run in one turn.
+export const NARRATION_EFFECT_MIN = -2
+export const NARRATION_EFFECT_MAX = 2
+export const NARRATION_MIN_CHOICES = 2
+export const NARRATION_MAX_CHOICES = 4
+/** Most turns should move two or three axes; this caps the greedy case. */
+export const MAX_EFFECT_AXES_PER_MOVE = 3
+export const MAX_STATE_ITEMS = 3
+const RECENT_TURN_WINDOW = 3
+
+export const NARRATION_MODEL = 'gpt-4o-mini'
+export const NARRATION_TIMEOUT_MS = 20_000
+export const NARRATION_MAX_TOKENS = 900
+
+const CHOICE_IDS = ['a', 'b', 'c', 'd'] as const
+
+/**
+ * Prose word bounds per shape.
+ *
+ * Silas, 2026-09-12: "Stories should not be verbose with purple prose, they
+ * should be direct, but this should be influenced by the narrator." Length is
+ * enforced numerically here and directness is enforced by PROSE_CONTRACT below;
+ * the narrator style modulates voice WITHIN both, it does not relax either.
+ *
+ * 'life' keeps the 20-400 band davinciNarration.ts shipped with, because
+ * utils/scripts/verifyDaVinciNarration.ts pins it and a live run's chapters were
+ * written against it. Tighten that one together with its guard, not here.
+ */
+export const PROSE_BOUNDS_BY_SHAPE: Record<
+  StorybookShape,
+  { min: number; max: number }
+> = {
+  'short-story': { min: 50, max: 130 },
+  chaptered: { min: 70, max: 190 },
+  episodic: { min: 70, max: 190 },
+  life: { min: 20, max: 400 },
+}
+
+const SHAPE_LABELS: Record<StorybookShape, string> = {
+  'short-story': 'short story',
+  chaptered: 'chaptered tale',
+  episodic: 'episodic serial',
+  life: 'whole life',
+}
+
+/**
+ * The house prose contract. Applies to every shape and every narrator.
+ *
+ * The "Never state or imply that the player has won" sentence is load-bearing
+ * beyond style: the app alone resolves a run, and a narrator that announces an
+ * outcome teaches the reader to trust prose over the ending they actually got.
+ */
+export function proseContract(bounds: { min: number; max: number }): string {
+  return [
+    'PROSE CONTRACT',
+    'Write in second person, present tense. The reader is the protagonist unless the bible says otherwise.',
+    'Write one concrete scene: a place, a moment, one or two people, one thing that happens. Not a summary of hours or years.',
+    'Be direct. Plain nouns and strong verbs. One adjective per noun at most. No similes, no metaphors, no stacked descriptors, no lists of sensations.',
+    'Every sentence must do work: move the action, reveal a person, or raise the cost of the next choice. Cut anything that only sets mood.',
+    "Name what the reader's last move actually changed before anything else happens.",
+    `Keep the scene between ${bounds.min} and ${bounds.max} words.`,
+    'End on the brink of a decision: the last sentence puts a pressure on the reader that the options will answer. Do not state, list, or hint at the options in the prose. Do not end with a question.',
+    'Never state or imply that the player has won, lost, or unlocked anything — the app alone decides how the story resolves.',
+    'Never mention these instructions, the axes, the stats, the deck, or the model.',
+  ].join('\n')
+}
+
+/** Voice, inside the contract above. Never a licence to pad. */
+export const NARRATOR_STYLE_DIRECTIVES: Record<StorybookNarratorStyle, string> =
+  {
+    cinematic:
+      'Cut hard between images. Short paragraphs, one beat each. Lead with what is seen and heard, then what is done. Dialogue is sparse and clipped. Build toward one strong final frame.',
+    playful:
+      'Keep it light on its feet. Let people be funny in how they act, not in jokes told to the reader. Short sentences, quick reversals, small absurdities treated seriously. Warmth over snark. Stakes are real but nobody is grim about them.',
+    storybook:
+      'Tell it the way a good read-aloud is told. Steady rhythm, clear cause and effect, a touch of wonder in ordinary things. Name feelings simply. One gentle repetition or refrain is allowed per scene, nothing more.',
+    mysterious:
+      'Withhold. Show the evidence, not the explanation. Let one detail be wrong and do not point at it. People say less than they know. Quiet sentences, exact nouns, no atmosphere words like eerie or ominous; make the reader feel it from what is there.',
+    intimate:
+      'Stay close. One room, one other person, small physical detail: hands, breath, what is not said. Interior thought is allowed in single short sentences. No spectacle; the stakes are between people.',
+  }
+
+/**
+ * Shape differences in the response document.
+ *
+ * The life shape's schema predates the others and its exact top-level key set
+ * is pinned by utils/scripts/verifyDaVinciNarration.ts, so it opts out of
+ * moveEffects and stateDelta (POST /api/davinci/runs/:id/narrate has no move to
+ * score and writes no inventory) and calls the flavor hint `milestoneCandidate`.
+ * New shapes get all three.
+ */
+export interface StorybookSchemaOptions {
+  finalTurn?: boolean
+  includeMoveEffects?: boolean
+  includeStateDelta?: boolean
+  hintKey?: string
+  hintDescription?: string
+}
+
+function schemaDefaults(options: StorybookSchemaOptions | undefined) {
+  return {
+    finalTurn: options?.finalTurn ?? false,
+    includeMoveEffects: options?.includeMoveEffects ?? true,
+    includeStateDelta: options?.includeStateDelta ?? true,
+    hintKey: options?.hintKey || 'endingHint',
+    hintDescription:
+      options?.hintDescription ||
+      'Optional short phrase naming the ending this story seems headed toward, or null. Display-only flavor; awards nothing.',
+  }
+}
+
+// OpenAI structured-output strict mode requires every property to appear in
+// `required` and forbids additionalProperties, so an effects map lists all of
+// the deck's axes as nullable integers rather than as optional keys. Null means
+// "this choice does not move that axis" and is dropped during validation.
+//
+// Range and item-count bounds are deliberately NOT expressed as minimum/maximum/
+// minItems/maxItems: support for those keywords under strict mode is uneven, and
+// the app re-validates every bound anyway. They live in the descriptions so the
+// model still sees them.
+function effectsSchema(deck: DeckDefinition, purpose: string) {
+  return {
+    type: 'object',
+    description:
+      `${purpose} Each value is an integer from ${NARRATION_EFFECT_MIN} to ` +
+      `${NARRATION_EFFECT_MAX}, or null when it does not move that axis. Move ` +
+      `two or three axes, not all of them.`,
+    properties: Object.fromEntries(
+      deck.axes.map((axis) => [
+        axis.key,
+        {
+          type: ['integer', 'null'],
+          description: `Change to the ${axis.key} axis, or null.`,
+        },
+      ]),
+    ),
+    required: deck.axes.map((axis) => axis.key),
+    additionalProperties: false,
+  }
+}
+
+function stateDeltaSchema() {
+  return {
+    type: 'object',
+    description:
+      `What this scene changed, as short plain strings. At most ` +
+      `${MAX_STATE_ITEMS} entries per list. Inventory lists use exact Reward ` +
+      `slugs from the story bible and nothing else. Use empty arrays when ` +
+      `nothing changed.`,
+    properties: {
+      consequences: { type: 'array', items: { type: 'string' } },
+      relationshipShifts: { type: 'array', items: { type: 'string' } },
+      inventoryAdd: { type: 'array', items: { type: 'string' } },
+      inventoryRemove: { type: 'array', items: { type: 'string' } },
+    },
+    required: [
+      'consequences',
+      'relationshipShifts',
+      'inventoryAdd',
+      'inventoryRemove',
+    ],
+    additionalProperties: false,
+  }
+}
+
+export function storybookResponseSchema(
+  deck: DeckDefinition,
+  options?: StorybookSchemaOptions,
+): Record<string, unknown> {
+  const opts = schemaDefaults(options)
+  const properties: Record<string, unknown> = {
+    narrativeText: {
+      type: 'string',
+      description:
+        "This scene's prose, obeying the prose contract in the system message.",
+    },
+    choices: {
+      type: 'array',
+      description: opts.finalTurn
+        ? 'Empty. This is the last scene before the story resolves.'
+        : `Between ${NARRATION_MIN_CHOICES} and ${NARRATION_MAX_CHOICES} distinct options the protagonist could take next.`,
+      items: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            enum: [...CHOICE_IDS],
+            description: 'Stable id within this scene, in order.',
+          },
+          choiceText: {
+            type: 'string',
+            description: 'One sentence, phrased as an action the player takes.',
+          },
+          effects: effectsSchema(deck, 'Proposed axis deltas for this option.'),
+        },
+        required: ['id', 'choiceText', 'effects'],
+        additionalProperties: false,
+      },
+    },
+    artPrompt: {
+      type: ['string', 'null'],
+      description:
+        'Optional image prompt for this scene, or null. Visual detail only.',
+    },
+    [opts.hintKey]: {
+      type: ['string', 'null'],
+      description: opts.hintDescription,
+    },
+  }
+
+  if (opts.includeMoveEffects) {
+    properties.moveEffects = effectsSchema(
+      deck,
+      "What the reader's own move this turn cost or gained. Empty object when there was no move.",
+    )
+  }
+  if (opts.includeStateDelta) {
+    properties.stateDelta = stateDeltaSchema()
+  }
+
+  return {
+    type: 'object',
+    properties,
+    required: Object.keys(properties),
+    additionalProperties: false,
+  }
+}
+
+export interface StorybookValidationOptions extends StorybookSchemaOptions {
+  bounds?: { min: number; max: number }
+  /** Axes one move may touch. `null` disables the cap (the life shape). */
+  maxEffectAxes?: number | null
+  /** Reward slugs the fiction may hand out. */
+  treasureSlugs?: string[]
+  /** Reward slugs currently held, which the fiction may spend. */
+  inventorySlugs?: string[]
+}
+
+function cleanStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  const out: string[] = []
+  for (const entry of value) {
+    if (typeof entry !== 'string') continue
+    const text = entry.trim()
+    if (!text) continue
+    out.push(text)
+    if (out.length >= MAX_STATE_ITEMS) break
+  }
+  return out
+}
+
+function clampEffect(value: number): number {
+  return Math.max(
+    NARRATION_EFFECT_MIN,
+    Math.min(NARRATION_EFFECT_MAX, Math.trunc(value)),
+  )
+}
+
+/**
+ * Read an effects map against the deck's axes.
+ *
+ * `context` names the offender in the error, e.g. `Choice "a"` or `The move`.
+ * An axis the deck does not declare is REJECTED rather than dropped: the key
+ * would otherwise flow into a LifeStat row (that table accepts any key by
+ * design) and silently join the run's state without ever affecting an ending.
+ */
+function readEffects(
+  raw: unknown,
+  deck: DeckDefinition,
+  context: string,
+  maxAxes: number | null,
+): Record<string, number> {
+  const effects: Record<string, number> = {}
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return effects
+
+  const allowed = new Set(deck.axes.map((axis) => axis.key))
+  for (const [key, delta] of Object.entries(raw as Record<string, unknown>)) {
+    if (!allowed.has(key)) {
+      throw new Error(
+        `${context} proposed unknown dimension "${key}". Allowed: ${deck.axes
+          .map((axis) => axis.key)
+          .join(', ')}.`,
+      )
+    }
+    if (delta === null || delta === undefined) continue
+    if (typeof delta !== 'number' || !Number.isFinite(delta)) {
+      throw new Error(`${context} proposed a non-numeric delta for "${key}".`)
+    }
+    const clamped = clampEffect(delta)
+    if (clamped !== 0) effects[key] = clamped
+  }
+
+  // Keep the largest-magnitude axes when a narrator moves everything at once.
+  // Trimming beats rejecting: the scene it wrote is still good, and a greedy
+  // effects map is a tuning miss rather than a contract violation. `maxAxes:
+  // null` opts out entirely, which is what the life adapter passes -- that
+  // shape has been live with an uncapped effects map since davinci/t-016, and
+  // quietly narrowing an existing game's tuning is not this refactor's job.
+  const keys = Object.keys(effects)
+  if (maxAxes !== null && keys.length > maxAxes) {
+    const kept = keys
+      .sort((a, b) => Math.abs(effects[b]!) - Math.abs(effects[a]!))
+      .slice(0, maxAxes)
+    const trimmed: Record<string, number> = {}
+    for (const key of kept) trimmed[key] = effects[key]!
+    return trimmed
+  }
+  return effects
+}
+
+/**
+ * App-owned enforcement, run on every response even under strict mode: strict
+ * mode constrains shape, not values.
+ */
+export function validateStorybookNarration(
+  value: unknown,
+  deck: DeckDefinition,
+  options?: StorybookValidationOptions,
+): StorybookNarrationResult {
+  const opts = schemaDefaults(options)
+  const bounds = options?.bounds || PROSE_BOUNDS_BY_SHAPE['short-story']
+  const maxEffectAxes =
+    options && 'maxEffectAxes' in options
+      ? (options.maxEffectAxes ?? null)
+      : MAX_EFFECT_AXES_PER_MOVE
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('The narrator returned a non-object response.')
+  }
+  const payload = value as Record<string, unknown>
+
+  const narrativeText =
+    typeof payload.narrativeText === 'string'
+      ? payload.narrativeText.trim()
+      : ''
+  const wordCount = narrativeText.split(/\s+/).filter(Boolean).length
+  if (wordCount < bounds.min || wordCount > bounds.max) {
+    throw new Error(
+      `Scene prose must be ${bounds.min}-${bounds.max} words (got ${wordCount}).`,
+    )
+  }
+
+  if (!Array.isArray(payload.choices)) {
+    throw new Error('The narrator returned no choice list.')
+  }
+
+  const choices: StorybookChoiceOption[] = []
+  const seenIds = new Set<string>()
+  for (const raw of payload.choices) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new Error('Each choice must be an object.')
+    }
+    const option = raw as Record<string, unknown>
+
+    const choiceText =
+      typeof option.choiceText === 'string' ? option.choiceText.trim() : ''
+    if (!choiceText) throw new Error('Each choice needs non-empty choiceText.')
+
+    const id =
+      typeof option.id === 'string' && option.id.trim()
+        ? option.id.trim().toLowerCase()
+        : CHOICE_IDS[choices.length] || String(choices.length)
+    if (seenIds.has(id)) {
+      throw new Error(`Duplicate choice id "${id}" in one scene.`)
+    }
+    seenIds.add(id)
+
+    choices.push({
+      id,
+      choiceText,
+      effects: readEffects(
+        option.effects,
+        deck,
+        `Choice "${id}"`,
+        maxEffectAxes,
+      ),
+    })
+  }
+
+  if (opts.finalTurn) {
+    if (choices.length) {
+      throw new Error(
+        `The final scene must offer no choices (got ${choices.length}).`,
+      )
+    }
+  } else if (
+    choices.length < NARRATION_MIN_CHOICES ||
+    choices.length > NARRATION_MAX_CHOICES
+  ) {
+    throw new Error(
+      `A scene must offer ${NARRATION_MIN_CHOICES}-${NARRATION_MAX_CHOICES} choices (got ${choices.length}).`,
+    )
+  }
+
+  const moveEffects = opts.includeMoveEffects
+    ? readEffects(payload.moveEffects, deck, 'The move', maxEffectAxes)
+    : {}
+
+  const treasures = new Set(options?.treasureSlugs || [])
+  const held = new Set([
+    ...(options?.inventorySlugs || []),
+    ...(options?.treasureSlugs || []),
+  ])
+  const rawDelta =
+    opts.includeStateDelta &&
+    payload.stateDelta &&
+    typeof payload.stateDelta === 'object' &&
+    !Array.isArray(payload.stateDelta)
+      ? (payload.stateDelta as Record<string, unknown>)
+      : {}
+  const stateDelta: StorybookStateDelta = {
+    consequences: cleanStrings(rawDelta.consequences),
+    relationshipShifts: cleanStrings(rawDelta.relationshipShifts),
+    // Slug allowlists, not free text: the fiction may only hand out or spend
+    // Rewards the board actually put in play.
+    inventoryAdd: cleanStrings(rawDelta.inventoryAdd).filter((slug) =>
+      treasures.has(slug),
+    ),
+    inventoryRemove: cleanStrings(rawDelta.inventoryRemove).filter((slug) =>
+      held.has(slug),
+    ),
+  }
+
+  const artPrompt =
+    typeof payload.artPrompt === 'string' && payload.artPrompt.trim()
+      ? payload.artPrompt.trim()
+      : null
+  const rawHint = payload[opts.hintKey]
+  const endingHint =
+    typeof rawHint === 'string' && rawHint.trim() ? rawHint.trim() : null
+
+  return {
+    narrativeText,
+    moveEffects,
+    choices,
+    stateDelta,
+    artPrompt,
+    endingHint,
+  }
+}
+
+function axisLines(deck: DeckDefinition): string {
+  return deck.axes
+    .map((axis) =>
+      axis.description
+        ? `- ${axis.key} (${axis.label}): ${axis.description}`
+        : `- ${axis.key} (${axis.label})`,
+    )
+    .join('\n')
+}
+
+export function buildStorybookSystemPrompt(
+  request: StorybookNarrationRequest,
+): string {
+  const bounds = PROSE_BOUNDS_BY_SHAPE[request.shape]
+  const style = request.narratorStyle
+    ? NARRATOR_STYLE_DIRECTIVES[request.narratorStyle]
+    : ''
+
+  return [
+    `You are ${request.narrator.name}, narrating a ${SHAPE_LABELS[request.shape]} in Kind Robots' Storybook.`,
+    request.narrator.prompt || '',
+    request.narrator.personality
+      ? `Personality: ${request.narrator.personality}`
+      : '',
+    request.narrator.narrativeVoice
+      ? `Narrative voice: ${request.narrator.narrativeVoice}`
+      : '',
+    '',
+    proseContract(bounds),
+    style ? '' : '',
+    style ? `NARRATOR STYLE (${request.narratorStyle})\n${style}` : '',
+    '',
+    'HIDDEN AXES',
+    'The story is scored on these axes. Never name them to the reader.',
+    axisLines(request.deck),
+    `An axis passes at ${request.deck.passValue ?? DEFAULT_DECK_PASS_VALUE} or above, and the axes together decide which ending the story resolves into.`,
+    `Every option proposes integer deltas from ${NARRATION_EFFECT_MIN} to ${NARRATION_EFFECT_MAX} on two or three of them and null on the rest. Real trade-offs beat pure upgrades: an option that raises one axis should usually cost another.`,
+    'If the reader wrote their own action or played a card, judge what it cost or gained on the same axes in moveEffects.',
+    request.isFinalTurn
+      ? "This is the last scene before the story resolves. Land the reader's move, close the scene on a held breath, and return an empty choices array."
+      : '',
+  ]
+    .filter((line) => line !== '')
+    .join('\n')
+}
+
+function bibleBlock(bible: StoryBible): string[] {
+  const lines: string[] = [`Title: ${bible.title}`]
+
+  // THE PLOT THREAD IS THE FRAME, so it goes first -- before cast and facets,
+  // which are what bend it. Stated as a thread to be told rather than a summary
+  // to reproduce, because the point of framing a Scenario this way is that the
+  // other ingredients are allowed to change it.
+  if (bible.scenario) {
+    lines.push(
+      `Plot thread (the frame; the cast, setting and Facets below reshape how it plays out rather than decorating it): ${bible.scenario.title}${
+        bible.scenario.description ? ` — ${bible.scenario.description}` : ''
+      }`,
+    )
+  }
+
+  lines.push(
+    bible.premise && bible.premise.trim()
+      ? `Premise: ${bible.premise.trim()}`
+      : 'Premise: none — invent the inciting situation from the cast and setting.',
+  )
+
+  if (bible.cast.length) {
+    lines.push('Cast:')
+    for (const member of bible.cast) {
+      lines.push(
+        `- ${member.name}${member.role ? ` (${member.role})` : ''}${
+          member.description ? `: ${member.description}` : ''
+        }`,
+      )
+    }
+  }
+  if (bible.location) {
+    lines.push(
+      `Primary setting: ${bible.location.title}${
+        bible.location.description ? ` — ${bible.location.description}` : ''
+      }`,
+    )
+  }
+  if (bible.facets.length) {
+    lines.push(
+      `Creative Facets: ${bible.facets
+        .map((facet) =>
+          facet.description
+            ? `${facet.title} (${facet.description})`
+            : facet.title,
+        )
+        .join('; ')}`,
+    )
+  }
+  if (bible.treasures.length) {
+    lines.push(
+      'Rewards this story may hand out (use exact slugs in stateDelta):',
+    )
+    for (const treasure of bible.treasures) {
+      lines.push(
+        `- slug=${treasure.slug}; ${treasure.name} (${treasure.rarity} ${treasure.rewardType})${
+          treasure.effect ? `: ${treasure.effect}` : ''
+        }`,
+      )
+    }
+  }
+  if (bible.notes && bible.notes.trim()) {
+    lines.push(`Additional direction: ${bible.notes.trim()}`)
+  }
+  return lines
+}
+
+function moveBlock(request: StorybookNarrationRequest): string[] {
+  const move = request.move
+  if (!move) {
+    return request.turnIndex <= 1
+      ? ['Write the opening scene.']
+      : ['Write this scene again from the state above.']
+  }
+
+  if (move.source === 'sheet' && request.playedReward) {
+    const card = request.playedReward
+    const consumed = card.rewardType.toUpperCase() === 'ITEM'
+    return [
+      "The reader opens the protagonist's sheet and plays a card.",
+      `Card: ${card.name} (${card.rewardType}, ${card.rarity}).${
+        card.effect ? ` Effect: ${card.effect}.` : ''
+      }${card.flavorText ? ` Flavor: ${card.flavorText}.` : ''}`,
+      `Reader's note: ${move.text.trim() || 'none'}.`,
+      'The card is genuinely used this turn. Show its effect on the scene as a concrete action with a concrete result.',
+      'Let rarity set how decisively it works: COMMON nudges, RARE turns the moment, LEGENDARY changes the scene.',
+      consumed
+        ? 'The item is spent by the end of the scene.'
+        : 'The card stays with the protagonist.',
+      "Report the card's cost or gain on the hidden axes in moveEffects.",
+    ]
+  }
+
+  return [
+    move.source === 'custom'
+      ? `The reader wrote their own move: ${move.text}`
+      : `The reader chose: ${move.text}`,
+    'Judge what that move cost or gained on the hidden axes in moveEffects.',
+  ]
+}
+
+export function buildStorybookUserPrompt(
+  request: StorybookNarrationRequest,
+): string {
+  const stats = request.deck.axes
+    .map((axis) => `${axis.key}=${request.statsSoFar[axis.key] ?? 0}`)
+    .join(', ')
+
+  const history = request.recentTurns.length
+    ? request.recentTurns
+        .slice(-RECENT_TURN_WINDOW)
+        .map(
+          (turn) =>
+            `- Turn ${turn.turnIndex}: ${turn.narrativeText}${
+              turn.move ? `\n  The reader: ${turn.move.text}` : ''
+            }`,
+        )
+        .join('\n')
+    : '- (none yet — this is the opening scene)'
+
+  const inventory = request.inventory.length
+    ? request.inventory.map((item) => item.slug).join(', ')
+    : 'empty'
+
+  return [
+    'STORY BIBLE',
+    ...bibleBlock(request.bible),
+    '',
+    `Seed: ${request.seed}`,
+    request.turnBudget
+      ? `Turn ${request.turnIndex} of ${request.turnBudget}`
+      : `Turn ${request.turnIndex}`,
+    '',
+    `Axis values so far: ${stats}`,
+    `Inventory slugs: ${inventory}`,
+    '',
+    'Recent turns:',
+    history,
+    '',
+    ...moveBlock(request),
+  ].join('\n')
+}
+
+export interface GenerateStorybookTurnOptions extends StorybookSchemaOptions {
+  model?: string
+  timeoutMs?: number
+  maxTokens?: number
+  apiKey?: string
+}
+
+async function callNarrator(
+  request: StorybookNarrationRequest,
+  options: GenerateStorybookTurnOptions,
+): Promise<StorybookNarrationResult> {
+  const payload = await completeStructured({
+    system: buildStorybookSystemPrompt(request),
+    user: buildStorybookUserPrompt(request),
+    schemaName: 'storybook_scene',
+    schema: storybookResponseSchema(request.deck, options),
+    model: options.model || NARRATION_MODEL,
+    temperature: 0.9,
+    maxTokens: options.maxTokens ?? NARRATION_MAX_TOKENS,
+    timeoutMs: options.timeoutMs ?? NARRATION_TIMEOUT_MS,
+    apiKey: options.apiKey,
+    label: 'Storybook narration',
+  })
+
+  return validateStorybookNarration(payload, request.deck, {
+    ...options,
+    bounds: PROSE_BOUNDS_BY_SHAPE[request.shape],
+    treasureSlugs: request.bible.treasures.map((treasure) => treasure.slug),
+    inventorySlugs: request.inventory.map((item) => item.slug),
+  })
+}
+
+/**
+ * Top-level entry point for a single turn's narration.
+ *
+ * Retries once on a validation or parse failure -- models occasionally emit a
+ * truncated document even under strict mode -- then surfaces the original error
+ * rather than substituting a synthetic scene. A visible retry prompt beats a
+ * silently fabricated one. A timeout is not retried: the reader has already
+ * spent that budget staring at a spinner.
+ */
+export async function generateStorybookTurn(
+  request: StorybookNarrationRequest,
+  options: GenerateStorybookTurnOptions = {},
+): Promise<StorybookNarrationResult> {
+  try {
+    return await callNarrator(request, options)
+  } catch (firstError) {
+    if (firstError instanceof Error && firstError.name === 'AbortError') {
+      throw firstError
+    }
+    try {
+      return await callNarrator(request, options)
+    } catch {
+      throw firstError
+    }
+  }
+}

--- a/server/utils/structuredCompletion.ts
+++ b/server/utils/structuredCompletion.ts
@@ -1,0 +1,130 @@
+// /server/utils/structuredCompletion.ts
+//
+// One non-streaming, JSON-schema-constrained model call.
+//
+// Extracted from davinciNarration.ts's callNarrator when Storybook's narration
+// layer was generalized to every shape (storybook/t-031). Before this, three
+// call sites hand-rolled the same OpenAI strict-mode request with their own
+// timeout, their own error strings, and their own JSON-parse branch:
+// davinciNarration.ts, brainstormProvider.ts and commentBackfillGeneration.ts.
+// The chat routes' shared helper (textProviderService.ts) is streaming-only and
+// carries no schema, so it could not serve this shape.
+//
+// Deliberately NOT a provider abstraction. Strict `response_format:
+// json_schema` is an OpenAI-compatible feature; Anthropic and Ollama need
+// different plumbing for the same guarantee. Callers that need a provider
+// choice should keep using the chat routes. What this owns is the transport:
+// key, timeout, HTTP errors, empty responses, and JSON parsing -- everything up
+// to a parsed object. VALIDATION IS THE CALLER'S JOB, because "the model
+// returned an object" and "the object obeys our bounds" are different claims
+// and only the caller knows the second one.
+
+// `useRuntimeConfig` is auto-imported by Nitro (see server/utils/authGuard.ts).
+// Left un-imported deliberately: a static `#imports` import breaks the tsx
+// contract-test runner, which imports this module's callers directly.
+import { getRuntimeOpenAiKey } from './textProviderService'
+
+export const DEFAULT_STRUCTURED_MODEL = 'gpt-4o-mini'
+export const DEFAULT_STRUCTURED_TIMEOUT_MS = 20_000
+
+const OPENAI_CHAT_COMPLETIONS = 'https://api.openai.com/v1/chat/completions'
+
+export interface StructuredCompletionRequest {
+  system: string
+  user: string
+  /** Schema name sent to the provider; identifies the document, not the call. */
+  schemaName: string
+  schema: Record<string, unknown>
+  model?: string
+  temperature?: number
+  maxTokens?: number
+  timeoutMs?: number
+  /** Overrides the runtime key. Mostly for tests and one-off tools. */
+  apiKey?: string
+  /** Names the feature in error messages a user may see. */
+  label?: string
+}
+
+/**
+ * Ask for one JSON document matching `schema` and return it parsed.
+ *
+ * Throws with a readable message on: no key, HTTP failure, timeout, empty
+ * content, or unparseable JSON. An AbortError keeps its name so callers can
+ * decline to retry a timeout (retrying a call that already burned the budget
+ * just doubles the wait the reader is staring at).
+ */
+export async function completeStructured<T = unknown>(
+  request: StructuredCompletionRequest,
+): Promise<T> {
+  const label = request.label || 'This request'
+  const model = request.model || DEFAULT_STRUCTURED_MODEL
+  const apiKey = (
+    request.apiKey || getRuntimeOpenAiKey(useRuntimeConfig())
+  ).trim()
+  if (!apiKey) {
+    throw new Error(`No OpenAI API key is configured for ${label}.`)
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(
+    () => controller.abort(),
+    request.timeoutMs ?? DEFAULT_STRUCTURED_TIMEOUT_MS,
+  )
+  try {
+    const response = await fetch(OPENAI_CHAT_COMPLETIONS, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: apiKey.startsWith('Bearer ')
+          ? apiKey
+          : `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: 'system', content: request.system },
+          { role: 'user', content: request.user },
+        ],
+        temperature: request.temperature ?? 0.9,
+        max_tokens: request.maxTokens ?? 900,
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: request.schemaName,
+            strict: true,
+            schema: request.schema,
+          },
+        },
+      }),
+    })
+
+    const body = (await response.json().catch(() => null)) as {
+      choices?: Array<{ message?: { content?: string | null } }>
+      error?: { message?: string }
+    } | null
+    if (!response.ok) {
+      throw new Error(
+        body?.error?.message || `${label} failed (${response.status}).`,
+      )
+    }
+
+    const content = body?.choices?.[0]?.message?.content?.trim()
+    if (!content) throw new Error(`${label} returned an empty response.`)
+
+    try {
+      return JSON.parse(content) as T
+    } catch (error) {
+      throw new Error(`${label} returned invalid JSON.`, { cause: error })
+    }
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`${label} timed out before the serverless deadline.`, {
+        cause: error,
+      })
+    }
+    throw error
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/utils/scripts/verifyDaVinciNarration.ts
+++ b/utils/scripts/verifyDaVinciNarration.ts
@@ -15,11 +15,18 @@ import {
   buildNarrationUserPrompt,
   narrationResponseSchema,
   validateNarrationPayload,
+} from '../../server/utils/davinciNarration'
+// The bounds moved to the shared narration layer when davinciNarration.ts
+// became an adapter over it (storybook/t-031). Same numbers, one definition:
+// Nitro auto-imports server/utils, so two modules exporting these names made
+// every build warn. What this suite asserts is unchanged -- that the LIFE
+// shape still enforces them.
+import {
   NARRATION_EFFECT_MAX,
   NARRATION_EFFECT_MIN,
   NARRATION_MAX_CHOICES,
   NARRATION_MIN_CHOICES,
-} from '../../server/utils/davinciNarration'
+} from '../../server/utils/storybookNarration'
 // Imported from davinciDimensions, not davinci: this suite must stay free of
 // ./prisma, which throws at module load when DATABASE_URL is unset (as it is in
 // the contract-tests job).

--- a/utils/scripts/verifyEndingDeckMath.ts
+++ b/utils/scripts/verifyEndingDeckMath.ts
@@ -1,0 +1,211 @@
+// /utils/scripts/verifyEndingDeckMath.ts
+//
+// Contract check for server/utils/endingDeckMath.ts (storybook/t-031).
+//
+// This is the math that turns a finished run into exactly one ending, so the
+// properties asserted here are the ones a wrong answer corrupts silently: bit
+// order, determinism, the pass threshold, and the guarantee that the Life deck
+// still resolves to the keys its 1,024 seeded LifeEnding rows were generated
+// for. No network and no database.
+
+import {
+  LIFE_DECK,
+  deckEndingCount,
+  deckOutcomeKeys,
+  parseDeckAxes,
+  resolveDeckOutcomeKey,
+  serializeDeckAxes,
+  type DeckDefinition,
+} from '../../server/utils/endingDeckMath'
+// From davinciDimensions, not davinci: this suite must stay free of ./prisma,
+// which throws at module load when DATABASE_URL is unset (as it is in the
+// contract-tests job).
+import {
+  DAVINCI_DIMENSIONS,
+  DAVINCI_PASS_VALUE,
+  resolveOutcomeKey,
+} from '../../server/utils/davinciDimensions'
+
+let failures = 0
+
+function check(name: string, condition: boolean, detail = '') {
+  if (condition) {
+    console.log(`  PASS  ${name}`)
+  } else {
+    failures += 1
+    console.error(`  FAIL  ${name}${detail ? ` — ${detail}` : ''}`)
+  }
+}
+
+function rejects(name: string, run: () => unknown, expectedFragment: string) {
+  try {
+    run()
+    failures += 1
+    console.error(`  FAIL  ${name} — expected a rejection, got none`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (message.toLowerCase().includes(expectedFragment.toLowerCase())) {
+      console.log(`  PASS  ${name}`)
+    } else {
+      failures += 1
+      console.error(
+        `  FAIL  ${name} — rejected for the wrong reason: "${message}"`,
+      )
+    }
+  }
+}
+
+const mystery: DeckDefinition = {
+  key: 'genre-mystery',
+  passValue: 1,
+  axes: [
+    { key: 'truth', label: 'Truth' },
+    { key: 'trust', label: 'Trust' },
+    { key: 'nerve', label: 'Nerve' },
+  ],
+}
+
+console.log('Ending deck math — a small genre deck')
+
+check(
+  'a three-axis deck has eight endings',
+  deckEndingCount(mystery) === 8 && deckOutcomeKeys(mystery).length === 8,
+)
+check(
+  'every outcome key is distinct and the right width',
+  new Set(deckOutcomeKeys(mystery)).size === 8 &&
+    deckOutcomeKeys(mystery).every((key) => key.length === 3),
+)
+check(
+  'outcome keys run in ascending binary order',
+  deckOutcomeKeys(mystery).join(',') === '000,001,010,011,100,101,110,111',
+  deckOutcomeKeys(mystery).join(','),
+)
+check(
+  'bit i is axis i, not a sorted or hashed order',
+  resolveDeckOutcomeKey(mystery, { truth: 1 }) === '100' &&
+    resolveDeckOutcomeKey(mystery, { nerve: 1 }) === '001',
+)
+check(
+  'a missing stat fails its axis',
+  resolveDeckOutcomeKey(mystery, {}) === '000',
+)
+check(
+  'a below-threshold stat fails its axis',
+  resolveDeckOutcomeKey(mystery, { truth: 0, trust: -3 }) === '000',
+)
+check(
+  'the same stats always give the same key',
+  resolveDeckOutcomeKey(mystery, { truth: 2, nerve: 1 }) ===
+    resolveDeckOutcomeKey(mystery, { nerve: 1, truth: 2 }),
+)
+check(
+  'a stat the deck does not declare cannot change the key',
+  resolveDeckOutcomeKey(mystery, { truth: 1, notoriety: 99 }) === '100',
+)
+check(
+  'passValue raises the bar rather than being ignored',
+  resolveDeckOutcomeKey({ ...mystery, passValue: 3 }, { truth: 2 }) === '000' &&
+    resolveDeckOutcomeKey({ ...mystery, passValue: 3 }, { truth: 3 }) === '100',
+)
+
+console.log('Ending deck math — the Life deck still resolves as it always did')
+
+check(
+  'LIFE_DECK declares the ten Da Vinci dimensions in their fixed bit order',
+  LIFE_DECK.axes.map((axis) => axis.key).join(',') ===
+    DAVINCI_DIMENSIONS.join(','),
+  LIFE_DECK.axes.map((axis) => axis.key).join(','),
+)
+check('the Life deck has 1,024 endings', deckEndingCount(LIFE_DECK) === 1024)
+check(
+  'every Life axis carries a label and a description for the narrator',
+  LIFE_DECK.axes.every((axis) => Boolean(axis.label && axis.description)),
+)
+
+// The regression that would quietly re-key 1,024 seeded endings:
+// davinciDimensions.resolveOutcomeKey now delegates here, so the two must agree
+// on every stat map, not merely on the happy path.
+let identical = true
+let mismatch = ''
+for (let iteration = 0; iteration < 500; iteration += 1) {
+  const stats: Record<string, number> = {}
+  for (const dimension of DAVINCI_DIMENSIONS) {
+    if (Math.random() < 0.6) {
+      stats[dimension] = Math.floor(Math.random() * 6) - 2
+    }
+  }
+  const legacy = DAVINCI_DIMENSIONS.map((key) =>
+    (stats[key] ?? 0) >= DAVINCI_PASS_VALUE ? '1' : '0',
+  ).join('')
+  if (
+    resolveOutcomeKey(stats) !== legacy ||
+    resolveDeckOutcomeKey(LIFE_DECK, stats) !== legacy
+  ) {
+    identical = false
+    mismatch = JSON.stringify(stats)
+    break
+  }
+}
+check(
+  'the deck resolver and the pre-deck Da Vinci resolver agree on 500 random stat maps',
+  identical,
+  mismatch,
+)
+
+console.log('Ending deck math — axis parsing')
+
+const roundTripped = parseDeckAxes(serializeDeckAxes(LIFE_DECK.axes))
+check(
+  'axes survive a serialize/parse round trip in order',
+  roundTripped.map((axis) => axis.key).join(',') ===
+    LIFE_DECK.axes.map((axis) => axis.key).join(','),
+)
+check(
+  'a bare key gets its own label rather than an empty one',
+  parseDeckAxes('[{"key":"truth"}]')[0]!.label === 'truth',
+)
+check(
+  'optional copy normalizes to null rather than empty strings',
+  parseDeckAxes('[{"key":"truth","description":"  "}]')[0]!.description ===
+    null,
+)
+
+// Every rejection below protects the same invariant: an axis list that loads
+// with a silently missing or renamed entry renumbers every bit after it, which
+// corrupts already-seeded endings instead of merely erroring.
+rejects('rejects empty axes', () => parseDeckAxes(''), 'must declare its axes')
+rejects('rejects invalid JSON', () => parseDeckAxes('{oops'), 'valid JSON')
+rejects('rejects a non-array', () => parseDeckAxes('{"key":"truth"}'), 'array')
+rejects('rejects zero axes', () => parseDeckAxes('[]'), 'axes')
+rejects(
+  'rejects more axes than a deck may have',
+  () =>
+    parseDeckAxes(
+      JSON.stringify(
+        Array.from({ length: 13 }, (_, index) => ({ key: `axis_${index}` })),
+      ),
+    ),
+  'axes',
+)
+rejects(
+  'rejects a duplicate axis key',
+  () => parseDeckAxes('[{"key":"truth"},{"key":"truth"}]'),
+  'duplicate deck axis key',
+)
+rejects(
+  'rejects a non-snake_case axis key',
+  () => parseDeckAxes('[{"key":"Truth Level"}]'),
+  'snake_case',
+)
+rejects(
+  'rejects an axis that is not an object',
+  () => parseDeckAxes('["truth"]'),
+  'must be an object',
+)
+
+if (failures) {
+  console.error(`\n${failures} check(s) failed.`)
+  process.exit(1)
+}
+console.log('\nAll ending deck math checks passed.')

--- a/utils/scripts/verifyStorybookNarration.ts
+++ b/utils/scripts/verifyStorybookNarration.ts
@@ -1,0 +1,764 @@
+// /utils/scripts/verifyStorybookNarration.ts
+//
+// Contract check for server/utils/storybookNarration.ts (storybook/t-031),
+// the one narration layer every Storybook shape goes through.
+//
+// Model output reaching the play loop is the whole risk surface, so every
+// app-owned bound is asserted directly: the deck's axis allowlist, the delta
+// clamp, the choice band (including the final scene's empty band), the prose
+// word bounds per shape, and the Reward-slug allowlists on inventory changes.
+// The prompt assertions cover the two things Silas asked for by name -- direct
+// prose, and a narrator style that modulates it -- plus the sheet-play block.
+//
+// No network and no database: this exercises the validator and the prompt/schema
+// builders directly. The life shape's own bounds stay pinned by the older
+// verifyDaVinciNarration.ts, which runs against the adapter.
+
+import {
+  MAX_EFFECT_AXES_PER_MOVE,
+  MAX_STATE_ITEMS,
+  NARRATION_EFFECT_MAX,
+  NARRATION_EFFECT_MIN,
+  NARRATION_MAX_CHOICES,
+  NARRATION_MIN_CHOICES,
+  NARRATOR_STYLE_DIRECTIVES,
+  PROSE_BOUNDS_BY_SHAPE,
+  buildStorybookSystemPrompt,
+  buildStorybookUserPrompt,
+  storybookResponseSchema,
+  validateStorybookNarration,
+  type StorybookNarrationRequest,
+  type StorybookNarratorStyle,
+} from '../../server/utils/storybookNarration'
+import {
+  LIFE_DECK,
+  type DeckDefinition,
+} from '../../server/utils/endingDeckMath'
+import { validateNarrationPayload } from '../../server/utils/davinciNarration'
+
+let failures = 0
+
+function check(name: string, condition: boolean, detail = '') {
+  if (condition) {
+    console.log(`  PASS  ${name}`)
+  } else {
+    failures += 1
+    console.error(`  FAIL  ${name}${detail ? ` — ${detail}` : ''}`)
+  }
+}
+
+function rejects(name: string, run: () => unknown, expectedFragment: string) {
+  try {
+    run()
+    failures += 1
+    console.error(`  FAIL  ${name} — expected a rejection, got none`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (message.toLowerCase().includes(expectedFragment.toLowerCase())) {
+      console.log(`  PASS  ${name}`)
+    } else {
+      failures += 1
+      console.error(
+        `  FAIL  ${name} — rejected for the wrong reason: "${message}"`,
+      )
+    }
+  }
+}
+
+const deck: DeckDefinition = {
+  key: 'genre-mystery',
+  title: 'Mystery',
+  passValue: 1,
+  axes: [
+    {
+      key: 'truth',
+      label: 'Truth',
+      description: 'How much of the case is solved.',
+    },
+    {
+      key: 'trust',
+      label: 'Trust',
+      description: 'Whether allies are still allies.',
+    },
+    {
+      key: 'nerve',
+      label: 'Nerve',
+      description: 'What holding steady has cost.',
+    },
+  ],
+}
+
+const shape = 'short-story' as const
+const bounds = PROSE_BOUNDS_BY_SHAPE[shape]
+const prose = Array.from({ length: 80 }, (_, index) => `word${index}`).join(' ')
+const treasureSlugs = ['brass-key', 'cousin-who-knows-a-guy']
+
+function payload(overrides: Record<string, unknown> = {}) {
+  return {
+    narrativeText: prose,
+    moveEffects: { truth: 1, nerve: -1 },
+    choices: [
+      {
+        id: 'a',
+        choiceText: 'Open the ledger.',
+        effects: { truth: 2, trust: -1 },
+      },
+      {
+        id: 'b',
+        choiceText: 'Ask her instead.',
+        effects: { trust: 1, truth: -1 },
+      },
+    ],
+    stateDelta: {
+      consequences: ['The clerk saw you.'],
+      relationshipShifts: [],
+      inventoryAdd: ['brass-key'],
+      inventoryRemove: [],
+    },
+    artPrompt: null,
+    endingHint: null,
+    ...overrides,
+  }
+}
+
+function validate(value: unknown, options: Record<string, unknown> = {}) {
+  return validateStorybookNarration(value, deck, {
+    bounds,
+    treasureSlugs,
+    inventorySlugs: [],
+    ...options,
+  })
+}
+
+console.log('Storybook narration — happy path')
+
+const valid = validate(payload())
+check('accepts a well-formed scene', valid.choices.length === 2)
+check(
+  'preserves in-range deltas unchanged',
+  valid.choices[0]!.effects.truth === 2 &&
+    valid.choices[0]!.effects.trust === -1,
+  JSON.stringify(valid.choices[0]!.effects),
+)
+check(
+  "scores the reader's own move separately from the options",
+  valid.moveEffects.truth === 1 && valid.moveEffects.nerve === -1,
+  JSON.stringify(valid.moveEffects),
+)
+check('trims prose', valid.narrativeText === prose)
+check(
+  'normalizes an empty artPrompt/endingHint to null',
+  validate(payload({ artPrompt: '   ', endingHint: '' })).artPrompt === null,
+)
+check(
+  'keeps a non-empty endingHint as display-only flavor',
+  validate(payload({ endingHint: 'the cold case' })).endingHint ===
+    'the cold case',
+)
+
+console.log('Storybook narration — the deck owns the axes')
+
+// The core safety property, now deck-scoped: a genre deck's narrator cannot
+// reach the Life deck's axes, and no narrator can invent one. Without this the
+// key flows into a LifeStat row (that table accepts any key by design) and
+// joins the run's state without ever affecting an ending.
+rejects(
+  'rejects an axis the deck does not declare',
+  () =>
+    validate(
+      payload({
+        choices: [
+          { id: 'a', choiceText: 'One', effects: { charisma: 1 } },
+          { id: 'b', choiceText: 'Two', effects: { truth: 1 } },
+        ],
+      }),
+    ),
+  'unknown dimension',
+)
+rejects(
+  "rejects another deck's axis on this deck",
+  () =>
+    validate(
+      payload({
+        choices: [
+          { id: 'a', choiceText: 'One', effects: { legacy: 1 } },
+          { id: 'b', choiceText: 'Two', effects: { truth: 1 } },
+        ],
+      }),
+    ),
+  'unknown dimension',
+)
+rejects(
+  "rejects an unknown axis in the move's own effects",
+  () => validate(payload({ moveEffects: { charisma: 2 } })),
+  'unknown dimension',
+)
+check(
+  'the same payload validates against a deck that does declare the axis',
+  validateStorybookNarration(
+    payload({
+      moveEffects: { legacy: 1 },
+      choices: [
+        { id: 'a', choiceText: 'One', effects: { legacy: 1 } },
+        { id: 'b', choiceText: 'Two', effects: { love: 1 } },
+      ],
+      stateDelta: undefined,
+    }),
+    LIFE_DECK,
+    { bounds: PROSE_BOUNDS_BY_SHAPE.life },
+  ).moveEffects.legacy === 1,
+)
+
+console.log('Storybook narration — app-owned bounds')
+
+const clamped = validate(
+  payload({
+    choices: [
+      { id: 'a', choiceText: 'One', effects: { truth: 40, trust: -99 } },
+      { id: 'b', choiceText: 'Two', effects: { nerve: 3 } },
+    ],
+  }),
+)
+check(
+  `clamps an overpowered positive delta to +${NARRATION_EFFECT_MAX}`,
+  clamped.choices[0]!.effects.truth === NARRATION_EFFECT_MAX,
+  String(clamped.choices[0]!.effects.truth),
+)
+check(
+  `clamps an overpowered negative delta to ${NARRATION_EFFECT_MIN}`,
+  clamped.choices[0]!.effects.trust === NARRATION_EFFECT_MIN,
+  String(clamped.choices[0]!.effects.trust),
+)
+check(
+  'drops null deltas so a flavor-only choice carries no effects',
+  Object.keys(
+    validate(
+      payload({
+        choices: [
+          {
+            id: 'a',
+            choiceText: 'Pure flavor.',
+            effects: { truth: null, trust: null, nerve: null },
+          },
+          { id: 'b', choiceText: 'Two', effects: { truth: 1 } },
+        ],
+      }),
+    ).choices[0]!.effects,
+  ).length === 0,
+)
+check(
+  'drops zero deltas rather than writing a no-op stat row',
+  Object.keys(
+    validate(
+      payload({
+        choices: [
+          { id: 'a', choiceText: 'One', effects: { truth: 0, trust: 1 } },
+          { id: 'b', choiceText: 'Two', effects: { nerve: 1 } },
+        ],
+      }),
+    ).choices[0]!.effects,
+  ).join(',') === 'trust',
+)
+
+const greedy = validateStorybookNarration(
+  payload({
+    moveEffects: { legacy: 1, wealth: 2, love: 1, wisdom: 2, health: 1 },
+    choices: [
+      { id: 'a', choiceText: 'One', effects: { legacy: 1 } },
+      { id: 'b', choiceText: 'Two', effects: { love: 1 } },
+    ],
+    stateDelta: undefined,
+  }),
+  LIFE_DECK,
+  { bounds: PROSE_BOUNDS_BY_SHAPE.life },
+)
+check(
+  `trims a greedy effects map to ${MAX_EFFECT_AXES_PER_MOVE} axes, keeping the largest swings`,
+  Object.keys(greedy.moveEffects).length === MAX_EFFECT_AXES_PER_MOVE &&
+    greedy.moveEffects.wealth === 2 &&
+    greedy.moveEffects.wisdom === 2,
+  JSON.stringify(greedy.moveEffects),
+)
+// The life shape has been live with an uncapped effects map since davinci/t-016;
+// the adapter opts out so this refactor does not quietly retune a running game.
+check(
+  'the life adapter leaves an uncapped effects map alone',
+  Object.keys(
+    validateNarrationPayload({
+      narrativeText: prose,
+      choices: [
+        {
+          id: 'a',
+          choiceText: 'One',
+          effects: { legacy: 1, wealth: 1, love: 1, wisdom: 1, health: 1 },
+        },
+        { id: 'b', choiceText: 'Two', effects: { fame: 1 } },
+      ],
+      artPrompt: null,
+      milestoneCandidate: null,
+    }).choices[0]!.effects,
+  ).length === 5,
+)
+check(
+  'the life adapter still answers with milestoneCandidate, not endingHint',
+  validateNarrationPayload({
+    narrativeText: prose,
+    choices: [
+      { id: 'a', choiceText: 'One', effects: { legacy: 1 } },
+      { id: 'b', choiceText: 'Two', effects: { love: 1 } },
+    ],
+    artPrompt: null,
+    milestoneCandidate: 'the quiet legacy',
+  }).milestoneCandidate === 'the quiet legacy',
+)
+
+rejects(
+  `rejects fewer than ${NARRATION_MIN_CHOICES} choices`,
+  () =>
+    validate(
+      payload({ choices: [{ id: 'a', choiceText: 'Only one', effects: {} }] }),
+    ),
+  `${NARRATION_MIN_CHOICES}-${NARRATION_MAX_CHOICES} choices`,
+)
+rejects(
+  `rejects more than ${NARRATION_MAX_CHOICES} choices`,
+  () =>
+    validate(
+      payload({
+        choices: Array.from({ length: NARRATION_MAX_CHOICES + 1 }, (_, i) => ({
+          id: String.fromCharCode(97 + i),
+          choiceText: `Option ${i}`,
+          effects: {},
+        })),
+      }),
+    ),
+  `${NARRATION_MIN_CHOICES}-${NARRATION_MAX_CHOICES} choices`,
+)
+rejects(
+  'rejects duplicate choice ids',
+  () =>
+    validate(
+      payload({
+        choices: [
+          { id: 'a', choiceText: 'One', effects: {} },
+          { id: 'a', choiceText: 'Two', effects: {} },
+        ],
+      }),
+    ),
+  'duplicate choice id',
+)
+rejects(
+  'rejects an empty choiceText',
+  () =>
+    validate(
+      payload({
+        choices: [
+          { id: 'a', choiceText: '   ', effects: {} },
+          { id: 'b', choiceText: 'Two', effects: {} },
+        ],
+      }),
+    ),
+  'non-empty choiceText',
+)
+rejects('rejects a non-object response', () => validate('nope'), 'non-object')
+rejects(
+  'rejects a missing choice list',
+  () => validate(payload({ choices: undefined })),
+  'no choice list',
+)
+rejects(
+  'rejects a non-numeric delta',
+  () =>
+    validate(
+      payload({
+        choices: [
+          { id: 'a', choiceText: 'One', effects: { truth: 'lots' } },
+          { id: 'b', choiceText: 'Two', effects: {} },
+        ],
+      }),
+    ),
+  'non-numeric delta',
+)
+
+console.log('Storybook narration — the turn budget ends the story')
+
+check(
+  'the final scene accepts an empty choice list',
+  validate(payload({ choices: [] }), { finalTurn: true }).choices.length === 0,
+)
+rejects(
+  'the final scene refuses to offer another choice',
+  () => validate(payload(), { finalTurn: true }),
+  'no choices',
+)
+
+console.log('Storybook narration — prose length is per shape')
+
+const shortProse = Array.from({ length: 40 }, (_, i) => `word${i}`).join(' ')
+rejects(
+  'rejects prose under the shape minimum',
+  () => validate(payload({ narrativeText: shortProse })),
+  'words',
+)
+check(
+  'the same prose is fine for a shape with a lower floor',
+  validateStorybookNarration(
+    payload({
+      narrativeText: shortProse,
+      moveEffects: {},
+      stateDelta: undefined,
+    }),
+    deck,
+    { bounds: PROSE_BOUNDS_BY_SHAPE.life, treasureSlugs },
+  ).narrativeText === shortProse,
+)
+rejects(
+  'rejects prose over the shape maximum',
+  () =>
+    validate(
+      payload({
+        narrativeText: Array.from(
+          { length: bounds.max + 10 },
+          (_, i) => `word${i}`,
+        ).join(' '),
+      }),
+    ),
+  'words',
+)
+check(
+  'every shape declares a band, and none of them invites purple prose',
+  Object.values(PROSE_BOUNDS_BY_SHAPE).every(
+    (band) => band.min > 0 && band.max > band.min,
+  ),
+)
+
+console.log('Storybook narration — inventory changes are slug allowlists')
+
+check(
+  'accepts an add of a Reward the board actually put in play',
+  validate(payload()).stateDelta.inventoryAdd.join(',') === 'brass-key',
+)
+check(
+  'drops an invented Reward slug rather than granting it',
+  validate(
+    payload({
+      stateDelta: {
+        consequences: [],
+        relationshipShifts: [],
+        inventoryAdd: ['sword-of-nothing'],
+        inventoryRemove: [],
+      },
+    }),
+  ).stateDelta.inventoryAdd.length === 0,
+)
+check(
+  'drops a removal of something the protagonist never held',
+  validate(
+    payload({
+      stateDelta: {
+        consequences: [],
+        relationshipShifts: [],
+        inventoryAdd: [],
+        inventoryRemove: ['sword-of-nothing'],
+      },
+    }),
+  ).stateDelta.inventoryRemove.length === 0,
+)
+check(
+  'allows spending something currently held',
+  validate(
+    payload({
+      stateDelta: {
+        consequences: [],
+        relationshipShifts: [],
+        inventoryAdd: [],
+        inventoryRemove: ['lantern'],
+      },
+    }),
+    { inventorySlugs: ['lantern'] },
+  ).stateDelta.inventoryRemove.join(',') === 'lantern',
+)
+check(
+  `caps each state list at ${MAX_STATE_ITEMS} entries`,
+  validate(
+    payload({
+      stateDelta: {
+        consequences: ['a', 'b', 'c', 'd', 'e'],
+        relationshipShifts: [],
+        inventoryAdd: [],
+        inventoryRemove: [],
+      },
+    }),
+  ).stateDelta.consequences.length === MAX_STATE_ITEMS,
+)
+check(
+  'a missing stateDelta is an empty one, not a crash',
+  validate(payload({ stateDelta: undefined })).stateDelta.consequences
+    .length === 0,
+)
+
+console.log('Storybook narration — response schema')
+
+/* eslint-disable @typescript-eslint/no-explicit-any --
+   The schema is a plain JSON Schema document; asserting on its nested shape is
+   the point of these checks. */
+const schema = storybookResponseSchema(deck) as Record<string, any>
+check(
+  'schema forbids additional top-level properties',
+  schema.additionalProperties === false,
+)
+check(
+  'schema requires every top-level field (OpenAI strict mode)',
+  [
+    'narrativeText',
+    'choices',
+    'artPrompt',
+    'endingHint',
+    'moveEffects',
+    'stateDelta',
+  ].every((key) => schema.required.includes(key)),
+  JSON.stringify(schema.required),
+)
+const effectsProps = schema.properties.choices.items.properties.effects
+check(
+  "schema exposes exactly this deck's axes, not the Life deck's",
+  Object.keys(effectsProps.properties).join(',') === 'truth,trust,nerve',
+  Object.keys(effectsProps.properties).join(','),
+)
+check(
+  'schema requires every axis key and forbids others',
+  effectsProps.required.length === deck.axes.length &&
+    effectsProps.additionalProperties === false,
+)
+check(
+  'schema types axes as nullable integers so a choice can be flavor-only',
+  deck.axes.every(
+    (axis) =>
+      Array.isArray(effectsProps.properties[axis.key].type) &&
+      effectsProps.properties[axis.key].type.includes('null') &&
+      effectsProps.properties[axis.key].type.includes('integer'),
+  ),
+)
+check(
+  'the final-scene schema tells the narrator the choice list is empty',
+  String(
+    (storybookResponseSchema(deck, { finalTurn: true }) as any).properties
+      .choices.description,
+  )
+    .toLowerCase()
+    .includes('empty'),
+)
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+console.log('Storybook narration — prompts')
+
+function request(
+  overrides: Partial<StorybookNarrationRequest> = {},
+): StorybookNarrationRequest {
+  return {
+    shape,
+    deck,
+    narratorStyle: 'mysterious',
+    narrator: {
+      name: 'Amri',
+      personality: 'wry',
+      narrativeVoice: 'close third',
+      prompt: null,
+    },
+    seed: 'run-abc',
+    turnIndex: 3,
+    turnBudget: 5,
+    isFinalTurn: false,
+    bible: {
+      title: 'The Clockwork Orchard',
+      premise: 'A letter arrives from a star that should not exist.',
+      cast: [
+        {
+          name: 'Wren',
+          role: 'protagonist',
+          description: 'A tired archivist.',
+        },
+      ],
+      location: { title: 'The Abandoned Observatory' },
+      facets: [{ title: 'Mystery' }],
+      scenario: { title: 'The Midnight Letters' },
+      treasures: [
+        {
+          slug: 'brass-key',
+          name: 'Brass Key',
+          rewardType: 'ITEM',
+          rarity: 'COMMON',
+          effect: 'Opens one locked thing.',
+        },
+      ],
+    },
+    statsSoFar: { truth: 2 },
+    inventory: [],
+    recentTurns: [
+      {
+        turnIndex: 2,
+        narrativeText: 'The ledger was already open.',
+        move: { source: 'option', text: 'Follow the clerk.' },
+      },
+    ],
+    move: { source: 'custom', text: 'Read the letter aloud.' },
+    ...overrides,
+  }
+}
+
+const system = buildStorybookSystemPrompt(request())
+check('system prompt names the narrator', system.includes('Amri'))
+check(
+  'system prompt names the shape being told',
+  system.includes('short story'),
+)
+check(
+  'system prompt carries the direct-prose contract',
+  system.includes('PROSE CONTRACT') &&
+    system.includes('No similes, no metaphors') &&
+    system.includes('Plain nouns and strong verbs'),
+)
+check(
+  'system prompt states the shape word band',
+  system.includes(`between ${bounds.min} and ${bounds.max} words`),
+)
+check(
+  'system prompt forbids ending the scene on a question or listing the options',
+  system.includes('Do not end with a question') &&
+    system.includes('Do not state, list, or hint at the options'),
+)
+check(
+  'system prompt forbids the narrator from awarding anything',
+  system.includes('Never state or imply that the player has won'),
+)
+check(
+  'system prompt carries the selected narrator style directive',
+  system.includes(NARRATOR_STYLE_DIRECTIVES.mysterious),
+)
+check(
+  'system prompt carries no other style directive',
+  (Object.keys(NARRATOR_STYLE_DIRECTIVES) as StorybookNarratorStyle[])
+    .filter((style) => style !== 'mysterious')
+    .every((style) => !system.includes(NARRATOR_STYLE_DIRECTIVES[style])),
+)
+check(
+  'every narrator style has a directive, so none silently falls back to none',
+  (
+    ['cinematic', 'playful', 'storybook', 'mysterious', 'intimate'] as const
+  ).every((style) => NARRATOR_STYLE_DIRECTIVES[style].length > 40),
+)
+check(
+  'a style-less request still gets the prose contract',
+  buildStorybookSystemPrompt(request({ narratorStyle: null })).includes(
+    'PROSE CONTRACT',
+  ),
+)
+check(
+  "system prompt lists this deck's axes and keeps them from the reader",
+  deck.axes.every((axis) => system.includes(axis.key)) &&
+    system.includes('Never name them to the reader'),
+)
+check(
+  'the final scene is told to close rather than branch',
+  buildStorybookSystemPrompt(request({ isFinalTurn: true })).includes(
+    'return an empty choices array',
+  ),
+)
+
+const userPrompt = buildStorybookUserPrompt(request())
+check('user prompt includes the seed', userPrompt.includes('run-abc'))
+check(
+  'user prompt places the turn inside its budget',
+  userPrompt.includes('Turn 3 of 5'),
+)
+check(
+  'user prompt frames the plot thread before the ingredients that bend it',
+  userPrompt.indexOf('Plot thread') < userPrompt.indexOf('Cast:'),
+)
+check(
+  'user prompt includes every axis value, defaulting the unset ones to zero',
+  userPrompt.includes('truth=2') && userPrompt.includes('nerve=0'),
+)
+check(
+  'user prompt lists treasures with the exact slugs stateDelta must use',
+  userPrompt.includes('slug=brass-key'),
+)
+check(
+  'user prompt includes recent turns and what the reader did',
+  userPrompt.includes('The ledger was already open.') &&
+    userPrompt.includes('Follow the clerk.'),
+)
+check(
+  "user prompt carries the reader's own move",
+  userPrompt.includes('Read the letter aloud.'),
+)
+check(
+  'an absent premise asks the narrator to invent one rather than stalling',
+  buildStorybookUserPrompt(
+    request({
+      bible: { ...request().bible, premise: null },
+    }),
+  ).includes('invent the inciting situation'),
+)
+check(
+  'the opening turn asks for an opening scene',
+  buildStorybookUserPrompt(request({ move: null, turnIndex: 1 })).includes(
+    'Write the opening scene.',
+  ),
+)
+
+const sheetPrompt = buildStorybookUserPrompt(
+  request({
+    move: {
+      source: 'sheet',
+      text: 'I want the door open.',
+      rewardSlug: 'brass-key',
+    },
+    playedReward: {
+      slug: 'brass-key',
+      name: 'Brass Key',
+      rewardType: 'ITEM',
+      rarity: 'COMMON',
+      effect: 'Opens one locked thing.',
+      flavorText: 'Warm from a pocket.',
+    },
+  }),
+)
+check(
+  'a character-sheet play names the card and its effect',
+  sheetPrompt.includes('Brass Key') &&
+    sheetPrompt.includes('Opens one locked thing.'),
+)
+check(
+  'a character-sheet play insists the card is actually used',
+  sheetPrompt.includes('genuinely used this turn'),
+)
+check(
+  'rarity is what sets how decisively a card works',
+  sheetPrompt.includes('COMMON nudges'),
+)
+check(
+  'an ITEM is spent by the end of the scene',
+  sheetPrompt.includes('The item is spent'),
+)
+check(
+  'a SKILL stays with the protagonist instead',
+  buildStorybookUserPrompt(
+    request({
+      move: { source: 'sheet', text: '', rewardSlug: 'quick-tongue' },
+      playedReward: {
+        slug: 'quick-tongue',
+        name: 'Quick Tongue',
+        rewardType: 'SKILL',
+        rarity: 'RARE',
+        effect: 'Talk past one closed door.',
+      },
+    }),
+  ).includes('The card stays with the protagonist.'),
+)
+
+if (failures) {
+  console.error(`\n${failures} check(s) failed.`)
+  process.exit(1)
+}
+console.log('\nAll Storybook narration checks passed.')


### PR DESCRIPTION
First slice of the card-driven storymaker groundwork (conductor storybook/t-031, resolving t-025). No schema, no routes, no UI.

## Why

Silas, 2026-09-12: stories "should not be verbose with purple prose, they should be direct, but this should be influenced by the narrator." Nothing in Storybook said that. The beat loop's persona asked for "vivid, emotionally legible prose" and the life shape enforced only a 20–400 word count. Meanwhile the same idea — narrator config + seed objects + state + history → a structured response — was built twice, client-side for the beat shapes and server-side for the life shape. t-025 filed exactly that duplication and left one question open: where it should run. It runs on the server, because only the server can hold the offered choices between turns, and a client that authors its own stat deltas can author its own ending.

## What

- **`server/utils/endingDeckMath.ts`** (DB-free): deck-generic outcome math. A deck declares axes in bit order; `outcomeKey[i]` is `axes[i]`. Life is the deck with ten axes and 1,024 endings; a genre deck is three or four. Its axis-JSON parser rejects rather than repairs, because a silently dropped axis renumbers every bit after it and re-keys already-seeded endings. `davinciDimensions.resolveOutcomeKey` delegates here.
- **`server/utils/storybookNarration.ts`** (DB-free): one narration layer for all four shapes. The request carries the deck's axes, the board's bible, turn index and budget, inventory, recent turns, and the reader's move — an offered option, a written action, or a card played from the character sheet. The PROSE CONTRACT is the house rule; the five narrator styles modulate voice inside it. Word bounds are per shape. The validator enforces the deck's axis allowlist, the ±2 clamp, the 2–4 choice band (empty on the final scene), and Reward-slug allowlists on inventory changes.
- **`server/utils/structuredCompletion.ts`**: the shared JSON-schema model call, extracted from `davinciNarration`'s `callNarrator`. Three call sites hand-rolled this shape; the chat routes' helper is streaming-only and carries no schema.
- **`server/utils/davinciNarration.ts` is now an adapter.** Every exported name, bound, error string and response key behaves identically, and its existing contract test passes untouched. It deliberately keeps `milestoneCandidate`, omits `moveEffects`/`stateDelta`, and leaves its effects map uncapped while new shapes cap a move at three axes — narrowing a live game's tuning is a design change, not a refactor.
- The four bound constants have one home. Nitro auto-imports `server/utils`, so exporting them from two modules warned on every build; both narration guards now import them from the shared layer.
- New contract tests `verifyEndingDeckMath.ts` and `verifyStorybookNarration.ts`, wired into `package.json` and `contract-tests.yml`.

## Verified

| Check | Result |
|---|---|
| `npm run test` (nuxi prepare + vue-tsc) | clean |
| `npm run test:davinci-narration` | passes unchanged through the adapter |
| `npm run test:ending-deck-math`, `test:storybook-narration` | pass |
| `npm run test:storybook` | exit 0 |
| `npm run lint:js` | 334 problems, byte-identical to `main` (confirmed by stashing) |
| `npx prettier --check` on every touched file | clean |

The deck resolver is asserted identical to the pre-deck Da Vinci resolver over 500 random stat maps, which is the regression that would quietly re-key 1,024 seeded endings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hXcMTb3XVsamTqP38mkYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012hXcMTb3XVsamTqP38mkYJ)_