### PR TITLE
feat(css): open kr-icon-9 (interface-vision t-104 slice 242)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1861,6 +1861,22 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
   }
 
   /* Same bare sizeless-and-colorless icon-glyph shape as `.kr-icon-6`/
+   * `.kr-icon-7`/`.kr-icon-8`, one size up (interface-vision t-104 slice
+   * 242) -- `h-9 w-9`, previously hand-rolled identically in 9 files (11
+   * occurrences), plus its `size-9` shorthand spelling (2 files, 2
+   * occurrences, folded into the same slice as too small for its own).
+   * Picked as the next smallest well-bounded sibling outside the closed
+   * `kr-icon-3`/`kr-icon-3-5`/`kr-icon-4`/`kr-icon-5`/`kr-icon-6`/
+   * `kr-icon-7`/`kr-icon-8` family and their now-closed `size-*` shorthand
+   * siblings (slices 238-241): `h-10 w-10` (14 files, 15 occurrences) and
+   * `h-12 w-12` (9 files, 10 occurrences) remain open. Distinct from any
+   * future `.kr-icon-primary-9` (same size, carries `text-primary`) --
+   * this is the untinted sibling. */
+  .kr-icon-9 {
+    @apply h-9 w-9;
+  }
+
+  /* Same bare sizeless-and-colorless icon-glyph shape as `.kr-icon-6`/
    * `.kr-icon-7`/`.kr-icon-8`, one size down (interface-vision t-104 slice
    * 201) -- `h-3 w-3`, previously hand-rolled identically in 19 files (30
    * occurrences via subset-match), the smallest well-bounded sibling

--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -81,7 +81,7 @@
             class="flex items-center gap-2 rounded-lg px-2 py-2 hover:bg-base-200"
           >
             <span
-              class="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-base-200"
+              class="kr-icon-9 flex shrink-0 items-center justify-center overflow-hidden rounded-lg bg-base-200"
             >
               <img
                 v-if="facetArtwork(facet)"

--- a/components/art/collection-picker.vue
+++ b/components/art/collection-picker.vue
@@ -149,7 +149,7 @@
                   v-else
                   class="col-span-3 flex h-24 items-center justify-center text-base-content/30"
                 >
-                  <Icon name="kind-icon:gallery" class="h-9 w-9" />
+                  <Icon name="kind-icon:gallery" class="kr-icon-9" />
                 </div>
               </div>
 
@@ -195,7 +195,7 @@
                   v-else
                   class="col-span-3 flex h-24 items-center justify-center text-base-content/30"
                 >
-                  <Icon name="kind-icon:gallery" class="h-9 w-9" />
+                  <Icon name="kind-icon:gallery" class="kr-icon-9" />
                 </div>
               </div>
 

--- a/components/coloring/coloring-book-manager.vue
+++ b/components/coloring/coloring-book-manager.vue
@@ -184,7 +184,7 @@
               v-for="color in coloringStore.currentPalette"
               :key="color.id"
               type="button"
-              class="h-9 w-9 rounded-full border-2 transition-transform hover:scale-110"
+              class="kr-icon-9 rounded-full border-2 transition-transform hover:scale-110"
               :class="
                 coloringStore.currentPage?.activeColorId === color.id
                   ? 'border-primary ring-2 ring-primary/40'

--- a/components/dreams/dream-gallery.vue
+++ b/components/dreams/dream-gallery.vue
@@ -110,7 +110,7 @@
         >
           <button
             type="button"
-            class="btn btn-sm h-9 w-9 rounded-2xl p-0"
+            class="kr-icon-9 btn btn-sm rounded-2xl p-0"
             :class="selectedType === 'all' ? 'btn-primary' : 'btn-ghost'"
             :aria-pressed="selectedType === 'all'"
             title="All types"
@@ -124,7 +124,7 @@
             v-for="type in dreamTypes"
             :key="type"
             type="button"
-            class="btn btn-sm h-9 w-9 rounded-2xl p-0"
+            class="kr-icon-9 btn btn-sm rounded-2xl p-0"
             :class="selectedType === type ? 'btn-primary' : 'btn-ghost'"
             :aria-pressed="selectedType === type"
             :title="dreamTypeLabel(type)"

--- a/components/navigation/maturity-toggle.vue
+++ b/components/navigation/maturity-toggle.vue
@@ -11,7 +11,7 @@
       >
         <span class="flex min-w-0 items-center gap-3">
           <span
-            class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
+            class="kr-icon-9 flex shrink-0 items-center justify-center rounded-xl"
             :class="
               showMature
                 ? 'bg-warning/15 text-warning'

--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -168,7 +168,7 @@
             class="flex items-start gap-3 p-3"
           >
             <span
-              class="relative flex h-9 w-9 shrink-0 overflow-hidden rounded-lg border border-base-300 bg-base-200"
+              class="kr-icon-9 relative flex shrink-0 overflow-hidden rounded-lg border border-base-300 bg-base-200"
             >
               <img
                 v-if="tab.image"

--- a/components/navigation/navigation-trimmed.vue
+++ b/components/navigation/navigation-trimmed.vue
@@ -47,7 +47,7 @@
     >
       <div class="flex items-center gap-2">
         <span
-          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-base-300/70 bg-base-200"
+          class="kr-icon-9 flex shrink-0 items-center justify-center rounded-lg border border-base-300/70 bg-base-200"
         >
           <Icon :name="channel.icon" class="kr-icon-5" />
         </span>

--- a/components/navigation/server-selector.vue
+++ b/components/navigation/server-selector.vue
@@ -2,7 +2,7 @@
 <template>
   <div class="relative inline-flex shrink-0">
     <button
-      class="kr-btn-ghost-outline flex h-9 min-h-9 w-9 min-w-9 shrink-0 items-center justify-center p-0 sm:h-full sm:w-full sm:min-w-0"
+      class="kr-icon-9 kr-btn-ghost-outline flex min-h-9 min-w-9 shrink-0 items-center justify-center p-0 sm:h-full sm:w-full sm:min-w-0"
       type="button"
       title="Server settings"
       aria-label="Server settings"

--- a/components/user/messenger.vue
+++ b/components/user/messenger.vue
@@ -36,7 +36,7 @@
           @click="convo.loadMessages(c.id)"
         >
           <div class="avatar">
-            <div class="h-9 w-9 rounded-full bg-base-300">
+            <div class="kr-icon-9 rounded-full bg-base-300">
               <img
                 v-if="peer(c)?.avatarImage"
                 :src="peer(c)?.avatarImage || ''"

--- a/pages/email-confirmation.vue
+++ b/pages/email-confirmation.vue
@@ -15,7 +15,7 @@
           >
             <Icon
               :name="result.ok ? 'kind-icon:check' : 'kind-icon:alert'"
-              class="h-9 w-9"
+              class="kr-icon-9"
             />
           </div>
 

--- a/pages/play/aquarium/leaderboard/index.vue
+++ b/pages/play/aquarium/leaderboard/index.vue
@@ -75,7 +75,7 @@
               {{ entry.rank }}
             </span>
             <div
-              class="grid size-9 shrink-0 place-items-center overflow-hidden rounded-xl border border-base-300 bg-base-200"
+              class="kr-icon-9 grid shrink-0 place-items-center overflow-hidden rounded-xl border border-base-300 bg-base-200"
             >
               <img
                 v-if="entry.avatarImage"

--- a/utils/scripts/codemods/kr_icon_9_codemod.py
+++ b/utils/scripts/codemods/kr_icon_9_codemod.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `h-9 w-9` bare (colorless) icon glyphs to
+`kr-icon-9`.
+
+Same sizeless-and-colorless icon-glyph shape as `.kr-icon-6`/`.kr-icon-7`/
+`.kr-icon-8`/`.kr-icon-3`/`.kr-icon-5`/`.kr-icon-3-5` (interface-vision
+t-104 slices 198-203), one size up from `.kr-icon-8`. Distinct from any
+future `.kr-icon-primary-9` (same size, carries a `text-primary` color
+token): this is the plain untinted glyph. Picked as the next smallest
+well-bounded sibling outside the closed `kr-icon-3`/`kr-icon-3-5`/
+`kr-icon-4`/`kr-icon-5`/`kr-icon-6`/`kr-icon-7`/`kr-icon-8` family and
+their `size-*` shorthand siblings (slices 238-241): 9 files (11
+occurrences), smaller than `h-10 w-10` (14 files, 15 occurrences) and
+`h-12 w-12` (9 files, 10 occurrences) surveyed alongside it.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+class strings containing both `h-9` and `w-9` tokens are touched, and only
+in static `class="..."` attributes -- never `:class`/`v-bind:class` bindings
+(see _class_attr.py). A class string carrying any `text-*`/`stroke-*`/
+`fill-*` color token is left alone (that is the `kr-icon-primary-9`/future
+colored-sibling shape, not this one), regardless of the base tokens' order
+in the source. A source that already carries `kr-icon-9`, or is missing
+either base token, is also left untouched. Extra tokens beyond the base set
+are preserved verbatim after the primitive class, matching every other
+kr-*-codemod's subset-match convention -- pass --exact-only to restrict a
+slice to sources with no extra tokens at all.
+
+Deliberately does NOT touch sibling sizes (`h-3 w-3`, `h-3.5 w-3.5`,
+`h-4 w-4`, `h-5 w-5`, `h-6 w-6`, `h-7 w-7`, `h-8 w-8`, `h-10 w-10`,
+`h-12 w-12`) -- those are real, independently-repeated shapes of their
+own, already migrated or left for future slices.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-9"
+BASE_TOKENS = {"h-9", "w-9"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-9 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/scripts/codemods/kr_icon_9_size_shorthand_codemod.py
+++ b/utils/scripts/codemods/kr_icon_9_size_shorthand_codemod.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Find or migrate the `size-9` Tailwind shorthand to `kr-icon-9`.
+
+`size-9` is a plain alias for `h-9 w-9` (Tailwind's `size-*` utility sets
+both axes at once) -- CSS-identical to the bare icon-glyph shape
+`.kr-icon-9 { @apply h-9 w-9; }` (interface-vision t-104, opened alongside
+this codemod). `size-9` is a separate source spelling of the exact same
+primitive, not a new shape. Same convention as
+`kr_icon_5_size_shorthand_codemod.py`/`kr_icon_8_size_shorthand_codemod.py`
+(slices 240-241), just for the `size-9` sibling -- folded into the same
+slice that opens `.kr-icon-9` since it only covers 2 occurrences across 2
+files, too small to be its own slice.
+
+Excludes any class string carrying a `text-*`/`stroke-*`/`fill-*` token --
+that is the `kr-icon-primary-9` (or another future colored sibling) shape,
+not this one -- same convention as `kr_icon_5_size_shorthand_codemod.py`.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+static `class="..."` attributes are touched, never `:class`/`v-bind:class`
+bindings (see _class_attr.py). Pass --exact-only to restrict a slice to
+sources with no extra tokens beyond `size-9` itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-9"
+BASE_TOKEN = "size-9"
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or BASE_TOKEN not in tokens:
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token != BASE_TOKEN]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly `size-9` (no "
+        "extra utility tokens preserved).",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-9 (size-9 shorthand) {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
conductor interface-vision/t-104 (recurring kr-* consistency umbrella), slice 242 (kind: software)

### What changed / what I produced
- `assets/css/tailwind.css`: new `.kr-icon-9 { @apply h-9 w-9; }` primitive, the next bare
  (colorless) icon-glyph sibling in the `kr-icon-3/5/6/7/8` family.
- Two new codemods, modeled directly on `kr_icon_8_codemod.py` /
  `kr_icon_8_size_shorthand_codemod.py`:
  - `utils/scripts/codemods/kr_icon_9_codemod.py` — migrates the two-token `h-9 w-9` spelling.
  - `utils/scripts/codemods/kr_icon_9_size_shorthand_codemod.py` — migrates the `size-9`
    Tailwind shorthand spelling (folded into this slice: only 2 occurrences, too small to be
    its own slice).
- Migrated 11 occurrences across 9 files (`h-9 w-9`) and 2 occurrences across 2 files
  (`size-9`). Both codemods exclude any `text-*`/`stroke-*`/`fill-*` token (that's the
  `kr-icon-primary-9` shape, not this one) and preserve extra tokens verbatim after the
  primitive class, matching every other `kr-icon-*` codemod's subset-match convention.
  No color/behavior/API/schema/route/geometry change.

### How I verified
- Full-repo survey (Python, subset-match, excluding `text-*`/`stroke-*`/`fill-*`) found
  `h-9 w-9`: 11 occurrences / 9 files; `size-9`: 2 occurrences / 2 files — smaller and more
  bounded than the other open siblings surveyed alongside it (`h-10 w-10`: 15/14, `size-10`:
  14/12; `h-12 w-12`: 10/9, `size-12`: 10/6).
- Dry run of both codemods matched the survey exactly; `--write` migrated the exact set;
  re-running both dry-run afterward reports 0 remaining candidates (idempotent).
- `npx eslint` clean on every touched file. `dream-gallery.vue` shows 3 pre-existing
  `@typescript-eslint/unified-signatures` errors (unrelated overload signatures) — confirmed
  via `git stash` that they predate this change.
- Full-repo `vue-tsc --noEmit` — exit 0.

### Stakes
reversible

### Flags for Reviewer
- No CI workflow references `utils/scripts/codemods/` by name, so these codemods aren't
  wired into any automated verifier — same as every other `kr-icon-*`/`kr-badge-*` sibling
  codemod already in that directory.

### Kaizen suggestion
`h-10 w-10` (14 files, 15 occurrences) and `h-12 w-12` (9 files, 10 occurrences) remain open
as the next well-bounded siblings in this family — either is a reasonable next slice.

### Notes for reviewer
Routine recurring-task slice from an automated Conductor Agent sweep (interface-vision/t-104).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012i6nnZtwvPu9qxFfLPuCQi

---
_Generated by [Claude Code](https://claude.ai/code/session_012i6nnZtwvPu9qxFfLPuCQi)_