### PR TITLE
feat(css): open kr-icon-10 (interface-vision t-104 slice 244)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1877,6 +1877,19 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
   }
 
   /* Same bare sizeless-and-colorless icon-glyph shape as `.kr-icon-6`/
+   * `.kr-icon-7`/`.kr-icon-8`/`.kr-icon-9`, one size up (interface-vision
+   * t-104 slice 244) -- `h-10 w-10`, previously hand-rolled identically in
+   * 14 files (15 occurrences), plus its `size-10` shorthand spelling
+   * (folded into the same slice, same convention as `.kr-icon-9`/`size-9`
+   * in slice 242). Picked as the next well-bounded sibling per slice 242's
+   * kaizen note; `h-12 w-12` (9 files, 10 occurrences) remains open.
+   * Distinct from the existing `.kr-icon-primary-10` (same size, carries
+   * `text-primary`) -- this is the untinted sibling. */
+  .kr-icon-10 {
+    @apply h-10 w-10;
+  }
+
+  /* Same bare sizeless-and-colorless icon-glyph shape as `.kr-icon-6`/
    * `.kr-icon-7`/`.kr-icon-8`, one size down (interface-vision t-104 slice
    * 201) -- `h-3 w-3`, previously hand-rolled identically in 19 files (30
    * occurrences via subset-match), the smallest well-bounded sibling

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -129,7 +129,7 @@
           @keydown.enter.space.prevent="fileInput?.click()"
         >
           <span
-            class="flex h-10 w-10 items-center justify-center rounded-xl border border-base-300 bg-base-200 transition-transform"
+            class="kr-icon-10 flex items-center justify-center rounded-xl border border-base-300 bg-base-200 transition-transform"
             :class="
               isDragging
                 ? 'scale-110 border-primary/40 bg-primary/10 text-primary'

--- a/components/art/collection-card.vue
+++ b/components/art/collection-card.vue
@@ -77,7 +77,7 @@
         <div class="flex flex-col items-center gap-2 text-base-content/40">
           <Icon
             :name="isHiddenMature ? 'kind-icon:lock' : normalizedFallbackIcon"
-            class="h-10 w-10"
+            class="kr-icon-10"
           />
           <span class="kr-text-bold-xs">
             {{ isHiddenMature ? 'Mature hidden' : 'No preview' }}

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -78,7 +78,7 @@
         v-else
         class="absolute inset-0 flex flex-col items-center justify-center gap-2 p-4 text-center text-base-content/40"
       >
-        <Icon name="kind-icon:image" class="size-10 opacity-40" />
+        <Icon name="kind-icon:image" class="kr-icon-10 opacity-40" />
         <p class="text-xs font-semibold">
           No {{ activeCarouselSlide.label.toLowerCase() }} yet.
         </p>

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -59,7 +59,7 @@
           @click="addFacet(facet.id)"
         >
           <span
-            class="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-base-200"
+            class="kr-icon-10 flex shrink-0 items-center justify-center overflow-hidden rounded-lg bg-base-200"
           >
             <img
               v-if="artwork(facet)"

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -234,7 +234,7 @@
                   v-else
                   class="flex size-full items-center justify-center text-base-content/30"
                 >
-                  <icon name="kind-icon:palette" class="size-10" />
+                  <icon name="kind-icon:palette" class="kr-icon-10" />
                 </div>
                 <span
                   class="badge badge-sm absolute bottom-2 left-2 rounded-2xl"
@@ -255,7 +255,7 @@
                   v-else
                   class="flex size-full items-center justify-center text-base-content/30"
                 >
-                  <icon name="kind-icon:pencil" class="size-10" />
+                  <icon name="kind-icon:pencil" class="kr-icon-10" />
                 </div>
                 <span
                   class="badge badge-sm absolute bottom-2 left-2 rounded-2xl"

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -410,7 +410,7 @@
                same width-cascade fix, wrapper-owned size and border. -->
           <div
             v-if="artByName('ichthyonomicon')"
-            class="size-10 shrink-0 overflow-hidden rounded-2xl border border-base-300"
+            class="kr-icon-10 shrink-0 overflow-hidden rounded-2xl border border-base-300"
           >
             <kr-art-plate
               :source="{ imagePath: artByName('ichthyonomicon') }"

--- a/components/curation/coloring-book-curation.vue
+++ b/components/curation/coloring-book-curation.vue
@@ -108,7 +108,7 @@
                   class="grid size-full place-items-center text-base-content/30"
                 >
                   <div class="text-center">
-                    <Icon name="kind-icon:image" class="mx-auto size-10" />
+                    <Icon name="kind-icon:image" class="kr-icon-10 mx-auto" />
                     <p class="kr-text-bold-xs mt-2">No color candidate</p>
                   </div>
                 </div>
@@ -134,7 +134,7 @@
                   class="grid size-full place-items-center text-base-content/30"
                 >
                   <div class="text-center">
-                    <Icon name="kind-icon:image" class="mx-auto size-10" />
+                    <Icon name="kind-icon:image" class="kr-icon-10 mx-auto" />
                     <p class="kr-text-bold-xs mt-2">No B&amp;W candidate</p>
                   </div>
                 </div>

--- a/components/dreams/dream-relationship-gallery.vue
+++ b/components/dreams/dream-relationship-gallery.vue
@@ -60,7 +60,7 @@
         v-else-if="filteredDreams.length === 0"
         class="flex h-full min-h-48 flex-col items-center justify-center gap-3 kr-panel-dashed text-center text-base-content/60"
       >
-        <Icon name="kind-icon:dream" class="h-10 w-10 opacity-50" />
+        <Icon name="kind-icon:dream" class="kr-icon-10 opacity-50" />
         <div>
           <p class="font-bold">{{ emptyTitle }}</p>
           <p class="kr-text-faded-sm mt-1">{{ emptySubtitle }}</p>

--- a/components/gallery/kr-gallery.vue
+++ b/components/gallery/kr-gallery.vue
@@ -40,7 +40,7 @@
       v-else-if="error"
       class="flex min-h-64 flex-col items-center justify-center gap-2 text-error"
     >
-      <Icon name="kind-icon:warning" class="size-10" />
+      <Icon name="kind-icon:warning" class="kr-icon-10" />
       <b>{{ error }}</b>
     </div>
 

--- a/components/home/home-page.vue
+++ b/components/home/home-page.vue
@@ -301,7 +301,7 @@
                 :to="showcaseHref(project)"
                 class="group flex items-center gap-2 rounded-xl border border-base-300 bg-base-100 p-1.5 transition-shadow hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary motion-safe:transition-transform motion-safe:hover:-translate-y-0.5"
               >
-                <div class="size-10 shrink-0 overflow-hidden rounded-lg">
+                <div class="kr-icon-10 shrink-0 overflow-hidden rounded-lg">
                   <kr-art-plate
                     :source="project.art"
                     variant="icon"

--- a/components/lora/lora-discover.vue
+++ b/components/lora/lora-discover.vue
@@ -115,7 +115,7 @@
             v-else
             class="flex h-full w-full items-center justify-center text-base-content/40"
           >
-            <Icon name="kind-icon:image" class="h-10 w-10" />
+            <Icon name="kind-icon:image" class="kr-icon-10" />
           </div>
 
           <div class="absolute left-2 top-2 flex flex-wrap gap-1">

--- a/components/manager/kr-manager.vue
+++ b/components/manager/kr-manager.vue
@@ -188,7 +188,7 @@
       v-else
       class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 kr-note kr-note-warning text-center font-normal"
     >
-      <Icon name="kind-icon:warning" class="h-10 w-10" />
+      <Icon name="kind-icon:warning" class="kr-icon-10" />
 
       <div>
         <p class="kr-text-black-lg">Unknown tab: {{ activeTab }}</p>

--- a/components/navigation/navigation-health.vue
+++ b/components/navigation/navigation-health.vue
@@ -135,7 +135,7 @@
           <div class="flex items-start justify-between gap-3">
             <div class="flex min-w-0 items-start gap-3">
               <span
-                class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-base-300 bg-base-200"
+                class="kr-icon-10 flex shrink-0 items-center justify-center rounded-xl border border-base-300 bg-base-200"
               >
                 <Icon :name="channel.icon" class="kr-icon-5" />
               </span>

--- a/components/pages/conductor-pitch-manager.vue
+++ b/components/pages/conductor-pitch-manager.vue
@@ -134,7 +134,7 @@
           >
             <div class="flex items-start gap-3 border-b border-base-300/60 p-4">
               <span
-                class="flex size-10 shrink-0 items-center justify-center rounded-2xl"
+                class="kr-icon-10 flex shrink-0 items-center justify-center rounded-2xl"
                 :class="statusIconClass(pitch)"
               >
                 <Icon :name="statusIcon(pitch)" class="kr-icon-5" />

--- a/components/reviews/review-list.vue
+++ b/components/reviews/review-list.vue
@@ -43,7 +43,7 @@
       class="kr-panel flex items-start gap-3 p-3"
     >
       <div
-        class="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-primary/20 bg-primary/10"
+        class="kr-icon-10 flex shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-primary/20 bg-primary/10"
       >
         <img
           v-if="avatarFor(review)"

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -59,7 +59,7 @@
           @click="addFacet(facet.id)"
         >
           <span
-            class="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-base-200"
+            class="kr-icon-10 flex shrink-0 items-center justify-center overflow-hidden rounded-lg bg-base-200"
           >
             <img
               v-if="artwork(facet)"

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -300,7 +300,7 @@
         v-else-if="filteredRewards.length === 0"
         class="flex h-full flex-col items-center justify-center gap-3 kr-panel-muted text-center text-base-content/60"
       >
-        <Icon name="kind-icon:gift" class="h-10 w-10" />
+        <Icon name="kind-icon:gift" class="kr-icon-10" />
 
         <p class="kr-text-bold-lg">No rewards found.</p>
 

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -250,7 +250,7 @@
         v-else-if="filteredScenarios.length === 0"
         class="flex h-full min-h-48 flex-col items-center justify-center gap-3 kr-panel-dashed text-center text-base-content/60"
       >
-        <Icon name="kind-icon:map" class="h-10 w-10 opacity-50" />
+        <Icon name="kind-icon:map" class="kr-icon-10 opacity-50" />
 
         <div>
           <p class="font-bold">

--- a/components/scenarios/scenario-relationship-gallery.vue
+++ b/components/scenarios/scenario-relationship-gallery.vue
@@ -113,7 +113,7 @@
         v-else-if="filteredScenarios.length === 0"
         class="flex h-full min-h-48 flex-col items-center justify-center gap-3 kr-panel-dashed text-center text-base-content/60"
       >
-        <Icon name="kind-icon:map" class="h-10 w-10 opacity-50" />
+        <Icon name="kind-icon:map" class="kr-icon-10 opacity-50" />
         <div>
           <p class="font-bold">{{ emptyTitle }}</p>
           <p class="kr-text-faded-sm mt-1">{{ emptySubtitle }}</p>

--- a/components/scenarios/scenario-story.vue
+++ b/components/scenarios/scenario-story.vue
@@ -177,7 +177,7 @@
     >
       <div class="flex min-w-0 items-center gap-3">
         <div
-          class="h-10 w-10 shrink-0 overflow-hidden rounded-xl border border-base-300 bg-base-300"
+          class="kr-icon-10 shrink-0 overflow-hidden rounded-xl border border-base-300 bg-base-300"
         >
           <img
             :src="selectedScenarioImage"

--- a/components/servers/checkpoint-card.vue
+++ b/components/servers/checkpoint-card.vue
@@ -32,7 +32,7 @@
         <div class="flex flex-col items-center gap-2 text-base-content/45">
           <Icon
             :name="isHiddenMature ? 'kind-icon:lock' : normalizedFallbackIcon"
-            class="h-10 w-10"
+            class="kr-icon-10"
           />
           <span class="kr-text-bold-xs">
             {{ isHiddenMature ? 'Mature hidden' : 'No preview' }}

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -327,7 +327,7 @@
                     <img
                       :src="p.imagePath"
                       :alt="p.name"
-                      class="h-10 w-10 shrink-0 rounded-xl object-cover"
+                      class="kr-icon-10 shrink-0 rounded-xl object-cover"
                     />
                     <div class="min-w-0">
                       <p class="kr-text-bold-xs text-base-content truncate">
@@ -412,7 +412,7 @@
                     v-if="role.badgeImagePath"
                     :src="role.badgeImagePath"
                     :alt="role.label"
-                    class="h-10 w-10 rounded-2xl border border-base-300 object-cover"
+                    class="kr-icon-10 rounded-2xl border border-base-300 object-cover"
                   />
                   <div>
                     <h3 class="kr-text-black-sm text-base-content">

--- a/components/stages/stage-message.vue
+++ b/components/stages/stage-message.vue
@@ -45,7 +45,7 @@
   <!-- Speaker line -->
   <div v-else class="self-start max-w-[80%] flex items-start gap-2">
     <div
-      class="w-10 h-10 rounded-full bg-base-300 overflow-hidden shrink-0 flex items-center justify-center"
+      class="kr-icon-10 rounded-full bg-base-300 overflow-hidden shrink-0 flex items-center justify-center"
     >
       <img
         v-if="imageUrl"

--- a/components/storybook/storybook-state-panel.vue
+++ b/components/storybook/storybook-state-panel.vue
@@ -23,7 +23,7 @@
             class="flex items-center gap-2 rounded-xl border border-base-300 bg-base-200/40 p-2"
           >
             <span
-              class="relative flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-base-200"
+              class="kr-icon-10 relative flex shrink-0 items-center justify-center overflow-hidden rounded-lg bg-base-200"
             >
               <img
                 v-if="item.ingredient.imagePath"

--- a/components/user/user-galleries.vue
+++ b/components/user/user-galleries.vue
@@ -35,7 +35,7 @@
           >
             <div class="flex min-w-0 items-center gap-3">
               <div
-                class="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10"
+                class="kr-icon-10 flex shrink-0 items-center justify-center rounded-2xl bg-primary/10"
               >
                 <Icon :name="section.icon" class="kr-icon-primary-5" />
               </div>

--- a/pages/play/aquarium/browse/index.vue
+++ b/pages/play/aquarium/browse/index.vue
@@ -73,7 +73,7 @@
           >
             <div class="flex items-center gap-3">
               <div
-                class="grid size-10 shrink-0 place-items-center overflow-hidden rounded-xl border border-base-300 bg-base-200"
+                class="kr-icon-10 grid shrink-0 place-items-center overflow-hidden rounded-xl border border-base-300 bg-base-200"
               >
                 <img
                   v-if="tank.User.avatarImage"

--- a/utils/scripts/codemods/kr_icon_10_size_shorthand_codemod.py
+++ b/utils/scripts/codemods/kr_icon_10_size_shorthand_codemod.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Find or migrate the `size-10` Tailwind shorthand to `kr-icon-10`.
+
+`size-10` is a plain alias for `h-10 w-10` (Tailwind's `size-*` utility sets
+both axes at once) -- CSS-identical to the bare icon-glyph shape
+`.kr-icon-10 { @apply h-10 w-10; }` (interface-vision t-104 slice 244,
+opened alongside this codemod). `size-10` is a separate source spelling of
+the exact same primitive, not a new shape. Same convention as
+`kr_icon_9_size_shorthand_codemod.py`/`kr_icon_5_size_shorthand_codemod.py`
+(slices 240-242), just for the `size-10` sibling -- folded into the same
+slice that opens `.kr-icon-10`.
+
+Excludes any class string carrying a `text-*`/`stroke-*`/`fill-*` token --
+that is the `kr-icon-primary-10` shape, not this one -- same convention as
+every prior `size-N` shorthand codemod in this family.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+static `class="..."` attributes are touched, never `:class`/`v-bind:class`
+bindings (see _class_attr.py). Pass --exact-only to restrict a slice to
+sources with no extra tokens beyond `size-10` itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-10"
+BASE_TOKEN = "size-10"
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or BASE_TOKEN not in tokens:
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token != BASE_TOKEN]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly `size-10` (no "
+        "extra utility tokens preserved).",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-10 (size-10 shorthand) {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Conductor interface-vision/t-104 slice 244.

Opens the `.kr-icon-10` primitive (`h-10 w-10`), mirroring how slice 242 opened `kr-icon-9`, and migrates every occurrence its codemods discover — the natural continuation flagged by slice 243's own kaizen note.

### What changed
- `assets/css/tailwind.css`: new `.kr-icon-10 { @apply h-10 w-10; }`, documented the same way as its siblings (`kr-icon-6`..`kr-icon-9`).
- `utils/scripts/codemods/kr_icon_10_size_shorthand_codemod.py` (new): migrates the `size-10` Tailwind shorthand onto `kr-icon-10`, same convention as `kr_icon_9_size_shorthand_codemod.py`.
- Ran the existing `kr_icon_10_codemod.py` (added in #2672) with `--write`: 15 `h-10 w-10` occurrences across 14 files.
- Ran the new `kr_icon_10_size_shorthand_codemod.py --write`: 14 `size-10` occurrences across 12 files.
- Both codemods skip any class string carrying a `text-*`/`stroke-*`/`fill-*` color token (the existing `.kr-icon-primary-10` shape, not this one) — confirmed by re-running both with `--write` reporting 0 remaining candidates.

No color/behavior/API/schema/route/geometry change — template/class substitution only.

### How I verified
- `python3 utils/scripts/codemods/kr_icon_10_codemod.py --self-test`: ok
- Both codemods re-run after `--write`: 0 remaining candidates (idempotent)
- `npx eslint` on every touched file: 5 pre-existing errors on 3 files, confirmed via `git stash` to predate this change and unrelated to the touched lines (a prop-mutation/empty-block pair in `entity-art-manager.vue`, an unused-import in `conductor-pitch-manager.vue`, a deprecated `slot` attribute in `stage-manager.vue`)
- `npx vue-tsc --noEmit` (full project): clean
- `npm run test:layout-contract`: holds, 0 new violations (the reported viewport-grid baseline improvement is on `animation-manager.vue`, untouched by this diff)
- `npx prettier --check` on every touched file: pre-existing drift on 13 files, confirmed via `git stash` to predate this change
- `ruff check` on the new codemod file: clean

### Stakes
reversible

### Kaizen suggestion
`h-12 w-12` (9 files, 10 occurrences per slice 242's survey) is the next well-bounded sibling in this family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBXNnCxXGh33gtH6Q3KMAu

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBXNnCxXGh33gtH6Q3KMAu)_