### PR TITLE
ci: add non-blocking shellcheck pass alongside bash -n syntax check (interface-vision t-132)

### DIFF
--- a/.github/workflows/layout-contract.yml
+++ b/.github/workflows/layout-contract.yml
@@ -56,6 +56,16 @@ jobs:
             echo "bash -n $file"
             bash -n "$file"
           done
+          # Non-blocking shellcheck pass over the same changed-file set (reuses the
+          # mapfile discovery above rather than re-running git diff): flags real shell
+          # bugs (unquoted expansions, unsafe globbing, etc.) that `bash -n` can't catch.
+          # Warning-only while its false-positive rate on real PR traffic is unknown;
+          # `|| true` keeps it from failing the job even though the step itself still
+          # runs under `bash -e` for the syntax-check loop above.
+          if [ "${#shell_files[@]}" -gt 0 ]; then
+            echo "shellcheck ${shell_files[*]}"
+            shellcheck "${shell_files[@]}" || true
+          fi
 
       - name: Audit test-prefixed commits for executable assertions
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
### Task
interface-vision/t-132: Add a non-blocking shellcheck pass alongside the new `bash -n` syntax check (kind: software)

### What changed / what I produced
- `.github/workflows/layout-contract.yml`: extended the existing "Syntax-check changed shell scripts" step with a warning-only `shellcheck` pass over the same NUL-delimited changed-`*.sh`-file set the `bash -n` loop already discovers via `mapfile` — no second `git diff` invocation.
- The `shellcheck` call is followed by `|| true` so it can never fail the job; the pre-existing `bash -n` loop above it in the same step is untouched and keeps failing hard on real syntax errors.
- No install step added — `shellcheck` is preinstalled on the `ubuntu-latest` GitHub Actions runner image.

### How I verified
- `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses cleanly.
- Extracted the step's script to a standalone file and ran it directly against a real base SHA with zero changed `*.sh` files: no-ops cleanly, exits 0.
- Installed `shellcheck` locally and confirmed a real finding (an unquoted variable expansion, SC2086) on an existing repo script prints its warning but the step still exits 0 thanks to `|| true`.
- Did not run this from inside actual CI (no push access to trigger a dry run outside a real PR), but the logic is a minimal, mechanical addition to an already-passing step with no other step's behavior touched.

### Stakes
reversible

### Flags for Reviewer
- None — small, self-contained CI change, no runtime/app code touched.

### Kaizen suggestion
Once real PR traffic gives a sense of shellcheck's false-positive rate on this repo's shell scripts, consider promoting specific high-confidence rule classes (e.g. SC2086 unquoted expansions) to blocking while leaving the rest warning-only, rather than an all-or-nothing flip to a hard-failing step.

### Notes for reviewer
Conductor roadmap task interface-vision/t-132 claimed and will be closed out (`status: ready`, recurring-umbrella style bookkeeping) once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uz6ScZnkA8vJpWsdM38iBH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uz6ScZnkA8vJpWsdM38iBH)_