### PR TITLE
feat(css): open kr-icon-12 (interface-vision t-104 slice 245)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1890,6 +1890,20 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
   }
 
   /* Same bare sizeless-and-colorless icon-glyph shape as `.kr-icon-6`/
+   * `.kr-icon-7`/`.kr-icon-8`/`.kr-icon-9`/`.kr-icon-10`, one size up
+   * (interface-vision t-104 slice 245) -- `h-12 w-12`, previously
+   * hand-rolled identically in 9 files (10 occurrences), plus its
+   * `size-12` shorthand spelling (6 files, 10 occurrences, folded into the
+   * same slice, same convention as `.kr-icon-9`/`size-9` and
+   * `.kr-icon-10`/`size-10`). Picked as the last well-bounded sibling left
+   * open by slice 244's kaizen note, closing the `kr-icon-6` through
+   * `kr-icon-12` size survey. Distinct from any future `.kr-icon-primary-12`
+   * (same size, carries `text-primary`) -- this is the untinted sibling. */
+  .kr-icon-12 {
+    @apply h-12 w-12;
+  }
+
+  /* Same bare sizeless-and-colorless icon-glyph shape as `.kr-icon-6`/
    * `.kr-icon-7`/`.kr-icon-8`, one size down (interface-vision t-104 slice
    * 201) -- `h-3 w-3`, previously hand-rolled identically in 19 files (30
    * occurrences via subset-match), the smallest well-bounded sibling

--- a/components/animation/animation-manager.vue
+++ b/components/animation/animation-manager.vue
@@ -149,7 +149,7 @@
             @click="store.selectSlug(effect.id)"
           >
             <span
-              class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border bg-base-100/50"
+              class="kr-icon-12 flex shrink-0 items-center justify-center rounded-xl border bg-base-100/50"
               :style="{ borderColor: effect.color, color: effect.color }"
             >
               <Icon :name="effect.icon" class="kr-icon-6" />

--- a/components/brainstorm/brainstorm-manager.vue
+++ b/components/brainstorm/brainstorm-manager.vue
@@ -308,7 +308,7 @@
             v-if="resolvedSource.thumbnailUrl"
             :src="resolvedSource.thumbnailUrl"
             :alt="resolvedSource.title"
-            class="h-12 w-12 shrink-0 rounded-xl object-cover"
+            class="kr-icon-12 shrink-0 rounded-xl object-cover"
           />
           <div
             v-else

--- a/components/coloring/coloring-book-production-history.vue
+++ b/components/coloring/coloring-book-production-history.vue
@@ -59,7 +59,7 @@
           v-else
           class="flex aspect-[2/3] items-center justify-center bg-base-200 text-base-content/30"
         >
-          <icon name="kind-icon:image-off" class="size-12" />
+          <icon name="kind-icon:image-off" class="kr-icon-12" />
         </div>
 
         <div class="flex flex-col gap-3 p-4">

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -354,7 +354,7 @@
                  shapes as wanting: small and square, the intro piece to a
                  text-forward row. -->
             <div
-              class="size-12 shrink-0 overflow-hidden rounded-2xl border border-base-300"
+              class="kr-icon-12 shrink-0 overflow-hidden rounded-2xl border border-base-300"
             >
               <kr-art-plate
                 :source="withCthulhuquariumArt(entry)"
@@ -455,7 +455,7 @@
               <!-- cthulhuquarium/t-067: see the fish-list wrapper comment
                    above -- same width-cascade fix. -->
               <div
-                class="size-12 shrink-0 overflow-hidden rounded-2xl border border-base-300"
+                class="kr-icon-12 shrink-0 overflow-hidden rounded-2xl border border-base-300"
               >
                 <kr-art-plate
                   :source="
@@ -700,7 +700,7 @@
                    above -- same width-cascade fix. -->
               <div
                 v-if="artForEggTier(egg.rarity)"
-                class="size-12 shrink-0 overflow-hidden rounded-2xl border border-base-300"
+                class="kr-icon-12 shrink-0 overflow-hidden rounded-2xl border border-base-300"
               >
                 <kr-art-plate
                   :source="{ imagePath: artForEggTier(egg.rarity) }"
@@ -795,7 +795,7 @@
              row's full width. See the fish-list wrapper comment above for the
              root cause and fix (same width-cascade issue, same fix here). -->
         <div
-          class="size-12 shrink-0 overflow-hidden rounded-2xl border border-base-300"
+          class="kr-icon-12 shrink-0 overflow-hidden rounded-2xl border border-base-300"
         >
           <kr-art-plate
             :source="{ imagePath: setLastAquariumArt }"

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -31,7 +31,7 @@
             v-else
             class="absolute inset-0 flex flex-col items-center justify-center gap-2 p-6 text-center text-base-content/40"
           >
-            <Icon name="kind-icon:image" class="size-12 opacity-40" />
+            <Icon name="kind-icon:image" class="kr-icon-12 opacity-40" />
             <p class="kr-text-bold-sm">
               No {{ selectedSlot.label.toLowerCase() }} is attached yet.
             </p>

--- a/components/model-builder/model-builder-source-picker.vue
+++ b/components/model-builder/model-builder-source-picker.vue
@@ -166,7 +166,7 @@
           @click="store.selectSource(record)"
         >
           <div
-            class="grid h-12 w-12 shrink-0 place-items-center overflow-hidden rounded-xl bg-base-200"
+            class="kr-icon-12 grid shrink-0 place-items-center overflow-hidden rounded-xl bg-base-200"
           >
             <img
               v-if="recordImage(record)"

--- a/components/narrative/kr-narrator-stage.vue
+++ b/components/narrative/kr-narrator-stage.vue
@@ -31,7 +31,7 @@
             v-if="narratorImage"
             :src="narratorImage"
             :alt="narratorName"
-            class="h-12 w-12 shrink-0 rounded-full border-2 border-primary/40 bg-base-100 object-cover shadow-lg"
+            class="kr-icon-12 shrink-0 rounded-full border-2 border-primary/40 bg-base-100 object-cover shadow-lg"
             loading="lazy"
           />
           <div

--- a/components/navigation/workspace-sheet.vue
+++ b/components/navigation/workspace-sheet.vue
@@ -175,7 +175,7 @@
           >
             <div class="flex min-w-0 items-center gap-3">
               <div
-                class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-base-300 bg-base-200 shadow-sm"
+                class="kr-icon-12 flex shrink-0 items-center justify-center rounded-2xl border border-base-300 bg-base-200 shadow-sm"
               >
                 <Icon :name="card.icon" class="h-7 w-7 text-primary/60" />
               </div>

--- a/components/stages/stage-manager.vue
+++ b/components/stages/stage-manager.vue
@@ -372,11 +372,11 @@
                   v-if="pendingCastImage"
                   :src="pendingCastImage"
                   :alt="pendingCastName"
-                  class="h-12 w-12 rounded-2xl object-cover"
+                  class="kr-icon-12 rounded-2xl object-cover"
                 />
                 <div
                   v-else
-                  class="flex h-12 w-12 items-center justify-center rounded-2xl bg-base-300"
+                  class="kr-icon-12 flex items-center justify-center rounded-2xl bg-base-300"
                 >
                   <Icon name="mdi:account-star" class="kr-icon-primary-6" />
                 </div>

--- a/components/stages/stage-slot.vue
+++ b/components/stages/stage-slot.vue
@@ -6,7 +6,7 @@
     <template v-if="isFilled">
       <div class="flex items-center gap-2">
         <div
-          class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-base-300"
+          class="kr-icon-12 flex shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-base-300"
         >
           <img
             v-if="imageUrl"

--- a/components/user/avatar-picker.vue
+++ b/components/user/avatar-picker.vue
@@ -8,7 +8,7 @@
       class="flex shrink-0 items-center gap-3 kr-panel-flat px-4 py-3"
     >
       <span
-        class="relative flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/15 ring-2 ring-accent/40"
+        class="kr-icon-12 relative flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/15 ring-2 ring-accent/40"
       >
         <img
           v-if="previewUrl"

--- a/components/user/friend-gallery.vue
+++ b/components/user/friend-gallery.vue
@@ -116,7 +116,7 @@
         <div
           class="flex flex-col items-center gap-2 py-12 text-base-content/50"
         >
-          <Icon name="kind-icon:person" class="h-12 w-12" />
+          <Icon name="kind-icon:person" class="kr-icon-12" />
           <p>No public profiles yet.</p>
         </div>
       </template>

--- a/pages/admin/achievement-art.vue
+++ b/pages/admin/achievement-art.vue
@@ -77,7 +77,7 @@
                 @click="selectedId = achievement.id"
               >
                 <div
-                  class="grid size-12 shrink-0 place-items-center overflow-hidden rounded-xl bg-base-200"
+                  class="kr-icon-12 grid shrink-0 place-items-center overflow-hidden rounded-xl bg-base-200"
                 >
                   <img
                     v-if="achievement.imagePath"

--- a/pages/play/aquarium/browse/[username]/[slug].vue
+++ b/pages/play/aquarium/browse/[username]/[slug].vue
@@ -50,7 +50,7 @@
         >
           <div class="flex items-center gap-3">
             <div
-              class="grid size-12 shrink-0 place-items-center overflow-hidden rounded-2xl border border-base-300 bg-base-200"
+              class="kr-icon-12 grid shrink-0 place-items-center overflow-hidden rounded-2xl border border-base-300 bg-base-200"
             >
               <img
                 v-if="tank.User.avatarImage"
@@ -118,7 +118,7 @@
               shape="plate"
               frame="thin"
               fit="cover"
-              class="size-12 shrink-0"
+              class="kr-icon-12 shrink-0"
               placeholder-icon="kind-icon:fish"
             />
             <div class="min-w-0">

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -256,7 +256,7 @@
                     <p v-if="artNotice" class="mt-1 text-xs text-success">{{ artNotice }}</p>
                   </div>
                   <div v-else class="space-y-3">
-                    <Icon name="kind-icon:volume" class="mx-auto size-12 opacity-60" />
+                    <Icon name="kind-icon:volume" class="kr-icon-12 mx-auto opacity-60" />
                     <button type="button" class="kr-btn-primary-md-plain" @click="store.speak(currentCard)">Hear prompt</button>
                     <p class="kr-text-faded-xs-55">Listen without seeing the answer.</p>
                   </div>

--- a/utils/scripts/codemods/kr_icon_12_codemod.py
+++ b/utils/scripts/codemods/kr_icon_12_codemod.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled `h-12 w-12` bare (colorless) icon glyphs to
+`kr-icon-12`.
+
+Same sizeless-and-colorless icon-glyph shape as `.kr-icon-6`/`.kr-icon-7`/
+`.kr-icon-8`/`.kr-icon-9`/`.kr-icon-10` (interface-vision t-104 slices
+198-244), one size up from `.kr-icon-10`. Distinct from any future
+`.kr-icon-primary-12` (same size, carries a `text-primary` color token):
+this is the plain untinted glyph. Picked as the next well-bounded sibling
+per slice 244's kaizen note -- `h-12 w-12` (9 files, 10 occurrences) was
+the last size left open in the `kr-icon-6` through `kr-icon-10` survey.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+class strings containing both `h-12` and `w-12` tokens are touched, and
+only in static `class="..."` attributes -- never `:class`/`v-bind:class`
+bindings (see _class_attr.py). A class string carrying any
+`text-*`/`stroke-*`/`fill-*` color token is left alone (that is the
+`kr-icon-primary-12`/future colored-sibling shape, not this one),
+regardless of the base tokens' order in the source. A source that already
+carries `kr-icon-12`, or is missing either base token, is also left
+untouched. Extra tokens beyond the base set are preserved verbatim after
+the primitive class, matching every other kr-*-codemod's subset-match
+convention -- pass --exact-only to restrict a slice to sources with no
+extra tokens at all.
+
+Deliberately does NOT touch sibling sizes (`h-3 w-3`, `h-3.5 w-3.5`,
+`h-4 w-4`, `h-5 w-5`, `h-6 w-6`, `h-7 w-7`, `h-8 w-8`, `h-9 w-9`,
+`h-10 w-10`) -- those are real, independently-repeated shapes of their
+own, already migrated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-12"
+BASE_TOKENS = {"h-12", "w-12"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def self_test() -> None:
+    cases = [
+        ('<Icon class="h-12 w-12" />', False, '<Icon class="kr-icon-12" />', 1),
+        (
+            '<Icon class="animate-spin w-12 h-12" />',
+            False,
+            '<Icon class="kr-icon-12 animate-spin" />',
+            1,
+        ),
+        ('<Icon class="h-12 w-12 text-info" />', False, None, 0),
+        ('<Icon :class="\'h-12 w-12\'" />', False, None, 0),
+        ('<Icon class="h-12 w-12 animate-spin" />', True, None, 0),
+    ]
+    for source, exact_only, expected, expected_count in cases:
+        migrated, count = migrate_text(source, exact_only)
+        assert count == expected_count, (source, count)
+        if expected is not None:
+            assert migrated == expected, (source, migrated)
+        else:
+            assert migrated == source, (source, migrated)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
+    )
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        self_test()
+        print("kr-icon-12 codemod self-test: ok")
+        return 0
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-12 {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/scripts/codemods/kr_icon_12_size_shorthand_codemod.py
+++ b/utils/scripts/codemods/kr_icon_12_size_shorthand_codemod.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Find or migrate the `size-12` Tailwind shorthand to `kr-icon-12`.
+
+`size-12` is a plain alias for `h-12 w-12` (Tailwind's `size-*` utility
+sets both axes at once) -- CSS-identical to the bare icon-glyph shape
+`.kr-icon-12 { @apply h-12 w-12; }` (interface-vision t-104, opened
+alongside this codemod). `size-12` is a separate source spelling of the
+exact same primitive, not a new shape. Same convention as
+`kr_icon_9_size_shorthand_codemod.py`/`kr_icon_10_size_shorthand_codemod.py`
+(slices 242/244), just for the `size-12` sibling -- folded into the same
+slice that opens `.kr-icon-12`.
+
+Excludes any class string carrying a `text-*`/`stroke-*`/`fill-*` token --
+that is the `kr-icon-primary-12` (or another future colored sibling) shape,
+not this one -- same convention as every prior `size-N` shorthand codemod.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+static `class="..."` attributes are touched, never `:class`/`v-bind:class`
+bindings (see _class_attr.py). Pass --exact-only to restrict a slice to
+sources with no extra tokens beyond `size-12` itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-icon-12"
+BASE_TOKEN = "size-12"
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or BASE_TOKEN not in tokens:
+        return None
+    if any(
+        t.startswith("text-") or t.startswith("stroke-") or t.startswith("fill-")
+        for t in tokens
+    ):
+        return None
+    remaining = [token for token in tokens if token != BASE_TOKEN]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly `size-12` (no "
+        "extra utility tokens preserved).",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-icon-12 (size-12 shorthand) {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules (kind: software, recurring umbrella — slice 245)

### What changed / what I produced
- Opened `.kr-icon-12` (`h-12 w-12`) in `assets/css/tailwind.css` — the last well-bounded sibling left open by slice 244's kaizen note, closing the `kr-icon-6` through `kr-icon-12` untinted icon-glyph size survey.
- Added `kr_icon_12_codemod.py` and `kr_icon_12_size_shorthand_codemod.py` (mirroring the `kr-icon-9`/`kr-icon-10` codemods).
- Migrated 10 `h-12 w-12` occurrences across 9 files and 10 `size-12` shorthand occurrences across 6 files onto `.kr-icon-12`.
- No color/behavior/API/schema/route/geometry change — purely mechanical class-token substitution.

### How I verified
- Both codemods' self-test/dry-run report 0 remaining candidates after `--write`.
- `eslint` on touched files: 2 pre-existing errors (`daily-dream-object-art-workbench.vue` `vue/no-mutating-props`, `stage-manager.vue` `vue/no-deprecated-slot-attribute`) — confirmed pre-existing via `git stash` + re-run, unrelated to this diff.
- `vue-tsc --noEmit`: clean.
- `npm run test:layout-contract`: holds, no new violations. It also reports `animation-manager.vue`'s viewport-grid entries as ratchetable — confirmed via `git stash` that this improvement predates this diff (from an earlier merged PR) and is unrelated to this change; left as-is to keep this diff scoped.
- `prettier --check` on touched files: same warnings present before this diff (confirmed via `git stash`) — pre-existing repo drift, not a regression; this repo has no CI-enforced prettier check.

### Stakes
reversible

### Flags for Reviewer
- The layout-contract's viewport-grid ratchet opportunity in `animation-manager.vue` (2 entries) is unrelated pre-existing baseline drift, not touched here — worth a future one-line `--update` slice.

### Kaizen suggestion
This closes the `kr-icon-6`–`kr-icon-12` untinted-glyph size survey. Next candidate family: the `kr-icon-primary-*` colored siblings (`text-primary` + size) haven't been surveyed as a full size ladder the way the untinted family has — a future slice could inventory `h-N w-N text-primary` occurrences across sizes the same way this family was opened.

### Notes for reviewer
Return `interface-vision/t-104` to `status: ready` after merge (recurring umbrella convention) — conductor roadmap update follows in the same session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lg7mpatTpoxnF5rtSyGJaG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lg7mpatTpoxnF5rtSyGJaG)_