### PR TITLE
feat(css): open kr-toggle-* color family (interface-vision t-104 slice 246)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1416,6 +1416,56 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply checkbox checkbox-xs checkbox-primary;
   }
 
+  /* First toggle-color-family primitive (interface-vision t-104 slice 246,
+   * following a fresh full-repo class-frequency survey that turned up this
+   * family as the largest well-bounded pool left outside every family
+   * already closed -- kr-text-*, kr-icon-*, kr-input-*, kr-btn-*, kr-badge-*,
+   * kr-label-row): the plain warning-colored DaisyUI toggle at its default
+   * size -- `toggle toggle-warning`, no size modifier -- previously
+   * hand-rolled in 11 files (11 exact-match occurrences). Distinct from any
+   * future `.kr-toggle-warning-sm`/`-xs`, which would carry a size
+   * modifier too; this is the sizeless base, same shape as
+   * `.kr-badge-ghost`/`.kr-badge-outline` being separate from their own
+   * `-sm`/`-xs` siblings. */
+  .kr-toggle-warning {
+    @apply toggle toggle-warning;
+  }
+
+  /* The primary-colored counterpart to .kr-toggle-warning (same slice):
+   * `toggle toggle-primary`, previously hand-rolled in 6 files (9
+   * occurrences). */
+  .kr-toggle-primary {
+    @apply toggle toggle-primary;
+  }
+
+  /* The success-colored counterpart to .kr-toggle-warning (same slice):
+   * `toggle toggle-success`, previously hand-rolled in 5 files (5
+   * occurrences). */
+  .kr-toggle-success {
+    @apply toggle toggle-success;
+  }
+
+  /* The accent-colored counterpart to .kr-toggle-warning (same slice):
+   * `toggle toggle-accent`, previously hand-rolled in 2 files (2
+   * occurrences). */
+  .kr-toggle-accent {
+    @apply toggle toggle-accent;
+  }
+
+  /* The secondary-colored counterpart to .kr-toggle-warning (same slice):
+   * `toggle toggle-secondary`, previously hand-rolled in 1 file (1
+   * occurrence). */
+  .kr-toggle-secondary {
+    @apply toggle toggle-secondary;
+  }
+
+  /* The error-colored counterpart to .kr-toggle-warning (same slice):
+   * `toggle toggle-error`, previously hand-rolled in 1 file (1
+   * occurrence). */
+  .kr-toggle-error {
+    @apply toggle toggle-error;
+  }
+
   /* First badge-family primitive (interface-vision t-104 slice 109): the
    * small, ghost-styled DaisyUI badge -- `badge badge-ghost badge-sm` --
    * the single most common hand-rolled badge shape in the codebase (31

--- a/components/art/add-collection.vue
+++ b/components/art/add-collection.vue
@@ -50,7 +50,7 @@
           <input
             v-model="isPublic"
             type="checkbox"
-            class="toggle toggle-success"
+            class="kr-toggle-success"
             :disabled="isSaving || disabled"
           />
         </label>
@@ -61,7 +61,7 @@
           <input
             v-model="isMature"
             type="checkbox"
-            class="toggle toggle-warning"
+            class="kr-toggle-warning"
             :disabled="isSaving || disabled"
           />
         </label>

--- a/components/art/art-test.vue
+++ b/components/art/art-test.vue
@@ -978,7 +978,7 @@ onMounted(async () => {
               <input
                 v-model="showPayload"
                 type="checkbox"
-                class="toggle toggle-primary"
+                class="kr-toggle-primary"
               />
               <span class="label-text">Show payload</span>
             </label>
@@ -987,7 +987,7 @@ onMounted(async () => {
               <input
                 v-model="showRawResult"
                 type="checkbox"
-                class="toggle toggle-secondary"
+                class="kr-toggle-secondary"
               />
               <span class="label-text">Show raw result</span>
             </label>

--- a/components/bots/add-bot.vue
+++ b/components/bots/add-bot.vue
@@ -189,7 +189,7 @@
               <input
                 v-model="keepField.avatarImage"
                 type="checkbox"
-                class="toggle toggle-primary"
+                class="kr-toggle-primary"
                 @change="handleKeepFieldChange('avatarImage')"
               />
             </div>
@@ -410,7 +410,7 @@
             <input
               v-model="botStore.botForm.isPublic"
               type="checkbox"
-              class="toggle toggle-success"
+              class="kr-toggle-success"
             />
           </label>
 
@@ -420,7 +420,7 @@
             <input
               v-model="botStore.botForm.underConstruction"
               type="checkbox"
-              class="toggle toggle-warning"
+              class="kr-toggle-warning"
             />
           </label>
 
@@ -430,7 +430,7 @@
             <input
               v-model="botStore.botForm.canDelete"
               type="checkbox"
-              class="toggle toggle-error"
+              class="kr-toggle-error"
             />
           </label>
         </div>

--- a/components/characters/add-character.vue
+++ b/components/characters/add-character.vue
@@ -448,7 +448,7 @@
             <input
               v-model="characterStore.characterForm.isPublic"
               type="checkbox"
-              class="toggle toggle-primary"
+              class="kr-toggle-primary"
             />
           </label>
 
@@ -459,7 +459,7 @@
             <input
               v-model="characterStore.characterForm.isMature"
               type="checkbox"
-              class="toggle toggle-warning"
+              class="kr-toggle-warning"
             />
           </label>
         </div>

--- a/components/dreams/dream-maker.vue
+++ b/components/dreams/dream-maker.vue
@@ -280,7 +280,7 @@
                 <input
                   v-model="dreamStore.dreamForm.isPublic"
                   type="checkbox"
-                  class="toggle toggle-primary"
+                  class="kr-toggle-primary"
                 />
               </label>
 
@@ -289,7 +289,7 @@
                 <input
                   v-model="dreamStore.dreamForm.isMature"
                   type="checkbox"
-                  class="toggle toggle-warning"
+                  class="kr-toggle-warning"
                 />
               </label>
 
@@ -304,7 +304,7 @@
                 <input
                   v-model="dreamStore.dreamForm.allowReviews"
                   type="checkbox"
-                  class="toggle toggle-accent"
+                  class="kr-toggle-accent"
                 />
               </label>
 
@@ -313,7 +313,7 @@
                 <input
                   v-model="dreamStore.dreamForm.isActive"
                   type="checkbox"
-                  class="toggle toggle-success"
+                  class="kr-toggle-success"
                 />
               </label>
 

--- a/components/lora/add-lora.vue
+++ b/components/lora/add-lora.vue
@@ -203,7 +203,7 @@
         <input
           v-model="form.isMature"
           type="checkbox"
-          class="toggle toggle-warning"
+          class="kr-toggle-warning"
         />
 
         <span class="kr-label-bold">Mature (NSFW)</span>

--- a/components/model/add-model.vue
+++ b/components/model/add-model.vue
@@ -151,7 +151,7 @@
         <input
           v-model="form.isMature"
           type="checkbox"
-          class="toggle toggle-warning"
+          class="kr-toggle-warning"
         />
 
         <span class="kr-label-bold">Mature (NSFW)</span>

--- a/components/rewards/add-reward.vue
+++ b/components/rewards/add-reward.vue
@@ -161,7 +161,7 @@
             <input
               v-model="rewardStore.rewardForm.isPublic"
               type="checkbox"
-              class="toggle toggle-success"
+              class="kr-toggle-success"
             />
           </label>
 
@@ -170,7 +170,7 @@
             <input
               v-model="rewardStore.rewardForm.isMature"
               type="checkbox"
-              class="toggle toggle-warning"
+              class="kr-toggle-warning"
             />
           </label>
         </div>

--- a/components/scenarios/add-scenario.vue
+++ b/components/scenarios/add-scenario.vue
@@ -126,7 +126,7 @@
             <input
               v-model="scenarioStore.scenarioForm.isPublic"
               type="checkbox"
-              class="toggle toggle-success"
+              class="kr-toggle-success"
             />
           </label>
 
@@ -135,7 +135,7 @@
             <input
               v-model="scenarioStore.scenarioForm.isMature"
               type="checkbox"
-              class="toggle toggle-warning"
+              class="kr-toggle-warning"
             />
           </label>
         </div>

--- a/components/screenfx/animation-selector.vue
+++ b/components/screenfx/animation-selector.vue
@@ -84,7 +84,7 @@
       </span>
 
       <input
-        class="toggle toggle-primary shrink-0"
+        class="kr-toggle-primary shrink-0"
         type="checkbox"
         :checked="settings.adaptive"
         @change="setAdaptive"

--- a/components/servers/add-checkpoint.vue
+++ b/components/servers/add-checkpoint.vue
@@ -202,7 +202,7 @@
         <input
           v-model="form.isMature"
           type="checkbox"
-          class="toggle toggle-warning"
+          class="kr-toggle-warning"
         />
 
         <span class="kr-label-bold">Mature resource</span>

--- a/components/ui/ui-gallery.vue
+++ b/components/ui/ui-gallery.vue
@@ -463,7 +463,7 @@
               <span class="text-smart-compact">Checkbox</span>
             </label>
             <label class="flex items-center gap-3">
-              <input type="checkbox" class="toggle toggle-primary" checked />
+              <input type="checkbox" class="kr-toggle-primary" checked />
               <span class="text-smart-compact">Toggle</span>
             </label>
             <label class="flex items-center gap-3">

--- a/components/user/account-settings.vue
+++ b/components/user/account-settings.vue
@@ -145,7 +145,7 @@
             </span>
             <input
               type="checkbox"
-              class="toggle toggle-primary"
+              class="kr-toggle-primary"
               :checked="consent.isPublic"
               :disabled="account.isSaving"
               @change="onConsentToggle('isPublic', $event)"
@@ -161,7 +161,7 @@
             </span>
             <input
               type="checkbox"
-              class="toggle toggle-primary"
+              class="kr-toggle-primary"
               :checked="consent.showMature"
               :disabled="account.isSaving"
               @change="onConsentToggle('showMature', $event)"
@@ -181,7 +181,7 @@
             </span>
             <input
               type="checkbox"
-              class="toggle toggle-primary"
+              class="kr-toggle-primary"
               :checked="consent.listInDirectory"
               :disabled="account.isSaving"
               @change="onConsentToggle('listInDirectory', $event)"
@@ -197,7 +197,7 @@
             </span>
             <input
               type="checkbox"
-              class="toggle toggle-primary"
+              class="kr-toggle-primary"
               :checked="consent.allowFriendRequests"
               :disabled="account.isSaving"
               @change="onConsentToggle('allowFriendRequests', $event)"

--- a/components/user/dashboard-maturity-preference.vue
+++ b/components/user/dashboard-maturity-preference.vue
@@ -10,7 +10,7 @@
 
     <input
       type="checkbox"
-      class="toggle toggle-warning shrink-0"
+      class="kr-toggle-warning shrink-0"
       :checked="showDashboardMaturityToggle"
       @change="onChange"
     />

--- a/components/user/user-dashboard.vue
+++ b/components/user/user-dashboard.vue
@@ -133,7 +133,7 @@
 
                 <input
                   type="checkbox"
-                  class="toggle toggle-warning shrink-0"
+                  class="kr-toggle-warning shrink-0"
                   :checked="showDashboardMaturityToggle"
                   @change="onDashboardMaturityToggleChange"
                 />
@@ -282,7 +282,7 @@
                     </span>
                     <input
                       type="checkbox"
-                      class="toggle toggle-warning"
+                      class="kr-toggle-warning"
                       :checked="showMature"
                       :disabled="accountStore.isSaving"
                       @change="onMatureToggle"

--- a/pages/admin/scene-animator.vue
+++ b/pages/admin/scene-animator.vue
@@ -125,7 +125,7 @@
               <input
                 v-model="store.isMature"
                 type="checkbox"
-                class="toggle toggle-warning"
+                class="kr-toggle-warning"
                 :disabled="store.loading || store.queueing"
                 @change="onMaturityChange"
               />

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -245,7 +245,7 @@
             <input
               v-model="loop"
               type="checkbox"
-              class="toggle toggle-accent"
+              class="kr-toggle-accent"
             />
             <span class="kr-text-faded-sm">
               {{ loop ? 'Seamless loop' : 'Play once' }}

--- a/utils/scripts/codemods/kr_class_frequency_survey.py
+++ b/utils/scripts/codemods/kr_class_frequency_survey.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Full-repo class-frequency survey for the kr-* consistency umbrella
+(interface-vision t-104).
+
+Read-only reporting tool -- makes no code changes. Slice 245's kaizen note
+called for "a fresh full-repo class-frequency survey outside all now-closed
+families" as the input to picking slice 246's target, rather than
+re-surveying an already-closed family. This walks every static
+`class="..."` attribute (never `:class`/`v-bind:class` bindings, same
+CLASS_ATTR guard every kr-* codemod uses) under components/ and pages/,
+counts how often each exact multi-token class-string combination repeats
+across distinct files, and excludes any combination that already contains
+a `kr-` token (already migrated onto a shared primitive) or a Vue/Nuxt
+structural class known not to be a hand-rolled utility combo.
+
+Usage:
+    python3 utils/scripts/codemods/kr_class_frequency_survey.py [--min-files N] [--min-tokens N]
+
+Output: candidate exact class-string combos sorted by (distinct file count
+desc, total occurrence count desc), each with its file list, for a human
+(or the next slice) to pick the next well-bounded family from.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from pathlib import Path
+
+from _class_attr import CLASS_ATTR
+
+ROOTS = ["components", "pages", "layouts"]
+
+# Tokens that make a class string structural/dynamic-flavored rather than a
+# hand-rolled utility combo worth migrating -- skip combos containing these.
+SKIP_PREFIXES = ("kr-",)
+SKIP_EXACT = {"", }
+
+
+def iter_vue_files(repo_root: Path):
+    for root_name in ROOTS:
+        root = repo_root / root_name
+        if not root.exists():
+            continue
+        yield from root.rglob("*.vue")
+
+
+LAYOUT_PREFIXES = (
+    "flex",
+    "grid",
+    "gap",
+    "items-",
+    "justify-",
+    "content-",
+    "self-",
+    "wrap",
+    "shrink",
+    "grow",
+    "w-",
+    "h-",
+    "min-w",
+    "min-h",
+    "max-w",
+    "max-h",
+    "p-",
+    "px-",
+    "py-",
+    "pt-",
+    "pb-",
+    "pl-",
+    "pr-",
+    "m-",
+    "mx-",
+    "my-",
+    "mt-",
+    "mb-",
+    "ml-",
+    "mr-",
+    "space-",
+    "order-",
+    "col-",
+    "row-",
+    "hidden",
+    "block",
+    "inline",
+    "absolute",
+    "relative",
+    "static",
+    "sticky",
+    "top-",
+    "bottom-",
+    "left-",
+    "right-",
+    "inset-",
+    "z-",
+    "overflow-",
+    "sm:",
+    "md:",
+    "lg:",
+    "xl:",
+    "2xl:",
+)
+
+
+def is_layout_only(tokens: tuple[str, ...]) -> bool:
+    return all(any(t == p or t.startswith(p) for p in LAYOUT_PREFIXES) for t in tokens)
+
+
+def canonical_key(classes: str, layout_only: bool = False) -> tuple[str, ...] | None:
+    tokens = classes.split()
+    if len(tokens) < 2:
+        return None
+    if any(t.startswith(SKIP_PREFIXES) or t in SKIP_EXACT for t in tokens):
+        return None
+    key = tuple(sorted(tokens))
+    if not layout_only and is_layout_only(key):
+        return None
+    return key
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--min-files", type=int, default=4)
+    parser.add_argument("--min-tokens", type=int, default=2)
+    parser.add_argument("--top", type=int, default=40)
+    parser.add_argument(
+        "--layout-only",
+        action="store_true",
+        help="include pure layout combos (flex/gap/items/etc) instead of excluding them",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[3]
+    combo_files: dict[tuple[str, ...], set[Path]] = defaultdict(set)
+    combo_count: dict[tuple[str, ...], int] = defaultdict(int)
+
+    for path in iter_vue_files(repo_root):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for match in CLASS_ATTR.finditer(text):
+            key = canonical_key(match.group(1), layout_only=args.layout_only)
+            if key is None or len(key) < args.min_tokens:
+                continue
+            combo_files[key].add(path)
+            combo_count[key] += 1
+
+    candidates = [
+        (key, len(files), combo_count[key], files)
+        for key, files in combo_files.items()
+        if len(files) >= args.min_files
+    ]
+    candidates.sort(key=lambda c: (c[1], c[2]), reverse=True)
+
+    for key, nfiles, ntotal, files in candidates[: args.top]:
+        rel_files = sorted(str(f.relative_to(repo_root)) for f in files)
+        print(f"{nfiles} files / {ntotal} occurrences :: {' '.join(key)}")
+        for f in rel_files[:6]:
+            print(f"    {f}")
+        if len(rel_files) > 6:
+            print(f"    ... and {len(rel_files) - 6} more")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/scripts/codemods/kr_toggle_codemod.py
+++ b/utils/scripts/codemods/kr_toggle_codemod.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Find or migrate hand-rolled kr-toggle-{warning,primary,success,accent,
+secondary,error} (the sizeless, colored DaisyUI toggle base) toggles.
+
+Dry-run is the default. Pass --write to update matching Vue files in place.
+Only the approved sizeless-colored toggle shapes are touched (`toggle
+toggle-warning`, `toggle toggle-primary`, `toggle toggle-success`, `toggle
+toggle-accent`, `toggle toggle-secondary`, `toggle toggle-error`), and only
+in static `class="..."` attributes -- never `:class`/`v-bind:class`
+bindings, and regardless of the base tokens' order in the source. A source
+that already carries the target primitive, or is missing either base
+token, is left untouched. Extra tokens beyond the base set (shrink-0,
+ml-auto, ...) are preserved verbatim after the primitive class, matching
+the kr-badge-ghost/kr-badge-outline subset-match convention -- they're
+plain Tailwind utilities layered on top, not another component-root class.
+
+Picked from a fresh full-repo class-frequency survey (slice 245's kaizen
+note: "not a re-survey of an already-closed family") as the largest
+well-bounded pool left outside every family already closed (kr-text-*,
+kr-icon-*, kr-input-*, kr-btn-*, kr-badge-*, kr-label-row). This slice
+deliberately covers only the sizeless base -- `toggle-sm`/`toggle-xs`
+sized+colored combinations (e.g. `toggle toggle-sm toggle-warning`, ~15
+more occurrences) are a distinct, separately-bounded shape left for a
+future slice, same as `.kr-badge-ghost`/`.kr-badge-outline` were opened
+after their own `-sm`/`-xs` sized siblings already existed.
+
+FAMILIES is ordered by occurrence count, most common first; order among
+entries doesn't affect correctness here since no base set is a subset of
+another's (each carries a distinct color token).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+FAMILIES = [
+    ("kr-toggle-warning", {"toggle", "toggle-warning"}),
+    ("kr-toggle-primary", {"toggle", "toggle-primary"}),
+    ("kr-toggle-success", {"toggle", "toggle-success"}),
+    ("kr-toggle-accent", {"toggle", "toggle-accent"}),
+    ("kr-toggle-secondary", {"toggle", "toggle-secondary"}),
+    ("kr-toggle-error", {"toggle", "toggle-error"}),
+]
+
+# The bare {toggle, toggle-<color>} base sets are small enough to also
+# appear inside a sized combination (`toggle toggle-sm toggle-warning`).
+# Those carry a `toggle-sm`/`toggle-xs` extra token, which is exactly the
+# separately-bounded sized shape called out in the module docstring as out
+# of scope for this slice -- bound each family to only the specific
+# extra-token shapes actually audited for this slice (an exact match, or a
+# plain `shrink-0`), the same way kr-badge-ghost's first slice bounded its
+# own extras before a follow-up slice individually audited the rest.
+BOUNDED_EXTRAS: dict[str, set[frozenset[str]]] = {
+    name: {frozenset(), frozenset({"shrink-0"})} for name, _ in FAMILIES
+}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    for primitive, base_tokens in FAMILIES:
+        if primitive in tokens or not base_tokens.issubset(tokens):
+            continue
+        remaining = [token for token in tokens if token not in base_tokens]
+        if exact_only and remaining:
+            continue
+        allowed = BOUNDED_EXTRAS.get(primitive)
+        if allowed is not None and frozenset(remaining) not in allowed:
+            continue
+        return " ".join([primitive, *remaining])
+    return None
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved).",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        # newline="" preserves the file's original line endings verbatim
+        # (see kr_badge_codemod.py for the CRLF regression this guards
+        # against).
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-toggle-* {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Task
interface-vision/t-104 (kr-* consistency umbrella): slice 246 (kind: software)

### What changed / what I produced
- Added `utils/scripts/codemods/kr_class_frequency_survey.py`: a read-only, full-repo class-frequency survey tool (excludes pure layout combos — flex/gap/items/justify/etc — since those risk the geometry changes this umbrella explicitly avoids) to find the next well-bounded family per slice 245's kaizen note ("a fresh full-repo class-frequency survey outside all now-closed families").
- Survey turned up the sizeless colored DaisyUI toggle shape (`toggle toggle-<color>`, no size modifier) as the largest well-bounded pool left outside every already-closed family (kr-text-*, kr-icon-*, kr-input-*, kr-btn-*, kr-badge-*, kr-label-row).
- Added six new CSS primitives in `assets/css/tailwind.css`: `.kr-toggle-warning`, `.kr-toggle-primary`, `.kr-toggle-success`, `.kr-toggle-accent`, `.kr-toggle-secondary`, `.kr-toggle-error` — each a plain `@apply toggle toggle-<color>`.
- Added `utils/scripts/codemods/kr_toggle_codemod.py` and migrated 32 occurrences across 17 files onto the new primitives.
- Sized variants (`toggle-sm`/`toggle-xs` + color, ~15 more occurrences) are a distinct, separately-bounded shape intentionally left for a future slice — same precedent as `.kr-badge-ghost`/`.kr-badge-outline` being opened after their own sized siblings already existed.

### How I verified
- `eslint` on all touched `.vue` files: 3 errors, all confirmed pre-existing and unrelated via `git stash` (identical errors present before this diff).
- `prettier --check` on all touched files (including `tailwind.css`): 10 files + `tailwind.css` flagged, all confirmed pre-existing drift via `git stash` (this repo has no CI-enforced prettier check).
- `npm run test` (vue-tsc --noEmit): clean, exit 0.
- `npm run test:layout-contract`: holds, no new violations. It reports a pre-existing, unrelated `animation-manager.vue` viewport-grid improvement (same one noted in slice 245's TALKBACK) — confirmed via `git stash` that it predates this diff; left untouched rather than folding an unrelated ratchet into this PR's scope.

### Stakes
reversible

### Kaizen suggestion
Next slice: migrate the `toggle-sm`/`toggle-xs` sized+colored toggle combinations (e.g. `toggle toggle-sm toggle-warning`, `toggle toggle-xs toggle-primary`) onto matching sized primitives, mirroring how `kr-badge-*-sm`/`-xs` siblings were built out after the bare colors.

### Notes for reviewer
No color/behavior/API/schema/route/geometry change — every primitive resolves to the exact same DaisyUI utility classes it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3rNgxxrAQ62HdyHsycrou


---
_Generated by [Claude Code](https://claude.ai/code/session_01T3rNgxxrAQ62HdyHsycrou)_