### PR TITLE
feat(css): open kr-toggle-*-sm/-xs sized primitives (interface-vision t-134)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1466,6 +1466,90 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply toggle toggle-error;
   }
 
+  /* First sized-colored toggle primitive (interface-vision t-134, kaizen
+   * from t-104 slice 246): the small, primary-colored DaisyUI toggle --
+   * `toggle toggle-sm toggle-primary` -- previously hand-rolled in 4 files
+   * (4 occurrences). Distinct from .kr-toggle-primary (the sizeless base
+   * above); this is its -sm sized sibling, same relationship as
+   * .kr-checkbox-primary-sm to .kr-checkbox-primary. */
+  .kr-toggle-primary-sm {
+    @apply toggle toggle-sm toggle-primary;
+  }
+
+  /* The extra-small counterpart to .kr-toggle-primary-sm (same slice):
+   * `toggle toggle-xs toggle-primary`, previously hand-rolled in 4 files (4
+   * occurrences). */
+  .kr-toggle-primary-xs {
+    @apply toggle toggle-xs toggle-primary;
+  }
+
+  /* The warning-colored, small counterpart to .kr-toggle-primary-sm (same
+   * slice): `toggle toggle-sm toggle-warning`, previously hand-rolled in 4
+   * files (4 occurrences). */
+  .kr-toggle-warning-sm {
+    @apply toggle toggle-sm toggle-warning;
+  }
+
+  /* The accent-colored, extra-small counterpart to .kr-toggle-primary-sm
+   * (same slice): `toggle toggle-xs toggle-accent`, previously hand-rolled
+   * in 3 files (4 occurrences). */
+  .kr-toggle-accent-xs {
+    @apply toggle toggle-xs toggle-accent;
+  }
+
+  /* The warning-colored, extra-small counterpart to .kr-toggle-primary-sm
+   * (same slice): `toggle toggle-xs toggle-warning`, previously
+   * hand-rolled in 3 files (3 occurrences). */
+  .kr-toggle-warning-xs {
+    @apply toggle toggle-xs toggle-warning;
+  }
+
+  /* The success-colored, small counterpart to .kr-toggle-primary-sm (same
+   * slice): `toggle toggle-sm toggle-success`, previously hand-rolled in 3
+   * files (3 occurrences). */
+  .kr-toggle-success-sm {
+    @apply toggle toggle-sm toggle-success;
+  }
+
+  /* The accent-colored, small counterpart to .kr-toggle-primary-sm (same
+   * slice): `toggle toggle-sm toggle-accent`, previously hand-rolled in 2
+   * files (2 occurrences). */
+  .kr-toggle-accent-sm {
+    @apply toggle toggle-sm toggle-accent;
+  }
+
+  /* The secondary-colored, extra-small counterpart to .kr-toggle-primary-sm
+   * (same slice): `toggle toggle-xs toggle-secondary`, previously
+   * hand-rolled in 2 files (2 occurrences). */
+  .kr-toggle-secondary-xs {
+    @apply toggle toggle-xs toggle-secondary;
+  }
+
+  /* The success-colored, extra-small counterpart to .kr-toggle-primary-sm
+   * (same slice): `toggle toggle-xs toggle-success`, previously
+   * hand-rolled in 2 files (2 occurrences). */
+  .kr-toggle-success-xs {
+    @apply toggle toggle-xs toggle-success;
+  }
+
+  /* The error-colored, extra-small counterpart to .kr-toggle-primary-sm
+   * (same slice): `toggle toggle-xs toggle-error`, previously hand-rolled
+   * in 1 file (1 occurrence). */
+  .kr-toggle-error-xs {
+    @apply toggle toggle-xs toggle-error;
+  }
+
+  /* The secondary-colored, small counterpart to .kr-toggle-primary-sm (same
+   * slice): `toggle toggle-sm toggle-secondary`, previously hand-rolled in
+   * 1 file (1 occurrence). Closes the toggle-sm/toggle-xs sized+colored
+   * survey (interface-vision t-134) -- every color/size combination
+   * observed at survey time (11 of the 12 possible color x size pairs;
+   * toggle-sm toggle-error had zero occurrences) now has a matching
+   * primitive. */
+  .kr-toggle-secondary-sm {
+    @apply toggle toggle-sm toggle-secondary;
+  }
+
   /* First badge-family primitive (interface-vision t-104 slice 109): the
    * small, ghost-styled DaisyUI badge -- `badge badge-ghost badge-sm` --
    * the single most common hand-rolled badge shape in the codebase (31

--- a/components/art/art-gallery.vue
+++ b/components/art/art-gallery.vue
@@ -115,7 +115,7 @@
           <input
             v-model="showMature"
             type="checkbox"
-            class="toggle toggle-warning toggle-xs"
+            class="kr-toggle-warning-xs"
           />
         </label>
 

--- a/components/art/art-interact.vue
+++ b/components/art/art-interact.vue
@@ -289,7 +289,7 @@
                 <input
                   v-model="editForm.isPublic"
                   type="checkbox"
-                  class="toggle toggle-success toggle-sm"
+                  class="kr-toggle-success-sm"
                 />
               </label>
 
@@ -298,7 +298,7 @@
                 <input
                   v-model="editForm.isMature"
                   type="checkbox"
-                  class="toggle toggle-warning toggle-sm"
+                  class="kr-toggle-warning-sm"
                 />
               </label>
             </div>
@@ -434,7 +434,7 @@
                     </span>
                     <input
                       type="checkbox"
-                      class="toggle toggle-secondary toggle-sm"
+                      class="kr-toggle-secondary-sm"
                       :checked="imageCollectionIds.includes(collection.id)"
                       :disabled="isCollectionSaving"
                       @change="toggleCollection(collection.id)"

--- a/components/art/art-styler.vue
+++ b/components/art/art-styler.vue
@@ -508,7 +508,7 @@
             <input
               v-model="useNegative"
               type="checkbox"
-              class="toggle toggle-primary toggle-xs"
+              class="kr-toggle-primary-xs"
               :disabled="isGenerating"
             />
             <span class="kr-label-xs-semibold"> Inherit negative prompt </span>
@@ -517,7 +517,7 @@
             <input
               v-model="isPublic"
               type="checkbox"
-              class="toggle toggle-success toggle-xs"
+              class="kr-toggle-success-xs"
               :disabled="isGenerating"
             />
             <span class="kr-label-xs-semibold">Public</span>

--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -153,7 +153,7 @@
                     <input
                       v-model="form.loop"
                       type="checkbox"
-                      class="toggle toggle-accent toggle-sm"
+                      class="kr-toggle-accent-sm"
                     />
                     <span>{{ form.loop ? 'Loop' : 'Play once' }}</span>
                   </span>

--- a/components/art/image-upload.vue
+++ b/components/art/image-upload.vue
@@ -286,7 +286,7 @@
               <input
                 v-model="imageForm.cfgHalf"
                 type="checkbox"
-                class="toggle toggle-primary toggle-xs"
+                class="kr-toggle-primary-xs"
                 :disabled="isUploading"
               />
               <span class="kr-label-xs-semibold">CFG + 0.5</span>
@@ -295,7 +295,7 @@
               <input
                 v-model="imageForm.isPublic"
                 type="checkbox"
-                class="toggle toggle-success toggle-xs"
+                class="kr-toggle-success-xs"
                 :disabled="isUploading"
               />
               <span class="kr-label-xs-semibold">Public</span>
@@ -304,7 +304,7 @@
               <input
                 v-model="imageForm.isMature"
                 type="checkbox"
-                class="toggle toggle-warning toggle-xs"
+                class="kr-toggle-warning-xs"
                 :disabled="isUploading"
               />
               <span class="kr-label-xs-semibold">Mature</span>

--- a/components/bots/bot-gallery.vue
+++ b/components/bots/bot-gallery.vue
@@ -503,7 +503,7 @@
               <input
                 v-model="showMature"
                 type="checkbox"
-                class="toggle toggle-accent toggle-xs"
+                class="kr-toggle-accent-xs"
               />
             </label>
 

--- a/components/content-visibility-controls.vue
+++ b/components/content-visibility-controls.vue
@@ -27,7 +27,7 @@
         <input
           :checked="isMature"
           type="checkbox"
-          class="toggle toggle-warning toggle-sm"
+          class="kr-toggle-warning-sm"
           :disabled="disabled"
           @change="onMatureChange"
         />
@@ -45,7 +45,7 @@
         <input
           :checked="isPublic"
           type="checkbox"
-          class="toggle toggle-success toggle-sm"
+          class="kr-toggle-success-sm"
           :disabled="disabled"
           @change="onPublicChange"
         />

--- a/components/cthulhuquarium/cthulhuquarium-game.vue
+++ b/components/cthulhuquarium/cthulhuquarium-game.vue
@@ -841,7 +841,7 @@
         <label class="flex cursor-pointer items-center gap-2">
           <input
             type="checkbox"
-            class="toggle toggle-success toggle-sm"
+            class="kr-toggle-success-sm"
             :checked="tankStore.tank?.isPublic ?? false"
             :disabled="visibilitySaving"
             @change="onToggleVisibility"

--- a/components/facets/facet-gallery.vue
+++ b/components/facets/facet-gallery.vue
@@ -41,7 +41,7 @@
         <input
           v-model="artOnly"
           type="checkbox"
-          class="toggle toggle-secondary toggle-xs"
+          class="kr-toggle-secondary-xs"
         />
         Illustrated only
       </label>

--- a/components/facets/facet-profile-editor.vue
+++ b/components/facets/facet-profile-editor.vue
@@ -159,7 +159,7 @@
         <input
           v-model="form.isRandomizable"
           type="checkbox"
-          class="toggle toggle-secondary toggle-xs"
+          class="kr-toggle-secondary-xs"
         />
         Available to randomizers
       </label>
@@ -167,7 +167,7 @@
         <input
           v-model="form.artRequired"
           type="checkbox"
-          class="toggle toggle-accent toggle-xs"
+          class="kr-toggle-accent-xs"
         />
         Artwork expected
       </label>
@@ -175,7 +175,7 @@
         <input
           v-model="form.isPublic"
           type="checkbox"
-          class="toggle toggle-primary toggle-xs"
+          class="kr-toggle-primary-xs"
         />
         Public
       </label>
@@ -192,7 +192,7 @@
         <input
           v-model="form.allowReviews"
           type="checkbox"
-          class="toggle toggle-accent toggle-xs"
+          class="kr-toggle-accent-xs"
         />
         Allow reviews
       </label>
@@ -200,7 +200,7 @@
         <input
           v-model="form.isMature"
           type="checkbox"
-          class="toggle toggle-warning toggle-xs"
+          class="kr-toggle-warning-xs"
         />
         Mature
       </label>

--- a/components/navigation/maturity-toggle.vue
+++ b/components/navigation/maturity-toggle.vue
@@ -38,7 +38,7 @@
           <span v-if="isUpdating" class="kr-spinner-xs" />
           <input
             type="checkbox"
-            class="toggle toggle-warning toggle-sm"
+            class="kr-toggle-warning-sm"
             :checked="showMature"
             :disabled="isUpdating"
             :aria-label="buttonLabel"

--- a/components/newsfeed/newsfeed-filters.vue
+++ b/components/newsfeed/newsfeed-filters.vue
@@ -178,7 +178,7 @@
       <label class="kr-text-bold-xs flex w-fit items-center gap-2 pt-1">
         <input
           type="checkbox"
-          class="toggle toggle-primary toggle-sm"
+          class="kr-toggle-primary-sm"
           :checked="feedPreferenceStore.labelsVisible"
           @change="
             feedPreferenceStore.setLabelsVisible(

--- a/components/newsfeed/newsfeed-preferences.vue
+++ b/components/newsfeed/newsfeed-preferences.vue
@@ -60,7 +60,7 @@
           </button>
           <input
             type="checkbox"
-            class="toggle toggle-primary toggle-sm ml-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            class="kr-toggle-primary-sm ml-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
             checked
             :aria-label="`Disable ${feed.title}`"
             @change="feedPreferenceStore.disableFeed(feed.slug)"

--- a/components/pages/for-you-manager.vue
+++ b/components/pages/for-you-manager.vue
@@ -107,7 +107,7 @@
                   <input
                     v-model="showPausedProjects"
                     type="checkbox"
-                    class="toggle toggle-warning toggle-sm"
+                    class="kr-toggle-warning-sm"
                   />
                   <span>Show paused projects</span>
                   <span class="kr-badge-ghost-sm rounded-lg">

--- a/components/rewards/reward-gallery.vue
+++ b/components/rewards/reward-gallery.vue
@@ -375,7 +375,7 @@
               <input
                 v-model="showMature"
                 type="checkbox"
-                class="toggle toggle-accent toggle-xs"
+                class="kr-toggle-accent-xs"
               />
             </label>
 

--- a/components/scenarios/scenario-gallery.vue
+++ b/components/scenarios/scenario-gallery.vue
@@ -341,7 +341,7 @@
                 <input
                   v-model="showMature"
                   type="checkbox"
-                  class="toggle toggle-accent toggle-sm"
+                  class="kr-toggle-accent-sm"
                 />
               </label>
             </div>

--- a/components/user/user-manager-directory.vue
+++ b/components/user/user-manager-directory.vue
@@ -115,7 +115,7 @@
             <td class="text-center">
               <input
                 type="checkbox"
-                class="toggle toggle-xs toggle-primary"
+                class="kr-toggle-primary-xs"
                 :checked="u.showMature"
                 :disabled="store.isSaving"
                 @change="onMature(u.id, $event)"
@@ -124,7 +124,7 @@
             <td class="text-center">
               <input
                 type="checkbox"
-                class="toggle toggle-xs toggle-error"
+                class="kr-toggle-error-xs"
                 :checked="u.isRestricted"
                 :disabled="store.isSaving"
                 :title="
@@ -197,7 +197,7 @@
               <input
                 v-model="createForm.showMature"
                 type="checkbox"
-                class="toggle toggle-sm toggle-primary"
+                class="kr-toggle-primary-sm"
               />
             </label>
           </div>

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -114,7 +114,7 @@
             >
               <input
                 type="checkbox"
-                class="toggle toggle-sm toggle-primary"
+                class="kr-toggle-primary-sm"
                 :checked="triageStore.hideConfirmed"
                 @change="handleHideConfirmed"
               />

--- a/utils/scripts/codemods/kr_toggle_codemod.py
+++ b/utils/scripts/codemods/kr_toggle_codemod.py
@@ -1,32 +1,44 @@
 #!/usr/bin/env python3
 """Find or migrate hand-rolled kr-toggle-{warning,primary,success,accent,
-secondary,error} (the sizeless, colored DaisyUI toggle base) toggles.
+secondary,error} (colored DaisyUI toggles, sizeless and -sm/-xs sized)
+onto their shared primitives.
 
 Dry-run is the default. Pass --write to update matching Vue files in place.
-Only the approved sizeless-colored toggle shapes are touched (`toggle
-toggle-warning`, `toggle toggle-primary`, `toggle toggle-success`, `toggle
-toggle-accent`, `toggle toggle-secondary`, `toggle toggle-error`), and only
-in static `class="..."` attributes -- never `:class`/`v-bind:class`
-bindings, and regardless of the base tokens' order in the source. A source
-that already carries the target primitive, or is missing either base
-token, is left untouched. Extra tokens beyond the base set (shrink-0,
-ml-auto, ...) are preserved verbatim after the primitive class, matching
-the kr-badge-ghost/kr-badge-outline subset-match convention -- they're
-plain Tailwind utilities layered on top, not another component-root class.
+Only the approved colored toggle shapes are touched (the sizeless base --
+`toggle toggle-warning`, `toggle toggle-primary`, `toggle toggle-success`,
+`toggle toggle-accent`, `toggle toggle-secondary`, `toggle toggle-error` --
+and the -sm/-xs sized siblings, e.g. `toggle toggle-sm toggle-primary`),
+and only in static `class="..."` attributes -- never `:class`/
+`v-bind:class` bindings, and regardless of the base tokens' order in the
+source. A source that already carries the target primitive, or is missing
+any base token, is left untouched. Extra tokens beyond the base set
+(shrink-0, ml-auto, ...) are preserved verbatim after the primitive class,
+matching the kr-badge-ghost/kr-badge-outline subset-match convention --
+they're plain Tailwind utilities layered on top, not another
+component-root class.
 
-Picked from a fresh full-repo class-frequency survey (slice 245's kaizen
-note: "not a re-survey of an already-closed family") as the largest
-well-bounded pool left outside every family already closed (kr-text-*,
-kr-icon-*, kr-input-*, kr-btn-*, kr-badge-*, kr-label-row). This slice
-deliberately covers only the sizeless base -- `toggle-sm`/`toggle-xs`
-sized+colored combinations (e.g. `toggle toggle-sm toggle-warning`, ~15
-more occurrences) are a distinct, separately-bounded shape left for a
-future slice, same as `.kr-badge-ghost`/`.kr-badge-outline` were opened
-after their own `-sm`/`-xs` sized siblings already existed.
+The sizeless families were picked from a fresh full-repo class-frequency
+survey (slice 245's kaizen note: "not a re-survey of an already-closed
+family") as the largest well-bounded pool left outside every family
+already closed (kr-text-*, kr-icon-*, kr-input-*, kr-btn-*, kr-badge-*,
+kr-label-row). That slice (t-104 slice 246) deliberately left the
+`toggle-sm`/`toggle-xs` sized+colored combinations out of scope; this
+module now also covers them (interface-vision/t-134), same as
+`.kr-badge-ghost`/`.kr-badge-outline` being opened after their own
+`-sm`/`-xs` sized siblings already existed.
 
-FAMILIES is ordered by occurrence count, most common first; order among
-entries doesn't affect correctness here since no base set is a subset of
-another's (each carries a distinct color token).
+FAMILIES lists the sized (more specific) families first, then the
+sizeless ones. This matters for correctness, not just readability: the
+sizeless base token set (`{toggle, toggle-<color>}`) is a strict subset
+of its own sized sibling's (`{toggle, toggle-sm, toggle-<color>}`), so a
+sized source would also match the sizeless family if that family were
+tried first -- `toggle-sm`/`toggle-xs` would then be captured as an
+"extra" token rather than recognized as part of a more specific shape.
+Trying every sized family before any sizeless one avoids that regardless
+of BOUNDED_EXTRAS contents. Within each specificity tier, families are
+ordered by occurrence count, most common first; order among ties doesn't
+affect correctness since no two same-tier base sets are subsets of one
+another (each carries a distinct color, and/or size, token).
 """
 
 from __future__ import annotations
@@ -36,7 +48,32 @@ import re
 from pathlib import Path
 from _class_attr import CLASS_ATTR
 
-FAMILIES = [
+COLORS = ["warning", "primary", "success", "accent", "secondary", "error"]
+
+# (primitive, size, color) ordered by occurrence count observed at t-134
+# survey time, most common first. toggle-sm toggle-error had zero observed
+# occurrences, so it's intentionally absent -- add it if a future audit
+# finds one, following this same naming/ordering convention.
+_SIZED_ORDER = [
+    ("primary", "sm"),
+    ("primary", "xs"),
+    ("warning", "sm"),
+    ("accent", "xs"),
+    ("warning", "xs"),
+    ("success", "sm"),
+    ("accent", "sm"),
+    ("secondary", "xs"),
+    ("success", "xs"),
+    ("error", "xs"),
+    ("secondary", "sm"),
+]
+
+SIZED_FAMILIES = [
+    (f"kr-toggle-{color}-{size}", {"toggle", f"toggle-{size}", f"toggle-{color}"})
+    for color, size in _SIZED_ORDER
+]
+
+SIZELESS_FAMILIES = [
     ("kr-toggle-warning", {"toggle", "toggle-warning"}),
     ("kr-toggle-primary", {"toggle", "toggle-primary"}),
     ("kr-toggle-success", {"toggle", "toggle-success"}),
@@ -45,17 +82,28 @@ FAMILIES = [
     ("kr-toggle-error", {"toggle", "toggle-error"}),
 ]
 
-# The bare {toggle, toggle-<color>} base sets are small enough to also
-# appear inside a sized combination (`toggle toggle-sm toggle-warning`).
-# Those carry a `toggle-sm`/`toggle-xs` extra token, which is exactly the
-# separately-bounded sized shape called out in the module docstring as out
-# of scope for this slice -- bound each family to only the specific
-# extra-token shapes actually audited for this slice (an exact match, or a
-# plain `shrink-0`), the same way kr-badge-ghost's first slice bounded its
-# own extras before a follow-up slice individually audited the rest.
+FAMILIES = [*SIZED_FAMILIES, *SIZELESS_FAMILIES]
+
+# Bound each family to only the specific extra-token shapes actually
+# audited (an exact match, or a plain `shrink-0`), the same way
+# kr-badge-ghost's first slice bounded its own extras before a follow-up
+# slice individually audited the rest. One sized occurrence
+# (newsfeed-preferences.vue's toggle-sm toggle-primary) carries a distinct
+# extra-token shape audited for t-134, allowed explicitly below.
 BOUNDED_EXTRAS: dict[str, set[frozenset[str]]] = {
     name: {frozenset(), frozenset({"shrink-0"})} for name, _ in FAMILIES
 }
+BOUNDED_EXTRAS["kr-toggle-primary-sm"].add(
+    frozenset(
+        {
+            "ml-1",
+            "focus-visible:outline",
+            "focus-visible:outline-2",
+            "focus-visible:outline-offset-2",
+            "focus-visible:outline-primary",
+        }
+    )
+)
 
 
 def migrate_classes(classes: str, exact_only: bool) -> str | None:


### PR DESCRIPTION
### Task
interface-vision/t-134: migrate the toggle-sm/toggle-xs sized+colored toggle combinations onto matching kr-toggle-*-sm/-xs primitives (kind: software)

### What changed / what I produced
- Added 11 sized-colored toggle primitives to `assets/css/tailwind.css` (`.kr-toggle-<color>-sm`/`-xs`), covering every color/size pair actually observed in the repo (11 of the 12 possible `color × size` pairs — `toggle-sm toggle-error` had zero occurrences, intentionally absent per the codemod's own comment).
- Extended `utils/scripts/codemods/kr_toggle_codemod.py` with the new sized `FAMILIES` entries, ordered most-specific-first ahead of the existing sizeless entries (required for correctness: the sizeless base token set is a strict subset of its sized sibling's, so trying sizeless first would misclassify a sized source's size token as an "extra").
- Added a `BOUNDED_EXTRAS` allowance for the one occurrence (`newsfeed-preferences.vue`) that carries extra `focus-visible:*`/`ml-1` utility tokens alongside the base shape, matching the existing `kr-badge-ghost` precedent for bounding real extra-token shapes.
- Migrated all 30 discovered occurrences across 18 files via `--write`. A dry run afterward reports 0 remaining candidates. No color/behavior/API/schema/route/geometry change — purely a class-string substitution onto shared primitives, same convention as every other slice of this recurring umbrella (interface-vision/t-104).

### How I verified
- `python3 utils/scripts/codemods/kr_toggle_codemod.py` (dry run, before and after `--write`): 30 candidates found and migrated; 0 remaining after.
- `npx vue-tsc --noEmit`: clean.
- `npx eslint` on every touched file: 3 `@typescript-eslint/no-dynamic-delete` errors on `art-gallery.vue`/`for-you-manager.vue`, confirmed pre-existing and unrelated via `git stash` (identical errors present without this diff).
- `npx prettier --check` on touched files: warnings on 5 files, confirmed pre-existing via `git stash` (identical warnings present without this diff; this repo has no CI-enforced prettier check).
- `npx tsx utils/scripts/verifyLayoutContract.ts`: contract holds, no new violations. It also reports an unrelated pre-existing `animation-manager.vue` viewport-grid improvement (2 fewer baseline entries) — left untouched, not part of this diff's scope.
- Manually diffed every migrated occurrence to confirm the correct primitive was substituted and the two genuinely colorless `toggle toggle-sm` occurrences (no color token, out of this task's scope) were correctly left untouched.

### Stakes
reversible

### Flags for Reviewer
None.

### Kaizen suggestion
`toggle-sm toggle-error` is the one color/size pair with zero current occurrences — if a future PR introduces one, follow this same naming convention (`kr-toggle-error-sm`) rather than reaching for a bespoke class. Beyond that, the interface-vision/t-104 umbrella's next step (per its own kaizen note) is a fresh full-repo class-frequency survey outside all now-closed families (kr-text-*, kr-icon-*, kr-input-*, kr-btn-*, kr-badge-*, kr-label-row, kr-toggle-*) via `kr_class_frequency_survey.py`.

### Notes for reviewer
Session: conductor scheduled agent run, interface-vision/t-134 claimed and closed in the same cycle. Conductor roadmap task set to `status: review` before this PR opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTRBd8Q74Ux7kujnmqcGnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTRBd8Q74Ux7kujnmqcGnr)_