### PR TITLE
refactor(ui): make kingdom-health grid container-responsive (interface-vision t-131)

### DIFF
--- a/components/ruler-hooked/ruler-hooked-health.vue
+++ b/components/ruler-hooked/ruler-hooked-health.vue
@@ -2,7 +2,7 @@
      Read-only kingdom-health meters (data-model.md §4). Fill-% bars, one per axis,
      using the same rangeFill idea as components/abandonware/butterfly/single-slider.vue. -->
 <template>
-  <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+  <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,14rem),1fr))] gap-2">
     <div v-for="axis in axes" :key="axis.key" class="text-xs">
       <div class="mb-0.5 flex justify-between">
         <span class="font-medium capitalize">{{ axis.key }}</span>


### PR DESCRIPTION
### Task
interface-vision/t-131: Continue the viewport-grid burn-down (slice 2 onward) (kind: software)

### What changed / what I produced
- Converted the repeating kingdom-health meter grid (`components/ruler-hooked/ruler-hooked-health.vue`) from a viewport-breakpoint grid (`grid-cols-1 gap-2 sm:grid-cols-2`) to a container-responsive auto-fit/minmax fluid grid (`grid-cols-[repeat(auto-fit,minmax(min(100%,14rem),1fr))] gap-2`), matching the pattern established by t-129/t-131's prior slices.
- No color/behavior/API/schema/route change — purely a layout-token substitution for a genuinely repeating tile list (one meter per axis).

### How I verified
- This commit was already authored and pushed to the branch by a prior session; I discovered the branch had no PR open despite the roadmap task being at `status: review`, and opened this PR so the work is reviewable and mergeable rather than stranded.
- Diff reviewed: single-line, single-file change, matches the task's described scope exactly.

### Stakes
reversible

### Flags for Reviewer
- This PR is opening previously-authored, previously-pushed work that had no PR — the roadmap task (`interface-vision/t-131`) was left at `status: review` with the branch pushed but no PR ever created in this repo. Opening it now so the work isn't lost, per AGENTS.md's stranded-branch handling.

### Notes for reviewer
Part of the ongoing viewport-grid layout-contract burn-down umbrella (interface-vision/t-104 family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKcP4ULBdFe9SAGFu6ojb7

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKcP4ULBdFe9SAGFu6ojb7)_