### PR TITLE
feat(css): fold size-full object-cover shorthand into kr-img-cover (interface-vision t-104 slice 248)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -2679,7 +2679,12 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
    * shrink-0, or other modifier folded in at any site). Purely a sizing/
    * object-fit primitive: no color and no behavior, so this is the same
    * composition-only substitution as `kr-container`/`kr-icon-*` -- no
-   * geometry or rendering change at any of the 30 sites. */
+   * geometry or rendering change at any of the 30 sites. Its `size-full
+   * object-cover` shorthand spelling (Tailwind's `size-*` sets both axes at
+   * once) was folded in as a later slice (t-104 slice 248): 14 files, 19
+   * occurrences, extra tokens (absolute/inset-0, transition/hover/
+   * motion-reduce, grayscale) preserved verbatim -- same convention as the
+   * `kr-icon-N`/`size-N` shorthand siblings. */
   .kr-img-cover {
     @apply h-full w-full object-cover;
   }

--- a/components/art/art-facet-selector.vue
+++ b/components/art/art-facet-selector.vue
@@ -36,7 +36,7 @@
           <img
             :src="facetArtwork(facet) || ''"
             :alt="`${facet.title} artwork`"
-            class="size-full object-cover"
+            class="kr-img-cover"
           />
         </span>
         {{ facet.title }}
@@ -87,7 +87,7 @@
                 v-if="facetArtwork(facet)"
                 :src="facetArtwork(facet) || ''"
                 :alt="`${facet.title} artwork`"
-                class="size-full object-cover"
+                class="kr-img-cover"
                 loading="lazy"
               />
               <Icon

--- a/components/art/art-lora-picker.vue
+++ b/components/art/art-lora-picker.vue
@@ -188,7 +188,7 @@
                   v-if="previewImage(entry.resource)"
                   :src="previewImage(entry.resource)"
                   :alt="`${loraLabel(entry.resource)} preview`"
-                  class="size-full object-cover"
+                  class="kr-img-cover"
                   loading="lazy"
                   @error="hideBrokenImage"
                 />

--- a/components/art/entity-art-manager.vue
+++ b/components/art/entity-art-manager.vue
@@ -190,7 +190,7 @@
             v-if="slide.src"
             :src="slide.src"
             :alt="slide.label"
-            class="size-full object-cover"
+            class="kr-img-cover"
           />
           <span
             v-else

--- a/components/brainstorm/brainstorm-candidate-card.vue
+++ b/components/brainstorm/brainstorm-candidate-card.vue
@@ -147,7 +147,7 @@
         <img
           :src="`/api/art/images/${imageId}/file`"
           :alt="`Generated art for ${candidate.title || 'this candidate'}`"
-          class="size-full object-cover"
+          class="kr-img-cover"
           loading="lazy"
         />
       </a>

--- a/components/characters/character-facet-picker.vue
+++ b/components/characters/character-facet-picker.vue
@@ -30,7 +30,7 @@
           <img
             :src="artwork(facet) || ''"
             :alt="`${facet.title} artwork`"
-            class="size-full object-cover"
+            class="kr-img-cover"
           />
         </span>
         <span>{{ facet.title }}</span>
@@ -65,7 +65,7 @@
               v-if="artwork(facet)"
               :src="artwork(facet) || ''"
               :alt="`${facet.title} artwork`"
-              class="size-full object-cover"
+              class="kr-img-cover"
             />
             <Icon
               v-else

--- a/components/coloring/coloring-book-studio.vue
+++ b/components/coloring/coloring-book-studio.vue
@@ -227,7 +227,7 @@
                   v-if="proposal.colorUrl"
                   :src="proposal.colorUrl"
                   :alt="`${proposal.title} color candidate`"
-                  class="size-full object-cover"
+                  class="kr-img-cover"
                   loading="lazy"
                 />
                 <div
@@ -248,7 +248,7 @@
                   v-if="proposal.bwUrl"
                   :src="proposal.bwUrl"
                   :alt="`${proposal.title} black-and-white page`"
-                  class="size-full object-cover grayscale"
+                  class="kr-img-cover grayscale"
                   loading="lazy"
                 />
                 <div

--- a/components/dreams/daily-digest-object-dialog.vue
+++ b/components/dreams/daily-digest-object-dialog.vue
@@ -60,7 +60,7 @@
                   v-if="displayImage && !imageFailed"
                   :src="displayImage"
                   :alt="`${title} artwork`"
-                  class="absolute inset-0 size-full object-cover"
+                  class="kr-img-cover absolute inset-0"
                   @error="imageFailed = true"
                 />
                 <div

--- a/components/dreams/daily-dream-object-art-workbench.vue
+++ b/components/dreams/daily-dream-object-art-workbench.vue
@@ -24,7 +24,7 @@
             :key="currentSrc"
             :src="currentSrc"
             :alt="`${title} ${selectedSlot.label}`"
-            class="absolute inset-0 size-full object-cover"
+            class="kr-img-cover absolute inset-0"
             @error="imageFailed = true"
           />
           <div

--- a/components/facets/facet-picker.vue
+++ b/components/facets/facet-picker.vue
@@ -34,7 +34,7 @@
           <img
             :src="facetArtwork(facet) || ''"
             :alt="`${facet.title} artwork`"
-            class="size-full object-cover"
+            class="kr-img-cover"
           />
         </span>
         <span>{{ facet.title }}</span>
@@ -70,7 +70,7 @@
               v-if="facetArtwork(facet)"
               :src="facetArtwork(facet) || ''"
               :alt="`${facet.title} artwork`"
-              class="size-full object-cover"
+              class="kr-img-cover"
             />
             <Icon
               v-else

--- a/components/narrative/narrative-ingredient-card.vue
+++ b/components/narrative/narrative-ingredient-card.vue
@@ -19,7 +19,7 @@
         v-if="artwork"
         :src="artwork"
         alt=""
-        class="size-full object-cover transition duration-300 group-hover:scale-105 motion-reduce:transform-none motion-reduce:transition-none"
+        class="kr-img-cover transition duration-300 group-hover:scale-105 motion-reduce:transform-none motion-reduce:transition-none"
       />
       <span
         v-else

--- a/components/rewards/reward-facet-picker.vue
+++ b/components/rewards/reward-facet-picker.vue
@@ -30,7 +30,7 @@
           <img
             :src="artwork(facet) || ''"
             :alt="`${facet.title} artwork`"
-            class="size-full object-cover"
+            class="kr-img-cover"
           />
         </span>
         <span>{{ facet.title }}</span>
@@ -65,7 +65,7 @@
               v-if="artwork(facet)"
               :src="artwork(facet) || ''"
               :alt="`${facet.title} artwork`"
-              class="size-full object-cover"
+              class="kr-img-cover"
             />
             <Icon
               v-else

--- a/components/storybook/storybook-state-panel.vue
+++ b/components/storybook/storybook-state-panel.vue
@@ -29,7 +29,7 @@
                 v-if="item.ingredient.imagePath"
                 :src="item.ingredient.imagePath"
                 alt=""
-                class="absolute inset-0 size-full object-cover"
+                class="kr-img-cover absolute inset-0"
               />
               <Icon
                 v-else

--- a/pages/admin/achievement-art.vue
+++ b/pages/admin/achievement-art.vue
@@ -83,7 +83,7 @@
                     v-if="achievement.imagePath"
                     :src="achievement.imagePath"
                     :alt="achievement.label"
-                    class="size-full object-cover"
+                    class="kr-img-cover"
                   />
                   <Icon
                     v-else

--- a/pages/admin/lora-triage.vue
+++ b/pages/admin/lora-triage.vue
@@ -190,7 +190,7 @@
               <kr-deferred-image
                 :src="previewSrc(resource)"
                 :alt="resourceLabel(resource)"
-                class="size-full object-cover"
+                class="kr-img-cover"
               />
 
               <label

--- a/utils/scripts/codemods/kr_img_cover_size_full_shorthand_codemod.py
+++ b/utils/scripts/codemods/kr_img_cover_size_full_shorthand_codemod.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Find or migrate the `size-full object-cover` Tailwind shorthand pair onto
+the existing `.kr-img-cover` primitive.
+
+`.kr-img-cover { @apply h-full w-full object-cover; }` (opened earlier in
+the interface-vision t-104 umbrella) already exists and is used at 30
+sites. `size-full` is a plain alias for `h-full w-full` (Tailwind's
+`size-*` utility sets both axes at once), so `size-full object-cover` is
+CSS-identical to `h-full w-full object-cover` -- the same primitive under
+a different source spelling, not a new shape. This is the `kr-img-cover`
+sibling of the `kr-icon-N` `size-N` shorthand codemods (slices
+242/244/245): those folded a `size-N` spelling into a bare icon-glyph
+primitive that already existed under the `h-N w-N` spelling; this does the
+same for `kr-img-cover`.
+
+Found via a fresh full-repo class-frequency survey outside every closed
+family (t-104 slice 246's kaizen note): `object-cover size-full` was the
+single largest well-bounded pool left (10 files / 14 occurrences at survey
+time; the full `class="..."` scan below finds 19 occurrences across 15
+files once combos with extra tokens, e.g. `absolute inset-0 ...` prefixes
+or a `grayscale`/`transition ...` suffix, are included).
+
+Extra tokens beyond the base pair are preserved verbatim after the
+primitive class, same subset-match convention as kr-badge-ghost/
+kr-toggle-*: they are independent utilities layered on top (positioning,
+filters, transitions), not part of the object-fit shape itself.
+
+Dry-run by default, --write to update matching Vue files in place. Only
+static `class="..."` attributes are touched, never `:class`/`v-bind:class`
+bindings (see _class_attr.py). Pass --exact-only to restrict a slice to
+sources with no extra tokens beyond the base pair itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from _class_attr import CLASS_ATTR
+
+PRIMITIVE = "kr-img-cover"
+BASE_TOKENS = {"size-full", "object-cover"}
+
+
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
+    tokens = classes.split()
+    if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
+        return None
+    remaining = [token for token in tokens if token not in BASE_TOKENS]
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Only migrate class strings that are exactly `size-full "
+        "object-cover` (no extra utility tokens preserved).",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(args.root.rglob("*.vue")):
+        if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
+            continue
+        with path.open(encoding="utf-8", newline="") as f:
+            text = f.read()
+        migrated, count = migrate_text(text, args.exact_only)
+        if not count:
+            continue
+        total += count
+        print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
+
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-img-cover (size-full object-cover shorthand) {mode} occurrences: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/scripts/verifyStorybookStudio.mjs
+++ b/utils/scripts/verifyStorybookStudio.mjs
@@ -14,6 +14,23 @@ function includesAll(path, values) {
   }
 }
 
+// Some `values` entries are themselves a list of acceptable alternate
+// spellings of the same rendered shape -- e.g. the interface-vision t-104
+// kr-* consistency umbrella folds a hand-rolled utility combo into a shared
+// primitive that `@apply`s the exact same classes, so the literal source
+// text changes even though nothing renders differently. At least one
+// alternative in the group must be present.
+function includesAllOrAlternatives(path, values) {
+  const contents = source(path)
+  for (const value of values) {
+    const alternatives = Array.isArray(value) ? value : [value]
+    assert.ok(
+      alternatives.some((alt) => contents.includes(alt)),
+      `${path} must include ${alternatives.join(' or ')}`,
+    )
+  }
+}
+
 const pagePath = 'components/conductor/storybook-page.vue'
 const shellPath = 'components/pages/storybook-library-page.vue'
 const setupPath = 'components/storybook/storybook-visual-setup.vue'
@@ -138,9 +155,13 @@ assert.match(
   'Storybook setup must own a bounded scroll region, or the host clips it',
 )
 
-includesAll(ingredientCardPath, [
+includesAllOrAlternatives(ingredientCardPath, [
   'aspect-[2/3]',
-  'object-cover',
+  // 'object-cover' or its kr-img-cover primitive (interface-vision t-104
+  // slice 248): `.kr-img-cover { @apply h-full w-full object-cover; }`
+  // renders byte-identically to the hand-rolled `size-full object-cover`
+  // this card used before.
+  ['object-cover', 'kr-img-cover'],
   'bg-linear-to-t from-black/90',
 ])
 assert.ok(


### PR DESCRIPTION
### Task
interface-vision/t-104: Drive live front-end consistency onto shared kr-* components and composition rules — slice 248 (kind: software)

### What changed / what I produced
- Fresh full-repo class-frequency survey (`kr_class_frequency_survey.py`, excluding all now-closed families) turned up `object-cover size-full` as the largest well-bounded pool left: the `size-full` Tailwind shorthand spelling (sets both axes at once) of the exact same object-fit shape `.kr-img-cover` already covers (`h-full w-full object-cover`, opened in an earlier slice, already in use at 30 sites).
- Added `utils/scripts/codemods/kr_img_cover_size_full_shorthand_codemod.py` (mirrors the `kr-icon-N`/`size-N` shorthand codemod pattern) and migrated 19 occurrences across 14 files onto the existing `.kr-img-cover` primitive, preserving extra tokens (`absolute`/`inset-0`, `transition`/hover/`motion-reduce`, `grayscale`) verbatim after the primitive class.
- No color/behavior/API/schema/route/geometry change — `size-full` is CSS-identical to `h-full w-full`, so every migrated site renders byte-identically.

### How I verified
- `eslint` on all touched files: 5 pre-existing errors on 3 files (`vue/no-mutating-props`, `no-empty`), confirmed unrelated via `git stash` — none touch the migrated class attributes.
- `vue-tsc --noEmit`: clean.
- `prettier --check` on touched `.vue` files: drift on 10 files, confirmed pre-existing repo-wide formatting drift via `git stash`.
- `npx tsx utils/scripts/verifyLayoutContract.ts`: holds, no new violations (the reported viewport-grid improvement in `animation-manager.vue` predates this diff and is out of scope for this slice).
- Full `npm run build`: completes with exit 0 — no unknown-utility `@apply` failure (the class of bug slice 247 caught), not applicable here since `.kr-img-cover`'s own `@apply` tokens are unchanged.

### Stakes
reversible

### Notes for reviewer
Part of the ongoing kr-* consistency umbrella (interface-vision/t-104). Returns the recurring task to `ready` for the next bounded slice once merged.

### Kaizen suggestion
Next candidates from the same survey (excluding this now-closed pool): `font-semibold text-sm` (9 files/13 occurrences) and `size-5 text-primary` (9 files/11 occurrences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKcP4ULBdFe9SAGFu6ojb7

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKcP4ULBdFe9SAGFu6ojb7)_