### PR TITLE
feat(css): open kr-text-semibold-sm consistency family (t-104 slice 250)

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -2723,6 +2723,18 @@ section:has(div[class*='xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]'])
     @apply gap-1;
   }
 
+  /* `font-semibold text-sm` text (interface-vision t-104 slice 250) -- the
+   * next bounded text-weight family after the established `kr-text-bold-*`
+   * and `kr-text-black-*` primitives, surveyed and named in slice 249.
+   * `font-semibold` sits between those two weights, so this is its own
+   * sibling family rather than folding into either. Exact-only slice: 13
+   * occurrences across 9 files carry no extra tokens beyond the base pair;
+   * the wider subset-match pool is left for a future slice per this
+   * family's own established convention. */
+  .kr-text-semibold-sm {
+    @apply font-semibold text-sm;
+  }
+
   .text-smart {
     @apply text-sm md:text-lg lg:text-lg xl:text-xl;
   }

--- a/components/art/artjob-editor.vue
+++ b/components/art/artjob-editor.vue
@@ -109,7 +109,7 @@
             >
               <div class="flex flex-wrap items-start justify-between gap-2">
                 <div>
-                  <h4 class="text-sm font-semibold">Video options</h4>
+                  <h4 class="kr-text-semibold-sm">Video options</h4>
                   <p class="kr-text-dim-xs-55 mt-1">
                     These values update both the ArtJob metadata and the Comfy
                     workflow used by the relay.

--- a/components/art/artjob-failed-page-requeue.vue
+++ b/components/art/artjob-failed-page-requeue.vue
@@ -3,7 +3,7 @@
   <section v-if="failedJobIds.length || message" class="kr-panel-flat p-3">
     <div class="flex flex-wrap items-center justify-between gap-3">
       <div class="min-w-0">
-        <h3 class="text-sm font-semibold">Failed-job recovery</h3>
+        <h3 class="kr-text-semibold-sm">Failed-job recovery</h3>
         <p class="kr-text-dim-xs-60 mt-1">
           Only the failed jobs currently loaded on page
           {{ artJobStore.jobPage }}

--- a/components/art/artjob-feedback-manager.vue
+++ b/components/art/artjob-feedback-manager.vue
@@ -7,7 +7,7 @@
       <div class="flex flex-wrap items-start justify-between gap-2">
         <div>
           <div class="flex items-center gap-2">
-            <h3 class="text-sm font-semibold">Art trainer</h3>
+            <h3 class="kr-text-semibold-sm">Art trainer</h3>
             <span class="kr-badge-primary-sm rounded-2xl">
               {{ pendingCount }} waiting
             </span>

--- a/components/art/artjob-queue-browser.vue
+++ b/components/art/artjob-queue-browser.vue
@@ -106,7 +106,7 @@
       <div class="grid gap-3 xl:grid-cols-2">
         <div class="kr-panel-flat p-3">
           <div class="mb-2 flex items-center justify-between gap-2">
-            <h3 class="text-sm font-semibold">Private art servers</h3>
+            <h3 class="kr-text-semibold-sm">Private art servers</h3>
             <button
               type="button"
               class="kr-btn-xs-2xl"
@@ -181,7 +181,7 @@
 
         <div class="kr-panel-flat p-3">
           <div class="mb-2 flex items-center justify-between gap-2">
-            <h3 class="text-sm font-semibold">Uptime · {{ windowHours }}h</h3>
+            <h3 class="kr-text-semibold-sm">Uptime · {{ windowHours }}h</h3>
             <div
               class="flex items-center gap-3 text-[10px] text-base-content/50"
             >
@@ -241,7 +241,7 @@
       <section class="kr-panel-flat p-3">
         <div class="flex flex-col gap-3">
           <div class="flex flex-wrap items-center gap-2">
-            <h3 class="text-sm font-semibold">Queue browser</h3>
+            <h3 class="kr-text-semibold-sm">Queue browser</h3>
             <span class="text-[11px] text-base-content/50">
               {{ artJobStore.jobStatusFilter }} · showing {{ pageStart }}–{{
                 pageEnd

--- a/components/art/artjob-slideshow.vue
+++ b/components/art/artjob-slideshow.vue
@@ -46,7 +46,7 @@
             v-if="slideshowStore.loadingPool"
             class="kr-spinner-lg-primary"
           />
-          <p class="text-sm font-semibold">{{ stageMessage }}</p>
+          <p class="kr-text-semibold-sm">{{ stageMessage }}</p>
           <p v-if="slideshowStore.error" class="kr-text-error-xs">
             {{ slideshowStore.error }}
           </p>

--- a/components/pages/conductor-project-gallery-page.vue
+++ b/components/pages/conductor-project-gallery-page.vue
@@ -134,7 +134,7 @@
           <p class="kr-text-black-xs text-error">
             {{ task.projectTitle }} · {{ task.id }}
           </p>
-          <p class="text-sm font-semibold">{{ task.title }}</p>
+          <p class="kr-text-semibold-sm">{{ task.title }}</p>
           <p v-if="task.note" class="kr-text-dim-xs-55 line-clamp-2">
             {{ task.note }}
           </p>

--- a/components/pages/serendipity-page.vue
+++ b/components/pages/serendipity-page.vue
@@ -182,7 +182,7 @@
           :key="art.id"
           class="rounded-lg border border-base-300 bg-base-100 p-2"
         >
-          <p class="text-sm font-semibold">“{{ art.prompt }}”</p>
+          <p class="kr-text-semibold-sm">“{{ art.prompt }}”</p>
           <p class="kr-text-dim-xs-60 mt-0.5">
             style: {{ art.style || '—' }} · size: {{ art.size || '—' }} ·
             gallery: {{ art.gallery || '—' }}

--- a/pages/play/mandarin.vue
+++ b/pages/play/mandarin.vue
@@ -435,7 +435,7 @@
 
             <section class="border-t border-base-300 p-4">
               <div class="flex flex-wrap items-center gap-2">
-                <span class="text-sm font-semibold">Save to:</span>
+                <span class="kr-text-semibold-sm">Save to:</span>
                 <button
                   v-for="set in customSets"
                   :key="set.id"

--- a/pages/play/video-generator.vue
+++ b/pages/play/video-generator.vue
@@ -218,7 +218,7 @@
 
       <section class="grid gap-4 sm:grid-cols-3">
         <div class="space-y-1">
-          <label class="text-sm font-semibold">Time (seconds)</label>
+          <label class="kr-text-semibold-sm">Time (seconds)</label>
           <input
             v-model.number="durationSeconds"
             type="number"
@@ -229,7 +229,7 @@
           />
         </div>
         <div class="space-y-1">
-          <label class="text-sm font-semibold">FPS</label>
+          <label class="kr-text-semibold-sm">FPS</label>
           <input
             v-model.number="fps"
             type="number"
@@ -240,7 +240,7 @@
           />
         </div>
         <div class="space-y-1">
-          <label class="text-sm font-semibold">Loop</label>
+          <label class="kr-text-semibold-sm">Loop</label>
           <label class="flex h-12 cursor-pointer items-center gap-2">
             <input
               v-model="loop"

--- a/utils/scripts/codemods/kr_text_semibold_sm_codemod.py
+++ b/utils/scripts/codemods/kr_text_semibold_sm_codemod.py
@@ -1,22 +1,28 @@
 #!/usr/bin/env python3
-"""Find hand-rolled `font-semibold text-sm` text candidates.
+"""Find or migrate hand-rolled `font-semibold text-sm` text to
+`kr-text-semibold-sm`.
 
-Interface Vision t-104 slice 249. A fresh repository survey identified this
-pair as the next bounded text-weight family after the established
-`kr-text-bold-*` and `kr-text-black-*` primitives. This first slice is
-intentionally discovery-only: `kr-text-semibold-sm` does not exist yet, so
-this tool refuses `--write` rather than implying a runtime primitive that
-has not been opened.
+Interface Vision t-104 slice 249 surveyed this pair as the next bounded
+text-weight family after the established `kr-text-bold-*` and
+`kr-text-black-*` primitives and shipped this tool discovery-only, since the
+primitive did not exist yet. Slice 250 opens `.kr-text-semibold-sm` and
+enables `--write`.
 
-Only static `class="..."` attributes are inspected. Bound `:class` and
-`v-bind:class` expressions are outside this mechanical migration family.
-Extra utility tokens are preserved in the candidate report; `--exact-only`
-restricts discovery to class strings containing only the two base tokens.
+Dry-run by default, --write to update matching Vue files in place. Only the
+exact `font-semibold text-sm` shape is touched, and only in static
+`class="..."` attributes -- never `:class`/`v-bind:class` bindings,
+regardless of the base tokens' order in the source. A source that already
+carries `kr-text-semibold-sm`, or is missing either base token, is left
+untouched. Extra tokens beyond the base set are preserved verbatim after the
+primitive class, matching every other kr-text-*/kr-badge-*/kr-spinner-*
+codemod's subset-match convention -- pass --exact-only to restrict a slice
+to sources with no extra tokens at all, the safest and most literal pool.
 """
 
 from __future__ import annotations
 
 import argparse
+import re
 from pathlib import Path
 from _class_attr import CLASS_ATTR
 
@@ -24,47 +30,64 @@ PRIMITIVE = "kr-text-semibold-sm"
 BASE_TOKENS = {"font-semibold", "text-sm"}
 
 
-def is_candidate(classes: str, exact_only: bool) -> bool:
+def migrate_classes(classes: str, exact_only: bool) -> str | None:
     tokens = classes.split()
     if PRIMITIVE in tokens or not BASE_TOKENS.issubset(tokens):
-        return False
+        return None
     remaining = [token for token in tokens if token not in BASE_TOKENS]
-    return not exact_only or not remaining
+    if exact_only and remaining:
+        return None
+    return " ".join([PRIMITIVE, *remaining])
+
+
+def migrate_text(text: str, exact_only: bool) -> tuple[str, int]:
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        migrated = migrate_classes(match.group(1), exact_only)
+        if migrated is None:
+            return match.group(0)
+        count += 1
+        return f'class="{migrated}"'
+
+    return CLASS_ATTR.sub(replace, text), count
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--root", type=Path, default=Path.cwd())
-    parser.add_argument("--exact-only", action="store_true")
+    parser.add_argument("--write", action="store_true")
     parser.add_argument(
-        "--write",
+        "--exact-only",
         action="store_true",
-        help="Reserved for the follow-up slice after kr-text-semibold-sm exists.",
+        help="Only migrate class strings that are exactly the base token set "
+        "(no extra utility tokens preserved). Bounds a slice to the safest, "
+        "most literal candidates; re-run without this flag for the fuller "
+        "subset-match pool in a later slice.",
     )
     args = parser.parse_args()
-
-    if args.write:
-        parser.error(
-            "--write is intentionally disabled until the kr-text-semibold-sm primitive exists"
-        )
 
     total = 0
     for path in sorted(args.root.rglob("*.vue")):
         if any(part in {"node_modules", ".nuxt", ".output"} for part in path.parts):
             continue
+        # newline="" preserves the file's original line endings verbatim --
+        # see kr_badge_codemod.py for why this matters (kind_robots
+        # add-bot.vue, interface-vision t-104 slice 106).
         with path.open(encoding="utf-8", newline="") as f:
             text = f.read()
-        count = sum(
-            1
-            for match in CLASS_ATTR.finditer(text)
-            if is_candidate(match.group(1), args.exact_only)
-        )
+        migrated, count = migrate_text(text, args.exact_only)
         if not count:
             continue
         total += count
         print(f"{path.relative_to(args.root)}: {count}")
+        if args.write:
+            with path.open("w", encoding="utf-8", newline="") as f:
+                f.write(migrated)
 
-    print(f"kr-text-semibold-sm candidate occurrences: {total}")
+    mode = "migrated" if args.write else "candidate"
+    print(f"kr-text-semibold-sm {mode} occurrences: {total}")
     return 0
 
 


### PR DESCRIPTION
### Task
interface-vision/t-104: consistency slice 250 (kind: software)

### What changed / what I produced
- Opens `.kr-text-semibold-sm` (`font-semibold text-sm`) in `assets/css/tailwind.css`, the next bounded text-weight family after the established `kr-text-bold-*`/`kr-text-black-*` primitives (surveyed and named discovery-only in slice 249).
- Enables `--write` in `utils/scripts/codemods/kr_text_semibold_sm_codemod.py` and migrates the 13 exact-only occurrences across 9 files (`components/art/artjob-editor.vue`, `artjob-failed-page-requeue.vue`, `artjob-feedback-manager.vue`, `artjob-queue-browser.vue` (3), `artjob-slideshow.vue`, `components/pages/conductor-project-gallery-page.vue`, `serendipity-page.vue`, `pages/play/mandarin.vue`, `pages/play/video-generator.vue` (3)).
- Template/class-only change; no script, store, API, or behavior change. The wider subset-match pool (76 total candidates) is left for a future slice.

### How I verified
- `npx eslint` on all touched files: clean.
- `npx vue-tsc --noEmit`: clean.
- `npm run test:layout-contract`: holds, zero new violations (a pre-existing baseline improvement on `animation-manager.vue`/`ruler-hooked-health.vue` noted by prior slices was observed again and left untouched, out of scope).
- `npx prettier --check`: flags pre-existing drift on 5 files, confirmed via `git stash` to predate this change (identical warnings before and after), left alone.

### Stakes
reversible

### Kaizen suggestion
Next slice: migrate the remaining ~63 subset-match `font-semibold text-sm` occurrences (run the codemod without `--exact-only`), preserving each site's extra tokens per the established convention.

### Notes for reviewer
No runtime Vue/CSS behavior change in this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhTrvL5uWLvCdXZ7V1xgQm

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhTrvL5uWLvCdXZ7V1xgQm)_